### PR TITLE
feat(YouTube - Spoof app version): Remove target version `19.35.36`

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/spoof/SpoofAppVersionPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/spoof/SpoofAppVersionPatch.java
@@ -1,6 +1,5 @@
 package app.morphe.extension.youtube.patches.spoof;
 
-import app.morphe.extension.youtube.patches.VersionCheckPatch;
 import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
@@ -9,15 +8,18 @@ public class SpoofAppVersionPatch {
     private static final boolean SPOOF_APP_VERSION_ENABLED = Settings.SPOOF_APP_VERSION.get();
     private static final String SPOOF_APP_VERSION_TARGET = Settings.SPOOF_APP_VERSION_TARGET.get();
 
-    private static final boolean DISABLE_BOLD_ICONS = VersionCheckPatch.IS_20_31_OR_GREATER
-            && isSpoofingToLessThan("20.30.00");
+    private static final boolean DISABLE_BOLD_ICONS = isSpoofingToLessThan("20.30.00");
 
     /**
-     * injection point.
+     * Injection point.
+     * <p>
+     * Called before {@link #getShortsAppVersionOverride(String)}.
+     * Called from all endpoints.
      */
-    public static String getAppVersionOverride(String version) {
-        if (SPOOF_APP_VERSION_ENABLED) return SPOOF_APP_VERSION_TARGET;
-        return version;
+    public static String getUniversalAppVersionOverride(String version) {
+        return SPOOF_APP_VERSION_ENABLED
+                ? SPOOF_APP_VERSION_TARGET
+                : version;
     }
 
     public static boolean isSpoofingToLessThan(String version) {
@@ -26,9 +28,23 @@ public class SpoofAppVersionPatch {
 
     /**
      * Injection point.
+     * Used on YouTube 20.31 ~ 21.04.
      */
     public static boolean disableShortsBoldIcons(boolean original) {
         return !DISABLE_BOLD_ICONS && original;
+    }
+
+    /**
+     * Injection point.
+     * Used on YouTube 21.05+.
+     * <p>
+     * Called after {@link #getUniversalAppVersionOverride(String)}.
+     * Called from the '/reel/create_reel_items', '/reel/reel_item_watch', and '/reel/reel_watch_sequence' endpoints.
+     */
+    public static String getShortsAppVersionOverride(String version) {
+        return DISABLE_BOLD_ICONS
+                ? "20.30.40" // Oldest version that supports new Shorts overlay endpoint response.
+                : version;
     }
 
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -295,7 +295,7 @@ public class Settings extends BaseSettings {
     public static final EnumSetting<StartPage> CHANGE_START_PAGE = new EnumSetting<>("morphe_change_start_page", StartPage.DEFAULT, true);
     public static final BooleanSetting CHANGE_START_PAGE_ALWAYS = new BooleanSetting("morphe_change_start_page_always", FALSE, true,
             new ChangeStartPageTypeAvailability());
-    public static final StringSetting SPOOF_APP_VERSION_TARGET = new StringSetting("morphe_spoof_app_version_target", "19.35.36", true, parent(SPOOF_APP_VERSION));
+    public static final StringSetting SPOOF_APP_VERSION_TARGET = new StringSetting("morphe_spoof_app_version_target", "20.13.41", true, parent(SPOOF_APP_VERSION));
 
     // Custom filter
     public static final BooleanSetting CUSTOM_FILTER = new BooleanSetting("morphe_custom_filter", FALSE);

--- a/patches/src/main/resources/addresources/values/youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/youtube/arrays.xml
@@ -86,42 +86,30 @@
         <item>@string/morphe_spoof_app_version_target_entry_20_39</item>
         <item>@string/morphe_spoof_app_version_target_entry_20_28</item>
         <item>@string/morphe_spoof_app_version_target_entry_20_13</item>
-        <item>@string/morphe_spoof_app_version_target_entry_19_35</item>
     </string-array>
     <string-array name="morphe_spoof_app_version_target_entry_values">
         <item>20.39.41</item>
         <item>20.28.41</item>
         <item>20.13.41</item>
-        <item>19.35.36</item>
     </string-array>
     <string-array name="morphe_spoof_app_version_target_legacy_20_31_entries">
         <item>@string/morphe_spoof_app_version_target_entry_20_28</item>
         <item>@string/morphe_spoof_app_version_target_entry_20_13</item>
-        <item>@string/morphe_spoof_app_version_target_entry_19_35</item>
     </string-array>
     <string-array name="morphe_spoof_app_version_target_legacy_20_31_entry_values">
         <item>20.28.41</item>
         <item>20.13.41</item>
-        <item>19.35.36</item>
     </string-array>
-    <string-array name="morphe_spoof_app_version_target_legacy_20_30_entries">
+    <string-array name="morphe_spoof_app_version_target_legacy_20_14_entries">
         <item>@string/morphe_spoof_app_version_target_entry_20_13</item>
-        <item>@string/morphe_spoof_app_version_target_entry_19_35</item>
     </string-array>
-    <string-array name="morphe_spoof_app_version_target_legacy_20_30_entry_values">
+    <string-array name="morphe_spoof_app_version_target_legacy_20_14_entry_values">
         <item>20.13.41</item>
-        <item>19.35.36</item>
     </string-array>
-    <string-array name="morphe_spoof_app_version_target_legacy_20_13_entries">
-        <item>@string/morphe_spoof_app_version_target_entry_19_35</item>
-    </string-array>
-    <string-array name="morphe_spoof_app_version_target_legacy_20_13_entry_values">
-        <item>19.35.36</item>
-    </string-array>
-    <string-array name="morphe_spoof_app_version_target_legacy_19_34_entries">
+    <string-array name="morphe_spoof_app_version_target_legacy_19_02_entries">
         <item>19.01.34</item>
     </string-array>
-    <string-array name="morphe_spoof_app_version_target_legacy_19_34_entry_values">
+    <string-array name="morphe_spoof_app_version_target_legacy_19_02_entry_values">
         <item>19.01.34</item>
     </string-array>
 

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1284,7 +1284,6 @@ If later turned off, it is recommended to clear the app data to prevent UI bugs.
     <string name="morphe_spoof_app_version_target_entry_20_39">20.39.41 - Restore old save to playlist</string>
     <string name="morphe_spoof_app_version_target_entry_20_28">20.28.41 - Disable bold icons</string>
     <string name="morphe_spoof_app_version_target_entry_20_13">20.13.41 - Restore non collapsed video action bar</string>
-    <string name="morphe_spoof_app_version_target_entry_19_35">19.35.36 - Restore old Shorts player icons</string>
 
     <!-- layout.startpage.changeStartPagePatch -->
     <string name="morphe_change_start_page_title">Change start page</string>


### PR DESCRIPTION
### Remove `19.35.36` from the `Spoof app version target`.

- Some themes and UIs are now starting to break on YouTube 19.x.

- This means that the server no longer considers YouTube 19.x, and it seems that YouTube 19.x will be unavailable in the near future.

- Therefore, `19.35.36` has been removed from the `Spoof app version target`.

### Fixes an issue where Shorts overlays are missing when using `Spoof app version` in 21.05+.

While the `Spoof app version` patch no longer fails on YouTube 21.05+ since https://github.com/MorpheApp/morphe-patches/commit/3d7c0e6fc953775048c58a77004a4938e4df7ba8, https://github.com/MorpheApp/morphe-patches/issues/183 still exists on YouTube 21.05+.

This PR fixes this issue.

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
