### PR TITLE
refactor(YouTube): Rename preference screen `GENERAL_LAYOUT` to `GENERAL`

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -18,7 +18,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_VIDEO_ADS = new BooleanSetting("morphe_music_hide_video_ads", TRUE, true);
     public static final BooleanSetting HIDE_GET_PREMIUM_LABEL = new BooleanSetting("morphe_music_hide_get_premium_label", TRUE, true);
 
-    // General
+    // General (Layout)
     public static final EnumSetting<StartPage> CHANGE_START_PAGE = new EnumSetting<>("morphe_change_start_page", StartPage.DEFAULT, true);
     public static final BooleanSetting HIDE_CAST_BUTTON = new BooleanSetting("morphe_music_hide_cast_button", TRUE, true);
     public static final BooleanSetting HIDE_CATEGORY_BAR = new BooleanSetting("morphe_music_hide_category_bar", FALSE, true);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -295,7 +295,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_PLAYER_FLYOUT_VIDEO_QUALITY = new BooleanSetting("morphe_hide_player_flyout_video_quality", FALSE);
     public static final BooleanSetting HIDE_PLAYER_FLYOUT_WATCH_IN_VR = new BooleanSetting("morphe_hide_player_flyout_watch_in_vr", FALSE);
 
-    // General
+    // General (Layout)
     public static final BooleanSetting DISABLE_LAYOUT_UPDATES = new BooleanSetting("morphe_disable_layout_updates", FALSE, true, "morphe_disable_layout_updates_user_dialog_message");
     public static final BooleanSetting RESTORE_OLD_SETTINGS_MENUS = new BooleanSetting("morphe_restore_old_settings_menus", FALSE, true);
     public static final EnumSetting<FormFactor> CHANGE_FORM_FACTOR = new EnumSetting<>("morphe_change_form_factor", FormFactor.DEFAULT, true, "morphe_change_form_factor_user_dialog_message");

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -295,7 +295,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_PLAYER_FLYOUT_VIDEO_QUALITY = new BooleanSetting("morphe_hide_player_flyout_video_quality", FALSE);
     public static final BooleanSetting HIDE_PLAYER_FLYOUT_WATCH_IN_VR = new BooleanSetting("morphe_hide_player_flyout_watch_in_vr", FALSE);
 
-    // General layout
+    // General
     public static final BooleanSetting DISABLE_LAYOUT_UPDATES = new BooleanSetting("morphe_disable_layout_updates", FALSE, true, "morphe_disable_layout_updates_user_dialog_message");
     public static final BooleanSetting RESTORE_OLD_SETTINGS_MENUS = new BooleanSetting("morphe_restore_old_settings_menus", FALSE, true);
     public static final EnumSetting<FormFactor> CHANGE_FORM_FACTOR = new EnumSetting<>("morphe_change_form_factor", FormFactor.DEFAULT, true, "morphe_change_form_factor_user_dialog_message");

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/quic/DisableQUICProtocolPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/quic/DisableQUICProtocolPatch.kt
@@ -4,10 +4,10 @@ import app.morphe.patches.music.misc.extension.sharedExtensionPatch
 import app.morphe.patches.music.misc.settings.PreferenceScreen
 import app.morphe.patches.music.misc.settings.settingsPatch
 import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
-import app.morphe.patches.shared.misc.quic.disableQuicProtocolPatch
+import app.morphe.patches.shared.misc.quic.disableQUICProtocolPatch
 
 @Suppress("unused")
