### PR TITLE
fix(YouTube - Spoof app version): Change oldest spoof target to `19.35.36`

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -272,7 +272,7 @@ public class Settings extends BaseSettings {
     public static final EnumSetting<StartPage> CHANGE_START_PAGE = new EnumSetting<>("morphe_change_start_page", StartPage.DEFAULT, true);
     public static final BooleanSetting CHANGE_START_PAGE_ALWAYS = new BooleanSetting("morphe_change_start_page_always", FALSE, true,
             new ChangeStartPageTypeAvailability());
-    public static final StringSetting SPOOF_APP_VERSION_TARGET = new StringSetting("morphe_spoof_app_version_target", "19.01.34", true, parent(SPOOF_APP_VERSION));
+    public static final StringSetting SPOOF_APP_VERSION_TARGET = new StringSetting("morphe_spoof_app_version_target", "19.35.36", true, parent(SPOOF_APP_VERSION));
 
     // Custom filter
     public static final BooleanSetting CUSTOM_FILTER = new BooleanSetting("morphe_custom_filter", FALSE);

--- a/patches/src/main/resources/addresources/values/youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/youtube/arrays.xml
@@ -68,23 +68,19 @@
         <item>@string/morphe_spoof_app_version_target_entry_1</item>
         <item>@string/morphe_spoof_app_version_target_entry_2</item>
         <item>@string/morphe_spoof_app_version_target_entry_3</item>
-        <item>@string/morphe_spoof_app_version_target_entry_4</item>
     </string-array>
     <string-array name="morphe_spoof_app_version_target_entry_values">
         <item>20.13.41</item>
         <item>20.05.46</item>
         <item>19.35.36</item>
-        <item>19.01.34</item>
     </string-array>
     <string-array name="morphe_spoof_app_version_target_legacy_20_13_entries">
         <item>@string/morphe_spoof_app_version_target_entry_2</item>
         <item>@string/morphe_spoof_app_version_target_entry_3</item>
-        <item>@string/morphe_spoof_app_version_target_entry_4</item>
     </string-array>
     <string-array name="morphe_spoof_app_version_target_legacy_20_13_entry_values">
         <item>20.05.46</item>
         <item>19.35.36</item>
-        <item>19.01.34</item>
     </string-array>
     <string-array name="morphe_spoof_app_version_target_legacy_19_34_entries">
         <item>19.01.34</item>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1185,7 +1185,6 @@ If later turned off, it is recommended to clear the app data to prevent UI bugs.
     <string name="morphe_spoof_app_version_target_entry_1">20.13.41 - Restore non collapsed video action bar</string>
     <string name="morphe_spoof_app_version_target_entry_2">20.05.46 - Restore transcript functionality</string>
     <string name="morphe_spoof_app_version_target_entry_3">19.35.36 - Restore old Shorts player icons</string>
-    <string name="morphe_spoof_app_version_target_entry_4">19.01.34 - Restore old navigation icons</string>
 
     <!-- layout.startpage.changeStartPagePatch -->
     <string name="morphe_change_start_page_title">Change start page</string>


### PR DESCRIPTION
19.35 now also shows the old navigation icons so there doesn't seem to be any reason to spoof lower than that.

And spoofing to 19.01 now has too many UI glitches after turning off spoofing.

If anyone really wants to experiment with spoofing to 19.01 (or any other version), then you can still modify the import/export setting data and change to anything as old as 19.01, but there doesn't seem to be anything different from 19.35 except more UI glitches.