### PR TITLE
fix(YouTube - Hide layout components): Resolve "Hide subscribed channels bar" leaves empty space in landscape mode

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
@@ -41,7 +41,27 @@ internal object HideShowMoreLegacyButtonFingerprint : Fingerprint(
     )
 )
 
+/**
+ * 20.21+
+ */
 internal object HideSubscribedChannelsBarConstructorFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
+    filters = listOf(
+        resourceLiteral(ResourceType.ID, "parent_container"),
+        opcode(Opcode.MOVE_RESULT_OBJECT, location = MatchAfterWithin(3)),
+        newInstance("Landroid/widget/LinearLayout\$LayoutParams;", location = MatchAfterWithin(5))
+    ),
+    custom = { _, classDef ->
+        classDef.fields.any { field ->
+            field.type == "Landroid/support/v7/widget/RecyclerView;"
+        }
+    }
+)
+
+/**
+ * ~ 20.21
+ */
+internal object HideSubscribedChannelsBarConstructorLegacyFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
     filters = listOf(
         resourceLiteral(ResourceType.ID, "parent_container"),
@@ -55,7 +75,8 @@ internal object HideSubscribedChannelsBarLandscapeFingerprint : Fingerprint(
     parameters = listOf(),
     filters = listOf(
         resourceLiteral(ResourceType.DIMEN, "parent_view_width_in_wide_mode"),
-        opcode(Opcode.MOVE_RESULT, location = MatchAfterWithin(3)),
+        methodCall(opcode = Opcode.INVOKE_VIRTUAL, name = "getDimensionPixelSize"),
+        opcode(Opcode.MOVE_RESULT, location = MatchAfterImmediately()),
     )
 )
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -328,7 +328,11 @@ val hideLayoutComponentsPatch = bytecodePatch(
         // region Subscribed channels bar
 
         // Tablet
-        HideSubscribedChannelsBarConstructorFingerprint.let {
+        val constructorFingerprint = if (is_20_21_or_greater)
+            HideSubscribedChannelsBarConstructorFingerprint
+        else HideSubscribedChannelsBarConstructorLegacyFingerprint
+
+        constructorFingerprint.let {
             it.method.apply {
                 val index = it.instructionMatches[1].index
                 val register = getInstruction<OneRegisterInstruction>(index).registerA
@@ -343,7 +347,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
 
         // Phone (landscape mode)
         HideSubscribedChannelsBarLandscapeFingerprint.match(
-            HideSubscribedChannelsBarConstructorFingerprint.originalClassDef
+            constructorFingerprint.originalClassDef
         ).let {
             it.method.apply {
                 val index = it.instructionMatches.last().index


### PR DESCRIPTION
This is a follow-up PR to https://github.com/MorpheApp/morphe-patches/pull/404.

From YouTube 20.21 to 20.40, there were two very similar classes.

Since both classes had almost identical methods, they could not be distinguished from each other by the fingerprint in https://github.com/MorpheApp/morphe-patches/pull/404.

This is why it didn't work on YouTube 20.40.45.
