### PR TITLE
feat(YouTube - Hide Shorts components): Add "Hide AI button" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/ShortsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/ShortsFilter.java
@@ -234,7 +234,7 @@ public final class ShortsFilter extends Filter {
 
         reelCarouselBuffer.addAll(
                 new ByteArrayFilterGroup(
-                        Settings.HIDE_SHORTS_AI_DISCLOSURE_BUTTON,
+                        Settings.HIDE_SHORTS_AI_BUTTON,
                         "yt_outline_info_circle",
                         "yt_outline_experimental_info_circle"
                 ),

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -326,7 +326,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting DISABLE_RESUMING_SHORTS_PLAYER = new BooleanSetting("morphe_disable_resuming_shorts_player", FALSE);
     public static final BooleanSetting DISABLE_SHORTS_BACKGROUND_PLAYBACK = new BooleanSetting("morphe_shorts_disable_background_playback", FALSE);
     public static final EnumSetting<ShortsPlayerType> SHORTS_PLAYER_TYPE = new EnumSetting<>("morphe_shorts_player_type", ShortsPlayerType.SHORTS_PLAYER);
-    public static final BooleanSetting HIDE_SHORTS_AI_DISCLOSURE_BUTTON = new BooleanSetting("morphe_hide_shorts_ai_disclosure_button", FALSE);
+    public static final BooleanSetting HIDE_SHORTS_AI_BUTTON = new BooleanSetting("morphe_hide_shorts_ai_button", FALSE);
     public static final BooleanSetting HIDE_SHORTS_AUTO_DUBBED_LABEL = new BooleanSetting("morphe_hide_shorts_auto_dubbed_label", FALSE);
     public static final BooleanSetting HIDE_SHORTS_CHANNEL_BAR = new BooleanSetting("morphe_hide_shorts_channel_bar", FALSE);
     public static final BooleanSetting HIDE_SHORTS_COMMENTS_BUTTON = new BooleanSetting("morphe_hide_shorts_comments_button", FALSE);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
@@ -109,7 +109,7 @@ private val hideShortsComponentsResourcePatch = resourcePatch {
                     SwitchPreference("morphe_hide_shorts_stickers"),
 
                     // Bottom of the screen.
-                    SwitchPreference("morphe_hide_shorts_ai_disclosure_button"),
+                    SwitchPreference("morphe_hide_shorts_ai_button"),
                     SwitchPreference("morphe_hide_shorts_auto_dubbed_label"),
                     SwitchPreference("morphe_hide_shorts_location_label"),
                     SwitchPreference("morphe_hide_shorts_channel_bar"),

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -834,9 +834,9 @@ To show the Audio track menu, change \'Spoof video streams\' to \'Android No SDK
     <string name="morphe_hide_shorts_history_title">Hide Shorts in watch history</string>
     <string name="morphe_hide_shorts_history_summary_on">Hidden in watch history</string>
     <string name="morphe_hide_shorts_history_summary_off">Shown in watch history</string>
-    <string name="morphe_hide_shorts_ai_disclosure_button_title">Hide AI Disclosure button</string>
-    <string name="morphe_hide_shorts_ai_disclosure_button_summary_on">AI Disclosure button is hidden</string>
-    <string name="morphe_hide_shorts_ai_disclosure_button_summary_off">AI Disclosure button is shown</string>
+    <string name="morphe_hide_shorts_ai_button_title">Hide AI button</string>
+    <string name="morphe_hide_shorts_ai_button_summary_on">AI button is hidden</string>
+    <string name="morphe_hide_shorts_ai_button_summary_off">AI button is shown</string>
     <string name="morphe_hide_shorts_auto_dubbed_label_title">Hide \'Auto-dubbed\' label</string>
     <string name="morphe_hide_shorts_auto_dubbed_label_summary_on">Auto-dubbed label is hidden</string>
     <string name="morphe_hide_shorts_auto_dubbed_label_summary_off">Auto-dubbed label is shown</string>


### PR DESCRIPTION
Closes #435.

For some reason  using `reel_carousel.e$FEsfv_audio_pivot` also hides the AI button, so had to use `reel_carousel.e$yt_outline_experimental_audio` instead. 

The button itself on the Shorts player uses `AI` but YouTube internally calls it `AI Disclosure button` so I went with that. So should it be `Hide 'AI Disclosure' button` or `Hide 'AI Disclosure button'` or `Hide 'AI' button` or as is now, which is `Hide AI Disclosure button`? (confusing)

```kotlin
02-05 19:52:00.721  6109  6109 D morphe: LithoFilterPatch: Searching ID: reel_metapanel.eml|6c7d05774743177a Path: reel_metapanel.eml|6c7d05774743177a|ContainerType|ContainerType|reel_carousel.eml|f92eda6b2b269369|ScrollableContainerType|button.eml|baef84dd37c1642d|button_inner.eml|fc57601345feff8b|ContainerType|ImageType| BufferStrings: sans-serif❙yt_outline_info_circle_black_24❙AI Disclosure button❙$structured-description-body-state-id❙9structured-description-music-section-artists-row-state-id❙9structured-description-music-section-writers-row-state-id❙:structured-description-music-section-licenses-row-state-id❙//youtube/app/watch/Egk0NzUzNTc1MzgggQEoAQ%3D%3D❙video-description-ep-identifier❙
``` 