### PR TITLE
fix(YouTube - Hide ads): Fix "Hide YouTube Premium promotions" hiding YouTube Doodles

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AdsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AdsFilter.java
@@ -31,6 +31,8 @@ public final class AdsFilter extends Filter {
 
     private final StringTrieSearch exceptions = new StringTrieSearch();
 
+    private final StringFilterGroup promotionBanner;
+    private final ByteArrayFilterGroup promotionBannerBuffer;
     private final StringFilterGroup playerShoppingShelf;
     private final ByteArrayFilterGroup playerShoppingShelfBuffer;
     private final StringFilterGroup buyMovieAd;
@@ -137,9 +139,16 @@ public final class AdsFilter extends Filter {
                 "shopping_carousel.e" // Channel profile shopping shelf.
         );
 
-        final var promotionBanner = new StringFilterGroup(
+        promotionBanner = new StringFilterGroup(
                 Settings.HIDE_YOUTUBE_PREMIUM_PROMOTIONS,
                 "statement_banner"
+        );
+
+        promotionBannerBuffer = new ByteArrayFilterGroup(
+                null,
+                // YouTube Doodles uses https://www.gstatic.com/youtube/img/promos/ only.
+                // So, https://www.gstatic.com/youtube/img/promos/growth/ should hide the ad.
+                "img/promos/growth/"
         );
 
         final var selfSponsor = new StringFilterGroup(
@@ -169,6 +178,10 @@ public final class AdsFilter extends Filter {
 
         if (matchedGroup == buyMovieAd) {
             return contentIndex == 0 && buyMovieAdBuffer.check(buffer).isFiltered();
+        }
+
+        if (matchedGroup == promotionBanner) {
+            return contentIndex == 0 && promotionBannerBuffer.check(buffer).isFiltered();
         }
 
         return !exceptions.matches(path);

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -398,9 +398,7 @@ Limitations:
     <string name="morphe_hide_view_products_banner_summary_on">View products banner in player overlay is hidden</string>
     <string name="morphe_hide_view_products_banner_summary_off">View products banner in player overlay is shown</string>
     <string name="morphe_hide_youtube_premium_promotions_title">Hide YouTube Premium promotions</string>
-    <string name="morphe_hide_youtube_premium_promotions_summary_on">"YouTube Premium promotions are hidden
-
-Limitation: YouTube Doodles page is not available"</string>
+    <string name="morphe_hide_youtube_premium_promotions_summary_on">YouTube Premium promotions are hidden</string>
     <string name="morphe_hide_youtube_premium_promotions_summary_off">YouTube Premium promotions are shown</string>
 
     <!-- ad.video.videoAdsPatch -->


### PR DESCRIPTION
```kotlin
12-14 02:10:06.538 27009 27009 D Extended: LithoFilterPatch: Searching 
12-14 02:10:06.538 27009 27009 D Extended: LithoFilterPatch: ID: statement_banner.eml|b82cf0a19594a74f
12-14 02:10:06.538 27009 27009 D Extended: LithoFilterPatch: Path: statement_banner.eml|b82cf0a19594a74f|CellType|ContainerType|ContainerType|ContainerType|
12-14 02:10:06.538 27009 27009 D Extended: LithoFilterPatch: BufferStrings: statement-banner-container-transition❙statement_banner.simple_layout❙simple_layout.eml|585cbd4c3393c3a5❙8z&<❙https://www.gstatic.com/youtube/img/promos/growth/aff570fc7c4971ea256b7c74e7d19c310d8154468964a28a80cf422b5508317c_2880x900.png❙https://www.gstatic.com/youtube/img/promos/growth/0055fabab37e1369f10d045e372479fb2731d36aeed7ddd1af9c78ab22a1aaf7_1920x600.png❙https://www.gstatic.com/youtube/img/promos/growth/dc62e3cce9ad6ded89354baa3fecb08f383e29429af6e00a6b51dc7c29543cf5_960x300.png❙AB9zfpLKTf5cyxcJSI_R1I1T0YBh32HJ7TnZvLc1YUEZ-Rdd-wH_ogHxfP06ViC9xtTtp5QlmG5XZMelpuIrZcyQRwp9xN5-J3y7vWgjcqO4e1kjKDqvpuvt3w3NCI7738M17znkdjE6evwWW0U8fAVmRUoPjrsmXl8s5yV0UAP3HNBZUmpQLSDmxUHg6FW5uo83sPpeKfvh❙SPunlimited❙tkgNPIgkIAhIFbXVzaWMqGmNzYi1yZWEtbS1jYXBwdWNjaW5vUTIyMy1lOiIIBhgBKhwKGmNzYi1yZWEtbS1jYXBwdWNjaW5vUTIyMy1lOgIIAg%3D%3D<❙home_vertical_feed_prominence_group_key❙$6c6c9ce6-0000-2d6c-b6f1-582429cc6890❙$6c6c9ce6-0000-2d6c-b6f1-582429cc6890❙1765658225724062624❙statement_banner.eml|b82cf0a19594a74f❙statement_banner.view❙$6c6c9ce5-0000-2d6c-b6f1-582429cc6890❙AB9zfpI_DS2NfTF3jmA_e_xPasAwIBmJ5wEfnlaQ-flEFEbJqB-p-af9yJXaRmyM1p61Tl4EfA-8sgR9330Ec43n0rEpz8bCzlc-g_5zd3Aw7ScbnDCw8OV3xx2HlIZTahnztC3D_vQDoacBenY86LkPeRinhcl5GZyXrFjQ68nmY9GSPTosnzdd7yvikDncEykE1UpZOhLB❙
``` 

Waited a long time for the promo to show up and finally got to test it.