### PR TITLE
fix(YouTube - Hide Shorts components): Resolve "Hide 'Use this sound' button" and "Hide 'Use this template' button" breaking Shorts player

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/ShortsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/ShortsFilter.java
@@ -467,7 +467,7 @@ public final class ShortsFilter extends Filter {
             }
 
             if (matchedGroup == useButtons) {
-                return useButtonsBuffer.check(buffer).isFiltered();
+                return path.contains("button.e") && useButtonsBuffer.check(buffer).isFiltered();
             }
 
             if (matchedGroup == suggestedAction) {


### PR DESCRIPTION
### Description

Closes #741 and #825.

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
