### PR TITLE
fix(YouTube - Hide layout components): Replace "Hide AI comments summary" with "Sanitize category bar"

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/CommentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/CommentsFilter.java
@@ -1,11 +1,25 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ */
+
 package app.morphe.extension.youtube.patches.components;
 
+import androidx.annotation.NonNull;
+
+import java.util.List;
+
+import app.morphe.extension.shared.Logger;
 import app.morphe.extension.youtube.settings.Settings;
 import app.morphe.extension.youtube.shared.PlayerType;
 
 @SuppressWarnings("unused")
-final class CommentsFilter extends Filter {
+public class CommentsFilter extends Filter {
 
+    private static final String CHIP_BAR_PATH_PREFIX = "chip_bar.e";
     private static final String COMMENT_COMPOSER_PATH = "comment_composer.e";
     private static final String VIDEO_LOCKUP_WITH_ATTACHMENT_PATH = "video_lockup_with_attachment.e";
 
@@ -97,5 +111,26 @@ final class CommentsFilter extends Filter {
         }
 
         return true;
+    }
+
+    /**
+     * Injection point.
+     */
+    public static void sanitizeCommentsCategoryBar(@NonNull String identifier,
+                                                   @NonNull List<Object> treeNodeResultList) {
+        try {
+            if (Settings.SANITIZE_COMMENTS_CATEGORY_BAR.get()
+                    && identifier.startsWith(CHIP_BAR_PATH_PREFIX)
+                    // Playlist sort button uses same components and must only filter if the player is opened.
+                    && PlayerType.getCurrent().isMaximizedOrFullscreen()
+            ) {
+                int treeNodeResultListSize = treeNodeResultList.size();
+                if (treeNodeResultListSize > 2) {
+                    treeNodeResultList.subList(1, treeNodeResultListSize - 1).clear();
+                }
+            }
+        } catch (Exception ex) {
+            Logger.printException(() -> "Failed to sanitize comment category bar", ex);
+        }
     }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -240,6 +240,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_COMMENTS_SECTION = new BooleanSetting("morphe_hide_comments_section", FALSE);
     public static final BooleanSetting HIDE_COMMENTS_SECTION_IN_HOME_FEED = new BooleanSetting("morphe_hide_comments_section_in_home_feed", FALSE, parentNot(HIDE_COMMENTS_SECTION));
     public static final BooleanSetting HIDE_COMMENTS_THANKS_BUTTON = new BooleanSetting("morphe_hide_comments_thanks_button", TRUE);
+    public static final BooleanSetting SANITIZE_COMMENTS_CATEGORY_BAR = new BooleanSetting("morphe_sanitize_comments_category_bar", FALSE);
 
     // Description
     public static final BooleanSetting HIDE_AI_GENERATED_VIDEO_SUMMARY_SECTION = new BooleanSetting("morphe_hide_ai_generated_video_summary_section", FALSE);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -35,6 +35,8 @@ import app.morphe.patches.youtube.layout.hide.updatescreen.hideUpdateScreenPatch
 import app.morphe.patches.youtube.misc.engagement.engagementPanelHookPatch
 import app.morphe.patches.youtube.misc.litho.filter.addLithoFilter
 import app.morphe.patches.youtube.misc.litho.filter.lithoFilterPatch
+import app.morphe.patches.youtube.misc.litho.lazily.hookTreeNodeResult
+import app.morphe.patches.youtube.misc.litho.lazily.lazilyConvertedElementHookPatch
 import app.morphe.patches.youtube.misc.navigation.navigationBarHookPatch
 import app.morphe.patches.youtube.misc.playservice.is_20_21_or_greater
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
@@ -126,7 +128,8 @@ val hideLayoutComponentsPatch = bytecodePatch(
         versionCheckPatch,
         resourceMappingPatch,
         hideHorizontalShelvesPatch,
-        hideUpdateScreenPatch
+        hideUpdateScreenPatch,
+        lazilyConvertedElementHookPatch
     )
 
     compatibleWith(COMPATIBILITY_YOUTUBE)
@@ -178,6 +181,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
                     SwitchPreference("morphe_hide_comments_emoji_and_timestamp_buttons"),
                     SwitchPreference("morphe_hide_comments_preview_comment"),
                     SwitchPreference("morphe_hide_comments_thanks_button"),
+                    SwitchPreference("morphe_sanitize_comments_category_bar"),
                 ),
                 sorting = Sorting.UNSORTED,
             ),
@@ -310,6 +314,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
         addLithoFilter(COMMENTS_FILTER_CLASS_NAME)
         addLithoFilter(KEYWORD_FILTER_CLASS_NAME)
         addLithoFilter(CUSTOM_FILTER_CLASS_NAME)
+        hookTreeNodeResult("$COMMENTS_FILTER_CLASS_NAME->sanitizeCommentsCategoryBar")
 
         // region hide mix playlists
 

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -345,6 +345,9 @@ Changes include:
     <string name="morphe_hide_comments_thanks_button_title">Hide Thanks button</string>
     <string name="morphe_hide_comments_thanks_button_summary_on">Thanks button is hidden</string>
     <string name="morphe_hide_comments_thanks_button_summary_off">Thanks button is shown</string>
+    <string name="morphe_sanitize_comments_category_bar_title">Sanitize category bar</string>
+    <string name="morphe_sanitize_comments_category_bar_summary_on">Category buttons except \'Top\' and \'Newest\' are hidden in the comment category bar</string>
+    <string name="morphe_sanitize_comments_category_bar_summary_off">Category buttons are shown in the comment category bar</string>
     <string name="morphe_custom_filter_screen_title">Custom filter</string>
     <string name="morphe_custom_filter_screen_summary">Hide components using custom filters</string>
     <string name="morphe_custom_filter_title">Enable custom filter</string>


### PR DESCRIPTION
### Description

Closes https://github.com/MorpheApp/morphe-patches/issues/710.

### Hide AI comments summary

- Hides only the `Topics` category button in the comment category bar.

- The category bar may be hidden in YouTube 20.22+ (A/B testing?): https://github.com/MorpheApp/morphe-patches/issues/710.

### Sanitize category bar

- Hides all category buttons except `Top` and `Newest` in the comment category bar (Category buttons like `Members` are also hidden).

- Not affected by A/B testing.

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
