### PR TITLE
fix(Override certificate pinning): Handle element missing from network config

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/all/misc/network/OverrideCertificatePinningPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/all/misc/network/OverrideCertificatePinningPatch.kt
@@ -42,7 +42,14 @@ val overrideCertificatePinningPatch = resourcePatch(
                     "base-config",
                     "debug-overrides"
                 ).forEach { tagName ->
-                    val configElement = document.getNode(tagName) as Element
+                    val configElement = document.getNode(tagName) as? Element ?: tagName.let {
+                        document.getNode("network-security-config").adoptChild(tagName) {
+                            if (tagName == "base-config") {
+                                setAttribute("cleartextTrafficPermitted", "true")
+                            }
+                        }
+                        document.getNode(tagName)
+                    }
                     val configChildNodes = configElement.childNodes
                     for (i in 0 until configChildNodes.length) {
                         val anchorNode = configChildNodes.item(i)


### PR DESCRIPTION
### Description

Fixes an issue where the cert pinning patch would fail if the app already had an existing network security config, but it was missing one of the elements that the patch modifies.

### Additional context

Found when patching Instagram.

Error shown below.
```
SEVERE: "Override certificate pinning" failed:
app.morphe.patcher.patch.PatchException: null cannot be cast to non-null type org.w3c.dom.Element
        at app.morphe.patcher.Patcher$invoke$1.invokeSuspend$execute(Patcher.kt:87)
        [...]
Caused by: java.lang.NullPointerException: null cannot be cast to non-null type org.w3c.dom.Element
        at app.morphe.patches.all.misc.network.OverrideCertificatePinningPatchKt.overrideCertificatePinningPatch$lambda$7$lambda$6(OverrideCertificatePinningPatch.kt:45)
        at app.morphe.patcher.patch.Patch.execute(Patch.kt:71)
        at app.morphe.patcher.patch.ResourcePatch.execute$morphe_patcher(Patch.kt:247)
        at app.morphe.patcher.Patcher$invoke$1.invokeSuspend$execute(Patcher.kt:81)
        ... 27 more
```

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
