### PR TITLE
fix(YouTube - Hide layout components): Resolve "Hide Explore the podcast" not working

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/DescriptionComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/DescriptionComponentsFilter.java
@@ -48,12 +48,13 @@ final class DescriptionComponentsFilter extends Filter {
         playlistSectionGroupList.addAll(
                 new ByteArrayFilterGroup(
                         Settings.HIDE_EXPLORE_COURSE_SECTION,
-                        "yt_outline_creator_academy", // For Disable bold icons.
+                        "yt_outline_creator_academy",
                         "yt_outline_experimental_graduation_cap"
                 ),
                 new ByteArrayFilterGroup(
                         Settings.HIDE_EXPLORE_PODCAST_SECTION,
-                        "FEpodcasts_destination"
+                        "FEpodcasts_destination",
+                        "yt_outline_experimental_podcast"
                 )
         );
 


### PR DESCRIPTION
### Description

Partially closes #690.

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
