### PR TITLE
fix(YouTube - Captions): Sometimes auto captions are not disabled in Shorts

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AutoCaptionsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AutoCaptionsPatch.java
@@ -1,4 +1,15 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.youtube.patches;
+
 import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
@@ -48,7 +59,14 @@ public class AutoCaptionsPatch {
     /**
      * Injection point.
      */
-    public static void setCaptionsButtonStatus(boolean status) {
-        captionsButtonStatus = status;
+    public static void preFetchVideo() {
+        captionsButtonStatus = false;
+    }
+
+    /**
+     * Injection point.
+     */
+    public static void newVideoStarted(VideoInformation.PlaybackController ignoredPlayerController) {
+        captionsButtonStatus = true;
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/captions/AutoCaptionsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/captions/AutoCaptionsPatch.kt
@@ -1,5 +1,16 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to Morphe contributions.
+ */
+
 package app.morphe.patches.youtube.layout.captions
 
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
@@ -8,6 +19,8 @@ import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.playservice.is_20_26_or_greater
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
 import app.morphe.patches.youtube.misc.settings.settingsPatch
+import app.morphe.patches.youtube.video.information.onCreateHook
+import app.morphe.patches.youtube.video.information.videoInformationPatch
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 private const val EXTENSION_CLASS_DESCRIPTOR =
@@ -19,7 +32,8 @@ internal val autoCaptionsPatch = bytecodePatch(
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,
-        versionCheckPatch
+        versionCheckPatch,
+        videoInformationPatch
     )
 
     execute {
@@ -52,18 +66,12 @@ internal val autoCaptionsPatch = bytecodePatch(
             }
         }
 
-        arrayOf(
-            StartVideoInformerFingerprint to 0,
-            StoryboardRendererDecoderRecommendedLevelFingerprint to 1
-        ).forEach { (fingerprint, enabled) ->
-            fingerprint.method.addInstructions(
-                0,
-                """
-                    const/4 v0, 0x$enabled
-                    invoke-static { v0 }, $EXTENSION_CLASS_DESCRIPTOR->setCaptionsButtonStatus(Z)V
-                """
-            )
-        }
+        StartVideoInformerFingerprint.method.addInstruction(
+            0,
+            "invoke-static { }, $EXTENSION_CLASS_DESCRIPTOR->preFetchVideo()V"
+        )
+
+        onCreateHook(EXTENSION_CLASS_DESCRIPTOR, "newVideoStarted")
 
         if (is_20_26_or_greater) {
             NoVolumeCaptionsFeatureFlagFingerprint.method.apply {

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/captions/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/captions/Fingerprints.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to Morphe contributions.
+ */
+
 package app.morphe.patches.youtube.layout.captions
 
 import app.morphe.patcher.Fingerprint
@@ -18,13 +28,6 @@ internal object StartVideoInformerFingerprint : Fingerprint(
         Opcode.RETURN_VOID,
     ),
     strings = listOf("pc")
-)
-
-internal object StoryboardRendererDecoderRecommendedLevelFingerprint : Fingerprint(
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
-    returnType = "V",
-    parameters = listOf("L"),
-    strings = listOf("#-1#")
 )
 
 internal object SubtitleManagerFingerprint : Fingerprint(


### PR DESCRIPTION
### Description

In #591, the logic for disabling auto captions was changed from `checking if the caption button is drawn on the screen` to `checking if the storyboard has been fetched`.

While #591 fixed the issue where captions were permanently disabled in Shorts, I found another issue.

Unlike general video, Shorts are fetched 2 to 3 at a time and preloaded into memory.

Therefore, when passing through 4 to 5 Shorts and moving to previous Shorts, there are rare cases where auto captions are not disabled.

I fixed this issue by hooking the method where player controls are initialized (like the default video quality patch or SponsorBlock patch).

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
