### PR TITLE
fix(YouTube - Loop video): Fix looping button state

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LoopVideoButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LoopVideoButton.java
@@ -104,10 +104,8 @@ public class LoopVideoButton {
         PlayerControlButton localInstance = instance;
         if (localInstance == null) return;
 
-        Utils.runOnMainThread(() -> {
-            final boolean currentState = Settings.LOOP_VIDEO.get();
-            localInstance.setIcon(currentState ? LOOP_VIDEO_ON : LOOP_VIDEO_OFF);
-        });
+        final boolean currentState = Settings.LOOP_VIDEO.get();
+        localInstance.setIcon(currentState ? LOOP_VIDEO_ON : LOOP_VIDEO_OFF);
     }
 
     /**


### PR DESCRIPTION
If disable looping in the settings during playback, the overlay button did not respond to this