### PR TITLE
chore(Hex patch): Fix bug in implementation of Boyer-Moore algorithm

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/hex/HexPatchBuilder.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/hex/HexPatchBuilder.kt
@@ -110,18 +110,15 @@ class Replacement(
      */
     private fun indexOfPatternIn(haystack: ByteArray): Int {
         val needle = bytes
-
-        val haystackLength = haystack.size - 1
-        val needleLength = needle.size - 1
         val right = IntArray(256) { -1 }
 
-        for (i in 0 until needleLength) right[needle[i].toInt().and(0xFF)] = i
+        for (i in 0 until needle.size) right[needle[i].toInt().and(0xFF)] = i
 
         var skip: Int
-        for (i in 0..haystackLength - needleLength) {
+        for (i in 0..haystack.size - needle.size) {
             skip = 0
 
-            for (j in needleLength - 1 downTo 0) {
+            for (j in needle.size - 1 downTo 0) {
                 if (needle[j] != haystack[i + j]) {
                     skip = max(1, j - right[haystack[i + j].toInt().and(0xFF)])
 


### PR DESCRIPTION
Well, this was a miserable bug...

The current implementation was not matching the last byte of my pattern, so it was replacing a different byte string somewhere else in the binary. Really annoying when some of your hex patches work (still unique with 1 byte less), and then one doesn't.

Honestly not sure how this bug survived so long. I think this fix is sufficient, but after I tested it I didn't have any more brain capacity to check it against existing psuedocode of the algorithm. So maybe someone double check me.

Anyway, I have less hair now and probably a few more points on my blood pressure. 