### PR TITLE
fix(YouTube - Loop video): Wrong icon applied

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LoopVideoButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LoopVideoButton.java
@@ -72,16 +72,14 @@ public class LoopVideoButton {
             Utils.verifyOnMainThread();
 
             final boolean currentState = Settings.LOOP_VIDEO.get();
-            final boolean newState = userClickedButton ? !currentState : currentState;
+            final boolean newState = userClickedButton != currentState;
 
             instance.setIcon(newState
                     ? LOOP_VIDEO_ON
                     : LOOP_VIDEO_OFF);
 
             if (!userClickedButton) return;
-
             Settings.LOOP_VIDEO.save(newState);
-
             Utils.showToastShort(str(newState
                     ? "morphe_loop_video_button_toast_on"
                     : "morphe_loop_video_button_toast_off"));


### PR DESCRIPTION
#### Steps to reproduce the issue

1. Turn on both `Enable loop video` and `Show loop video button`.
2. The player `loop video button` icon should be `morphe_loop_video_button_on`, but `morphe_loop_video_button_off` is being used.