### PR TITLE
fix(YouTube - Navigation bar): Rename "Switch Create with Notifications" to "Swap Create with Notifications"

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/NavigationBarPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/NavigationBarPatch.java
@@ -29,8 +29,8 @@ public final class NavigationBarPatch {
         }
     };
 
-    private static final boolean SWITCH_CREATE_WITH_NOTIFICATIONS_BUTTON
-            = Settings.SWITCH_CREATE_WITH_NOTIFICATIONS_BUTTON.get();
+    private static final boolean SWAP_CREATE_WITH_NOTIFICATIONS_BUTTON
+            = Settings.SWAP_CREATE_WITH_NOTIFICATIONS_BUTTON.get();
 
     private static final boolean DISABLE_TRANSLUCENT_STATUS_BAR
             = Settings.DISABLE_TRANSLUCENT_STATUS_BAR.get();
@@ -47,8 +47,8 @@ public final class NavigationBarPatch {
     /**
      * Injection point.
      */
-    public static String switchCreateWithNotificationButton(String osName) {
-        return SWITCH_CREATE_WITH_NOTIFICATIONS_BUTTON
+    public static String swapCreateWithNotificationButton(String osName) {
+        return SWAP_CREATE_WITH_NOTIFICATIONS_BUTTON
                 ? "Android Automotive"
                 : osName;
     }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -293,14 +293,14 @@ public class Settings extends BaseSettings {
 
     // Navigation buttons
     public static final BooleanSetting HIDE_HOME_BUTTON = new BooleanSetting("morphe_hide_home_button", FALSE, true);
-    public static final BooleanSetting HIDE_CREATE_BUTTON = new BooleanSetting("morphe_hide_create_button", TRUE, true);
     public static final BooleanSetting HIDE_SHORTS_BUTTON = new BooleanSetting("morphe_hide_shorts_button", TRUE, true);
     public static final BooleanSetting HIDE_SUBSCRIPTIONS_BUTTON = new BooleanSetting("morphe_hide_subscriptions_button", FALSE, true);
     public static final BooleanSetting HIDE_NAVIGATION_BUTTON_LABELS = new BooleanSetting("morphe_hide_navigation_button_labels", FALSE, true);
     public static final BooleanSetting NARROW_NAVIGATION_BUTTONS = new BooleanSetting("morphe_narrow_navigation_buttons", FALSE, true);
     public static final BooleanSetting HIDE_NOTIFICATIONS_BUTTON = new BooleanSetting("morphe_hide_notifications_button", FALSE, true);
-    public static final BooleanSetting SWITCH_CREATE_WITH_NOTIFICATIONS_BUTTON = new BooleanSetting("morphe_switch_create_with_notifications_button", TRUE, true,
-            "morphe_switch_create_with_notifications_button_user_dialog_message");
+    public static final BooleanSetting SWAP_CREATE_WITH_NOTIFICATIONS_BUTTON = new BooleanSetting("morphe_swap_create_with_notifications_button", TRUE, true,
+            "morphe_swap_create_with_notifications_button_user_dialog_message");
+    public static final BooleanSetting HIDE_CREATE_BUTTON = new BooleanSetting("morphe_hide_create_button", FALSE, true, parentNot(SWAP_CREATE_WITH_NOTIFICATIONS_BUTTON));
     public static final BooleanSetting NAVIGATION_BAR_ANIMATIONS = new BooleanSetting("morphe_navigation_bar_animations", FALSE);
     public static final BooleanSetting DISABLE_TRANSLUCENT_STATUS_BAR = new BooleanSetting("morphe_disable_translucent_status_bar", FALSE, true,
             "morphe_disable_translucent_status_bar_user_dialog_message");

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/shared/NavigationBar.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/shared/NavigationBar.java
@@ -315,7 +315,7 @@ public final class NavigationBar {
         SUBSCRIPTIONS("PIVOT_SUBSCRIPTIONS", "TAB_SUBSCRIPTIONS_CAIRO"),
         /**
          * Notifications tab.  Only present when
-         * {@link Settings#SWITCH_CREATE_WITH_NOTIFICATIONS_BUTTON} is active.
+         * {@link Settings#SWAP_CREATE_WITH_NOTIFICATIONS_BUTTON} is active.
          */
         NOTIFICATIONS("TAB_ACTIVITY", "TAB_ACTIVITY_CAIRO"),
         /**

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
@@ -65,7 +65,7 @@ val navigationBarPatch = bytecodePatch(
             SwitchPreference("morphe_hide_create_button"),
             SwitchPreference("morphe_hide_subscriptions_button"),
             SwitchPreference("morphe_hide_notifications_button"),
-            SwitchPreference("morphe_switch_create_with_notifications_button"),
+            SwitchPreference("morphe_swap_create_with_notifications_button"),
             SwitchPreference("morphe_hide_navigation_button_labels"),
             SwitchPreference("morphe_narrow_navigation_buttons"),
         )
@@ -94,7 +94,7 @@ val navigationBarPatch = bytecodePatch(
         // Switch create with notifications button.
         addOSNameHook(
             Endpoint.GUIDE,
-            "$EXTENSION_CLASS_DESCRIPTOR->switchCreateWithNotificationButton(Ljava/lang/String;)Ljava/lang/String;",
+            "$EXTENSION_CLASS_DESCRIPTOR->swapCreateWithNotificationButton(Ljava/lang/String;)Ljava/lang/String;",
         )
 
         // Hide navigation button labels.

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -635,14 +635,14 @@ Cookies will be saved automatically if they are valid"</string>
     <string name="morphe_hide_subscriptions_button_title">Hide Subscriptions</string>
     <string name="morphe_hide_subscriptions_button_summary_on">Subscriptions button is hidden</string>
     <string name="morphe_hide_subscriptions_button_summary_off">Subscriptions button is shown</string>
+    <!-- 'Notifications' should be translated using the same localized wording YouTube displays for the tab. -->
     <string name="morphe_hide_notifications_button_title">Hide Notifications</string>
     <string name="morphe_hide_notifications_button_summary_on">Notifications button is hidden</string>
     <string name="morphe_hide_notifications_button_summary_off">Notifications button is shown</string>
-    <!-- 'Notifications' should be translated using the same localized wording YouTube displays for the tab. -->
-    <string name="morphe_switch_create_with_notifications_button_title">Switch Create with Notifications</string>
-    <string name="morphe_switch_create_with_notifications_button_summary_on">Create button is switched with Notifications button</string>
-    <string name="morphe_switch_create_with_notifications_button_summary_off">Create button is not switched with Notifications button</string>
-    <string name="morphe_switch_create_with_notifications_button_user_dialog_message">If changing this setting does not take effect, try switching to Incognito mode.</string>
+    <string name="morphe_swap_create_with_notifications_button_title">Swap Create with Notifications</string>
+    <string name="morphe_swap_create_with_notifications_button_summary_on">Create button is swapped with Notifications button</string>
+    <string name="morphe_swap_create_with_notifications_button_summary_off">Create button is not swapped with Notifications button</string>
+    <string name="morphe_swap_create_with_notifications_button_user_dialog_message">If changing this setting does not take effect, try switching to Incognito mode.</string>
     <string name="morphe_hide_navigation_button_labels_title">Hide navigation button labels</string>
     <string name="morphe_hide_navigation_button_labels_summary_on">Labels are hidden</string>
     <string name="morphe_hide_navigation_button_labels_summary_off">Labels are shown</string>


### PR DESCRIPTION
Renamed "Switch Create with Notifications" to "Swap Create with Notifications". 

Turned "Hide Create" setting to default off and made it a parentNot() of "Swap Create with Notifications", as "Hide Create" won't work when "Swap Create with Notifications" setting is on.