### PR TITLE
fix(Spoof video streams): Close streams in JavaScriptManager.readFromFile

### DIFF
--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/spoof/js/JavaScriptManager.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/spoof/js/JavaScriptManager.java
@@ -426,11 +426,12 @@ public final class JavaScriptManager {
                 //noinspection ReadWriteStringCanBeUsed
                 return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
             } else {
-                FileInputStream fis = new FileInputStream(file);
-                BufferedReader reader = new BufferedReader(new InputStreamReader(fis));
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    sb.append(line).append("\n");
+                try (FileInputStream fis = new FileInputStream(file);
+                     BufferedReader reader = new BufferedReader(new InputStreamReader(fis))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        sb.append(line).append("\n");
+                    }
                 }
                 return sb.toString();
             }


### PR DESCRIPTION
This fixes a resource leak where FileInputStream and BufferedReader were not being closed on Android API < 26.

The bug could cause:  Memory leaks,File descriptor exhaustion ,App crashes after repeated calls

Fixed by using try-with-resources to ensure streams are always closed properly.