### PR TITLE
fix(Spoof video streams): Change default client to VR 1.47.48

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/spoof/SpoofVideoStreamsPatch.java
@@ -18,12 +18,11 @@ public class SpoofVideoStreamsPatch {
      * Injection point.
      */
     public static void setClientOrderToUse() {
+        // For some users No SDK can fail at 1 minute. Only use it if the user has explicitly set it.
         List<ClientType> availableClients = List.of(
-                ANDROID_NO_SDK,
                 ANDROID_VR_1_47_48,
                 VISIONOS,
-                ANDROID_VR_1_54_20,
-                ANDROID_MUSIC_NO_SDK
+                ANDROID_VR_1_54_20
         );
 
         app.morphe.extension.shared.spoof.SpoofVideoStreamsPatch.setClientsToUse(

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -35,7 +35,7 @@ public class Settings extends BaseSettings {
 
     // Miscellaneous
     public static final EnumSetting<ClientType> SPOOF_VIDEO_STREAMS_CLIENT_TYPE = new EnumSetting<>("morphe_spoof_video_streams_client_type",
-            ClientType.ANDROID_MUSIC_NO_SDK, true, parent(SPOOF_VIDEO_STREAMS));
+            ClientType.ANDROID_VR_1_47_48, true, parent(SPOOF_VIDEO_STREAMS));
 
     public static final BooleanSetting FORCE_ORIGINAL_AUDIO = new BooleanSetting("morphe_force_original_audio", TRUE, true);
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/spoof/SpoofVideoStreamsPatch.java
@@ -42,11 +42,11 @@ public class SpoofVideoStreamsPatch {
             client = ANDROID_VR_1_54_20;
         }
 
+        // For some users No SDK can fail at 1 minute. Only use it if the user has explicitly set it.
         List<ClientType> availableClients = List.of(
                 VISIONOS,
                 ANDROID_VR_1_47_48,
-                ANDROID_CREATOR,
-                ANDROID_NO_SDK
+                ANDROID_CREATOR
         );
 
         app.morphe.extension.shared.spoof.SpoofVideoStreamsPatch.setClientsToUse(

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -364,7 +364,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting EXTERNAL_BROWSER = new BooleanSetting("morphe_external_browser", TRUE, true);
     public static final BooleanSetting SPOOF_DEVICE_DIMENSIONS = new BooleanSetting("morphe_spoof_device_dimensions", FALSE, true,
             "morphe_spoof_device_dimensions_user_dialog_message");
-    public static final EnumSetting<ClientType> SPOOF_VIDEO_STREAMS_CLIENT_TYPE = new EnumSetting<>("morphe_spoof_video_streams_client_type", ClientType.ANDROID_NO_SDK, true, parent(SPOOF_VIDEO_STREAMS));
+    public static final EnumSetting<ClientType> SPOOF_VIDEO_STREAMS_CLIENT_TYPE = new EnumSetting<>("morphe_spoof_video_streams_client_type", ClientType.ANDROID_VR_1_47_48, true, parent(SPOOF_VIDEO_STREAMS));
     public static final BooleanSetting SPOOF_VIDEO_STREAMS_AV1 = new BooleanSetting("morphe_spoof_video_streams_av1", FALSE, true,
             "morphe_spoof_video_streams_av1_user_dialog_message", new SpoofClientAv1Availability());
     public static final BooleanSetting DEBUG_PROTOBUFFER = new BooleanSetting("morphe_debug_protobuffer", FALSE, false,


### PR DESCRIPTION
Some users are reporting No SDK is starting to fail at 1 minute playback, which prevents falling over to a different spoof client.

This changes the default client to VR 1.47.48.

No SDK can still be manually selected and used if you have no problems, but if using a different spoof client that doesn't work for a given video it will not fall-over to No SDK.

