### PR TITLE
fix(YouTube - Hide layout components): Resolve "Hide comments section in Home feed" not hiding comments

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/CommentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/CommentsFilter.java
@@ -42,7 +42,7 @@ final class CommentsFilter extends Filter {
         );
 
         comments = new StringFilterGroup(
-                Settings.HIDE_COMMENTS_SECTION,
+                null,
                 "video_metadata_carousel",
                 "_comments"
         );


### PR DESCRIPTION
### Description

Closes #472.

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
