### PR TITLE
fix(YouTube - Hide Shorts components): Resolve "Hide 'Use this sound' button" and "Hide 'Use this template' button" not working

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/ShortsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/ShortsFilter.java
@@ -272,23 +272,27 @@ public final class ShortsFilter extends Filter {
                 // through the "Short remixing this video" section.
                 "floating_action_button.e",
                 // Second filter needed for "Use this sound" that can appear below the video title.
-                REEL_METAPANEL_PATH
+                REEL_METAPANEL_PATH,
+                REEL_PLAYER_OVERLAY_PATH
         );
 
         useSoundButtonBuffer = new ByteArrayFilterGroup(
                 null,
-                "yt_outline_camera_"
+                "yt_outline_camera_",
+                "yt_outline_experimental_camera_"
         );
 
         useTemplateButton = new StringFilterGroup(
                 Settings.HIDE_SHORTS_USE_TEMPLATE_BUTTON,
                 // Second filter needed for "Use this template" that can appear below the video title.
-                REEL_METAPANEL_PATH
+                REEL_METAPANEL_PATH,
+                REEL_PLAYER_OVERLAY_PATH
         );
 
         useTemplateButtonBuffer = new ByteArrayFilterGroup(
                 null,
-                "yt_outline_template_add_"
+                "yt_outline_template_add_",
+                "yt_outline_experimental_template_add_"
         );
 
         shortsActionButton = new StringFilterGroup(


### PR DESCRIPTION
### Description

Closes #783.

### Additional context

```kotlin
03-12 00:30:31.176 17956 17956 D morphe: LithoFilterPatch: Searching ID: floating_action_button.eml-fe|a30a4279ae937e81 Path: floating_action_button.eml-fe|a30a4279ae937e81|ContainerType| BufferStrings: button.eml-fe|ab72e9fa6342fc10*❙'yt_outline_experimental_camera_black_18"❙Shortj❙CAQ%3D❙gOwTw4LzfxEX❙*22AMBqgQCCAHgBgHCBxUBO2AyImBOfPNxszJevspektD44QI%3DZ❙Use this sound8❙Use this sound2❙sans-serif❙theme|7ab0a914963d1eb3❙333?❙dismiss❙$KEN_BURNS_ANIMATION_TYPE_UNSPECIFIED❙capabilities|793a39b3cf64d3612❙theme|7ab0a914963d1eb3❙capabilities|793a39b3cf64d361❙theme|7ab0a914963d1eb3❙capabilities|793a39b3cf64d361❙
03-12 00:33:36.846 17956 17956 D morphe: LithoFilterPatch: Searching ID: reel_player_overlay.eml-fe|3bbc2014e99ef098 Path: reel_player_overlay.eml-fe|3bbc2014e99ef098|ContainerType|ContainerType| BufferStrings: 'reel_action_bar.eml-fe|4bdb7810f4e94e52*❙"yt_delhi_thumbs_up_not_filled_24dp❙609"w❙1qz0mF1kJQQ24Cg0KCzFxejBtRjFrSlFRIAAoATILCIj5xs0GEPnNkUs4BA%3D%3D*+like this video along with 609 other people8❙id.reel_like_button❙yt_delhi_thumbs_up_filled_24dp❙610"w❙1qz0mF1kJQQB4Cg0KCzFxejBtRjFrSlFRGAAgASoLCIj5xs0GEK7akUswBA%3D%3D*❙610 likes8❙id.reel_like_toggled_button❙EgsxcXowbUYxa0pRUSA-KAE%3D2❙EgsxcXowbUYxa0pRUSA-KAE%3D❙$yt_delhi_thumbs_down_not_filled_24dp❙Dislike"w❙1qz0mF1kJQQ:4Cg0KCzFxejBtRjFrSlFREAAYASILCIj5xs0GEJrVkUsoBA%3D%3D*❙Dislike this video8❙id.reel_dislike_button❙ yt_delhi_thumbs_down_filled_24dp❙Dislike"w❙1qz0mF1kJQQB4Cg0KCzFxejBtRjFrSlFRGAAgASoLCIj5xs0GEK7akUswBA%3D%3D*❙Dislike this video8❙id.reel_dislike_toggled_button❙EgsxcXowbUYxa0pRUSA-KAE%3D❙EgsxcXowbUYxa0pRUSA-KAE%3D❙yt_delhi_comment_24dp❙shorts-comments-panel*❙View comments8❙id.reel_comment_button❙yt_delhi_share_24dp❙Share"❙ss_2C5gAglHKvjkYkhJ*❙^CgsxcXowbUYxa0pRUVICCAJiLiIsCgsxcXowbUYxa0pRUTILZ093VHc0THpmeEU6DgigmQISCAg3EMC72bACSAGgAQM%3D❙ss_2C5gAglHKvjkYkhJJ❙Share this video8❙id.reel_share_button❙Share❙yt_delhi_remix_24dp❙282"❙Use this sound❙Shortj❙CAkQucD9t8HwuL3TAQ%3D%3D❙gOwTw4LzfxE❙*22AMBqgQCCAHgBgHCBxUBO2AyImBOfPNxszJevspektD44QI%3DB❙1qz0mF1kJQQP❙Use this template❙Shortj❙gOwTw4LzfxE❙1qz0mF1kJQQ❙effects_expansion* ❙1qz0mF1kJQQ❙effects_expansion❙Collab❙Shortj❙CAcQucD9t8HwuL3TAQ%3D%3D❙1qz0mF1kJQQ❙gOwTw4LzfxE❙Green Screen❙Shortj❙CAYQucD9t8HwuL3TAQ%3D%3D❙1qz0mF1kJQQ❙gOwTw4LzfxE❙Cut this video❙Shortj❙CAUQucD9t8HwuL3TAQ%3D%3D❙1qz0mF1kJQQ❙gOwTw4LzfxE❙*-Remix this Short along with 282 other remixes8❙id.reel_remix_button❙Remix❙vhttps://lh3.googleusercontent.com/9-sV2HETTS6Qp2ECdS0Fb1dLdDmYAtb4c7eB33XxVZU7OElPZ6Kwyl4_8W6lgiTdI0xTRpOFvyUyWAhO=h48 0(0❙vhttps://lh3.googleusercontent.com/9-sV2HETTS6Qp2ECdS0Fb1dLdDmYAtb4c7eB33XxVZU7OElPZ6Kwyl4_8W6lgiTdI0xTRpOFvyUyWAhO=h88 X(X❙whttps://lh3.googleusercontent.com/9-sV2HETTS6Qp2ECdS0Fb1dLdDmYAtb4c7eB33XxVZU7OElPZ6Kwyl4_8W6lgiTdI0xTRpOFvyUyWAhO=h176 ❙FEsfv_audio_pivot❙8gVfClISQwoLZ093VHc0THpmeEUSC2dPd1R3NEx6ZnhFGgsxcXowbUYxa0pRUSIOCKCZAhIICDcQwLvZsAIqChIICDcQwLvZsAIaCzFxejBtRjFrSlFRKLnA_bfB8Li90wE%3D❙s* See more videos using this soundh❙theme|7ab0a914963d1eb3❙333?❙dismiss❙$KEN_BURNS_ANIMATION_TYPE_UNSPECIFIED❙capabilities|793a39b3cf64d3612❙theme|7ab0a914963d1eb3❙capabilities|793a39b3cf64d361❙theme|7ab0a914963d1eb3❙capabilities|793a39b3cf64d361❙"'reel_player_overlay.reel_action_bar_key❙
03-12 00:33:36.847 17956 17956 D morphe: LithoFilterPatch: Searching ID: reel_player_overlay.eml-fe|3bbc2014e99ef098 Path: reel_player_overlay.eml-fe|3bbc2014e99ef098|ContainerType|ContainerType|reel_metapanel.eml-fe|394c64f9e997a71a|ContainerType|ContainerType| BufferStrings: button.eml-fe|ab72e9fa6342fc10*❙-yt_outline_experimental_template_add_black_24❙Use this template"❙Shortj❙gOwTw4LzfxE❙1qz0mF1kJQQ❙effects_expansion* ❙1qz0mF1kJQQ❙effects_expansion❙Use this template8❙theme|7ab0a914963d1eb3❙333?❙dismiss❙$KEN_BURNS_ANIMATION_TYPE_UNSPECIFIED❙capabilities|793a39b3cf64d3612❙theme|7ab0a914963d1eb3❙capabilities|793a39b3cf64d361❙theme|7ab0a914963d1eb3❙capabilities|793a39b3cf64d361❙
``` 

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
