### PR TITLE
fix(YouTube - Hide Shorts components): Hide Shorts shelf hides autoplaying videos in the feed

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/ShortsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/ShortsFilter.java
@@ -32,10 +32,6 @@ import kotlin.Unit;
 public final class ShortsFilter extends Filter {
     private static final boolean HIDE_SHORTS_NAVIGATION_BAR = Settings.HIDE_SHORTS_NAVIGATION_BAR.get();
     private static final String COMPONENT_TYPE = "ComponentType";
-    private static final String[] REEL_ACTION_BAR_PATHS = {
-            "reel_action_bar.", // Regular Shorts.
-            "reels_player_overlay_layout." // Shorts ads.
-    };
     private final String REEL_CHANNEL_BAR_PATH = "reel_channel_bar.e";
 
     /**
@@ -516,6 +512,16 @@ public final class ShortsFilter extends Filter {
         final boolean hideHistory = Settings.HIDE_SHORTS_HISTORY.get();
 
         if (!hideHome && !hideSubscriptions && !hideSearch && !hideVideoDescription && !hideHistory) {
+            return false;
+        }
+        // The litho path of the feed video is 'video_lockup_with_attachment.e'.
+        // It appears [shortsCompactFeedVideoBuffer] is used after 20 seconds during autoplay in the feed in YouTube 20.44.38.
+        // If the Shorts shelf is hidden on the Home feed, the video in the feed will be hidden after 20 seconds have passed since autoplay began in the feed.
+        // See: https://github.com/MorpheApp/morphe-patches/issues/773.
+        //
+        // When a video is autoplaying in the feed, no new components are drawn on the screen.
+        // Therefore, filtering is skipped when the current PlayerType is [INLINE_MINIMAL].
+        if (PlayerType.getCurrent() == PlayerType.INLINE_MINIMAL) {
             return false;
         }
         if (hideHome && hideSubscriptions && hideSearch && hideVideoDescription && hideHistory) {


### PR DESCRIPTION
### Description

Closes https://github.com/MorpheApp/morphe-patches/issues/773.

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
