### PR TITLE
feat: Add `Disable QUIC protocol` patch

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/DisableQUICProtocolPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/DisableQUICProtocolPatch.java
@@ -1,0 +1,12 @@
+package app.morphe.extension.shared.patches;
+
+import app.morphe.extension.shared.settings.SharedYouTubeSettings;
+
+@SuppressWarnings("unused")
+public class DisableQUICProtocolPatch {
+
+    public static boolean disableQUICProtocol(boolean original) {
+        boolean isDisabled = SharedYouTubeSettings.DISABLE_QUIC_PROTOCOL.get();
+        return !isDisabled && original;
+    }
+}

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
@@ -21,6 +21,8 @@ public class SharedYouTubeSettings extends BaseSettings {
 
     public static final BooleanSetting DISABLE_DRC_AUDIO = new BooleanSetting("morphe_disable_drc_audio", FALSE, true);
 
+    public static final BooleanSetting DISABLE_QUIC_PROTOCOL = new BooleanSetting("morphe_disable_quic_protocol", FALSE, true);
+
     public static final BooleanSetting SPOOF_VIDEO_STREAMS = new BooleanSetting("morphe_spoof_video_streams", TRUE, true, "morphe_spoof_video_streams_user_dialog_message");
     public static final BooleanSetting SPOOF_VIDEO_STREAMS_STATS_FOR_NERDS = new BooleanSetting("morphe_spoof_video_streams_stats_for_nerds", TRUE, parent(SPOOF_VIDEO_STREAMS));
     public static final EnumSetting<JavaScriptVariant> SPOOF_VIDEO_STREAMS_JS_VARIANT = new EnumSetting<>("morphe_spoof_video_streams_js_variant", JavaScriptVariant.PHONE, true, new SpoofClientJavaScriptVariantAvailability());

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/quic/DisableQUICProtocolPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/quic/DisableQUICProtocolPatch.kt
@@ -1,0 +1,20 @@
+package app.morphe.patches.music.misc.quic
+
+import app.morphe.patches.music.misc.extension.sharedExtensionPatch
+import app.morphe.patches.music.misc.settings.PreferenceScreen
+import app.morphe.patches.music.misc.settings.settingsPatch
+import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
+import app.morphe.patches.shared.misc.quic.disableQuicProtocolPatch
+
+@Suppress("unused")
+val disableQuicProtocolPatchMusic = disableQuicProtocolPatch(
+    block = {
+        dependsOn(
+            sharedExtensionPatch,
+            settingsPatch
+        )
+
+        compatibleWith(COMPATIBILITY_YOUTUBE_MUSIC)
+    },
+    preferenceScreen = PreferenceScreen.MISC
+)

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/quic/DisableQUICProtocolPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/quic/DisableQUICProtocolPatch.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ */
+
+package app.morphe.patches.shared.misc.quic
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.BytecodePatchBuilder
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.misc.settings.preference.BasePreferenceScreen
+import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+
+private const val EXTENSION_CLASS_DESCRIPTOR =
+    "Lapp/morphe/extension/shared/patches/DisableQUICProtocolPatch;"
+
+internal fun disableQuicProtocolPatch(
+    block: BytecodePatchBuilder.() -> Unit,
+    preferenceScreen: BasePreferenceScreen.Screen,
+) = bytecodePatch(
+    name = "Disable QUIC protocol",
+    description = "Adds an option to disable the QUIC (Quick UDP Internet Connections) network protocol."
+) {
+    block()
+
+    execute {
+        preferenceScreen.addPreferences(
+            SwitchPreference("morphe_disable_quic_protocol")
+        )
+
+        arrayOf(
+            CronetEngineBuilderFingerprint,
+            ExperimentalCronetEngineBuilderFingerprint
+        ).forEach { fingerprint ->
+
+            fingerprint.method.addInstructions(
+                0,
+                """
+                    invoke-static { p1 }, $EXTENSION_CLASS_DESCRIPTOR->disableQUICProtocol(Z)Z
+                    move-result p1
+                """
+            )
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/quic/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/quic/Fingerprints.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ */
+
+package app.morphe.patches.shared.misc.quic
+
+import app.morphe.patcher.Fingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+internal object CronetEngineBuilderFingerprint : Fingerprint(
+    definingClass = "/CronetEngine\$Builder;",
+    name = "enableQuic",
+    accessFlags = listOf(AccessFlags.PUBLIC),
+    returnType = "L",
+    parameters = listOf("Z")
+)
+
+internal object ExperimentalCronetEngineBuilderFingerprint : Fingerprint(
+    definingClass = "/ExperimentalCronetEngine\$Builder;",
+    name = "enableQuic",
+    accessFlags = listOf(AccessFlags.PUBLIC),
+    returnType = "L",
+    parameters = listOf("Z")
+)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/quic/DisableQUICProtocolPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/quic/DisableQUICProtocolPatch.kt
@@ -1,0 +1,20 @@
+package app.morphe.patches.youtube.misc.quic
+
+import app.morphe.patches.shared.misc.quic.disableQuicProtocolPatch
+import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
+import app.morphe.patches.youtube.misc.settings.PreferenceScreen
+import app.morphe.patches.youtube.misc.settings.settingsPatch
+import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
+
+@Suppress("unused")
+val disableQuicProtocolPatchYouTube = disableQuicProtocolPatch(
+    block = {
+        dependsOn(
+            sharedExtensionPatch,
+            settingsPatch
+        )
+
+        compatibleWith(COMPATIBILITY_YOUTUBE)
+    },
+    preferenceScreen = PreferenceScreen.MISC
+)

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -99,7 +99,12 @@ To sign in, press continue below"</string>
     <string name="morphe_oauth2_toast_reset">Logged out of Android VR</string>
     <string name="morphe_oauth2_toast_invalid">Invalid VR sign in token, try signing in to VR again</string>
 
-    <!-- misc.audio.drc.drcAudioPatch -->
+    <!-- misc.quic.disableQUICProtocolPatch -->
+    <string name="morphe_disable_quic_protocol_title">Disable QUIC protocol</string>
+    <string name="morphe_disable_quic_protocol_summary_on">QUIC protocol is disabled</string>
+    <string name="morphe_disable_quic_protocol_summary_off">QUIC protocol is enabled</string>
+
+    <!-- misc.audio.drc.disableDRCAudioPatch  -->
     <string name="morphe_disable_drc_audio_title">Disable DRC audio</string>
     <string name="morphe_disable_drc_audio_summary_on">DRC audio is disabled</string>
     <string name="morphe_disable_drc_audio_summary_off">DRC audio is enabled</string>


### PR DESCRIPTION
### Description

Code adapted from @inotia00 https://github.com/inotia00/revanced-patches/

Closes #566.

### Additional context

 I tested with Wireshark, and yes the patch is working, when enabled there's no QUIC detected under protocol.

<details><summary>Result</summary>
<p>

| Before | After |
|--------|--------|
| <img width="97" height="625" alt="Screenshot 2026-02-19 222429" src="https://github.com/user-attachments/assets/7a139239-2f66-4f16-897e-2d4a6a978d13" /> | <img width="92" height="599" alt="Screenshot 2026-02-19 222342" src="https://github.com/user-attachments/assets/f3db43a5-9ef0-4567-a4ec-b8796a77e18c" /> | 

</p>
</details> 

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
