### PR TITLE
feat(Spoof video streams): Default client maintenance

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -4,6 +4,7 @@ import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static app.morphe.extension.shared.settings.Setting.parent;
 
+import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.settings.BaseSettings;
 import app.morphe.extension.shared.settings.BooleanSetting;
 import app.morphe.extension.shared.settings.EnumSetting;
@@ -38,4 +39,16 @@ public class Settings extends BaseSettings {
             ClientType.ANDROID_VR_1_47_48, true, parent(SPOOF_VIDEO_STREAMS));
 
     public static final BooleanSetting FORCE_ORIGINAL_AUDIO = new BooleanSetting("morphe_force_original_audio", TRUE, true);
+
+    static {
+        // region Migration
+
+        // TV Simply may require PoToken
+        if (SPOOF_VIDEO_STREAMS_CLIENT_TYPE.get() == ClientType.TV_SIMPLY) {
+            Logger.printInfo(() -> "Migrating from TV Simply to TV");
+            SPOOF_VIDEO_STREAMS_CLIENT_TYPE.save(ClientType.TV);
+        }
+
+        // endregion
+    }
 }

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/BaseSettings.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/BaseSettings.java
@@ -7,6 +7,7 @@ import static app.morphe.extension.shared.settings.Setting.parent;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.patches.CustomBrandingPatch;
+import app.morphe.extension.shared.spoof.js.JavaScriptVariant;
 
 /**
  * Settings shared across multiple apps.
@@ -41,8 +42,11 @@ public class BaseSettings {
     //
 
     public static final BooleanSetting SPOOF_VIDEO_STREAMS = new BooleanSetting("morphe_spoof_video_streams", TRUE, true, "morphe_spoof_video_streams_user_dialog_message");
-    public static final BooleanSetting SPOOF_STREAMING_DATA_STATS_FOR_NERDS = new BooleanSetting("morphe_spoof_streaming_data_stats_for_nerds", TRUE, parent(SPOOF_VIDEO_STREAMS));
+    public static final BooleanSetting SPOOF_VIDEO_STREAMS_STATS_FOR_NERDS = new BooleanSetting("morphe_spoof_video_streams_stats_for_nerds", TRUE, parent(SPOOF_VIDEO_STREAMS));
+    public static final EnumSetting<JavaScriptVariant> SPOOF_VIDEO_STREAMS_JS_VARIANT = new EnumSetting<>("morphe_spoof_video_streams_js_variant", JavaScriptVariant.TV, true, parent(SPOOF_VIDEO_STREAMS));
 
+    public static final StringSetting SPOOF_VIDEO_STREAMS_JS_HASH = new StringSetting("morphe_spoof_video_streams_js_hash", "", false);
+    public static final LongSetting SPOOF_VIDEO_STREAMS_JS_SAVED_MILLISECONDS = new LongSetting("morphe_spoof_video_streams_js_saved_milliseconds", -1L, false);
     public static final StringSetting OAUTH2_REFRESH_TOKEN = new StringSetting("morphe_oauth2_refresh_token", "", false, false);
 
     public static final BooleanSetting SANITIZE_SHARED_LINKS = new BooleanSetting("morphe_sanitize_sharing_links", TRUE);

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/spoof/ClientType.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/spoof/ClientType.java
@@ -112,28 +112,6 @@ public enum ClientType {
             "TV"
     ),
     /**
-     * Video not playable: None.
-     * Uses non adaptive bitrate.
-     * AV1 codec available.
-     */
-    TV_SIMPLY(75,
-            "TVHTML5_SIMPLY",
-            "Microsoft",
-            "Xbox 360",
-            "Xbox",
-            "6.1",
-            "1.0",
-            "GAME_CONSOLE",
-            "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; Xbox)",
-            true,
-            // PoToken is required to play videos while signed out.
-            true,
-            true,
-            false,
-            true,
-            "TV Simply"
-    ),
-    /**
      * Internal YT client for an unreleased YT client. May stop working at any time.
      */
     VISIONOS(101,
@@ -151,6 +129,27 @@ public enum ClientType {
             false,
             false,
             "visionOS"
+    ),
+    /**
+     * Here only to migrate data.
+     */
+    @Deprecated
+    TV_SIMPLY(75,
+            "TVHTML5_SIMPLY",
+            "Microsoft",
+            "Xbox 360",
+            "Xbox",
+            "6.1",
+            "1.0",
+            "GAME_CONSOLE",
+            "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; Xbox)",
+            true,
+            // PoToken is required to play videos while signed out.
+            true,
+            true,
+            false,
+            true,
+            "TV Simply"
     );
 
     /**

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
@@ -8,7 +8,6 @@ import android.text.TextUtils;
 import androidx.annotation.Nullable;
 
 import java.lang.ref.WeakReference;
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -37,7 +36,7 @@ public class SpoofVideoStreamsPatch {
     private static final String INTERNET_CONNECTION_CHECK_URI_STRING = "https://www.google.com/gen_204";
     private static final Uri INTERNET_CONNECTION_CHECK_URI = Uri.parse(INTERNET_CONNECTION_CHECK_URI_STRING);
 
-    private static final boolean SPOOF_STREAMING_DATA = BaseSettings.SPOOF_VIDEO_STREAMS.get();
+    private static final boolean SPOOF_VIDEO_STREAMS = BaseSettings.SPOOF_VIDEO_STREAMS.get();
 
     @Nullable
     private static volatile AppLanguage languageOverride;
@@ -87,7 +86,7 @@ public class SpoofVideoStreamsPatch {
 
     public static boolean spoofingToClientWithNoMultiAudioStreams() {
         return isPatchIncluded()
-                && SPOOF_STREAMING_DATA
+                && SPOOF_VIDEO_STREAMS
                 && !preferredClient.supportsMultiAudioTracks;
     }
 
@@ -99,7 +98,7 @@ public class SpoofVideoStreamsPatch {
      * @return An unreachable URI if the request is a /get_watch request, otherwise the original URI.
      */
     public static Uri blockGetWatchRequest(Uri playerRequestUri) {
-        if (SPOOF_STREAMING_DATA) {
+        if (SPOOF_VIDEO_STREAMS) {
             try {
                 String path = playerRequestUri.getPath();
 
@@ -118,7 +117,7 @@ public class SpoofVideoStreamsPatch {
 
     /**
      * Injection point.
-     *
+     * <p>
      * Blocks /get_watch requests by returning an unreachable URI.
      * /att/get requests are used to obtain a PoToken challenge.
      * See: <a href="https://github.com/FreeTubeApp/FreeTube/blob/4b7208430bc1032019a35a35eb7c8a84987ddbd7/src/botGuardScript.js#L15">botGuardScript.js#L15</a>
@@ -127,7 +126,7 @@ public class SpoofVideoStreamsPatch {
      * Blocking /att/get requests are not a problem.
      */
     public static String blockGetAttRequest(String originalUrlString) {
-        if (SPOOF_STREAMING_DATA) {
+        if (SPOOF_VIDEO_STREAMS) {
             try {
                 var originalUri = Uri.parse(originalUrlString);
                 String path = originalUri.getPath();
@@ -151,7 +150,7 @@ public class SpoofVideoStreamsPatch {
      * Blocks /initplayback requests.
      */
     public static String blockInitPlaybackRequest(String originalUrlString) {
-        if (SPOOF_STREAMING_DATA) {
+        if (SPOOF_VIDEO_STREAMS) {
             try {
                 var originalUri = Uri.parse(originalUrlString);
                 String path = originalUri.getPath();
@@ -173,7 +172,7 @@ public class SpoofVideoStreamsPatch {
      * Injection point.
      */
     public static boolean isSpoofingEnabled() {
-        return SPOOF_STREAMING_DATA;
+        return SPOOF_VIDEO_STREAMS;
     }
 
     /**
@@ -181,7 +180,7 @@ public class SpoofVideoStreamsPatch {
      * Only invoked when playing a livestream on an Apple client.
      */
     public static boolean fixHLSCurrentTime(boolean original) {
-        if (!SPOOF_STREAMING_DATA) {
+        if (!SPOOF_VIDEO_STREAMS) {
             return original;
         }
         return false;
@@ -192,7 +191,7 @@ public class SpoofVideoStreamsPatch {
      * Fix audio stuttering in YouTube Music.
      */
     public static boolean disableSABR() {
-        return SPOOF_STREAMING_DATA;
+        return SPOOF_VIDEO_STREAMS;
     }
 
     /**
@@ -204,7 +203,7 @@ public class SpoofVideoStreamsPatch {
             Logger.printDebug(() -> "useMediaFetchHotConfigReplacement is set on");
         }
 
-        if (!SPOOF_STREAMING_DATA) {
+        if (!SPOOF_VIDEO_STREAMS) {
             return original;
         }
         return false;
@@ -219,7 +218,7 @@ public class SpoofVideoStreamsPatch {
             Logger.printDebug(() -> "usePlaybackStartFeatureFlag is set on");
         }
 
-        if (!SPOOF_STREAMING_DATA) {
+        if (!SPOOF_VIDEO_STREAMS) {
             return original;
         }
         return false;
@@ -234,7 +233,7 @@ public class SpoofVideoStreamsPatch {
             Logger.printDebug(() -> "useMediaSessionFeatureFlag is set on");
         }
 
-        if (!SPOOF_STREAMING_DATA) {
+        if (!SPOOF_VIDEO_STREAMS) {
             return original;
         }
         return false;
@@ -244,7 +243,7 @@ public class SpoofVideoStreamsPatch {
      * Injection point.
      */
     public static void fetchStreams(String url, Map<String, String> requestHeaders) {
-        if (SPOOF_STREAMING_DATA) {
+        if (SPOOF_VIDEO_STREAMS) {
             try {
                 Uri uri = Uri.parse(url);
                 String path = uri.getPath();
@@ -282,7 +281,7 @@ public class SpoofVideoStreamsPatch {
      */
     @Nullable
     public static byte[] getStreamingData(String videoId) {
-        if (SPOOF_STREAMING_DATA) {
+        if (SPOOF_VIDEO_STREAMS) {
             try {
                 StreamingDataRequest request = StreamingDataRequest.getRequestForVideoId(videoId);
                 if (request != null) {
@@ -317,7 +316,7 @@ public class SpoofVideoStreamsPatch {
      */
     @Nullable
     public static byte[] removeVideoPlaybackPostBody(Uri uri, int method, byte[] postData) {
-        if (SPOOF_STREAMING_DATA) {
+        if (SPOOF_VIDEO_STREAMS) {
             try {
                 final int methodPost = 2;
                 if (method == methodPost) {
@@ -339,7 +338,7 @@ public class SpoofVideoStreamsPatch {
      */
     public static String appendSpoofedClient(String videoFormat) {
         try {
-            if (SPOOF_STREAMING_DATA && BaseSettings.SPOOF_STREAMING_DATA_STATS_FOR_NERDS.get()
+            if (SPOOF_VIDEO_STREAMS && BaseSettings.SPOOF_VIDEO_STREAMS_STATS_FOR_NERDS.get()
                     && !TextUtils.isEmpty(videoFormat)) {
                 // Force LTR layout, to match the same LTR video time/length layout YouTube uses for all languages.
                 return "\u202D" + videoFormat + "\u2009(" // u202D = left to right override

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/spoof/js/JavaScriptManager.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/spoof/js/JavaScriptManager.java
@@ -3,7 +3,6 @@ package app.morphe.extension.shared.spoof.js;
 import static app.morphe.extension.shared.Utils.isNotEmpty;
 
 import android.os.Build;
-import android.util.Pair;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -15,8 +14,9 @@ import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URLDecoder;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
@@ -24,7 +24,10 @@ import java.util.regex.Pattern;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.innertube.PlayerResponseOuterClass.Format;
+import app.morphe.extension.shared.innertube.PlayerResponseOuterClass.StreamingData;
 import app.morphe.extension.shared.requests.Requester;
+import app.morphe.extension.shared.settings.BaseSettings;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -41,15 +44,6 @@ import java.net.URL;
  * - <a href="https://github.com/TeamNewPipe/NewPipeExtractor/blob/d9e9911e78d5a6db45c1daeeea5280d10ca3f70d/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java">TeamNewPipe/NewPipeExtractor#YoutubeThrottlingParameterUtils</a>
  */
 public final class JavaScriptManager {
-    /**
-     * Typically, there are 10 to 30 available formats for a video.
-     * Each format has a different streaming url, but the 'n' parameter in the response is the same.
-     * If the obfuscated 'n' parameter and the deobfuscated 'n' parameter are put in a Map,
-     * the remaining 9 to 29 streaming urls can be deobfuscated quickly using the values put in the Map.
-     */
-    @NonNull
-    private static final Map<String, String> CACHED_THROTTLING_PARAMETERS = Collections.synchronizedMap(
-            Utils.createSizeRestrictedMap(50));
     /**
      * Regular expression pattern to find the signature timestamp.
      */
@@ -69,13 +63,16 @@ public final class JavaScriptManager {
     /**
      * Regular expression pattern to find variables used in JavaScript url.
      */
-    private static final Pattern PLAYER_JS_IDENTIFIER_PATTERN =
+    private static final Pattern PLAYER_JS_HASH_PATTERN =
             Pattern.compile("player\\\\/([a-z0-9]{8})\\\\/");
+    /**
+     * Variant of JavaScript url.
+     */
+    private static final JavaScriptVariant PLAYER_JS_VARIANT = BaseSettings.SPOOF_VIDEO_STREAMS_JS_VARIANT.get();
     /**
      * Format of JavaScript url.
      */
-    private static final String BASE_JS_PLAYER_URL_FORMAT =
-            "https://www.youtube.com/s/player/%s/tv-player-ias.vflset/tv-player-ias.js";
+    private static final String BASE_JS_PLAYER_URL_FORMAT = PLAYER_JS_VARIANT.format;
     /**
      * Url used to find variables used in JavaScript url.
      */
@@ -83,10 +80,10 @@ public final class JavaScriptManager {
     /**
      * Player JavaScript is approximately 3MB in size,
      * So downloading it every time the app is launched results in unnecessary data usage.
-     * Player JavaScript has a lifespan of approximately one month, and new versions are released from the server every week.
-     * Downloaded player JavaScript is saved in the cache directory and remains valid for approximately one week.
+     * Player JavaScript has a lifespan of approximately one month, and new versions are released from the server every 3 days.
+     * Downloaded player JavaScript is saved in the cache directory and remains valid for approximately 3 days.
      */
-    private static final long PLAYER_JS_CACHE_EXPIRATION_MILLISECONDS = 7 * 24 * 60 * 60 * 1000L; // 7 days.
+    private static final long PLAYER_JS_CACHE_EXPIRATION_MILLISECONDS = 3 * 24 * 60 * 60 * 1000L; // 3 days.
     /**
      * User-agent of the TV client.
      */
@@ -108,10 +105,10 @@ public final class JavaScriptManager {
     @Nullable
     private volatile static File cachedPlayerJsFile = null;
     /**
-     * Javascript url identifier.
+     * Javascript url hash.
      */
     @Nullable
-    private volatile static String cachedPlayerJsIdentifier = null;
+    private volatile static String cachedPlayerJsHash = null;
     /**
      * Javascript url.
      */
@@ -131,7 +128,7 @@ public final class JavaScriptManager {
         if (cachedPlayerDataExtractor == null) {
             String playerJs = getPlayerJs();
             if (isNotEmpty(playerJs)) {
-                cachedPlayerDataExtractor = new PlayerDataExtractor(playerJs, Objects.requireNonNull(cachedPlayerJsIdentifier));
+                cachedPlayerDataExtractor = new PlayerDataExtractor(playerJs, Objects.requireNonNull(cachedPlayerJsHash));
             } else {
                 Logger.printException(() -> "playerJs not found");
             }
@@ -146,22 +143,28 @@ public final class JavaScriptManager {
             String playerJsUrl = getPlayerJsUrl();
             if (isNotEmpty(playerJsUrl)) {
                 File cacheFile = Objects.requireNonNull(cachedPlayerJsFile);
+                String cacheFileName = cacheFile.getName();
                 long currentTime = System.currentTimeMillis();
 
+                // There is a player javascript saved in the cache and it was saved within 3 days.
+                // Use the player javascript saved in the cache.
                 if (cacheFile.exists() && (currentTime - cacheFile.lastModified()) < PLAYER_JS_CACHE_EXPIRATION_MILLISECONDS) {
                     String cachedData = readFromFile(cacheFile);
                     if (isNotEmpty(cachedData)) {
-                        Logger.printDebug(() -> "Player js cache found: " + cachedPlayerJsIdentifier);
+                        Logger.printDebug(() -> "Player js cache found: " + cacheFileName);
                         cachedPlayerJs = cachedData;
                         return cachedData;
                     }
                 }
 
+                // There is no player javascript save in the cache,
+                // or if there is a player javascript, it has been more than 3 days since it was last saved.
+                // Download the latest player javascript.
                 String playerJs = downloadUrl(playerJsUrl);
                 if (isNotEmpty(playerJs)) {
                     cachedPlayerJs = playerJs;
                     saveToFile(cacheFile, playerJs);
-                    Logger.printDebug(() -> "Saved Player js cache: " + cachedPlayerJsIdentifier);
+                    Logger.printDebug(() -> "Saved Player js cache: " + cacheFileName);
                 }
             } else {
                 Logger.printException(() -> "playerJsUrl not found");
@@ -174,16 +177,36 @@ public final class JavaScriptManager {
     @Nullable
     private static String getPlayerJsUrl() {
         if (cachedPlayerJsUrl == null) {
-            String iframeContent = downloadUrl(IFRAME_API_URL);
-            if (isNotEmpty(iframeContent)) {
-                Matcher matcher = PLAYER_JS_IDENTIFIER_PATTERN.matcher(iframeContent);
-                if (matcher.find()) {
-                    cachedPlayerJsIdentifier = matcher.group(1);
-                    cachedPlayerJsFile = new File(Utils.getContext().getCacheDir(), "player_js_" + cachedPlayerJsIdentifier + ".js");
-                    cachedPlayerJsUrl = String.format(BASE_JS_PLAYER_URL_FORMAT, cachedPlayerJsIdentifier);
-                } else {
-                    Logger.printException(() -> "iframeContent not found");
+            long currentTime = System.currentTimeMillis();
+            long lastSavedTime = BaseSettings.SPOOF_VIDEO_STREAMS_JS_SAVED_MILLISECONDS.get();
+
+            if (!BaseSettings.SPOOF_VIDEO_STREAMS_JS_HASH.isSetToDefault()
+                    && currentTime - lastSavedTime < PLAYER_JS_CACHE_EXPIRATION_MILLISECONDS) {
+                // There is a hash saved in the settings and it was saved within 3 days.
+                // Use the hash saved in the settings.
+                cachedPlayerJsHash = BaseSettings.SPOOF_VIDEO_STREAMS_JS_HASH.get();
+                String playerJsHash = cachedPlayerJsHash;
+                Logger.printDebug(() -> "Player js hash found in cache: " + playerJsHash);
+            } else {
+                // There is no hash save in the settings,
+                // or if there is a hash, it has been more than 3 days since it was last saved.
+                // To get the latest hash, fetch the iframe API.
+                String iframeContent = downloadUrl(IFRAME_API_URL);
+                if (isNotEmpty(iframeContent)) {
+                    Matcher matcher = PLAYER_JS_HASH_PATTERN.matcher(iframeContent);
+                    if (matcher.find()) {
+                        cachedPlayerJsHash = matcher.group(1);
+                        BaseSettings.SPOOF_VIDEO_STREAMS_JS_HASH.save(cachedPlayerJsHash);
+                        BaseSettings.SPOOF_VIDEO_STREAMS_JS_SAVED_MILLISECONDS.save(currentTime);
+                    } else {
+                        Logger.printException(() -> "iframeContent not found");
+                    }
                 }
+            }
+
+            if (isNotEmpty(cachedPlayerJsHash)) {
+                cachedPlayerJsFile = new File(Utils.getContext().getCacheDir(), "player_js_" + PLAYER_JS_VARIANT.name().toLowerCase() + "_" + cachedPlayerJsHash + ".js");
+                cachedPlayerJsUrl = String.format(BASE_JS_PLAYER_URL_FORMAT, cachedPlayerJsHash);
             }
         }
 
@@ -217,6 +240,16 @@ public final class JavaScriptManager {
     }
 
     @Nullable
+    public static String getJavaScriptHash() {
+        return cachedPlayerJsHash;
+    }
+
+    @NonNull
+    public static String getJavaScriptVariant() {
+        return PLAYER_JS_VARIANT.name();
+    }
+
+    @Nullable
     public static String downloadUrl(@NonNull String url) {
         String content = null;
 
@@ -245,175 +278,135 @@ public final class JavaScriptManager {
         return content;
     }
 
-    @Nullable
-    public static String deobfuscateStreamingUrl(
-            @NonNull String videoId,
-            @Nullable String url,
-            @Nullable String signatureCipher) {
-        String streamUrl = null;
-        if (isNotEmpty(url)) {
-            streamUrl = url;
-        } else if (isNotEmpty(signatureCipher)) {
-            streamUrl = getUrlWithThrottlingParameterObfuscated(
-                    videoId,
-                    signatureCipher
-            );
-        }
-        if (isNotEmpty(streamUrl)) {
-            return getUrlWithThrottlingParameterDeobfuscated(
-                    videoId,
-                    streamUrl
-            );
-        }
-        return null;
+    /**
+     * JavaScript clients require deciphering.
+     * Deciphering is performed in format, adaptiveFormat, and serverAbrStreamingUrl.
+     * Deciphering is performed by executing the player JavaScript with the V8 runtime.
+     * A single execution of the V8 runtime requires significant computational time.
+     * To minimize computational time, all query parameters requiring deciphering are stored in a single request (List),
+     * and all query parameters are deobfuscated with a single run of the runtime.
+     *
+     * @param streamingData StreamingData containing obfuscated parameters.
+     * @return              StreamingData builder containing deobfuscated parameters.
+     */
+    public static StreamingData.Builder getDeobfuscatedStreamingData(StreamingData streamingData) {
+        StreamingData.Builder streamingDataBuilder = streamingData.toBuilder();
+        String serverAbrStreamingUrl = streamingData.getServerAbrStreamingUrl();
+
+        // Initialize streamingDataBuilder before adding formats.
+        streamingDataBuilder.clearFormats();
+
+        // Deobfuscate formats.
+        deobfuscateFormat(
+                streamingDataBuilder,
+                streamingData.getFormatsList(),
+                serverAbrStreamingUrl,
+                false
+        );
+
+        // Initialize streamingDataBuilder before adding adaptiveFormats.
+        streamingDataBuilder.clearAdaptiveFormats();
+
+        // Deobfuscate adaptiveFormats.
+        deobfuscateFormat(
+                streamingDataBuilder,
+                streamingData.getAdaptiveFormatsList(),
+                serverAbrStreamingUrl,
+                true
+        );
+
+        return streamingDataBuilder;
     }
 
-    /**
-     * Convert signatureCipher to streaming url with obfuscated 'n' parameter.
-     * <p>
-     *
-     * @param videoId         Current video id.
-     * @param signatureCipher The 'signatureCipher' included in the response.
-     * @return Streaming url with obfuscated 'n' parameter.
-     */
-    @Nullable
-    private static String getUrlWithThrottlingParameterObfuscated(@NonNull String videoId, @NonNull String signatureCipher) {
-        try {
-            PlayerDataExtractor playerDataExtractor = getPlayerDataExtractor();
-            if (playerDataExtractor != null) {
-                Matcher paramSMatcher = THROTTLING_PARAM_S_PATTERN.matcher(signatureCipher);
-                Matcher paramUrlMatcher = THROTTLING_PARAM_URL_PATTERN.matcher(signatureCipher);
-                if (paramSMatcher.find() && paramUrlMatcher.find()) {
-                    // The 's' parameter from signatureCipher.
-                    String sParam = paramSMatcher.group(1);
-                    // The 'url' parameter from signatureCipher.
-                    String urlParam = paramUrlMatcher.group(1);
-                    if (isNotEmpty(sParam) && isNotEmpty(urlParam)) {
-                        // The 'sig' parameter converted by javascript rules.
-                        String decodedSigParm = playerDataExtractor.extractSig(decodeURL(sParam));
-                        if (isNotEmpty(decodedSigParm)) {
-                            String decodedUriParm = decodeURL(urlParam);
-                            Logger.printDebug(() -> "Converted signatureCipher to obfuscatedUrl, videoId: " + videoId);
-                            return decodedUriParm + "&sig=" + decodedSigParm;
+    private static void deobfuscateFormat(StreamingData.Builder streamingDataBuilder,
+                                         List<Format> formats,
+                                         String serverAbrStreamingUrl,
+                                         boolean isAdaptiveFormats) {
+        PlayerDataExtractor playerDataExtractor = getPlayerDataExtractor();
+
+        if (playerDataExtractor != null && formats != null && !formats.isEmpty()) {
+            // In streamingData, all n-parameters have the same value.
+            String obfuscatedNParameter = null;
+
+            List<String> obfuscatedSParameters = new ArrayList<>();
+            List<String> obfuscatedUrlParameters = new ArrayList<>();
+
+            // formats or adaptiveFormats have a signatureCipher or a url.
+            // Therefore, the computation time can be reduced by checking whether the first format has a signatureCipher or not.
+            boolean hasSignatureCipher = isNotEmpty(formats.get(0).getSignatureCipher());
+
+            for (Format format : formats) {
+                // If a signatureCipher is present, the url field must be assembled while iterating over each format.
+                if (hasSignatureCipher) {
+                    String signatureCipher = format.getSignatureCipher();
+                    Matcher sParamMatcher = THROTTLING_PARAM_S_PATTERN.matcher(signatureCipher);
+                    Matcher urlParamMatcher = THROTTLING_PARAM_URL_PATTERN.matcher(signatureCipher);
+                    if (sParamMatcher.find() && urlParamMatcher.find()) {
+                        // The s-parameter from signatureCipher.
+                        String obfuscatedSParameter = sParamMatcher.group(1);
+                        // The url-parameter from signatureCipher.
+                        String obfuscatedUrl = urlParamMatcher.group(1);
+                        if (isNotEmpty(obfuscatedSParameter) && isNotEmpty(obfuscatedUrl)) {
+                            obfuscatedUrl = decodeURL(obfuscatedUrl);
+
+                            obfuscatedSParameters.add(decodeURL(obfuscatedSParameter));
+                            obfuscatedUrlParameters.add(obfuscatedUrl);
+
+                            if (obfuscatedNParameter == null) {
+                                obfuscatedNParameter = getNQueryParameter(obfuscatedUrl);
+                            }
                         }
+                    }
+                } else { // If a url is present, simply iterate over each format and replace the n-parameters.
+                    String nQueryParameter = getNQueryParameter(format.getUrl());
+                    if (isNotEmpty(nQueryParameter)) {
+                        obfuscatedNParameter = nQueryParameter;
+                        break;
                     }
                 }
             }
-        } catch (Exception ex) {
-            Logger.printException(() -> "Failed to convert signatureCipher, videoId: " + videoId + ", signatureCipher: " + signatureCipher, ex);
-        }
 
-        Logger.printDebug(() -> "Failed to convert signatureCipher, videoId: " + videoId);
-        return null;
-    }
+            // streamingData always has one n-parameter.
+            if (isNotEmpty(obfuscatedNParameter)) {
+                var results = playerDataExtractor.bulkSigExtract(
+                        Collections.singletonList(obfuscatedNParameter),
+                        obfuscatedSParameters
+                );
 
-    /**
-     * Deobfuscates the obfuscated 'n' parameter to a valid streaming url.
-     * <p>
-     *
-     * @param videoId       Current video id.
-     * @param obfuscatedUrl Streaming url with obfuscated 'n' parameter.
-     * @return Deobfuscated streaming url.
-     */
-    @Nullable
-    private static String getUrlWithThrottlingParameterDeobfuscated(@NonNull String videoId, @NonNull String obfuscatedUrl) {
-        try {
-            // Obfuscated url is empty.
-            if (!isNotEmpty(obfuscatedUrl)) {
-                Logger.printDebug(() -> "obfuscatedUrl is empty, videoId: " + videoId);
-                return obfuscatedUrl;
-            }
+                // Since there is only one obfuscated n-parameter, there is also only one deobfuscated n-parameter
+                String deobfuscatedNParameter = results.first.get(0);
+                List<String> deobfuscatedSParameters = results.second;
 
-            // The 'n' parameter from obfuscatedUrl.
-            String obfuscatedNParams = getThrottlingParameterFromStreamingUrl(obfuscatedUrl);
+                int i = 0;
+                for (Format format : formats) {
+                    Format.Builder formatBuilder = format.toBuilder();
+                    String obfuscatedUrl = hasSignatureCipher
+                            // Assemble the url.
+                            ? obfuscatedUrlParameters.get(i) + "&sig=" + deobfuscatedSParameters.get(i)
+                            : format.getUrl();
+                    formatBuilder.setUrl(obfuscatedUrl.replace(obfuscatedNParameter, deobfuscatedNParameter));
+                    formatBuilder.clearSignatureCipher();
+                    Format newFormat = formatBuilder.build();
 
-            // The 'n' parameter is null or empty.
-            if (!isNotEmpty(obfuscatedNParams)) {
-                Logger.printDebug(() -> "'n' parameter not found in obfuscated streaming url, videoId: " + videoId);
-                return obfuscatedUrl;
-            }
-
-            // If the deobfuscated 'n' parameter is in the Map, return it.
-            String deobfuscatedNParam = CACHED_THROTTLING_PARAMETERS.get(obfuscatedNParams);
-            if (deobfuscatedNParam != null) {
-                Logger.printDebug(() -> "Cached 'n' parameter found, videoId: " + videoId + ", deobfuscatedNParams: " + deobfuscatedNParam);
-                return replaceNParam(obfuscatedUrl, obfuscatedNParams, deobfuscatedNParam);
-            }
-
-            // Deobfuscate the 'n' parameter.
-            Pair<String, String> deobfuscatedNParamPairs = decodeNParam(obfuscatedUrl, obfuscatedNParams);
-            String deobfuscatedUrl = deobfuscatedNParamPairs.first;
-            String deobfuscatedNParams = deobfuscatedNParamPairs.second;
-            if (!deobfuscatedNParams.isEmpty()) {
-                // If the 'n' parameter obfuscation was successful, put it in the map.
-                CACHED_THROTTLING_PARAMETERS.put(obfuscatedNParams, deobfuscatedNParams);
-                Logger.printDebug(() -> "Deobfuscated the 'n' parameter, videoId: " + videoId + ", obfuscatedNParams: " + obfuscatedNParams + ", deobfuscatedNParams: " + deobfuscatedNParams);
-                return deobfuscatedUrl;
-            }
-        } catch (Exception ex) {
-            Logger.printException(() -> "Failed to deobfuscate 'n' parameters, videoId: " + videoId + ", obfuscatedUrl: " + obfuscatedUrl, ex);
-        }
-
-        Logger.printDebug(() -> "Failed to deobfuscate 'n' parameter, videoId: " + videoId);
-        return obfuscatedUrl;
-    }
-
-    /**
-     * Extract the 'n' parameter from the streaming Url.
-     * <p>
-     *
-     * @param streamingUrl The streaming url.
-     * @return The 'n' parameter.
-     */
-    @Nullable
-    private static String getThrottlingParameterFromStreamingUrl(@NonNull String streamingUrl) {
-        if (streamingUrl.contains("&n=") || streamingUrl.contains("?n=")) {
-            final Matcher matcher = THROTTLING_PARAM_N_PATTERN.matcher(streamingUrl);
-            if (matcher.find()) {
-                return matcher.group(1);
-            }
-        }
-        return "";
-    }
-
-    /**
-     * Replace the 'n' parameter.
-     *
-     * @param obfuscatedUrl       Streaming url with obfuscated 'n' parameter.
-     * @param obfuscatedNParams   Obfuscated 'n' parameter.
-     * @param deObfuscatedNParams Deobfuscated 'n' parameter.
-     * @return Deobfuscated streaming url.
-     */
-    @NonNull
-    private static String replaceNParam(@NonNull String obfuscatedUrl, @NonNull String obfuscatedNParams, @NonNull String deObfuscatedNParams) {
-        return obfuscatedUrl.replaceFirst("n=" + obfuscatedNParams, "n=" + deObfuscatedNParams);
-    }
-
-    /**
-     * Deobfuscate the 'n' parameter.
-     * <p>
-     *
-     * @param obfuscatedUrl     Streaming url with obfuscated 'n' parameter.
-     * @param obfuscatedNParams Obfuscated 'n' parameter.
-     * @return Deobfuscated Pair(Deobfuscated streaming url, Deobfuscated 'n' parameter).
-     */
-    @NonNull
-    private static Pair<String, String> decodeNParam(@NonNull String obfuscatedUrl, @NonNull String obfuscatedNParams) {
-        try {
-            PlayerDataExtractor playerDataExtractor = getPlayerDataExtractor();
-            if (playerDataExtractor != null) {
-                // The 'n' parameter deobfuscated by javascript rules.
-                String deObfuscatedNParams = playerDataExtractor.extractNSig(obfuscatedNParams);
-                if (isNotEmpty(deObfuscatedNParams)) {
-                    String deObfuscatedUrl = replaceNParam(obfuscatedUrl, obfuscatedNParams, deObfuscatedNParams);
-                    return new Pair<>(deObfuscatedUrl, deObfuscatedNParams);
+                    if (isAdaptiveFormats) {
+                        streamingDataBuilder.addAdaptiveFormats(newFormat);
+                    } else {
+                        streamingDataBuilder.addFormats(newFormat);
+                    }
+                    i++;
                 }
-            }
-        } catch (Exception ex) {
-            Logger.printException(() -> "Failed to deobfuscate 'n' parameter, obfuscatedUrl: " + obfuscatedUrl + ", obfuscatedNParams: " + obfuscatedNParams, ex);
-        }
 
-        return new Pair<>(obfuscatedUrl, "");
+                streamingDataBuilder.setServerAbrStreamingUrl(isNotEmpty(serverAbrStreamingUrl)
+                        ? serverAbrStreamingUrl.replace(obfuscatedNParameter, deobfuscatedNParameter)
+                        : ""
+                );
+            }
+        }
+    }
+
+    private static String getNQueryParameter(String url) {
+        Matcher matcher = THROTTLING_PARAM_N_PATTERN.matcher(url);
+        return matcher.find() ? matcher.group(1) : "";
     }
 
     private static String decodeURL(String urlDecoded) {

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/spoof/js/JavaScriptVariant.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/spoof/js/JavaScriptVariant.java
@@ -1,0 +1,17 @@
+package app.morphe.extension.shared.spoof.js;
+
+public enum JavaScriptVariant {
+    HOUSE_BRAND("https://youtube.googleapis.com/s/player/%s/house_brand_player.vflset/en_US/base.js"),
+    PHONE("https://m.youtube.com/s/player/%s/player-plasma-ias-phone-en_US.vflset/base.js"),
+    TV("https://www.youtube.com/s/player/%s/tv-player-ias.vflset/tv-player-ias.js"),
+    TV_ES6("https://www.youtube.com/s/player/%s/tv-player-es6.vflset/tv-player-es6.js"),
+    WEB("https://www.youtube.com/s/player/%s/player_ias.vflset/en_US/base.js"),
+    WEB_ES6("https://www.youtube.com/s/player/%s/player_es6.vflset/en_US/base.js"),
+    WEB_EMBED("https://www.youtube.com/s/player/%s/player_embed.vflset/en_US/base.js");
+
+    public final String format;
+
+    JavaScriptVariant(String format) {
+        this.format = format;
+    }
+}

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/spoof/js/PlayerDataExtractor.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/spoof/js/PlayerDataExtractor.java
@@ -2,7 +2,10 @@ package app.morphe.extension.shared.spoof.js;
 
 import android.util.Pair;
 
+import androidx.annotation.NonNull;
+
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import app.morphe.extension.shared.Logger;
@@ -14,61 +17,78 @@ import app.morphe.extension.shared.spoof.js.nsigsolver.provider.*;
  * - <a href="https://github.com/yuliskov/MediaServiceCore/blob/c0415f34ea59b2c35c8d72cdf21ff22d82218c1c/youtubeapi/src/main/java/com/liskovsoft/youtubeapi/app/playerdata/PlayerDataExtractor.kt">yuliskov/MediaServiceCore#PlayerDataExtractor</a>
  */
 public class PlayerDataExtractor {
-    private Pair<String, String> nSigTmp = null;
 
-    public PlayerDataExtractor(String playerJS, String playerJSIdentifier) {
-        V8ChallengeProvider.getInstance().setPlayerJS(playerJS, playerJSIdentifier);
+    public PlayerDataExtractor(String playerJS, String playerJSHash) {
+        V8ChallengeProvider.getInstance().setPlayerJS(playerJS, playerJSHash);
         V8ChallengeProvider.getInstance().warmup();
 
         checkAllData();
     }
 
-    public String extractNSig(String nParam) {
-        if (nSigTmp != null && nSigTmp.first.equals(nParam)) {
-            return nSigTmp.second;
-        }
+    public Pair<List<String>, List<String>> bulkSigExtract(List<String> nParams, List<String> sParams) {
+        List<String> nProcessed = new ArrayList<>();
+        List<String> sProcessed = new ArrayList<>();
 
-        String nSig = extractNSigReal(nParam);
-
-        nSigTmp = new Pair<>(nParam, nSig);
-
-        return nSig;
-    }
-
-    public String extractSig(String sParam) {
-        List<JsChallengeRequest> requests = new ArrayList<>();
-        requests.add(new JsChallengeRequest(JsChallengeType.SIG, new ChallengeInput(sParam)));
-
+        List<JsChallengeRequest> requests = getJsChallengeRequests(nParams, sParams);
         List<JsChallengeProviderResponse> result = V8ChallengeProvider.getInstance().bulkSolve(requests);
 
-        if (!result.isEmpty()) {
-            var response = result.get(0).getResponse();
-            if (response != null) {
-                return response.getOutput().getResults().get(sParam);
+        for (JsChallengeProviderResponse item : result) {
+            var response = item.getResponse();
+            if (response == null) continue;
+
+            var type = response.getType();
+            if (type == JsChallengeType.N) {
+                if (nParams != null && !nParams.isEmpty()) {
+                    for (String key : nParams) {
+                        nProcessed.add(response.getOutput().getResults().get(key));
+                    }
+                }
+            } else if (type == JsChallengeType.SIG) {
+                if (sParams != null && !sParams.isEmpty()) {
+                    for (String key : sParams) {
+                        sProcessed.add(response.getOutput().getResults().get(key));
+                    }
+                }
             }
         }
 
-        return null;
+        return new Pair<>(nProcessed, sProcessed);
     }
 
-    private String extractNSigReal(String nParam) {
-        List<JsChallengeRequest> requests = new ArrayList<>();
-        requests.add(new JsChallengeRequest(JsChallengeType.N, new ChallengeInput(nParam)));
-
-        List<JsChallengeProviderResponse> result = V8ChallengeProvider.getInstance().bulkSolve(requests);
-
-        if (!result.isEmpty()) {
-            var response = result.get(0).getResponse();
-            if (response != null) {
-                return response.getOutput().getResults().get(nParam);
+    @NonNull
+    private static List<JsChallengeRequest> getJsChallengeRequests(List<String> nParams, List<String> sParams) {
+        JsChallengeRequest nRequest = null;
+        if (nParams != null && !nParams.isEmpty()) {
+            List<String> filtered = new ArrayList<>();
+            for (String s : nParams) {
+                if (s != null && !s.isEmpty() && !filtered.contains(s)) {
+                    filtered.add(s);
+                }
+            }
+            if (!filtered.isEmpty()) {
+                nRequest = new JsChallengeRequest(JsChallengeType.N, new ChallengeInput(filtered));
             }
         }
 
-        return null;
+        JsChallengeRequest sRequest = null;
+        if (sParams != null && !sParams.isEmpty()) {
+            List<String> filtered = new ArrayList<>();
+            for (String s : sParams) {
+                if (s != null && !s.isEmpty() && !filtered.contains(s)) filtered.add(s);
+            }
+            if (!filtered.isEmpty()) {
+                sRequest = new JsChallengeRequest(JsChallengeType.SIG, new ChallengeInput(filtered));
+            }
+        }
+
+        List<JsChallengeRequest> requests = new ArrayList<>();
+        if (nRequest != null) requests.add(nRequest);
+        if (sRequest != null) requests.add(sRequest);
+        return requests;
     }
 
     private void checkAllData() {
-        String param = "5cNpZqIJ7ixNqU68Y7S";
+        List<String> param = Collections.singletonList("5cNpZqIJ7ixNqU68Y7S");
 
         try {
             List<JsChallengeRequest> requests = new ArrayList<>();

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/spoof/js/nsigsolver/provider/ChallengeInput.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/spoof/js/nsigsolver/provider/ChallengeInput.java
@@ -1,13 +1,15 @@
 package app.morphe.extension.shared.spoof.js.nsigsolver.provider;
 
-public class ChallengeInput {
-    private final String challenge;
+import java.util.List;
 
-    public ChallengeInput(String challenge) {
-        this.challenge = challenge;
+public class ChallengeInput {
+    private final List<String> challenges;
+
+    public ChallengeInput(List<String> challenges) {
+        this.challenges = challenges;
     }
 
-    public String getChallenge() {
-        return challenge;
+    public List<String> getChallenges() {
+        return challenges;
     }
 }

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/spoof/js/nsigsolver/runtime/JsRuntimeChalBaseJCP.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/spoof/js/nsigsolver/runtime/JsRuntimeChalBaseJCP.java
@@ -27,7 +27,7 @@ public abstract class JsRuntimeChalBaseJCP extends JsChallengeProvider {
     private static final Type SOLVER_OUTPUT_TYPE = new TypeToken<SolverOutput>() {}.getType();
 
     private String playerJS = "";
-    private String playerJSIdentifier = "";
+    private String playerJSHash = "";
     private final String repository = "yt-dlp/ejs";
 
     private final Map<ScriptType, String> scriptFilenames;
@@ -67,9 +67,9 @@ public abstract class JsRuntimeChalBaseJCP extends JsChallengeProvider {
 
     protected abstract String runJsRuntime(String stdin) throws JsChallengeProviderError;
 
-    public void setPlayerJS(String jsCode, String jsIdentifier) {
+    public void setPlayerJS(String jsCode, String playerJSHash) {
         this.playerJS = jsCode;
-        this.playerJSIdentifier = jsIdentifier;
+        this.playerJSHash = playerJSHash;
     }
 
     @Override
@@ -77,7 +77,7 @@ public abstract class JsRuntimeChalBaseJCP extends JsChallengeProvider {
         List<JsChallengeProviderResponse> responses = new ArrayList<>();
 
         try {
-            CachedData data = cacheService.get(CACHE_SECTION, "player:" + playerJSIdentifier);
+            CachedData data = cacheService.get(CACHE_SECTION, "player:" + playerJSHash);
             String player = (data != null) ? data.getCode() : null;
             boolean cached;
 
@@ -107,7 +107,7 @@ public abstract class JsRuntimeChalBaseJCP extends JsChallengeProvider {
 
             String preprocessed = output.getPreprocessedPlayer();
             if (preprocessed != null) {
-                cacheService.save(CACHE_SECTION, "player:" + playerJSIdentifier, new CachedData(preprocessed));
+                cacheService.save(CACHE_SECTION, "player:" + playerJSHash, new CachedData(preprocessed));
             }
 
             List<ResponseData> outputResponses = output.getResponses();
@@ -147,7 +147,7 @@ public abstract class JsRuntimeChalBaseJCP extends JsChallengeProvider {
         for (JsChallengeRequest request : requests) {
             Map<String, Object> reqMap = new HashMap<>();
             reqMap.put("type", request.getType().getValue());
-            reqMap.put("challenges", Collections.singletonList(request.getInput().getChallenge()));
+            reqMap.put("challenges", request.getInput().getChallenges());
             jsonRequests.add(reqMap);
         }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -512,6 +512,12 @@ public class Settings extends BaseSettings {
             SPOOF_VIDEO_STREAMS_CLIENT_TYPE.resetToDefault();
         }
 
+        // TV Simply may require PoToken
+        if (SPOOF_VIDEO_STREAMS_CLIENT_TYPE.get() == ClientType.TV_SIMPLY) {
+            Logger.printInfo(() -> "Migrating from TV Simply to TV");
+            SPOOF_VIDEO_STREAMS_CLIENT_TYPE.save(ClientType.TV);
+        }
+
         // endregion
 
         // region SB import/export callbacks

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/preference/SpoofStreamingDataSideEffectsPreference.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/preference/SpoofStreamingDataSideEffectsPreference.java
@@ -92,13 +92,21 @@ public class SpoofStreamingDataSideEffectsPreference extends Preference {
             case ANDROID_VR_1_47_48, ANDROID_VR_1_54_20 ->
                     summary = str("morphe_spoof_video_streams_about_no_audio_tracks")
                             + '\n' + str("morphe_spoof_video_streams_about_no_stable_volume");
-            case TV, TV_SIMPLY ->
+            case TV ->
                     summary = str("morphe_spoof_video_streams_about_js");
+            case TV_SIMPLY ->
+                    summary = str("morphe_spoof_video_streams_about_js")
+                            + '\n' + str("morphe_spoof_video_streams_about_playback_failure");
             case VISIONOS ->
                     summary = str("morphe_spoof_video_streams_about_experimental")
                             + '\n' + str("morphe_spoof_video_streams_about_no_audio_tracks")
                             + '\n' + str("morphe_spoof_video_streams_about_no_av1");
             default -> Logger.printException(() -> "Unknown client: " + clientType);
+        }
+
+        // Only Android VR supports 360° VR immersive mode.
+        if (clientType != ClientType.ANDROID_VR_1_47_48 && clientType != ClientType.ANDROID_VR_1_54_20) {
+            summary += '\n' + str("morphe_spoof_video_streams_about_no_immersive_mode");
         }
 
         // Use better formatting for bullet points.

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/SpoofVideoStreamsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/SpoofVideoStreamsPatch.kt
@@ -79,7 +79,7 @@ private val spoofVideoStreamsRawResourcePatch = rawResourcePatch {
                 "astring-1.9.0.min.js",
                 "meriyah-6.1.4.min.js",
                 "polyfill.js",
-                "yt.solver.core.js", // yt-dlp-ejs 0.4.0
+                "yt.solver.core.js", // yt-dlp-ejs 0.4.0.r2: https://github.com/yt-dlp/ejs/pull/48
             )
         )
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/spoof/SpoofVideoStreamsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/spoof/SpoofVideoStreamsPatch.kt
@@ -72,7 +72,8 @@ val spoofVideoStreamsPatch = spoofVideoStreamsPatch(
                         selectable = true,
                     ),
                     SwitchPreference("morphe_spoof_video_streams_av1"),
-                    SwitchPreference("morphe_spoof_streaming_data_stats_for_nerds"),
+                    ListPreference("morphe_spoof_video_streams_js_variant"),
+                    SwitchPreference("morphe_spoof_video_streams_stats_for_nerds"),
                 )
             )
         )

--- a/patches/src/main/resources/addresources/values/music/arrays.xml
+++ b/patches/src/main/resources/addresources/values/music/arrays.xml
@@ -33,13 +33,11 @@
     <string-array name="morphe_spoof_video_streams_client_type_entries">
         <item>Android VR</item>
         <item>TV</item>
-        <item>TV Simply</item>
         <item>visionOS</item>
     </string-array>
     <string-array name="morphe_spoof_video_streams_client_type_entry_values">
         <item>ANDROID_VR_1_47_48</item>
         <item>TV</item>
-        <item>TV_SIMPLY</item>
         <item>VISIONOS</item>
     </string-array>
 </resources>

--- a/patches/src/main/resources/addresources/values/youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/youtube/arrays.xml
@@ -34,15 +34,31 @@
         <item>Android Studio</item>
         <item>Android VR</item>
         <item>TV</item>
-        <item>TV Simply</item>
         <item>visionOS</item>
     </string-array>
     <string-array name="morphe_spoof_video_streams_client_type_entry_values">
         <item>ANDROID_CREATOR</item>
         <item>ANDROID_VR_1_47_48</item>
         <item>TV</item>
-        <item>TV_SIMPLY</item>
         <item>VISIONOS</item>
+    </string-array>
+    <string-array name="morphe_spoof_video_streams_js_variant_entries">
+        <item>House Brand</item>
+        <item>Phone</item>
+        <item>TV</item>
+        <item>TV ES6</item>
+        <item>Web</item>
+        <item>Web ES6</item>
+        <item>Web Embed</item>
+    </string-array>
+    <string-array name="morphe_spoof_video_streams_js_variant_entry_values">
+        <item>HOUSE_BRAND</item>
+        <item>PHONE</item>
+        <item>TV</item>
+        <item>TV_ES6</item>
+        <item>WEB</item>
+        <item>WEB_ES6</item>
+        <item>WEB_EMBED</item>
     </string-array>
 
     <!-- interaction.swipecontrols.swipeControlsResourcePatch -->

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -734,10 +734,10 @@ Cookies will be saved automatically if they are valid"</string>
     <string name="morphe_hide_player_flyout_audio_track_summary_on">Audio track menu is hidden</string>
     <string name="morphe_hide_player_flyout_audio_track_summary_off">Audio track menu is shown</string>
     <!-- 'Spoof video streams' should match the language used in 'morphe_spoof_video_streams_screen_title'.
-          'Android No SDK' must be kept untranslated. -->
+          'TV' must be kept untranslated. -->
     <string name="morphe_hide_player_flyout_audio_track_not_available">"Audio track menu is hidden
 
-To show the Audio track menu, change \'Spoof video streams\' to \'Android No SDK\'"</string>
+To show the Audio track menu, change \'Spoof video streams\' to \'TV\'"</string>
     <!-- 'Watch in VR' should be translated using the same localized wording YouTube displays for the menu item. -->
     <string name="morphe_hide_player_flyout_watch_in_vr_title">Hide Watch in VR</string>
     <string name="morphe_hide_player_flyout_watch_in_vr_summary_on">Watch in VR menu is hidden</string>
@@ -1623,13 +1623,16 @@ Playback may stutter or drop frames"</string>
 Video playback with AV1 may stutter or drop frames."</string>
     <string name="morphe_spoof_video_streams_about_title">Spoofing side effects</string>
     <string name="morphe_spoof_video_streams_about_experimental">• Experimental client and may stop working anytime</string>
+    <string name="morphe_spoof_video_streams_about_playback_failure">• Video may stop at 1:00, or may not be available in some regions</string>
     <string name="morphe_spoof_video_streams_about_no_audio_tracks">• Audio track menu is missing</string>
     <string name="morphe_spoof_video_streams_about_no_av1">• No AV1 video codec</string>
+    <string name="morphe_spoof_video_streams_about_no_immersive_mode">• 360° VR immersive mode is not available</string>
     <string name="morphe_spoof_video_streams_about_no_stable_volume">• Stable volume is not available</string>
-    <string name="morphe_spoof_video_streams_about_js">• Video may start late</string>
+    <string name="morphe_spoof_video_streams_about_js">• If deobfuscation fails, playback may fail</string>
     <!-- "Force original audio" should match the language used in 'morphe_force_original_audio_title'. -->
     <string name="morphe_spoof_video_streams_about_no_force_original_audio">• Force original audio is not available</string>
-    <string name="morphe_spoof_streaming_data_stats_for_nerds_title">Show in Stats for nerds</string>
-    <string name="morphe_spoof_streaming_data_stats_for_nerds_summary_on">Client type is shown in Stats for nerds</string>
-    <string name="morphe_spoof_streaming_data_stats_for_nerds_summary_off">Client is hidden in Stats for nerds</string>
+    <string name="morphe_spoof_video_streams_js_variant_title">Player JavaScript variant</string>
+    <string name="morphe_spoof_video_streams_stats_for_nerds_title">Show in Stats for nerds</string>
+    <string name="morphe_spoof_video_streams_stats_for_nerds_summary_on">Client type is shown in Stats for nerds</string>
+    <string name="morphe_spoof_video_streams_stats_for_nerds_summary_off">Client is hidden in Stats for nerds</string>
 </resources>


### PR DESCRIPTION
### `TV Simply` client has been removed

- `TV Simply` requires a PoToken when signed out.

- In the near future, `TV Simply` may also require a PoToken when signed in.

- The PoToken generator needs to be rewritten from scratch, so it will take time to implement.

- For this reason, the `TV Simply` client has been removed.

- Since `TV` already exists as a replacement client for `TV Simply`, this is not a major issue.

- If the `TV Simply` client is deemed usable again in the future, it will be restored.

### `Player JavaScript variant` setting has been added.

- According to https://github.com/yt-dlp/yt-dlp/issues/15814, deciphering has failed for certain player JavaScript variants:

<img width="538" height="576" alt="player_js_variant_issue" src="https://github.com/user-attachments/assets/283481e8-cc81-460d-a794-ffbe195d0549" />

- While Morphe is currently unaffected by this, I felt it could fail to decipher for variants at any time.

- Therefore, I added a setting to select the Player JavaScript variant, similar to yt-dlp (Default: TV):

<img width="454" height="132" alt="player_js_variant_readme" src="https://github.com/user-attachments/assets/29df9e3c-6164-41f7-b01f-8a7c154c2a56" />

- Depending on the variant, the total decipher time may vary.

### Player JavaScript update cycle has been changed to three days.

- Since a new version of Player JavaScript is released every three days, the update cycle has also been changed to three days.

### yt-dlp-ejs has been updated to the build from the PR branch.

- https://github.com/yt-dlp/yt-dlp/issues/15814 is fixed in this build.

### Decipher logic has been rewritten.

- The J2V8 runtime has high context switching overhead.

- Because the warm-up time is longer than the decipher time, there was previously an issue where video playback would start too late due to frequent runtime calls.

(It appears that RYD API/SponsorBlock API error toast messages are frequently shown when videos start late)

### Old decipher logic

- There are 30 to 120 formats per video, with one runtime call per format.

- Music videos use twice as many runtime calls as regular videos.

- The latency of regular videos is approximately **500 to 1,500 ms**.

- The latency of music videos is approximately **3,500 to 4,500 ms**.

### New decipher logic

- All obfuscated parameters are deciphered with a single runtime call.

- The latency of regular videos is approximately **200 to 400 ms**.

- The latency of music videos is approximately **500 to 700 ms**.

- Setting the default client to `TV` now works without major issues when playing Shorts or using YouTube Music.

### Updated side effects

- Some outdated phrases have been removed.

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
