### PR TITLE
feat(YouTube - Hide layout components): Add "Hide video title" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -264,6 +264,11 @@ public final class LayoutComponentsFilter extends Filter {
                 "endorsement_header_footer.e"
         );
 
+        final var videoTitle = new StringFilterGroup(
+                Settings.HIDE_VIDEO_TITLE,
+                "player_overlay_video_heading.e"
+        );
+
         final var webLinkPanel = new StringFilterGroup(
                 Settings.HIDE_WEB_SEARCH_RESULTS,
                 "web_link_panel",
@@ -339,6 +344,7 @@ public final class LayoutComponentsFilter extends Filter {
                 subscriptionsChipBar,
                 surveys,
                 timedReactions,
+                videoTitle,
                 videoRecommendationLabels,
                 webLinkPanel
         );

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -173,6 +173,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting HIDE_RELATED_VIDEOS = new BooleanSetting("morphe_hide_related_videos", FALSE);
     public static final BooleanSetting HIDE_SUBSCRIBERS_COMMUNITY_GUIDELINES = new BooleanSetting("morphe_hide_subscribers_community_guidelines", TRUE);
     public static final BooleanSetting HIDE_TIMED_REACTIONS = new BooleanSetting("morphe_hide_timed_reactions", TRUE);
+    public static final BooleanSetting HIDE_VIDEO_TITLE = new BooleanSetting("morphe_hide_video_title", FALSE);
     public static final BooleanSetting OPEN_VIDEOS_FULLSCREEN_PORTRAIT = new BooleanSetting("morphe_open_videos_fullscreen_portrait", FALSE);
     public static final BooleanSetting PLAYBACK_SPEED_DIALOG_BUTTON = new BooleanSetting("morphe_playback_speed_dialog_button", FALSE);
     public static final BooleanSetting VIDEO_QUALITY_DIALOG_BUTTON = new BooleanSetting("morphe_video_quality_dialog_button", FALSE);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -167,6 +167,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
             SwitchPreference("morphe_hide_related_videos"),
             SwitchPreference("morphe_hide_subscribers_community_guidelines"),
             SwitchPreference("morphe_hide_timed_reactions"),
+            SwitchPreference("morphe_hide_video_title"),
         )
 
         PreferenceScreen.FEED.addPreferences(

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -167,6 +167,9 @@ If a Doodle is currently showing in your region and this hide setting is on, the
     <string name="morphe_hide_timed_reactions_title">Hide timed reactions</string>
     <string name="morphe_hide_timed_reactions_summary_on">Timed reactions are hidden</string>
     <string name="morphe_hide_timed_reactions_summary_off">Timed reactions are shown</string>
+    <string name="morphe_hide_video_title_title">Hide video title</string>
+    <string name="morphe_hide_video_title_summary_on">Video title in player overlay is hidden</string>
+    <string name="morphe_hide_video_title_summary_off">Video title in player overlay is shown</string>
     <string name="morphe_hide_ai_generated_video_summary_section_title">Hide \'AI-generated video summary\'</string>
     <string name="morphe_hide_ai_generated_video_summary_section_summary_on">AI-generated video summary section is hidden</string>
     <string name="morphe_hide_ai_generated_video_summary_section_summary_off">AI-generated video summary section is shown</string>
@@ -379,8 +382,8 @@ Limitations:
     <string name="morphe_hide_shopping_links_summary_on">Shopping links in video description are hidden</string>
     <string name="morphe_hide_shopping_links_summary_off">Shopping links in video description are shown</string>
     <string name="morphe_hide_view_products_banner_title">Hide view products banner</string>
-    <string name="morphe_hide_view_products_banner_summary_on">View products banner in video overlay is hidden</string>
-    <string name="morphe_hide_view_products_banner_summary_off">View products banner in video overlay is shown</string>
+    <string name="morphe_hide_view_products_banner_summary_on">View products banner in player overlay is hidden</string>
+    <string name="morphe_hide_view_products_banner_summary_off">View products banner in player overlay is shown</string>
     <string name="morphe_hide_youtube_premium_promotions_title">Hide YouTube Premium promotions</string>
     <string name="morphe_hide_youtube_premium_promotions_summary_on">"YouTube Premium promotions are hidden
 


### PR DESCRIPTION
One of the requested features in #43.
```kotlin
01-27 22:49:04.411   887   887 D morphe: LithoFilterPatch: Searching ID: player_overlay_video_heading.eml|1f1a2e6a96212ef8 Path: player_overlay_video_heading.eml|1f1a2e6a96212ef8|ContainerType| BufferStrings: 1player_overlay_video_heading.eml|1f1a2e6a96212ef8*❙theme|3d06f804e67f84cc❙333?❙dismiss❙$KEN_BURNS_ANIMATION_TYPE_UNSPECIFIED❙capabilities|6159e498f573fb3b❙/VanossGaming 2 Hours of Gmod Hide & Seek Part 2 ❙@VanossGamingEditorP❙/youtube/app/engagement_panel❙theme|3d06f804e67f84cc❙capabilities|6159e498f573fb3b❙1player_overlay_video_heading.eml|1f1a2e6a96212ef82❙176953401433935400❙
``` 