-val disableQuicProtocolPatchMusic = disableQuicProtocolPatch(
+val disableQUICProtocolPatchMusic = disableQUICProtocolPatch(
     block = {
         dependsOn(
             sharedExtensionPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/quic/DisableQUICProtocolPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/quic/DisableQUICProtocolPatch.kt
@@ -14,7 +14,7 @@ import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 private const val EXTENSION_CLASS_DESCRIPTOR =
     "Lapp/morphe/extension/shared/patches/DisableQUICProtocolPatch;"
 
-internal fun disableQuicProtocolPatch(
+internal fun disableQUICProtocolPatch(
     block: BytecodePatchBuilder.() -> Unit,
     preferenceScreen: BasePreferenceScreen.Screen,
 ) = bytecodePatch(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/dialog/RemoveViewerDiscretionDialogPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/dialog/RemoveViewerDiscretionDialogPatch.kt
@@ -31,7 +31,7 @@ val removeViewerDiscretionDialogPatch = bytecodePatch(
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {
-        PreferenceScreen.GENERAL_LAYOUT.addPreferences(
+        PreferenceScreen.GENERAL.addPreferences(
             SwitchPreference("morphe_remove_viewer_discretion_dialog"),
         )
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/branding/CustomBrandingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/branding/CustomBrandingPatch.kt
@@ -18,7 +18,7 @@ val customBrandingPatch = baseCustomBrandingPatch(
     mainActivityOnCreateFingerprint = YouTubeActivityOnCreateFingerprint,
     mainActivityName = YOUTUBE_MAIN_ACTIVITY_NAME,
     activityAliasNameWithIntents = "com.google.android.youtube.app.honeycomb.Shell\$HomeActivity",
-    preferenceScreen = PreferenceScreen.GENERAL_LAYOUT,
+    preferenceScreen = PreferenceScreen.GENERAL,
 
     block = {
         dependsOn(sharedExtensionPatch)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/branding/header/ChangeHeaderPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/branding/header/ChangeHeaderPatch.kt
@@ -76,7 +76,7 @@ val changeHeaderPatch = baseChangeHeaderPatch(
     variants = variants,
     logoResourceNames = logoResourceNames,
     appendVariantToLogo = true,
-    preferenceScreen = PreferenceScreen.GENERAL_LAYOUT,
+    preferenceScreen = PreferenceScreen.GENERAL,
     block = {
         dependsOn(changeHeaderBytecodePatch)
         compatibleWith(COMPATIBILITY_YOUTUBE)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
@@ -91,7 +91,7 @@ val navigationBarPatch = bytecodePatch(
             navPreferences += SwitchPreference("morphe_disable_translucent_navigation_bar_light")
             navPreferences += SwitchPreference("morphe_disable_translucent_navigation_bar_dark")
 
-            PreferenceScreen.GENERAL_LAYOUT.addPreferences(
+            PreferenceScreen.GENERAL.addPreferences(
                 SwitchPreference("morphe_disable_translucent_status_bar")
             )
 
@@ -100,7 +100,7 @@ val navigationBarPatch = bytecodePatch(
             }
         }
 
-        PreferenceScreen.GENERAL_LAYOUT.addPreferences(
+        PreferenceScreen.GENERAL.addPreferences(
             PreferenceScreenPreference(
                 key = "morphe_navigation_buttons_screen",
                 sorting = Sorting.UNSORTED,
@@ -324,7 +324,7 @@ val navigationBarPatch = bytecodePatch(
             toolbarPreferences += SwitchPreference("morphe_wide_searchbar")
         }
 
-        PreferenceScreen.GENERAL_LAYOUT.addPreferences(
+        PreferenceScreen.GENERAL.addPreferences(
             PreferenceScreenPreference(
                 key = "morphe_toolbar_screen",
                 sorting = Sorting.UNSORTED,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/disableupdates/ChangeFormFactorPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/disableupdates/ChangeFormFactorPatch.kt
@@ -23,7 +23,7 @@ val disableLayoutUpdatesPatch = bytecodePatch(
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {
-        PreferenceScreen.GENERAL_LAYOUT.addPreferences(
+        PreferenceScreen.GENERAL.addPreferences(
             SwitchPreference("morphe_disable_layout_updates")
         )
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/formfactor/ChangeFormFactorPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/formfactor/ChangeFormFactorPatch.kt
@@ -32,7 +32,7 @@ val changeFormFactorPatch = bytecodePatch(
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {
-        PreferenceScreen.GENERAL_LAYOUT.addPreferences(
+        PreferenceScreen.GENERAL.addPreferences(
             ListPreference("morphe_change_form_factor")
         )
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -295,7 +295,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
             )
         }
 
-        PreferenceScreen.GENERAL_LAYOUT.addPreferences(
+        PreferenceScreen.GENERAL.addPreferences(
             PreferenceScreenPreference(
                 key = "morphe_custom_filter_screen",
                 sorting = Sorting.UNSORTED,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/music/OverrideYouTubeMusicActionsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/music/OverrideYouTubeMusicActionsPatch.kt
@@ -57,7 +57,7 @@ val overrideYouTubeMusicActionsPatch = bytecodePatch(
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {
-        PreferenceScreen.GENERAL_LAYOUT.addPreferences(
+        PreferenceScreen.GENERAL.addPreferences(
             PreferenceCategory(
                 titleKey = null,
                 sorting = Sorting.UNSORTED,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/spoofappversion/SpoofAppVersionPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/spoofappversion/SpoofAppVersionPatch.kt
@@ -45,7 +45,7 @@ val spoofAppVersionPatch = bytecodePatch(
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {
-        PreferenceScreen.GENERAL_LAYOUT.addPreferences(
+        PreferenceScreen.GENERAL.addPreferences(
             // Group the switch and list preference together, since General menu is sorted by name
             // and the preferences can be scattered apart with non-English languages.
             PreferenceCategory(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/startpage/ChangeStartPagePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/startpage/ChangeStartPagePatch.kt
@@ -28,7 +28,7 @@ val changeStartPagePatch = bytecodePatch(
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {
-        PreferenceScreen.GENERAL_LAYOUT.addPreferences(
+        PreferenceScreen.GENERAL.addPreferences(
             PreferenceCategory(
                 titleKey = null,
                 sorting = Sorting.UNSORTED,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -190,7 +190,7 @@ val themePatch = baseThemePatch(
     },
 
     executeBlock = {
-        PreferenceScreen.GENERAL_LAYOUT.addPreferences(
+        PreferenceScreen.GENERAL.addPreferences(
             SwitchPreference("morphe_gradient_loading_screen")
         )
 
@@ -218,7 +218,7 @@ val themePatch = baseThemePatch(
         )
 
         if (is_19_47_or_greater) {
-            PreferenceScreen.GENERAL_LAYOUT.addPreferences(
+            PreferenceScreen.GENERAL.addPreferences(
                 ListPreference("morphe_splash_screen_animation_style")
             )
         }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/quic/DisableQUICProtocolPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/quic/DisableQUICProtocolPatch.kt
@@ -1,13 +1,13 @@
 package app.morphe.patches.youtube.misc.quic
 
-import app.morphe.patches.shared.misc.quic.disableQuicProtocolPatch
+import app.morphe.patches.shared.misc.quic.disableQUICProtocolPatch
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 
 @Suppress("unused")
-val disableQuicProtocolPatchYouTube = disableQuicProtocolPatch(
+val disableQUICProtocolPatchYouTube = disableQUICProtocolPatch(
     block = {
         dependsOn(
             sharedExtensionPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/settings/SettingsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/settings/SettingsPatch.kt
@@ -212,16 +212,16 @@ val settingsPatch = bytecodePatch(
         )
 
         if (is_19_34_or_greater) {
-            PreferenceScreen.GENERAL_LAYOUT.addPreferences(
+            PreferenceScreen.GENERAL.addPreferences(
                 SwitchPreference("morphe_restore_old_settings_menus")
             )
         }
 
-        PreferenceScreen.GENERAL_LAYOUT.addPreferences(
+        PreferenceScreen.GENERAL.addPreferences(
             SwitchPreference("morphe_settings_search_history"),
         )
 
-        PreferenceScreen.GENERAL_LAYOUT.addPreferences(
+        PreferenceScreen.GENERAL.addPreferences(
             SwitchPreference("morphe_show_menu_icons")
         )
 
@@ -394,7 +394,7 @@ object PreferenceScreen : BasePreferenceScreen() {
         iconBold = "@drawable/morphe_settings_screen_03_feed_bold",
         layout = "@layout/preference_with_icon",
     )
-    val GENERAL_LAYOUT = Screen(
+    val GENERAL = Screen(
         key = "morphe_settings_screen_04_general",
         summaryKey = null,
         icon = "@drawable/morphe_settings_screen_04_general",


### PR DESCRIPTION
### Description

A simple refactor to rename from `GENERAL_LAYOUT` to `GENERAL`.

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)

