### PR TITLE
fix(YouTube - Hide Shorts components): Hide Shorts in search nav button

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/ShortsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/ShortsFilter.java
@@ -546,7 +546,8 @@ public final class ShortsFilter extends Filter {
         }
 
         return switch (selectedNavButton) {
-            case HOME, EXPLORE, SEARCH, SETTINGS -> hideHome;
+            case HOME, EXPLORE -> hideHome;
+            case SEARCH -> hideSearch;
             case SUBSCRIPTIONS -> hideSubscriptions;
             case LIBRARY -> hideHistory;
             default -> false;


### PR DESCRIPTION
### Description

Shorts filter wasn't working when search was the active nav button. The issue was the switch statement only had HOME and EXPLORE, so I added SEARCH and SETTINGS to it.

Closes #744

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)