### PR TITLE
fix: `backtick` is replaced with an empty string in bash

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -20,7 +20,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "node ./generate-patches-bundles.js \"${nextRelease.version}\" \"${nextRelease.notes}\""
+        "prepareCmd": "node ./generate-patches-bundles.js \"${nextRelease.version}\" \"$(echo \"${nextRelease.notes}\" | jq -sRr @json)\""
       }
     ],
     [


### PR DESCRIPTION
Strings surrounded by backticks (`) are [converted to empty strings in bash](https://github.com/MorpheApp/morphe-patches/commit/c21246e19304cbb87ea7936f617a4d0cfbb62a06).

#### CHANGELOG.md

<img width="884" height="59" alt="changelog" src="https://github.com/user-attachments/assets/e564622f-2945-42c8-afc1-78dd8cc5dbfb" />

#### patches-bundle.json

<img width="384" height="57" alt="bundle" src="https://github.com/user-attachments/assets/e35f3c7c-2757-4ceb-8110-476dd50e4038" />

This PR handles exceptions for backticks.

