### PR TITLE
feat(YouTube): Add experimental support for `21.02.32`

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/autocaptions/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/autocaptions/Fingerprints.kt
@@ -3,6 +3,7 @@ package app.morphe.patches.youtube.layout.autocaptions
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.OpcodesFilter
 import app.morphe.patcher.literal
+import app.morphe.patcher.string
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 
@@ -16,29 +17,13 @@ internal object StartVideoInformerFingerprint : Fingerprint(
     strings = listOf("pc")
 )
 
-internal object StoryboardRendererDecoderRecommendedLevelFingerprint : Fingerprint(
-    returnType = "V",
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
-    parameters = listOf("L"),
-    strings = listOf("#-1#")
-)
-
 internal object SubtitleTrackFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "Z",
     parameters = listOf(),
-    filters = OpcodesFilter.opcodesToFilters(
-        Opcode.CONST_STRING,
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.MOVE_RESULT_OBJECT,
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.MOVE_RESULT,
-        Opcode.RETURN,
-    ),
-    strings = listOf("DISABLE_CAPTIONS_OPTION"),
-    custom = { _, classDef ->
-        classDef.endsWith("/SubtitleTrack;")
-    }
+    filters = listOf(
+        string("DISABLE_CAPTIONS_OPTION")
+    )
 )
 
 /**

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/startpage/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/startpage/Fingerprints.kt
@@ -14,7 +14,7 @@ internal object IntentActionFingerprint : Fingerprint(
 )
 
 internal object BrowseIdFingerprint : Fingerprint(
-    returnType = "Lcom/google/android/apps/youtube/app/common/ui/navigation/PaneDescriptor;",
+    returnType = "L",
 
     //parameters() // 20.30 and earlier is no parameters = listOf(.  20.31+ parameter is L.),
     filters = listOf(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/shared/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/shared/Fingerprints.kt
@@ -123,7 +123,7 @@ internal object SeekbarOnDrawFingerprint : Fingerprint(
 internal object SubtitleButtonControllerFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "V",
-    parameters = listOf("Lcom/google/android/libraries/youtube/player/subtitles/model/SubtitleTrack;"),
+    parameters = listOf("L"),
     filters = listOf(
         resourceLiteral(ResourceType.STRING, "accessibility_captions_unavailable"),
         resourceLiteral(ResourceType.STRING, "accessibility_captions_button_name"),


### PR DESCRIPTION
#### Update: This is moved to https://github.com/MorpheApp/morphe-patches/pull/138

As mentioned [here](https://github.com/MorpheApp/morphe-documentation/blob/main/docs/morphe-resources/questions.md#20-can-i-patch-the-latest-youtube-version-can-i-patch-newer-than-the-recommended-version), Morphe tries to support the very latest YouTube and YT Music for users who like to experiment.

This marks the first YT release for 2026.

To patch this, use Morphe home page patching and provide YT [21.02.32 (universal nodpi)](https://www.google.com/search?q=youtube+21.02.32+nodpi), and confirm the Morphe warning that the version is not the recommended version.

If you experience bugs or issues that only happen on the latest YT release, but are confirmed not happen with the recommended version (`20.37.48` at the time of this PR), then please post your findings in https://github.com/MorpheApp/morphe-patches/issues/36#issuecomment-3722993530