### PR TITLE
feat(YouTube - Playback speed): Allows disabling tap and hold speed

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ */
+
 package app.morphe.extension.youtube.patches.playback.speed;
 
 import static app.morphe.extension.shared.StringRef.str;
@@ -66,6 +74,11 @@ public class CustomPlaybackSpeedPatch {
     private static final float PROGRESS_BAR_VALUE_SCALE = 100;
 
     /**
+     * Disable tap and hold speed, true when TAP_AND_HOLD_SPEED is 0.
+     */
+    private static final boolean DISABLE_TAP_AND_HOLD_SPEED;
+
+    /**
      * Tap and hold speed.
      */
     private static final float TAP_AND_HOLD_SPEED;
@@ -101,7 +114,12 @@ public class CustomPlaybackSpeedPatch {
         speedFormatter.setMaximumFractionDigits(2);
 
         final float holdSpeed = Settings.SPEED_TAP_AND_HOLD.get();
-        if (holdSpeed > 0 && holdSpeed <= PLAYBACK_SPEED_MAXIMUM) {
+        DISABLE_TAP_AND_HOLD_SPEED = holdSpeed == 0;
+
+        if (DISABLE_TAP_AND_HOLD_SPEED) {
+            // A value for handling exceptions, but this is not used.
+            TAP_AND_HOLD_SPEED = Settings.SPEED_TAP_AND_HOLD.defaultValue;
+        } else if (holdSpeed > 0 && holdSpeed <= PLAYBACK_SPEED_MAXIMUM) {
             TAP_AND_HOLD_SPEED = holdSpeed;
         } else {
             showInvalidCustomSpeedToast();
@@ -111,6 +129,14 @@ public class CustomPlaybackSpeedPatch {
         customPlaybackSpeeds = loadCustomSpeeds();
         customPlaybackSpeedsMin = customPlaybackSpeeds[0];
         customPlaybackSpeedsMax = customPlaybackSpeeds[customPlaybackSpeeds.length - 1];
+    }
+
+    /**
+     * Injection point.
+     * Called before {@link #getTapAndHoldSpeed()}
+     */
+    public static boolean disableTapAndHoldSpeed(boolean original) {
+        return !DISABLE_TAP_AND_HOLD_SPEED && original;
     }
 
     /**

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/custom/CustomPlaybackSpeedPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/custom/CustomPlaybackSpeedPatch.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ */
+
 package app.morphe.patches.youtube.video.speed.custom
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
@@ -178,6 +186,18 @@ internal val customPlaybackSpeedPatch = bytecodePatch(
                         """
                             invoke-static { }, $EXTENSION_CLASS_DESCRIPTOR->getTapAndHoldSpeed()F
                             move-result v$speedRegister
+                        """
+                    )
+
+                    val enabledIndex = it.instructionMatches[3].index
+                    val enabledRegister =
+                        getInstruction<OneRegisterInstruction>(enabledIndex).registerA
+
+                    addInstructions(
+                        enabledIndex,
+                        """
+                            invoke-static { v$enabledRegister }, $EXTENSION_CLASS_DESCRIPTOR->disableTapAndHoldSpeed(Z)Z
+                            move-result v$enabledRegister
                         """
                     )
                 }

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1671,7 +1671,9 @@ Enabling this can unlock higher video qualities"</string>
     <string name="morphe_custom_playback_speeds_parse_exception">Invalid custom playback speeds</string>
     <string name="morphe_custom_playback_speeds_auto">Auto</string>
     <string name="morphe_speed_tap_and_hold_title">Custom tap and hold speed</string>
-    <string name="morphe_speed_tap_and_hold_summary">Playback speed between 0-8</string>
+    <string name="morphe_speed_tap_and_hold_summary">"Playback speed between 0-8
+
+If 0, tap and hold speed is disabled"</string>
 
     <!-- video.speed.remember.rememberPlaybackSpeedPatch -->
     <string name="morphe_remember_playback_speed_last_selected_title">Remember playback speed changes</string>


### PR DESCRIPTION
### Description

Closes https://github.com/MorpheApp/morphe-patches/issues/103.

### Additional context

If **Custom tap and hold speed** is set to **0**, tap and hold speed is disabled.

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
