### PR TITLE
feat(YouTube - Hide layout components): Add "Hide live chat replay button" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -69,8 +69,14 @@ public final class LayoutComponentsFilter extends Filter {
                 "chips_shelf"
         );
 
+        final var liveChatReplay = new StringFilterGroup(
+                Settings.HIDE_LIVE_CHAT_REPLAY_BUTTON,
+                "live_chat_ep_entrypoint.e"
+        );
+
         addIdentifierCallbacks(
-                chipsShelf
+                chipsShelf,
+                liveChatReplay
         );
 
         // Paths.

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -166,6 +166,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting HIDE_INFO_CARDS = new BooleanSetting("morphe_hide_info_cards", FALSE);
     public static final BooleanSetting HIDE_INFO_PANELS = new BooleanSetting("morphe_hide_info_panels", TRUE);
     public static final BooleanSetting HIDE_JOIN_MEMBERSHIP_BUTTON = new BooleanSetting("morphe_hide_join_membership_button", TRUE);
+    public static final BooleanSetting HIDE_LIVE_CHAT_REPLAY_BUTTON = new BooleanSetting("morphe_hide_live_chat_replay_button", FALSE);
     public static final BooleanSetting HIDE_MEDICAL_PANELS = new BooleanSetting("morphe_hide_medical_panels", TRUE);
     public static final BooleanSetting HIDE_PLAYER_CONTROL_BUTTONS_BACKGROUND = new BooleanSetting("morphe_hide_player_control_buttons_background", FALSE, true);
     public static final BooleanSetting HIDE_PLAYER_PREVIOUS_NEXT_BUTTONS = new BooleanSetting("morphe_hide_player_previous_next_buttons", FALSE, true);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -162,6 +162,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
             SwitchPreference("morphe_hide_emergency_box"),
             SwitchPreference("morphe_hide_info_panels"),
             SwitchPreference("morphe_hide_join_membership_button"),
+            SwitchPreference("morphe_hide_live_chat_replay_button"),
             SwitchPreference("morphe_hide_medical_panels"),
             SwitchPreference("morphe_hide_quick_actions"),
             SwitchPreference("morphe_hide_related_videos"),

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -153,10 +153,15 @@ If a Doodle is currently showing in your region and this hide setting is on, the
     <string name="morphe_hide_info_panels_summary_on">Info panels are hidden</string>
     <string name="morphe_hide_info_panels_summary_off">Info panels are shown</string>
     <!-- 'Join' should be translated using the same localized wording YouTube displays for the button.
-          This appears in the video player for certain videos. -->
+          This button usually appears in the video player for certain videos. -->
     <string name="morphe_hide_join_membership_button_title">Hide Join button</string>
     <string name="morphe_hide_join_membership_button_summary_on">Join button is hidden</string>
     <string name="morphe_hide_join_membership_button_summary_off">Join button is shown</string>
+    <!-- 'Live chat replay' should be translated using the same localized wording YouTube displays for the button.
+          This button usually appears in the player overlay for live streamed videos after opening live chat. -->
+    <string name="morphe_hide_live_chat_replay_button_title">Hide \'Live chat replay\' button</string>
+    <string name="morphe_hide_live_chat_replay_button_summary_on">Live chat replay button in player overlay is hidden</string>
+    <string name="morphe_hide_live_chat_replay_button_summary_off">Live chat replay button in player overlay is shown</string>
     <string name="morphe_hide_medical_panels_title">Hide medical panels</string>
     <string name="morphe_hide_medical_panels_summary_on">Medical panels are hidden</string>
     <string name="morphe_hide_medical_panels_summary_off">Medical panels are shown</string>
@@ -541,7 +546,7 @@ Adjust volume by swiping vertically on the right side of the screen"</string>
     <string name="morphe_hide_comments_button_summary_on">Comments button is hidden</string>
     <string name="morphe_hide_comments_button_summary_off">Comments button is shown</string>
     <!-- 'Report' should be translated using the same localized wording YouTube displays for the button.
-          This button usually only shows on live streams. -->
+          This button usually appears on live streamed videos. -->
     <string name="morphe_hide_report_button_title">Hide Report</string>
     <string name="morphe_hide_report_button_summary_on">Report button is hidden</string>
     <string name="morphe_hide_report_button_summary_off">Report button is shown</string>
@@ -554,7 +559,7 @@ Adjust volume by swiping vertically on the right side of the screen"</string>
     <string name="morphe_hide_download_button_summary_on">Download button is hidden</string>
     <string name="morphe_hide_download_button_summary_off">Download button is shown</string>
     <!-- 'Hype' should be translated using the same localized wording YouTube displays for the button.
-          This button only shows on videos uploaded by the logged-in user. -->
+          This button usually appears on videos uploaded by the logged-in user. -->
     <string name="morphe_hide_hype_button_title">Hide Hype</string>
     <string name="morphe_hide_hype_button_summary_on">Hype button is hidden</string>
     <string name="morphe_hide_hype_button_summary_off">Hype button is shown</string>
@@ -567,7 +572,7 @@ Adjust volume by swiping vertically on the right side of the screen"</string>
     <string name="morphe_hide_thanks_button_summary_on">Thanks button is hidden</string>
     <string name="morphe_hide_thanks_button_summary_off">Thanks button is shown</string>
     <!-- 'Ask' should be translated using the same localized wording YouTube displays for the button.
-          This button only shows if the user ip is from specific region such as the USA or EU. -->
+          This button usually appears if the user IP is from a specific region such as the USA or EU. -->
     <string name="morphe_hide_ask_button_title">Hide Ask</string>
     <string name="morphe_hide_ask_button_summary_on">Ask button is hidden</string>
     <string name="morphe_hide_ask_button_summary_off">Ask button is shown</string>


### PR DESCRIPTION
![Screenshot_20260129_175718_YouTube](https://github.com/user-attachments/assets/4e2856a8-dbc2-4d70-b9ad-a1cc15088993)
