### PR TITLE
feat(Theme): Use dynamic system accents for Material You colors

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -60,7 +60,7 @@ internal val darkThemeBackgroundColorOption = stringOption(
     default = "@android:color/black",
     values = mapOf(
         "Pure black" to "@android:color/black",
-        "Material You (Neutral)" to "@android:color/system_neutral1_950",
+        "Material You (Neutral)" to "@android:color/system_neutral1_900",
         "Material You - Primary" to "@android:color/system_accent1_800",
         "Material You - Secondary" to "@android:color/system_accent2_800",
         "Material You - Tertiary" to "@android:color/system_accent3_800",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -45,7 +45,7 @@ val themePatch = baseThemePatch(
             default = "@android:color/white",
             values =  mapOf(
                 "White" to "@android:color/white",
-                "Material You (Neutral)" to "@android:color/system_neutral1_50",
+                "Material You (Neutral)" to "@android:color/system_neutral1_100",
                 "Material You - Primary" to "@android:color/system_accent1_200",
                 "Material You - Secondary" to "@android:color/system_accent2_200",
                 "Material You - Tertiary" to "@android:color/system_accent3_200",


### PR DESCRIPTION
### Description

Closes #216.

### Additional context

Previously, the "Material You" option in the `Theme` patch used `@android:color/system_neutral1`, which is mostly a static dark/light gray and does not heavily reflect the user's actual wallpaper color palette.

This PR replaces the static neutral option with three new dynamic options based on the user's wallpaper palette:
- Material You - Primary (`@android:color/system_accent1`)
- Material You - Secondary (`@android:color/system_accent2`)
- Material You - Tertiary (`@android:color/system_accent3`)

This allows the patched app to natively and dynamically adapt to the user's device theme without requiring a repatch.

| Material You (Neutral) | Material You - Primary| Material You - Secondary | Material You - Teritiary |
|--------|--------|--------|--------|
| ![Screenshot_20260308_145027_YouTube](https://github.com/user-attachments/assets/1f6894c3-7904-420b-9120-e550b2ee46de) | ![Screenshot_20260308_144120_YouTube](https://github.com/user-attachments/assets/039cec5d-703d-406c-9029-8870244111c7) | ![Screenshot_20260308_143520_YouTube](https://github.com/user-attachments/assets/2a787518-dbc6-4668-a721-f4d70df2bca6) | ![Screenshot_20260308_143024_YouTube](https://github.com/user-attachments/assets/5724f110-2f0f-46d5-828b-5dda58172bd5) |
| ![Screenshot_20260308_145040_YouTube](https://github.com/user-attachments/assets/adc98f44-3a6e-4f1a-92fb-0e421dd4f556) | ![Screenshot_20260308_144111_YouTube](https://github.com/user-attachments/assets/cc5a2a9c-b736-4a0d-a0a3-566cab9bc06b) | ![Screenshot_20260308_143529_YouTube](https://github.com/user-attachments/assets/5ca7d92a-bfa5-4024-86fd-224b0d3fd1e0) | ![Screenshot_20260308_143016_YouTube](https://github.com/user-attachments/assets/928b3f93-2a2f-4c2a-9586-7d0497fb43c5) |

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
