### PR TITLE
fix(YouTube - Hide layout components): `Hide Show more button` leaves empty space

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -8,7 +8,10 @@ import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
 import android.widget.ImageView;
+import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 
@@ -537,19 +540,92 @@ public final class LayoutComponentsFilter extends Filter {
         imageView.setImageDrawable(replacement);
     }
 
+    private static final FrameLayout.LayoutParams EMPTY_LAYOUT_PARAMS = new FrameLayout.LayoutParams(0, 0);
     private static final boolean HIDE_SHOW_MORE_BUTTON_ENABLED = Settings.HIDE_SHOW_MORE_BUTTON.get();
+
+    /**
+     * The ShowMoreButton should not always be hidden.
+     * According to the preference summary, only the ShowMoreButton in search results is hidden.
+     * Since the ShowMoreButton should be visible on other pages, such as channels,
+     * the original values of the Views are saved in fields.
+     */
+    private static FrameLayout.LayoutParams cachedLayoutParams;
+    private static int cachedButtonContainerMinimumHeight = -1;
+    private static int cachedPlaceHolderMinimumHeight = -1;
+    private static int cachedRootViewMinimumHeight = -1;
 
     /**
      * Injection point.
      */
-    public static void hideShowMoreButton(View view) {
+    public static void hideShowMoreButton(View view, View buttonContainer, TextView textView) {
         if (HIDE_SHOW_MORE_BUTTON_ENABLED
-                && NavigationBar.isSearchBarActive()
-                // Search bar can be active but behind the player.
-                && !PlayerType.getCurrent().isMaximizedOrFullscreen()) {
-            // FIXME: "Show more" button is visible hidden,
-            //        but an empty space remains that can be clicked.
-            Utils.hideViewByLayoutParams(view);
+                && view instanceof ViewGroup rootView
+                && buttonContainer != null
+                && textView != null
+                && buttonContainer.getLayoutParams() instanceof FrameLayout.LayoutParams lp
+        ) {
+            View placeHolder = rootView.getChildAt(0);
+
+            // For some users, ShowMoreButton has a PlaceHolder ViewGroup (A/B tests).
+            // When a PlaceHolder is present, a different method is used to hide or show the ViewGroup.
+            boolean hasPlaceHolder = placeHolder instanceof FrameLayout;
+
+            // Only in search results, the content description of RootView and the text of TextView match.
+            // Hide ShowMoreButton in search results, but show ShowMoreButton in other pages (e.g. channels).
+            boolean isSearchResults = TextUtils.equals(rootView.getContentDescription(), textView.getText());
+
+            if (hasPlaceHolder) {
+                hideShowMoreButtonWithPlaceHolder(placeHolder, isSearchResults);
+            } else {
+                hideShowMoreButtonWithOutPlaceHolder(buttonContainer, lp, isSearchResults);
+            }
+
+            if (cachedRootViewMinimumHeight == -1) {
+                cachedRootViewMinimumHeight = rootView.getMinimumHeight();
+            }
+
+            if (isSearchResults) {
+                rootView.setMinimumHeight(0);
+                rootView.setVisibility(View.GONE);
+            } else {
+                rootView.setMinimumHeight(cachedRootViewMinimumHeight);
+                rootView.setVisibility(View.VISIBLE);
+            }
+        }
+    }
+
+    private static void hideShowMoreButtonWithPlaceHolder(View placeHolder, boolean isSearchResults) {
+        if (cachedPlaceHolderMinimumHeight == -1) {
+            cachedPlaceHolderMinimumHeight = placeHolder.getMinimumHeight();
+        }
+
+        if (isSearchResults) {
+            placeHolder.setMinimumHeight(0);
+            placeHolder.setVisibility(View.GONE);
+        } else {
+            placeHolder.setMinimumHeight(cachedPlaceHolderMinimumHeight);
+            placeHolder.setVisibility(View.VISIBLE);
+        }
+    }
+
+    private static void hideShowMoreButtonWithOutPlaceHolder(View buttonContainer, FrameLayout.LayoutParams lp,
+                                                             boolean isSearchResults) {
+        if (cachedButtonContainerMinimumHeight == -1) {
+            cachedButtonContainerMinimumHeight = buttonContainer.getMinimumHeight();
+        }
+
+        if (cachedLayoutParams == null) {
+            cachedLayoutParams = lp;
+        }
+
+        if (isSearchResults) {
+            buttonContainer.setMinimumHeight(0);
+            buttonContainer.setLayoutParams(EMPTY_LAYOUT_PARAMS);
+            buttonContainer.setVisibility(View.GONE);
+        } else {
+            buttonContainer.setMinimumHeight(cachedButtonContainerMinimumHeight);
+            buttonContainer.setLayoutParams(cachedLayoutParams);
+            buttonContainer.setVisibility(View.VISIBLE);
         }
     }
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
@@ -18,26 +18,38 @@ import app.morphe.util.customLiteral
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 
-/**
- * 20.26+
- */
-internal object HideShowMoreButtonFingerprint : Fingerprint(
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL, AccessFlags.SYNTHETIC),
+internal object HideShowMoreButtonSetViewFingerprint : Fingerprint(
     returnType = "V",
-    parameters = listOf("L", "Ljava/lang/Object;"),
     filters = listOf(
-        resourceLiteral(ResourceType.LAYOUT, "expand_button_down"),
-        methodCall(smali = "Landroid/view/LayoutInflater;->inflate(ILandroid/view/ViewGroup;Z)Landroid/view/View;"),
-        opcode(Opcode.MOVE_RESULT_OBJECT, location = MatchAfterImmediately())
+        resourceLiteral(ResourceType.ID, "link_text_start"),
+        fieldAccess(
+            opcode = Opcode.IPUT_OBJECT,
+            definingClass = "this",
+            type = "Landroid/widget/TextView;"
+        ),
+        resourceLiteral(ResourceType.ID, "expand_button_container"),
+        fieldAccess(
+            opcode = Opcode.IPUT_OBJECT,
+            definingClass = "this",
+            type = "Landroid/view/View;"
+        )
     )
 )
 
-internal object HideShowMoreLegacyButtonFingerprint : Fingerprint(
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
+internal object HideShowMoreButtonGetParentViewFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "Landroid/view/View;",
+    parameters = listOf()
+)
+
+internal object HideShowMoreButtonFingerprint : Fingerprint(
+    returnType = "V",
+    parameters = listOf("L", "Ljava/lang/Object;"),
     filters = listOf(
-        resourceLiteral(ResourceType.LAYOUT, "expand_button_down"),
-        methodCall(smali = "Landroid/view/View;->inflate(Landroid/content/Context;ILandroid/view/ViewGroup;)Landroid/view/View;"),
-        opcode(Opcode.MOVE_RESULT_OBJECT)
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            smali = "Landroid/view/View;->setContentDescription(Ljava/lang/CharSequence;)V"
+        )
     )
 )
 


### PR DESCRIPTION
- Fix: `Hide Show more button` leaves empty space.
- Fix: `Hide Show more button` hides the button not only in search results but also in channels.
- Tested on YouTube 20.14, 20.21, 20.40, and 21.05.