### PR TITLE
fix(YouTube - Navigation bar): Resolve experimental player black bar when "Disable translucent status bar" is enabled

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/NavigationBarPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/NavigationBarPatch.java
@@ -86,6 +86,14 @@ public final class NavigationBarPatch {
     /**
      * Injection point.
      */
+    public static boolean allowCollapsingToolbarLayout(boolean original) {
+        if (DISABLE_TRANSLUCENT_STATUS_BAR) return false;
+        return original;
+    }
+
+    /**
+     * Injection point.
+     */
     public static boolean useTranslucentNavigationStatusBar(boolean original) {
         // Must check Android version, as forcing this on Android 11 or lower causes app hang and crash.
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/Fingerprints.kt
@@ -32,6 +32,15 @@ internal object AnimatedNavigationTabsFeatureFlagFingerprint : Fingerprint(
     )
 )
 
+internal object CollapsingToolbarLayoutFeatureFlag : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "Z",
+    parameters = listOf(),
+    filters = listOf(
+        literal(45736608L)
+    )
+)
+
 internal object PivotBarStyleFingerprint : Fingerprint(
     returnType = "V",
     parameters = listOf("L"),

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
@@ -19,6 +19,7 @@ import app.morphe.patches.youtube.misc.navigation.navigationBarHookPatch
 import app.morphe.patches.youtube.misc.playservice.is_19_25_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_20_15_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_20_31_or_greater
+import app.morphe.patches.youtube.misc.playservice.is_20_46_or_greater
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
@@ -135,6 +136,16 @@ val navigationBarPatch = bytecodePatch(
                 it.method.insertLiteralOverride(
                     it.instructionMatches.first().index,
                     "$EXTENSION_CLASS_DESCRIPTOR->useAnimatedNavigationButtons(Z)Z"
+                )
+            }
+        }
+
+        if (is_20_46_or_greater) {
+            // Feature interferes with translucent status bar and must be forced off.
+            CollapsingToolbarLayoutFeatureFlag.let {
+                it.method.insertLiteralOverride(
+                    it.instructionMatches.first().index,
+                    "$EXTENSION_CLASS_DESCRIPTOR->allowCollapsingToolbarLayout(Z)Z"
                 )
             }
         }

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -666,7 +666,7 @@ Cookies will be saved automatically if they are valid"</string>
     <string name="morphe_disable_translucent_status_bar_summary_off">Status bar is opaque or translucent</string>
     <string name="morphe_disable_translucent_status_bar_user_dialog_message">"Limitations:
 • A black bar may appear at the top of the video player.
-• On some devices, enabling this feature can change the system navigation bar to transparent."</string>
+• The system navigation bar can change to transparent and it's not possible to comment on videos."</string>
     <string name="morphe_disable_translucent_navigation_bar_light_title">Disable light translucent bar</string>
     <string name="morphe_disable_translucent_navigation_bar_light_summary_on">Light mode navigation bar is opaque</string>
     <string name="morphe_disable_translucent_navigation_bar_light_summary_off">Light mode navigation bar is opaque or translucent</string>


### PR DESCRIPTION
### Description

Fixes black bar showing above the player if translucent status bar is disabled with experimental app targets.

If the translucent status bar is forced off, then an additional flag related to "collapsable toolbar layout" is also forced off. Unclear what the collapsable toolbar is.

Also fixes background PiP showing a black border.

Partially closes #160
Closes #395

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
