### PR TITLE
feat(YouTube): Add `Disable layout updates` patch

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableLayoutUpdatesPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableLayoutUpdatesPatch.java
@@ -1,0 +1,33 @@
+package app.morphe.extension.youtube.patches;
+
+import java.util.List;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.youtube.settings.Settings;
+
+@SuppressWarnings("unused")
+public class DisableLayoutUpdatesPatch {
+
+    private static final List<String> REQUEST_HEADER_KEYS = List.of(
+            "X-Youtube-Cold-Config-Data",
+            "X-Youtube-Cold-Hash-Data",
+            "X-Youtube-Hot-Config-Data",
+            "X-Youtube-Hot-Hash-Data"
+    );
+
+    private static final boolean DISABLE_LAYOUT_UPDATES = Settings.DISABLE_LAYOUT_UPDATES.get();
+
+    /**
+     * @param key   Keys to be added to the header of CronetBuilder.
+     * @param value Values to be added to the header of CronetBuilder.
+     * @return Empty value if setting is enabled.
+     */
+    public static String disableLayoutUpdates(String key, String value) {
+        if (DISABLE_LAYOUT_UPDATES && REQUEST_HEADER_KEYS.contains(key)) {
+            Logger.printDebug(() -> "Blocking: " + key);
+            return "";
+        }
+
+        return value;
+    }
+}

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -281,6 +281,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting HIDE_PLAYER_FLYOUT_WATCH_IN_VR = new BooleanSetting("morphe_hide_player_flyout_watch_in_vr", FALSE);
 
     // General layout
+    public static final BooleanSetting DISABLE_LAYOUT_UPDATES = new BooleanSetting("morphe_disable_layout_updates", FALSE, true, "morphe_disable_layout_updates_user_dialog_message");
     public static final BooleanSetting RESTORE_OLD_SETTINGS_MENUS = new BooleanSetting("morphe_restore_old_settings_menus", FALSE, true);
     public static final EnumSetting<FormFactor> CHANGE_FORM_FACTOR = new EnumSetting<>("morphe_change_form_factor", FormFactor.DEFAULT, true, "morphe_change_form_factor_user_dialog_message");
     public static final BooleanSetting BYPASS_IMAGE_REGION_RESTRICTIONS = new BooleanSetting("morphe_bypass_image_region_restrictions", FALSE, true);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/disableupdates/ChangeFormFactorPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/disableupdates/ChangeFormFactorPatch.kt
@@ -1,0 +1,44 @@
+package app.morphe.patches.youtube.layout.disableupdates
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
+import app.morphe.patches.youtube.misc.settings.PreferenceScreen
+import app.morphe.patches.youtube.misc.settings.settingsPatch
+import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
+
+private const val EXTENSION_CLASS_DESCRIPTOR = "Lapp/morphe/extension/youtube/patches/DisableLayoutUpdatesPatch;"
+
+@Suppress("unused")
+val disableLayoutUpdatesPatch = bytecodePatch(
+    name = "Disable layout updates",
+    description = "Adds an option to disable server side layout updates and use an older UI.",
+) {
+    dependsOn(
+        sharedExtensionPatch,
+        settingsPatch
+    )
+
+    compatibleWith(COMPATIBILITY_YOUTUBE)
+
+    execute {
+        PreferenceScreen.GENERAL_LAYOUT.addPreferences(
+            SwitchPreference("morphe_disable_layout_updates")
+        )
+
+        CronetHeaderFingerprint.let {
+            it.method.apply {
+                val index = it.instructionMatches.first().index
+
+                addInstructions(
+                    index,
+                    """
+                        invoke-static { p1, p2 }, $EXTENSION_CLASS_DESCRIPTOR->disableLayoutUpdates(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+                        move-result-object p2
+                    """
+                )
+            }
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/disableupdates/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/disableupdates/Fingerprints.kt
@@ -1,0 +1,18 @@
+package app.morphe.patches.youtube.layout.disableupdates
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.string
+import com.android.tools.smali.dexlib2.AccessFlags
+
+internal object CronetHeaderFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    parameters = listOf("Ljava/lang/String;", "Ljava/lang/String;"),
+    filters = listOf(
+        string("Accept-Encoding")
+    ),
+    // In YouTube 19.16.39 or earlier, there are two methods with almost the same structure.
+    // Check the fields of the class to identify them correctly.
+    custom = { _, classDef ->
+        classDef.fields.find { it.type == "J" } != null
+    }
+)

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -49,6 +49,21 @@ This can help identify components when creating custom filters.
 
 However, enabling this will also log some user data such as your IP address."</string>
 
+    <!-- layout.disableLayoutUpdatesPatch -->
+    <string name="morphe_disable_layout_updates_title">Disable layout updates</string>
+    <string name="morphe_disable_layout_updates_summary_on">Layout will not be updated by the server</string>
+    <string name="morphe_disable_layout_updates_summary_off">Layout will be updated by the server</string>
+    <string name="morphe_disable_layout_updates_user_dialog_message">"App layout reverts to the layout used when first installed.
+
+Some server-side layouts may not revert.
+
+Changes include:
+• Components in player flyout menu (or related settings) may not work.
+• Rolling numbers are not animated.
+• Library tab is shown.
+• Music section of video description may not work.
+• Account switch button may not appear on the Library tab."</string>
+
     <!-- layout.hide.general.hideLayoutComponentsPatch -->
     <string name="morphe_hide_creator_store_shelf_title">Hide creator store shelf</string>
     <string name="morphe_hide_creator_store_shelf_summary_on">Creator store shelf under video player is hidden</string>


### PR DESCRIPTION
### Description

Adapts patch from @inotia00  https://github.com/inotia00/revanced-patches

Closes #490

### Additional context

The 'Change accounts' button will not show in the library tab, but changing the account can be done thru:

`Home feed settings menu > Tap YouTube account name > Tap different account`

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
