### PR TITLE
fix(YouTube - Hide video action buttons): Some action buttons cannot be hidden in YouTube 20.22+

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/VideoActionButtonsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/VideoActionButtonsFilter.java
@@ -1,29 +1,142 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ */
+
 package app.morphe.extension.youtube.patches.components;
 
-import app.morphe.extension.youtube.patches.VersionCheckPatch;
+import app.morphe.extension.youtube.patches.VideoInformation;
 import app.morphe.extension.youtube.settings.Settings;
+import androidx.annotation.GuardedBy;
+import androidx.annotation.NonNull;
+
+import com.google.protobuf.MessageLite;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.youtube.innertube.NextResponseOuterClass.ActionButtons;
+import app.morphe.extension.youtube.innertube.NextResponseOuterClass.SecondaryContents;
+import app.morphe.extension.youtube.innertube.NextResponseOuterClass.SingleColumnWatchNextResults;
+import app.morphe.extension.youtube.innertube.NextResponseOuterClass.NewElement;
 
 @SuppressWarnings("unused")
-final class VideoActionButtonsFilter extends Filter {
-    private static final String COMPACT_CHANNEL_BAR_PATH_PREFIX = "compact_channel_bar.e";
-    private static final String VIDEO_ACTION_BAR_PATH_PREFIX = "video_action_bar.e";
-    private static final String VIDEO_ACTION_BAR_PATH = "video_action_bar.e";
+public class VideoActionButtonsFilter extends Filter {
+
+    public enum ActionButton {
+        UNKNOWN(false),
+        ASK(
+                Settings.HIDE_ASK_BUTTON.get(),
+                "yt_fill_experimental_spark",
+                "yt_fill_spark"
+        ),
+        CHANNEL_PROFILE(false),
+        CLIP(Settings.HIDE_CLIP_BUTTON.get()),
+        COMMENTS(
+                Settings.HIDE_COMMENTS_BUTTON.get(),
+                "yt_outline_experimental_text_bubble",
+                "yt_outline_message_bubble"
+        ),
+        DOWNLOAD(Settings.HIDE_DOWNLOAD_BUTTON.get()),
+        HYPE(
+                Settings.HIDE_HYPE_BUTTON.get(),
+                "yt_outline_experimental_hype",
+                "yt_outline_star_shooting"
+        ),
+        LIKE_DISLIKE(Settings.HIDE_LIKE_DISLIKE_BUTTON.get()),
+        PROMOTE(
+                Settings.HIDE_PROMOTE_BUTTON.get(),
+                "yt_outline_experimental_megaphone",
+                "yt_outline_megaphone"
+        ),
+        REMIX(
+                Settings.HIDE_REMIX_BUTTON.get(),
+                "yt_outline_youtube_shorts_plus",
+                "yt_outline_experimental_remix"
+        ),
+        REPORT(
+                Settings.HIDE_REPORT_BUTTON.get(),
+                "yt_outline_experimental_flag",
+                "yt_outline_flag"
+        ),
+        SAVE(Settings.HIDE_SAVE_BUTTON.get()),
+        SHARE(
+                Settings.HIDE_SHARE_BUTTON.get(),
+                "yt_outline_experimental_share",
+                "yt_outline_share"
+        ),
+        SHOP(
+                Settings.HIDE_SHOP_BUTTON.get(),
+                "yt_outline_experimental_bag",
+                "yt_outline_bag"
+        ),
+        STOP_ADS(
+                Settings.HIDE_STOP_ADS_BUTTON.get(),
+                "yt_outline_experimental_circle_slash",
+                "yt_outline_slash_circle_left"
+        ),
+        THANKS(
+                Settings.HIDE_THANKS_BUTTON.get(),
+                "yt_outline_experimental_dollar_sign_heart",
+                "yt_outline_dollar_sign_heart"
+        );
+
+        public final boolean shouldHide;
+        @NonNull
+        public final List<String> iconNames;
+
+        ActionButton(boolean shouldHide) {
+            this.shouldHide = shouldHide;
+            this.iconNames = Collections.emptyList();
+        }
+
+        ActionButton(boolean shouldHide, @NonNull String... iconNames) {
+            this.shouldHide = shouldHide;
+            this.iconNames = Arrays.asList(iconNames);
+        }
+    }
+
     /**
-     * Video bar path when the video information is collapsed. Seems to shown only with 20.14+
+     * Whether to perform {@link #onLazilyConvertedElementLoaded(String, List)}.
      */
-    private static final String COMPACTIFY_VIDEO_ACTION_BAR_PATH = "compactify_video_action_bar.e";
-    private static final String ANIMATED_VECTOR_TYPE_PATH = "AnimatedVectorType";
+    private static final boolean HIDE_ACTION_BUTTON;
+
+    static {
+        boolean hideActionButton = false;
+        for (ActionButton button : ActionButton.values()) {
+            if (button.shouldHide) {
+                hideActionButton = true;
+                break;
+            }
+        }
+        HIDE_ACTION_BUTTON = hideActionButton;
+    }
+
+    /**
+     * Caches a list of action buttons based on video ID.
+     */
+    @GuardedBy("itself")
+    private static final Map<String, List<ActionButton>> actionButtonLookup =
+            Utils.createSizeRestrictedMap(10);
+
+    private static final String COMPACT_CHANNEL_BAR_PREFIX = "compact_channel_bar.e";
+    private static final String COMPACTIFY_VIDEO_ACTION_BAR_PREFIX = "compactify_video_action_bar.e";
+    private static final String VIDEO_ACTION_BAR_PREFIX = "video_action_bar.e";
 
     private final StringFilterGroup likeSubscribeGlow;
-    private final StringFilterGroup actionBarGroup;
-    private final StringFilterGroup buttonFilterPathGroup;
-    private final StringFilterGroupList accessibilityButtonsGroupList = new StringFilterGroupList();
-    private final ByteArrayFilterGroupList bufferButtonsGroupList = new ByteArrayFilterGroupList();
 
     public VideoActionButtonsFilter() {
-        actionBarGroup = new StringFilterGroup(
-                null,
-                VIDEO_ACTION_BAR_PATH
+        StringFilterGroup actionBarGroup = new StringFilterGroup(
+                Settings.HIDE_ACTION_BAR,
+                VIDEO_ACTION_BAR_PREFIX
         );
         addIdentifierCallbacks(actionBarGroup);
 
@@ -33,143 +146,188 @@ final class VideoActionButtonsFilter extends Filter {
                 "animated_button_border.e"
         );
 
-        buttonFilterPathGroup = new StringFilterGroup(
-                null,
-                "|ContainerType|button.e"
-        );
-
-        addPathCallbacks(
-                likeSubscribeGlow,
-                new StringFilterGroup(
-                        Settings.HIDE_LIKE_DISLIKE_BUTTON,
-                        "|segmented_like_dislike_button"
-                ),
-                new StringFilterGroup(
-                        Settings.HIDE_DOWNLOAD_BUTTON,
-                        "|download_button.e"
-                ),
-                new StringFilterGroup(
-                        Settings.HIDE_SAVE_BUTTON,
-                        "|save_to_playlist_button"
-                ),
-                new StringFilterGroup(
-                        Settings.HIDE_CLIP_BUTTON,
-                        "|clip_button.e"
-                )
-        );
-
-        addPathCallbacks(buttonFilterPathGroup);
-
-        if (VersionCheckPatch.IS_20_22_OR_GREATER) {
-            // FIXME: Most buttons do not have an accessibilityId.
-            //        Instead, they have an accessibilityText, so hiding functionality must be implemented using this
-            //        (e.g. custom filter - 'video_action_bar#Hype')
-            accessibilityButtonsGroupList.addAll(
-                    new StringFilterGroup(
-                            Settings.HIDE_SHARE_BUTTON,
-                            "id.video.share.button"
-                    ),
-                    new StringFilterGroup(
-                            Settings.HIDE_REMIX_BUTTON,
-                            "id.video.remix.button"
-                    )
-            );
-        } else {
-            bufferButtonsGroupList.addAll(
-                    new ByteArrayFilterGroup(
-                            Settings.HIDE_REPORT_BUTTON,
-                            "yt_outline_flag"
-                    ),
-                    new ByteArrayFilterGroup(
-                            Settings.HIDE_SHARE_BUTTON,
-                            "yt_outline_share"
-                    ),
-                    new ByteArrayFilterGroup(
-                            Settings.HIDE_REMIX_BUTTON,
-                            "yt_outline_youtube_shorts_plus"
-                    ),
-                    new ByteArrayFilterGroup(
-                            Settings.HIDE_THANKS_BUTTON,
-                            "yt_outline_dollar_sign_heart"
-                    ),
-                    new ByteArrayFilterGroup(
-                            Settings.HIDE_ASK_BUTTON,
-                            "yt_fill_spark"
-                    ),
-                    new ByteArrayFilterGroup(
-                            Settings.HIDE_SHOP_BUTTON,
-                            "yt_outline_bag"
-                    ),
-                    new ByteArrayFilterGroup(
-                            Settings.HIDE_STOP_ADS_BUTTON,
-                            "yt_outline_slash_circle_left"
-                    ),
-                    new ByteArrayFilterGroup(
-                            Settings.HIDE_COMMENTS_BUTTON,
-                            "yt_outline_message_bubble_right"
-                    ),
-                    // Check for clip button both here and using a path filter,
-                    // as there's a chance the path is a generic action button and won't contain 'clip_button'
-                    new ByteArrayFilterGroup(
-                            Settings.HIDE_CLIP_BUTTON,
-                            "yt_outline_scissors"
-                    ),
-                    new ByteArrayFilterGroup(
-                            Settings.HIDE_HYPE_BUTTON,
-                            "yt_outline_star_shooting"
-                    ),
-                    new ByteArrayFilterGroup(
-                            Settings.HIDE_PROMOTE_BUTTON,
-                            "yt_outline_megaphone"
-                    )
-            );
-        }
-    }
-
-    private boolean isEveryFilterGroupEnabled() {
-        for (var group : pathCallbacks) {
-            if (!group.isEnabled()) return false;
-        }
-
-        var buttonList = VersionCheckPatch.IS_20_22_OR_GREATER
-                ? accessibilityButtonsGroupList
-                : bufferButtonsGroupList;
-        for (var group : buttonList) {
-            if (!group.isEnabled()) return false;
-        }
-
-        return true;
-    }
-
-    private boolean hideButtons(String path, String accessibility, byte[] buffer) {
-        // Make sure the current path is the right one to avoid false positives.
-        if (!path.startsWith(VIDEO_ACTION_BAR_PATH) && !path.startsWith(COMPACTIFY_VIDEO_ACTION_BAR_PATH)) {
-            return false;
-        }
-
-        return VersionCheckPatch.IS_20_22_OR_GREATER
-                ? accessibilityButtonsGroupList.check(accessibility).isFiltered()
-                : bufferButtonsGroupList.check(buffer).isFiltered();
+        addPathCallbacks(likeSubscribeGlow);
     }
 
     @Override
     boolean isFiltered(String identifier, String accessibility, String path, byte[] buffer,
                        StringFilterGroup matchedGroup, FilterContentType contentType, int contentIndex) {
         if (matchedGroup == likeSubscribeGlow) {
-            return path.startsWith(VIDEO_ACTION_BAR_PATH_PREFIX) || path.startsWith(COMPACT_CHANNEL_BAR_PATH_PREFIX)
-                    || path.startsWith(COMPACTIFY_VIDEO_ACTION_BAR_PATH);
-        }
-
-        // If the current matched group is the action bar group,
-        // in case every filter group is enabled, hide the action bar.
-        if (matchedGroup == actionBarGroup) {
-            return isEveryFilterGroupEnabled();
-        }
-
-        if (matchedGroup == buttonFilterPathGroup) {
-            return hideButtons(path, accessibility, buffer);
+            return Utils.startsWithAny(path, COMPACT_CHANNEL_BAR_PREFIX, COMPACTIFY_VIDEO_ACTION_BAR_PREFIX, VIDEO_ACTION_BAR_PREFIX);
         }
 
         return true;
+    }
+
+    /**
+     * Injection point.
+     * Called after {@link #onSingleColumnWatchNextResultsLoaded(MessageLite)}.
+     */
+    public static void onLazilyConvertedElementLoaded(@NonNull String identifier,
+                                                      @NonNull List<Object> treeNodeResultList) {
+        // Check if hide video action buttons is enabled.
+        if (!HIDE_ACTION_BUTTON) {
+            return;
+        }
+        // Check if it is a video action bar.
+        if (!Utils.startsWithAny(identifier, COMPACTIFY_VIDEO_ACTION_BAR_PREFIX, VIDEO_ACTION_BAR_PREFIX)) {
+            return;
+        }
+        synchronized (actionButtonLookup) {
+            // Check if a video action button list exists in actionButtonLookup.
+            String videoId = VideoInformation.getVideoId();
+            List<ActionButton> actionButtons = actionButtonLookup.get(videoId);
+            if (actionButtons == null) {
+                return;
+            }
+
+            // Check that the size of actionButtons matches the size of treeNodeResultList.
+            // If they don't match, unintended buttons may be hidden.
+            int actionButtonSize = actionButtons.size();
+            int treeNodeResultListSize = treeNodeResultList.size();
+            if (actionButtonSize != treeNodeResultListSize) {
+                // Should never happen, but handle just in case.
+                Logger.printDebug(() -> "The sizes of the lists do not match, actionButtonSize: " + actionButtonSize + ", treeNodeResultListSize: " + treeNodeResultListSize);
+                return;
+            }
+
+            // Remove buttons from treeNodeResultList by iterating over actionButtons.
+            for (int i = actionButtonSize - 1; i > -1; i--) {
+                ActionButton actionButton = actionButtons.get(i);
+                if (actionButton.shouldHide && i < treeNodeResultListSize) {
+                    treeNodeResultList.remove(i);
+                }
+            }
+        }
+    }
+
+    /**
+     * Injection point.
+     * Invoke as soon as the endpoint response is received.
+     * <p>
+     * The code to parse the nested innerTube response structure is quite complex,
+     * but due to the efficient parsing performance of the proto parser, the parsing is completed within 20ms.
+     */
+    public static void onSingleColumnWatchNextResultsLoaded(MessageLite messageLite) {
+        // Check if hide video action buttons is enabled.
+        if (!HIDE_ACTION_BUTTON) {
+            return;
+        }
+        synchronized (actionButtonLookup) {
+            try {
+                var singleColumnWatchNextResults = SingleColumnWatchNextResults.parseFrom(messageLite.toByteArray());
+                var primaryResults = singleColumnWatchNextResults.getPrimaryResults();
+                var secondaryResults = primaryResults.getSecondaryResults();
+
+                // Find the contents that have slimVideoMetadataSectionRenderer.
+                SecondaryContents finalSecondaryContents = null;
+                for (var secondaryContents : secondaryResults.getSecondaryContentsList()) {
+                    if (secondaryContents.hasSlimVideoMetadataSectionRenderer()) {
+                        finalSecondaryContents = secondaryContents;
+                        break;
+                    }
+                }
+                if (finalSecondaryContents == null) return;
+
+                var slimVideoMetadataSectionRenderer = finalSecondaryContents.getSlimVideoMetadataSectionRenderer();
+
+                // slimVideoMetadataSectionRenderer has a videoId field.
+                var videoId = slimVideoMetadataSectionRenderer.getVideoId();
+
+                // If there is already an ActionButton list in actionButtonLookup, it just exits.
+                if (actionButtonLookup.containsKey(videoId)) {
+                    return;
+                }
+
+                // Find a NewElement that has a video action bar.
+                NewElement finalNewElement = null;
+                for (var tertiaryContentsList : slimVideoMetadataSectionRenderer.getTertiaryContentsList()) {
+                    var elementRenderer = tertiaryContentsList.getElementRenderer();
+                    var newElement = elementRenderer.getNewElement();
+                    var properties = newElement.getProperties();
+                    var identifierProperties = properties.getIdentifierProperties();
+                    String identifier = identifierProperties.getIdentifier();
+                    if (Utils.startsWithAny(identifier, COMPACTIFY_VIDEO_ACTION_BAR_PREFIX, VIDEO_ACTION_BAR_PREFIX)) {
+                        finalNewElement = newElement;
+                        break;
+                    }
+                }
+                if (finalNewElement == null) return;
+
+                var type = finalNewElement.getType();
+                var componentType = type.getComponentType();
+                var model = componentType.getModel();
+                List<ActionButtons> finalActionButtons = null;
+
+                if (model.hasYoutubeModel()) { // Collapsed video action bar.
+                    var youtubeModel = model.getYoutubeModel();
+                    var viewModel = youtubeModel.getViewModel();
+                    var compactifyVideoActionBarViewModel = viewModel.getCompactifyVideoActionBarViewModel();
+
+                    finalActionButtons = compactifyVideoActionBarViewModel.getActionButtonsList();
+                } else if (model.hasVideoActionBarModel()) { // Non-collapsed video action bar.
+                    var videoActionBarModel = model.getVideoActionBarModel();
+                    var videoActionBarData = videoActionBarModel.getVideoActionBarData();
+
+                    finalActionButtons = videoActionBarData.getActionButtonsList();
+                } else {
+                    // Should never happen, but handle just in case.
+                    Logger.printDebug(() -> "Unknown model: " + model + ", videoId: " + videoId);
+                }
+                if (finalActionButtons == null || finalActionButtons.isEmpty()) return;
+
+                int size = finalActionButtons.size();
+                int i = 0;
+                List<ActionButton> actionButtons = new ArrayList<>(size);
+
+                // Iterate through the action bar and populate the ActionButton list.
+                for (var buttons : finalActionButtons) {
+                    ActionButton actionButton = ActionButton.UNKNOWN;
+                    var primaryButtonViewModel = buttons.getPrimaryButtonViewModel();
+                    if (primaryButtonViewModel.hasSecondaryButtonViewModel()) {
+                        var secondaryButtonViewModel = primaryButtonViewModel.getSecondaryButtonViewModel();
+                        String iconName = secondaryButtonViewModel.getIconName();
+                        if (iconName != null) {
+                            for (ActionButton button : ActionButton.values()) {
+                                if (actionButton == ActionButton.UNKNOWN) {
+                                    for (String icon : button.iconNames) {
+                                        if (iconName.contains(icon)) {
+                                            actionButton = button;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            // This is a new button that has not yet been implemented in settings.
+                            // It will be treated as 'ActionButton.UNKNOWN' and ignored.
+                            if (actionButton == ActionButton.UNKNOWN) {
+                                Logger.printDebug(() -> "Unknown iconName: " + iconName + ", videoId: " + videoId);
+                            }
+                        }
+                    } else if (primaryButtonViewModel.hasAddToPlaylistButtonViewModel()) {
+                        actionButton = ActionButton.SAVE;
+                    } else if (primaryButtonViewModel.hasClipButtonViewModel()) {
+                        actionButton = ActionButton.CLIP;
+                    }  else if (primaryButtonViewModel.hasCompactChannelBarViewModel()) {
+                        actionButton = ActionButton.CHANNEL_PROFILE;
+                    } else if (primaryButtonViewModel.hasDownloadButtonViewModel()) {
+                        actionButton = ActionButton.DOWNLOAD;
+                    } else if (primaryButtonViewModel.hasSegmentedLikeDislikeButtonViewModel()) {
+                        actionButton = ActionButton.LIKE_DISLIKE;
+                    } else {
+                        // Due to A/B testing, a new type of ButtonViewModel was used that was not defined in the proto file.
+                        Logger.printDebug(() -> "Unknown buttonViewModel: " + primaryButtonViewModel + ", videoId: " + videoId);
+                    }
+                    actionButtons.add(i, actionButton);
+                    i++;
+                }
+
+                // Once the iteration is complete, add the ActionButton list to actionButtonLookup.
+                Logger.printDebug(() -> "New video id: " + videoId + ", action buttons: " + actionButtons);
+                actionButtonLookup.put(videoId, actionButtons);
+            } catch (Exception ex) {
+                Logger.printException(() -> "Failed to parse SingleColumnWatchNextResults", ex);
+            }
+        }
     }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -266,20 +266,22 @@ public class Settings extends SharedYouTubeSettings {
 
     // Action buttons
     public static final BooleanSetting DISABLE_LIKE_SUBSCRIBE_GLOW = new BooleanSetting("morphe_disable_like_subscribe_glow", FALSE);
-    public static final BooleanSetting HIDE_ASK_BUTTON = new BooleanSetting("morphe_hide_ask_button", FALSE);
-    public static final BooleanSetting HIDE_CLIP_BUTTON = new BooleanSetting("morphe_hide_clip_button", FALSE, "morphe_hide_clip_button_user_dialog_message");
-    public static final BooleanSetting HIDE_COMMENTS_BUTTON = new BooleanSetting("morphe_hide_comments_button", FALSE);
-    public static final BooleanSetting HIDE_DOWNLOAD_BUTTON = new BooleanSetting("morphe_hide_download_button", FALSE);
-    public static final BooleanSetting HIDE_HYPE_BUTTON = new BooleanSetting("morphe_hide_hype_button", FALSE);
-    public static final BooleanSetting HIDE_LIKE_DISLIKE_BUTTON = new BooleanSetting("morphe_hide_like_dislike_button", FALSE);
-    public static final BooleanSetting HIDE_PROMOTE_BUTTON = new BooleanSetting("morphe_hide_promote_button", FALSE);
-    public static final BooleanSetting HIDE_REMIX_BUTTON = new BooleanSetting("morphe_hide_remix_button", FALSE);
-    public static final BooleanSetting HIDE_REPORT_BUTTON = new BooleanSetting("morphe_hide_report_button", FALSE);
-    public static final BooleanSetting HIDE_SAVE_BUTTON = new BooleanSetting("morphe_hide_save_button", FALSE);
-    public static final BooleanSetting HIDE_SHARE_BUTTON = new BooleanSetting("morphe_hide_share_button", FALSE);
-    public static final BooleanSetting HIDE_SHOP_BUTTON = new BooleanSetting("morphe_hide_shop_button", FALSE);
-    public static final BooleanSetting HIDE_STOP_ADS_BUTTON = new BooleanSetting("morphe_hide_stop_ads_button", FALSE);
-    public static final BooleanSetting HIDE_THANKS_BUTTON = new BooleanSetting("morphe_hide_thanks_button", FALSE);
+    public static final BooleanSetting HIDE_ACTION_BAR = new BooleanSetting("morphe_hide_action_bar", FALSE);
+    public static final BooleanSetting HIDE_ASK_BUTTON = new BooleanSetting("morphe_hide_ask_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_CLIP_BUTTON = new BooleanSetting("morphe_hide_clip_button", FALSE, true,
+            "morphe_hide_clip_button_user_dialog_message", parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_COMMENTS_BUTTON = new BooleanSetting("morphe_hide_comments_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_DOWNLOAD_BUTTON = new BooleanSetting("morphe_hide_download_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_HYPE_BUTTON = new BooleanSetting("morphe_hide_hype_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_LIKE_DISLIKE_BUTTON = new BooleanSetting("morphe_hide_like_dislike_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_PROMOTE_BUTTON = new BooleanSetting("morphe_hide_promote_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_REMIX_BUTTON = new BooleanSetting("morphe_hide_remix_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_REPORT_BUTTON = new BooleanSetting("morphe_hide_report_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_SAVE_BUTTON = new BooleanSetting("morphe_hide_save_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_SHARE_BUTTON = new BooleanSetting("morphe_hide_share_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_SHOP_BUTTON = new BooleanSetting("morphe_hide_shop_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_STOP_ADS_BUTTON = new BooleanSetting("morphe_hide_stop_ads_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_THANKS_BUTTON = new BooleanSetting("morphe_hide_thanks_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
 
     // Player flyout menu items
     public static final BooleanSetting HIDE_PLAYER_FLYOUT_ADDITIONAL_SETTINGS = new BooleanSetting("morphe_hide_player_flyout_additional_settings", FALSE);

--- a/extensions/youtube/src/main/proto/app/morphe/extension/youtube/innertube/next_response.proto
+++ b/extensions/youtube/src/main/proto/app/morphe/extension/youtube/innertube/next_response.proto
@@ -27,14 +27,155 @@ message SecondaryResults {
 
 message SecondaryContents {
     oneof data {
+        SlimVideoMetadataSectionRenderer slimVideoMetadataSectionRenderer = 216561405;
         ItemSectionRenderer itemSectionRenderer = 50195462;
         ShelfRenderer shelfRenderer = 51845067;
     }
 }
 
+message SlimVideoMetadataSectionRenderer {
+    repeated TertiaryContents tertiaryContents = 1;
+    string videoId = 2;
+}
+
 message ItemSectionRenderer {
+    repeated TertiaryContents tertiaryContents = 1;
     string sectionIdentifier = 7;
 }
 
 message ShelfRenderer {
+    Content content = 5;
+}
+
+message Content {
+    HorizontalListRenderer horizontalListRenderer = 51431404;
+}
+
+message HorizontalListRenderer {
+    int32 visibleItemCount = 7;
+}
+
+message TertiaryContents {
+    ElementRenderer elementRenderer = 153515154;
+}
+
+message ElementRenderer {
+    NewElement newElement = 172660663;
+}
+
+message NewElement {
+    Type type = 1;
+    Properties properties = 2;
+}
+
+message Properties {
+    IdentifierProperties identifierProperties = 183314536;
+}
+
+message IdentifierProperties {
+    string identifier = 1; // litho identifier
+}
+
+message Type {
+    ComponentType componentType = 168777401;
+}
+
+message ComponentType {
+    Model model = 5;
+}
+
+message Model {
+    oneof data {
+        VideoActionBarModel videoActionBarModel = 389155117;
+        VideoMetadataCarouselModel videoMetadataCarouselModel = 408379376;
+        YoutubeModel youtubeModel = 413471385;
+    }
+}
+
+// region video metadata carousel
+
+message VideoMetadataCarouselModel {
+    Data data = 1;
+}
+
+message Data {
+    repeated CarouselTitleDatas carouselTitleDatas = 1;
+    repeated CarouselItemDatas carouselItemDatas = 2;
+}
+
+message CarouselTitleDatas {
+    string title = 1;
+}
+
+message CarouselItemDatas {
+}
+
+// endregion
+
+// region collapsed video action bar
+
+message YoutubeModel {
+    ViewModel viewModel = 1;
+}
+
+message ViewModel {
+    CompactifyVideoActionBarViewModel compactifyVideoActionBarViewModel = 2185;
+}
+
+message CompactifyVideoActionBarViewModel {
+    repeated ActionButtons actionButtons = 1;
+}
+
+// endregion
+
+// region non-collapsed video action bar
+
+message VideoActionBarModel {
+    VideoActionBarData videoActionBarData = 17;
+}
+
+message VideoActionBarData {
+    repeated ActionButtons actionButtons = 1;
+}
+
+// endregion
+
+message ActionButtons {
+    PrimaryButtonViewModel primaryButtonViewModel = 10;
+}
+
+message PrimaryButtonViewModel {
+    oneof data {
+        AddToPlaylistButtonViewModel addToPlaylistButtonViewModel = 484598023;
+        SecondaryButtonViewModel secondaryButtonViewModel = 461054335;
+        ClipButtonViewModel clipButtonViewModel = 490025863;
+        CompactChannelBarViewModel compactChannelBarViewModel = 1107;
+        DownloadButtonViewModel downloadButtonViewModel = 33561776;
+        SegmentedLikeDislikeButtonViewModel segmentedLikeDislikeButtonViewModel = 484586709;
+    }
+}
+
+message AddToPlaylistButtonViewModel {
+    string addToPlaylistEntityKey = 2;
+}
+
+message SecondaryButtonViewModel {
+    string iconName = 2;
+    optional string accessibilityId = 17;
+}
+
+message ClipButtonViewModel {
+    string videoActionButtonEnablementEntityKey = 2;
+}
+
+message CompactChannelBarViewModel {
+    bool enableCompactChannelBarInnerRefactor = 29;
+}
+
+message DownloadButtonViewModel {
+    string videoId = 1;
+}
+
+message SegmentedLikeDislikeButtonViewModel {
+    string teasersOrderEntityKey = 10;
 }

--- a/patches/src/main/kotlin/app/morphe/patches/shared/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/Fingerprints.kt
@@ -32,10 +32,3 @@ internal object BoldIconsFeatureFlagFingerprint : Fingerprint(
         literal(45685201L)
     )
 )
-
-internal object ProtobufClassParseByteArrayFingerprint : Fingerprint(
-    name = "parseFrom",
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
-    returnType = "L",
-    parameters = listOf("L", "[B")
-)

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/fix/proto/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/fix/proto/Fingerprints.kt
@@ -1,7 +1,15 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ */
+
 package app.morphe.patches.shared.misc.fix.proto
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.opcode
 import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
 
 internal object EmptyRegistryFingerprint : Fingerprint(
     definingClass = "Lcom/google/protobuf/ExtensionRegistryLite;",
@@ -17,4 +25,30 @@ internal object MessageLiteWriteToFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.ABSTRACT),
     parameters = listOf("L"),
     returnType = "V"
+)
+
+internal object ProtobufClassParseByteArrayFingerprint : Fingerprint(
+    name = "parseFrom",
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
+    returnType = "L",
+    parameters = listOf("L", "[B")
+)
+
+internal object StreamingDataOuterClassFingerprint : Fingerprint(
+    definingClass = "Lcom/google/protos/youtube/api/innertube/StreamingDataOuterClass\$StreamingData;",
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf(),
+    filters = listOf(
+        methodCall(
+            opcode = Opcode.INVOKE_INTERFACE,
+            parameters = listOf(),
+            returnType = "Z"
+        ),
+        opcode(Opcode.IF_NEZ),
+        methodCall(
+            opcode = Opcode.INVOKE_STATIC,
+            name = "mutableCopy"
+        )
+    )
 )

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/fix/proto/FixProtoLibraryPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/fix/proto/FixProtoLibraryPatch.kt
@@ -1,20 +1,38 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ */
+
 package app.morphe.patches.shared.misc.fix.proto
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
 import app.morphe.util.cloneMutable
+import app.morphe.util.getReference
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
 import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
+import java.lang.ref.WeakReference
+
+internal lateinit var parseByteArrayMethod: MutableMethod
+
+internal lateinit var immutableMethodRef : WeakReference<MethodReference>
+internal lateinit var mutableCopyMethodRef : WeakReference<MethodReference>
 
 /**
  * Some classes that exist in YouTube are not merged.
  * Instead of relocating all classes in the extension,
  * Only the methods necessary for the patch to function are added.
  */
-internal val fixProtoLibraryPatch = bytecodePatch{
+internal val fixProtoLibraryPatch = bytecodePatch(
+    description = "Fix method not found exception that can occur when proto libraries used in extensions are merged."
+) {
     execute {
         EmptyRegistryFingerprint.let {
             it.method.apply {
@@ -55,6 +73,23 @@ internal val fixProtoLibraryPatch = bytecodePatch{
                         )
                     )
                 )
+            }
+        }
+
+        parseByteArrayMethod = ProtobufClassParseByteArrayFingerprint.method
+
+        StreamingDataOuterClassFingerprint.let {
+            it.method.apply {
+                val immutableMethodIndex = it.instructionMatches.first().index
+                val mutableCopyMethodIndex = it.instructionMatches.last().index
+
+                val immutableMethodReference =
+                    getInstruction<ReferenceInstruction>(immutableMethodIndex).reference as MethodReference
+                val mutableCopyMethodReference =
+                    getInstruction<ReferenceInstruction>(mutableCopyMethodIndex).reference as MethodReference
+
+                immutableMethodRef = WeakReference(immutableMethodReference)
+                mutableCopyMethodRef = WeakReference(mutableCopyMethodReference)
             }
         }
     }

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/SpoofVideoStreamsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/SpoofVideoStreamsPatch.kt
@@ -20,8 +20,8 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.rawResourcePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
-import app.morphe.patches.shared.ProtobufClassParseByteArrayFingerprint
 import app.morphe.patches.shared.misc.fix.proto.fixProtoLibraryPatch
+import app.morphe.patches.shared.misc.fix.proto.parseByteArrayMethod
 import app.morphe.util.ResourceGroup
 import app.morphe.util.copyResources
 import app.morphe.util.findFreeRegister
@@ -215,7 +215,6 @@ internal fun spoofVideoStreamsPatch(
                     "$resultMethodType->$setStreamDataMethodName($videoDetailsClass)V",
             )
 
-            val parseByteArrayMethod = ProtobufClassParseByteArrayFingerprint.method
             val setStreamingDataIndex = CreateStreamingDataFingerprint.instructionMatches.first().index
 
             val playerProtoClass = getInstruction(setStreamingDataIndex + 1)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/HideVideoActionButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/HideVideoActionButtonsPatch.kt
@@ -1,64 +1,91 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ */
+
 package app.morphe.patches.youtube.layout.buttons.action
 
-import app.morphe.patcher.patch.resourcePatch
-import app.morphe.patches.shared.misc.mapping.resourceMappingPatch
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.misc.fix.proto.fixProtoLibraryPatch
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.litho.filter.addLithoFilter
 import app.morphe.patches.youtube.misc.litho.filter.lithoFilterPatch
-import app.morphe.patches.youtube.misc.playservice.is_20_22_or_greater
-import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
+import app.morphe.patches.youtube.misc.litho.lazily.hookTreeNodeResult
+import app.morphe.patches.youtube.misc.litho.lazily.lazilyConvertedElementHookPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
+import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
+import app.morphe.patches.youtube.shared.WatchNextResponseParserFingerprint
+import app.morphe.patches.youtube.video.information.videoInformationPatch
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+
+private const val FILTER_CLASS_DESCRIPTOR =
+    "Lapp/morphe/extension/youtube/patches/components/VideoActionButtonsFilter;"
 
 @Suppress("unused")
-val hideVideoActionButtonsPatch = resourcePatch(
+val hideVideoActionButtonsPatch = bytecodePatch(
     name = "Hide video action buttons",
-    description = "Adds options to hide action buttons (such as the Download button) under videos. " +
-            "Patching version 20.21.37 or lower can hide more player button types."
+    description = "Adds options to hide action buttons (such as the Download button) under videos."
 ) {
     dependsOn(
-        resourceMappingPatch,
+        settingsPatch,
+        sharedExtensionPatch,
         lithoFilterPatch,
-        versionCheckPatch,
+        lazilyConvertedElementHookPatch,
+        fixProtoLibraryPatch,
+        videoInformationPatch,
     )
 
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {
-        val preferences = mutableSetOf(
-            SwitchPreference("morphe_disable_like_subscribe_glow"),
-            SwitchPreference("morphe_hide_download_button"),
-            SwitchPreference("morphe_hide_like_dislike_button"),
-            SwitchPreference("morphe_hide_comments_button"),
-            SwitchPreference("morphe_hide_clip_button"),
-            SwitchPreference("morphe_hide_save_button"),
-            SwitchPreference("morphe_hide_remix_button"),
-            SwitchPreference("morphe_hide_share_button"),
-        )
-
-        // 20.22+ cannot hide all action buttons because of buffer changes.
-        if (!is_20_22_or_greater) {
-            preferences.addAll(
-                listOf(
-                    SwitchPreference("morphe_hide_hype_button"),
+        PreferenceScreen.PLAYER.addPreferences(
+            PreferenceScreenPreference(
+                key = "morphe_hide_buttons_screen",
+                preferences = setOf(
+                    SwitchPreference("morphe_disable_like_subscribe_glow"),
+                    SwitchPreference("morphe_hide_action_bar"),
                     SwitchPreference("morphe_hide_ask_button"),
+                    SwitchPreference("morphe_hide_clip_button"),
+                    SwitchPreference("morphe_hide_comments_button"),
+                    SwitchPreference("morphe_hide_download_button"),
+                    SwitchPreference("morphe_hide_hype_button"),
+                    SwitchPreference("morphe_hide_like_dislike_button"),
                     SwitchPreference("morphe_hide_promote_button"),
+                    SwitchPreference("morphe_hide_remix_button"),
                     SwitchPreference("morphe_hide_report_button"),
+                    SwitchPreference("morphe_hide_save_button"),
+                    SwitchPreference("morphe_hide_share_button"),
                     SwitchPreference("morphe_hide_shop_button"),
                     SwitchPreference("morphe_hide_stop_ads_button"),
                     SwitchPreference("morphe_hide_thanks_button"),
                 )
             )
-        }
-
-        PreferenceScreen.PLAYER.addPreferences(
-            PreferenceScreenPreference(
-                "morphe_hide_buttons_screen",
-                preferences = preferences
-            )
         )
 
-        addLithoFilter("Lapp/morphe/extension/youtube/patches/components/VideoActionButtonsFilter;")
+        addLithoFilter(FILTER_CLASS_DESCRIPTOR)
+
+        hookTreeNodeResult("$FILTER_CLASS_DESCRIPTOR->onLazilyConvertedElementLoaded")
+
+        WatchNextResponseParserFingerprint.let {
+            it.clearMatch() // Fingerprint is shared and indexes may no longer be correct.
+            it.method.apply {
+                val index = it.instructionMatches[5].index
+                val register = getInstruction<OneRegisterInstruction>(index).registerA
+
+                addInstruction(
+                    index + 1,
+                    "invoke-static { v$register }, $FILTER_CLASS_DESCRIPTOR->" +
+                            "onSingleColumnWatchNextResultsLoaded(Lcom/google/protobuf/MessageLite;)V"
+                )
+            }
+        }
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/Fingerprints.kt
@@ -315,22 +315,3 @@ internal object SettingIntentFingerprint : Fingerprint(
         )
     )
 )
-
-internal object StreamingDataOuterClassFingerprint : Fingerprint(
-    definingClass = "Lcom/google/protos/youtube/api/innertube/StreamingDataOuterClass\$StreamingData;",
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
-    returnType = "V",
-    parameters = listOf(),
-    filters = listOf(
-        methodCall(
-            opcode = Opcode.INVOKE_INTERFACE,
-            parameters = listOf(),
-            returnType = "Z"
-        ),
-        opcode(Opcode.IF_NEZ),
-        methodCall(
-            opcode = Opcode.INVOKE_STATIC,
-            name = "mutableCopy"
-        )
-    )
-)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
@@ -16,8 +16,10 @@ import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
-import app.morphe.patches.shared.ProtobufClassParseByteArrayFingerprint
 import app.morphe.patches.shared.misc.fix.proto.fixProtoLibraryPatch
+import app.morphe.patches.shared.misc.fix.proto.immutableMethodRef
+import app.morphe.patches.shared.misc.fix.proto.mutableCopyMethodRef
+import app.morphe.patches.shared.misc.fix.proto.parseByteArrayMethod
 import app.morphe.patches.shared.misc.settings.preference.ListPreference
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference.Sorting
@@ -229,8 +231,6 @@ val navigationBarPatch = bytecodePatch(
                 )
             }
         }
-
-        val parseByteArrayMethod = ProtobufClassParseByteArrayFingerprint.method
 
         PivotBarRendererFingerprint.let {
             it.method.apply {
@@ -530,14 +530,6 @@ val navigationBarPatch = bytecodePatch(
             }
         }
 
-        val (immutableMethod, mutableCopyMethod) =
-            with (StreamingDataOuterClassFingerprint.instructionMatches) {
-                Pair(
-                    first().instruction.getReference<MethodReference>()!!,
-                    last().instruction.getReference<MethodReference>()!!
-                )
-            }
-
         TopBarRendererSecondaryFilterFingerprint.let {
             it.method.apply {
                 val protoListIndex = it.instructionMatches.first().index
@@ -549,14 +541,14 @@ val navigationBarPatch = bytecodePatch(
                 addInstructionsWithLabels(
                     protoListIndex,
                     """
-                        invoke-interface { v$protoListRegister }, $immutableMethod
+                        invoke-interface { v$protoListRegister }, ${immutableMethodRef.get()}
                         move-result v$protoListFreeRegister
                         
                         # Check if ProtoList is immutable or not.
                         if-nez v$protoListFreeRegister, :immutable
                         
                         # If mutable, copy the ProtoList.
-                        invoke-static { v$protoListRegister }, $mutableCopyMethod
+                        invoke-static { v$protoListRegister }, ${mutableCopyMethodRef.get()}
                         move-result-object v$protoListRegister
                         
                         # Rearrange buttons.

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/relatedvideos/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/relatedvideos/Fingerprints.kt
@@ -6,34 +6,13 @@
 package app.morphe.patches.youtube.layout.hide.relatedvideos
 
 import app.morphe.patcher.Fingerprint
-import app.morphe.patcher.InstructionLocation.MatchAfterImmediately
 import app.morphe.patcher.InstructionLocation.MatchAfterWithin
 import app.morphe.patcher.fieldAccess
-import app.morphe.patcher.literal
 import app.morphe.patcher.methodCall
 import app.morphe.patcher.opcode
 import app.morphe.patcher.string
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
-
-internal object StreamingDataOuterClassFingerprint : Fingerprint(
-    definingClass = "Lcom/google/protos/youtube/api/innertube/StreamingDataOuterClass\$StreamingData;",
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
-    returnType = "V",
-    parameters = listOf(),
-    filters = listOf(
-        methodCall(
-            opcode = Opcode.INVOKE_INTERFACE,
-            parameters = listOf(),
-            returnType = "Z"
-        ),
-        opcode(Opcode.IF_NEZ),
-        methodCall(
-            opcode = Opcode.INVOKE_STATIC,
-            name = "mutableCopy"
-        )
-    )
-)
 
 internal object RelatedItemSectionFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
@@ -66,30 +45,5 @@ internal object WatchNextResponseModelClassResolverFingerprint : Fingerprint(
             opcode = Opcode.CHECK_CAST,
             location = MatchAfterWithin(3)
         )
-    )
-)
-
-internal object WatchNextResponseParserFingerprint : Fingerprint(
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
-    parameters = listOf("Ljava/lang/Object;"),
-    returnType = "Ljava/util/List;",
-    filters = listOf(
-        literal(49399797L),
-        opcode(Opcode.SGET_OBJECT),
-        fieldAccess(
-            opcode = Opcode.IGET_OBJECT,
-            location = MatchAfterImmediately()
-        ),
-        literal(51779735L),
-        fieldAccess(
-            opcode = Opcode.IGET_OBJECT,
-            type = "Ljava/lang/Object;",
-            location = MatchAfterWithin(5)
-        ),
-        opcode(
-            Opcode.CHECK_CAST,
-            location = MatchAfterImmediately()
-        ),
-        literal(46659098L),
     )
 )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/relatedvideos/HideRelatedVideosPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/relatedvideos/HideRelatedVideosPatch.kt
@@ -15,11 +15,14 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.string
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
 import app.morphe.patches.shared.misc.fix.proto.fixProtoLibraryPatch
+import app.morphe.patches.shared.misc.fix.proto.immutableMethodRef
+import app.morphe.patches.shared.misc.fix.proto.mutableCopyMethodRef
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
+import app.morphe.patches.youtube.shared.WatchNextResponseParserFingerprint
 import app.morphe.util.getReference
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
@@ -52,7 +55,7 @@ val hideRelatedVideosPatch = bytecodePatch(
         )
 
         val continuationsField = with (WatchNextResponseParserFingerprint) {
-            clearMatch()
+            clearMatch() // Fingerprint is shared and indexes may no longer be correct.
             instructionMatches[2].instruction.getReference<FieldReference>()!!
         }
         val resultsClass = continuationsField.definingClass
@@ -83,14 +86,6 @@ val hideRelatedVideosPatch = bytecodePatch(
 
         val sectionIdentifierField = RelatedItemSectionFingerprint
             .instructionMatches[1].instruction.getReference<FieldReference>()!!
-
-        val (immutableMethod, mutableCopyMethod) =
-            with (StreamingDataOuterClassFingerprint.instructionMatches) {
-                Pair(
-                    first().instruction.getReference<MethodReference>()!!,
-                    last().instruction.getReference<MethodReference>()!!
-                )
-            }
 
         val watchNextResponseModelClass = WatchNextResponseModelClassResolverFingerprint
             .instructionMatches.last().instruction.getReference<TypeReference>()!!.type
@@ -166,14 +161,14 @@ val hideRelatedVideosPatch = bytecodePatch(
 
                             if-eqz v0, :ignore
                             iget-object v0, p1, $contentsField
-                            invoke-interface { v0 }, $immutableMethod
+                            invoke-interface { v0 }, ${immutableMethodRef.get()}
                             move-result v1
 
                             # Check if ProtoList is immutable or not.
                             if-nez v1, :ignore
                             
                             # If mutable, copy the ProtoList.
-                            invoke-static { v0 }, $mutableCopyMethod
+                            invoke-static { v0 }, ${mutableCopyMethodRef.get()}
                             move-result-object v0
                             
                             invoke-interface { v0 }, Ljava/util/List;->iterator()Ljava/util/Iterator;

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/shared/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/shared/Fingerprints.kt
@@ -199,3 +199,28 @@ internal object VideoQualityChangedFingerprint : Fingerprint(
         )
     )
 )
+
+internal object WatchNextResponseParserFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    parameters = listOf("Ljava/lang/Object;"),
+    returnType = "Ljava/util/List;",
+    filters = listOf(
+        literal(49399797L),
+        opcode(Opcode.SGET_OBJECT),
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            location = MatchAfterImmediately()
+        ),
+        literal(51779735L),
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            type = "Ljava/lang/Object;",
+            location = MatchAfterWithin(5)
+        ),
+        opcode(
+            Opcode.CHECK_CAST,
+            location = MatchAfterImmediately()
+        ),
+        literal(46659098L),
+    )
+)

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -577,6 +577,9 @@ Adjust volume by swiping vertically on the right side of the screen"</string>
     <string name="morphe_disable_like_subscribe_glow_title">Disable Like and Subscribe glow</string>
     <string name="morphe_disable_like_subscribe_glow_summary_on">Like and Subscribe button will not glow when mentioned</string>
     <string name="morphe_disable_like_subscribe_glow_summary_off">Like and Subscribe button will glow when mentioned</string>
+    <string name="morphe_hide_action_bar_title">Hide action bar</string>
+    <string name="morphe_hide_action_bar_summary_on">Action bar is hidden</string>
+    <string name="morphe_hide_action_bar_summary_off">Action bar is shown</string>
     <string name="morphe_hide_like_dislike_button_title">Hide Like and Dislike</string>
     <string name="morphe_hide_like_dislike_button_summary_on">Like and Dislike buttons are hidden</string>
     <string name="morphe_hide_like_dislike_button_summary_off">Like and Dislike buttons are shown</string>


### PR DESCRIPTION
### Hiding video action buttons like Ask, Hype, Report, and Thanks is now supported in YouTube 20.22+

- Starting with YouTube 20.22, the way apps read proto buffers has changed.

- For this reason, hiding some action buttons has not been available in YouTube 20.22+ until now.

- As a workaround, I spent about a week writing a proto file to parse the `/next` endpoint response, and the patch is now supported regardless of YouTube version.

- Closes https://github.com/MorpheApp/morphe-patches/issues/102.

### [Hiding action buttons leaves empty space](https://github.com/inotia00/ReVanced_Extended/issues/17) that hasn't been fixed for about 4 years has finally been fixed

#### Before
<img width="810" height="106" alt="before_pr" src="https://github.com/user-attachments/assets/14c4a304-a843-4557-ae4d-8d5f12efd4ce" />

#### After
<img width="810" height="106" alt="after_pr" src="https://github.com/user-attachments/assets/96e38161-1be9-49ec-976b-1e2f9a1da4d3" />

- While [the issue was opened in the RVX issue repo](https://github.com/inotia00/ReVanced_Extended/issues/17) in November 2022, the `Hide action buttons` patch was first implemented in Vanced Extended around June 2022 (with help from @0xrxl), and the issue has been around since then.

- Personally, I'm satisfied that the proto parser has solved an issue that I couldn't fix for about 4 years.

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
