### PR TITLE
feat(YouTube): Add experimental support for `21.03.34`

### DIFF
--- a/patches/api/patches.api
+++ b/patches/api/patches.api
@@ -758,6 +758,7 @@ public final class app/morphe/patches/youtube/misc/playservice/VersionCheckPatch
 	public static final fun is_20_46_or_greater ()Z
 	public static final fun is_20_49_or_greater ()Z
 	public static final fun is_21_02_or_greater ()Z
+	public static final fun is_21_03_or_greater ()Z
 }
 
 public final class app/morphe/patches/youtube/misc/privacy/SanitizeSharingLinksPatchKt {

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/HideVideoActionButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/HideVideoActionButtonsPatch.kt
@@ -9,7 +9,6 @@ import app.morphe.patches.youtube.misc.litho.filter.lithoFilterPatch
 import app.morphe.patches.youtube.misc.playservice.is_20_22_or_greater
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
-import java.util.logging.Logger
 
 @Suppress("unused")
 val hideVideoActionButtonsPatch = resourcePatch(
@@ -45,17 +44,8 @@ val hideVideoActionButtonsPatch = resourcePatch(
             SwitchPreference("morphe_hide_share_button"),
         )
 
-        if (is_20_22_or_greater) {
-            // 20.22+ filtering of the action buttons doesn't work because
-            // the buffer is the same for all buttons.
-            // TODO: Eventually remove this warning.
-            Logger.getLogger(this::class.java.name).warning(
-                "\n!!!" +
-                        "\n!!! Not all player action buttons can be set hidden when patching 20.22+" +
-                        "\n!!! Patch 20.21.37 if you want to hide more player action buttons" +
-                        "\n!!!"
-            )
-        } else {
+        // 20.22+ cannot hide all action buttons because of buffer changes.
+        if (!is_20_22_or_greater) {
             preferences.addAll(
                 listOf(
                     SwitchPreference("morphe_hide_hype_button"),

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/Fingerprints.kt
@@ -16,7 +16,8 @@ import com.android.tools.smali.dexlib2.Opcode
 internal object ComponentContextParserFingerprint : Fingerprint(
     returnType = "L",
     filters = listOf(
-        string("Number of bits must be positive")
+        string("Failed to parse Element proto."),
+        string("Cannot read theme key from model.")
     )
 )
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/Fingerprints.kt
@@ -5,6 +5,7 @@ package app.morphe.patches.youtube.layout.miniplayer
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.InstructionLocation.MatchAfterWithin
 import app.morphe.patcher.OpcodesFilter
+import app.morphe.patcher.anyInstruction
 import app.morphe.patcher.checkCast
 import app.morphe.patcher.literal
 import app.morphe.patcher.methodCall
@@ -150,8 +151,14 @@ internal object MiniplayerMinimumSizeFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
     filters = listOf(
         resourceLiteral(ResourceType.DIMEN, "miniplayer_max_size"),
-        literal(192), // Default miniplayer width constant.
-        literal(128)  // Default miniplayer height constant.
+        anyInstruction( // Default miniplayer width constant.
+            literal(192),
+            literal(192.0f), // 21.03+
+        ),
+        anyInstruction( // Default miniplayer height constant.
+            literal(128),
+            literal(128.0f), // 21.03+
+        )
     )
 )
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/returnyoutubedislike/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/returnyoutubedislike/Fingerprints.kt
@@ -101,10 +101,14 @@ internal object RollingNumberTextViewFingerprint : Fingerprint(
 )
 
 internal object TextComponentConstructorFingerprint : Fingerprint(
-    accessFlags = listOf(AccessFlags.CONSTRUCTOR, AccessFlags.PRIVATE),
     filters = listOf(
         string("TextComponent")
-    )
+    ),
+    custom = { method, _ ->
+        // 20.23+ is public.
+        // 20.22 and lower is private.
+        AccessFlags.CONSTRUCTOR.isSet(method.accessFlags)
+    }
 )
 
 internal object TextComponentDataFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/startupshortsreset/DisableResumingShortsOnStartupPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/startupshortsreset/DisableResumingShortsOnStartupPatch.kt
@@ -5,6 +5,7 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.playservice.is_20_03_or_greater
+import app.morphe.patches.youtube.misc.playservice.is_21_03_or_greater
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
@@ -36,10 +37,16 @@ val disableResumingShortsOnStartupPatch = bytecodePatch(
             "20.26.46",
             "20.31.42",
             "20.37.48",
+            // This patch is obsolete with 20.03 because YT seems to have
+            // removed resuming Shorts functionality.
+            // TODO: Before adding 20.03+, merge this patch into `Hide Shorts component`
         )
     )
 
     execute {
+        // 21.03+ seems to no longer have resuming Shorts functionality.
+        if (is_21_03_or_greater) return@execute
+
         PreferenceScreen.SHORTS.addPreferences(
             SwitchPreference("morphe_disable_resuming_shorts_player"),
         )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playservice/VersionCheckPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playservice/VersionCheckPatch.kt
@@ -115,6 +115,8 @@ var is_20_49_or_greater : Boolean by Delegates.notNull()
     private set
 var is_21_02_or_greater : Boolean by Delegates.notNull()
     private set
+var is_21_03_or_greater : Boolean by Delegates.notNull()
+    private set
 
 
 val versionCheckPatch = resourcePatch(
@@ -168,5 +170,6 @@ val versionCheckPatch = resourcePatch(
         is_20_46_or_greater = 254705000 <= playStoreServicesVersion
         is_20_49_or_greater = 255005000 <= playStoreServicesVersion
         is_21_02_or_greater = 260305000 <= playStoreServicesVersion
+        is_21_03_or_greater = 260405000 <= playStoreServicesVersion
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/information/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/information/Fingerprints.kt
@@ -89,7 +89,7 @@ internal object SeekFingerprint : Fingerprint(
             // 20.xx
             string("Attempting to seek during an ad"),
             // 21.02+
-            string("Attempting to seek during an ad or non-seekable video")
+            string("currentPositionMs.")
         )
     )
 )


### PR DESCRIPTION
Adds experimental support for patching the currently beta YouTube apk.

The `Disable resuming Shorts on startup` patch no longer seems to be needed with 21.03, because it appears YouTube has removed the resuming Shorts functionality. Eventually `Disable resuming Shorts on startup` will be merged into another Shorts related patch and the patch functionality will be applied only for 20.02 and lower.

### How to patch 21.03.34
1. Download the [original YouTube 21.03.34 apk](https://google.com/search?q=21.03.34+YouTube+nodpi+universal+apk)
2. After selecting the APK during patching, click past the generic "This apk may not work" message
3. If you experience issues that do not happen with the recommended `20.37.48`, then post your findings [here](https://github.com/MorpheApp/morphe-patches/issues/36)

