### PR TITLE
feat(YouTube): Add `Reload video` patch

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LoopVideoPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LoopVideoPatch.java
@@ -11,7 +11,6 @@ public class LoopVideoPatch {
         boolean shouldLoop = status != null && "ENDED".equals(status.name())
                 && Settings.LOOP_VIDEO.get();
         // Instead of calling a method to loop the video, just seek to 00:00.
-        if (shouldLoop) VideoInformation.seekTo(0);
-        return shouldLoop;
+        return shouldLoop && VideoInformation.seekTo(0);
     }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ReloadVideoPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ReloadVideoPatch.java
@@ -64,7 +64,7 @@ public final class ReloadVideoPatch {
                 String playlistId = VideoInformation.getPlaylistId();
 
                 // Dismiss the player.
-                playerInterfaceRef.get().patch_dismissPlayer();
+                playerInterface.patch_dismissPlayer();
 
                 // Reopens the video after 500ms.
                 // If the video was opened from a playlist, the playlist ID is also used.

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ReloadVideoPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ReloadVideoPatch.java
@@ -62,8 +62,12 @@ public final class ReloadVideoPatch {
             } else {
                 String videoId = VideoInformation.getVideoId();
                 String playlistId = VideoInformation.getPlaylistId();
+
+                // Dismiss the player.
                 playerInterfaceRef.get().patch_dismissPlayer();
 
+                // Reopens the video after 500ms.
+                // If the video was opened from a playlist, the playlist ID is also used.
                 Utils.runOnMainThreadDelayed(() -> openVideo(playlistId, videoId), 500);
             }
         } catch (Exception ex) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ReloadVideoPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ReloadVideoPatch.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to Morphe contributions.
+ */
+
+package app.morphe.extension.youtube.patches;
+
+import static app.morphe.extension.shared.StringRef.str;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+
+import java.lang.ref.WeakReference;
+import java.util.Objects;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
+
+@SuppressWarnings("unused")
+public final class ReloadVideoPatch {
+
+    /**
+     * Interface to use obfuscated methods.
+     */
+    public interface PlayerInterface {
+        // Method is added during patching.
+        void patch_dismissPlayer();
+    }
+
+    private static WeakReference<Activity> activityRef = new WeakReference<>(null);
+    private static WeakReference<PlayerInterface> playerInterfaceRef = new WeakReference<>(null);
+
+    /**
+     * Injection point.
+     */
+    public static void setMainActivity(Activity mainActivity) {
+        activityRef = new WeakReference<>(mainActivity);
+    }
+
+    /**
+     * Injection point.
+     */
+    public static void initialize(@NonNull PlayerInterface playerInterface) {
+        playerInterfaceRef = new WeakReference<>(Objects.requireNonNull(playerInterface));
+    }
+
+    /**
+     * If the player is not active, the layout may break.
+     * Use it only when it is guaranteed to be used in situations where the player is active.
+     */
+    public static void reloadVideo() {
+        try {
+            PlayerInterface playerInterface = playerInterfaceRef.get();
+            if (playerInterface == null) {
+                Utils.showToastShort(str("morphe_dismiss_player_not_available_toast"));
+            } else {
+                String videoId = VideoInformation.getVideoId();
+                String playlistId = VideoInformation.getPlaylistId();
+                playerInterfaceRef.get().patch_dismissPlayer();
+
+                Utils.runOnMainThreadDelayed(() -> openVideo(playlistId, videoId), 500);
+            }
+        } catch (Exception ex) {
+            Logger.printException(() -> "Failed to reload video", ex);
+        }
+    }
+
+    @SuppressWarnings("ExtractMethodRecommender")
+    private static void openVideo(String playlistId, String videoId) {
+        try {
+            String parameterSeparator = "?";
+            StringBuilder builder = new StringBuilder("https://youtu.be/");
+            builder.append(videoId);
+            if (!playlistId.isEmpty()) {
+                builder.append(parameterSeparator);
+                parameterSeparator = "&";
+                builder.append("list=");
+                builder.append(playlistId);
+            }
+            long currentVideoTimeInSeconds = VideoInformation.getVideoTime() / 1000;
+            if (currentVideoTimeInSeconds > 0) {
+                builder.append(parameterSeparator);
+                builder.append("t=");
+                builder.append(currentVideoTimeInSeconds);
+            }
+            Uri content = Uri.parse(builder.toString());
+
+            // If possible, use the main activity as the context.
+            // Otherwise, fall back on using the application context.
+            Context context = activityRef.get();
+            boolean isActivityContext = true;
+            if (context == null) {
+                // Utils context is the application context, and not an activity context.
+                //
+                // Edit: This check may no longer be needed since YT can now
+                // only be launched from the main Activity (embedded usage in other apps no longer works).
+                context = Utils.getContext();
+                isActivityContext = false;
+            }
+
+            Intent intent = new Intent("android.intent.action.VIEW", content);
+            intent.setPackage(context.getPackageName());
+            if (!isActivityContext) {
+                Logger.printDebug(() -> "Using new task intent");
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            }
+            context.startActivity(intent);
+        } catch (Exception e) {
+            Logger.printException(() -> "Failed to open video", e);
+        }
+    }
+
+}

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
@@ -66,6 +66,7 @@ public final class VideoInformation {
     private static long videoLength = 0;
     private static long videoTime = -1;
 
+    private static volatile String playerResponsePlaylistId = "";
     private static volatile String playerResponseVideoId = "";
     private static volatile boolean playerResponseVideoIdIsShort;
     private static volatile boolean videoIdIsShort;
@@ -180,6 +181,18 @@ public final class VideoInformation {
             }
         }
         return signature; // Return the original value since we are observing and not modifying.
+    }
+
+    /**
+     * Injection point.  Called off the main thread.
+     *
+     * @param playlistId The ID of the last playlist loaded.
+     */
+    public static void setPlayerResponsePlaylistId(@Nullable String playlistId, boolean isShortAndOpeningOrPlaying) {
+        if (!playerResponseVideoIdIsShort && Utils.isNotEmpty(playlistId) && !playerResponsePlaylistId.equals(playlistId)) {
+            Logger.printDebug(() -> "New player response playlist ID: " + playlistId);
+            playerResponsePlaylistId = playlistId;
+        }
     }
 
     /**
@@ -344,6 +357,16 @@ public final class VideoInformation {
     @NonNull
     public static String getVideoId() {
         return videoId;
+    }
+
+    /**
+     * This is the playlistId of the player response, but since Shorts does not support playlists, it is the same as the current playlistId.
+     *
+     * @return The playlist id of the video.
+     */
+    @NonNull
+    public static String getPlaylistId() {
+        return playerResponsePlaylistId;
     }
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
@@ -189,9 +189,15 @@ public final class VideoInformation {
      * @param playlistId The ID of the last playlist loaded.
      */
     public static void setPlayerResponsePlaylistId(@Nullable String playlistId, boolean isShortAndOpeningOrPlaying) {
-        if (!playerResponseVideoIdIsShort && Utils.isNotEmpty(playlistId) && !playerResponsePlaylistId.equals(playlistId)) {
-            Logger.printDebug(() -> "New player response playlist ID: " + playlistId);
-            playerResponsePlaylistId = playlistId;
+        if (!playerResponseVideoIdIsShort) {
+            if (playlistId == null) {
+                playlistId = "";
+            }
+            if (!playerResponsePlaylistId.equals(playlistId)) {
+                String finalPlaylistId = playlistId;
+                Logger.printDebug(() -> "New player response playlist ID: " + finalPlaylistId);
+                playerResponsePlaylistId = playlistId;
+            }
         }
     }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -196,6 +196,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_VIDEO_TITLE = new BooleanSetting("morphe_hide_video_title", FALSE);
     public static final BooleanSetting OPEN_VIDEOS_FULLSCREEN_PORTRAIT = new BooleanSetting("morphe_open_videos_fullscreen_portrait", FALSE);
     public static final BooleanSetting PLAYBACK_SPEED_DIALOG_BUTTON = new BooleanSetting("morphe_playback_speed_dialog_button", FALSE);
+    public static final BooleanSetting RELOAD_VIDEO = new BooleanSetting("morphe_reload_video", FALSE);
     public static final BooleanSetting VIDEO_QUALITY_DIALOG_BUTTON = new BooleanSetting("morphe_video_quality_dialog_button", FALSE);
     public static final IntegerSetting PLAYER_OVERLAY_OPACITY = new IntegerSetting("morphe_player_overlay_opacity", 100, true);
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/ui/CreateSegmentButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/ui/CreateSegmentButton.java
@@ -32,7 +32,7 @@ public class CreateSegmentButton {
     /**
      * injection point.
      */
-    public static void initialize(View controlsView) {
+    public static void initializeButton(View controlsView) {
         try {
             instance = new PlayerControlButton(
                     controlsView,
@@ -43,15 +43,15 @@ public class CreateSegmentButton {
                     null
             );
 
-            // FIXME: Bold YT player icons are currently forced off.
-            //        Enable this logic when the new player icons are not forced off.
-            ImageView icon = Utils.getChildViewByResourceName(controlsView,
-                    "morphe_sb_create_segment_button");
             if (false) {
+                // FIXME: Bold YT player icons are currently forced off.
+                //        Enable this logic when the new player icons are not forced off.
+                ImageView icon = Utils.getChildViewByResourceName(controlsView,
+                        "morphe_sb_create_segment_button");
                 icon.setImageResource(DRAWABLE_SB_LOGO);
             }
         } catch (Exception ex) {
-            Logger.printException(() -> "initialize failure", ex);
+            Logger.printException(() -> "initializeButton failure", ex);
         }
     }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/ReloadVideoButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/ReloadVideoButton.java
@@ -1,23 +1,17 @@
-package app.morphe.extension.youtube.sponsorblock.ui;
+package app.morphe.extension.youtube.videoplayer;
 
 import android.view.View;
 
 import androidx.annotation.Nullable;
 
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.youtube.patches.ReloadVideoPatch;
 import app.morphe.extension.youtube.settings.Settings;
-import app.morphe.extension.youtube.sponsorblock.SegmentPlaybackController;
-import app.morphe.extension.youtube.sponsorblock.SponsorBlockUtils;
-import app.morphe.extension.youtube.videoplayer.PlayerControlButton;
 
 @SuppressWarnings("unused")
-public class VotingButton {
+public class ReloadVideoButton {
     @Nullable
     private static PlayerControlButton instance;
-
-    public static void hideControls() {
-        if (instance != null) instance.hide();
-    }
 
     /**
      * injection point.
@@ -26,14 +20,14 @@ public class VotingButton {
         try {
             instance = new PlayerControlButton(
                     controlsView,
-                    "morphe_sb_voting_button",
+                    "morphe_reload_video_button",
                     null,
-                    VotingButton::isButtonEnabled,
-                    v -> SponsorBlockUtils.onVotingClicked(v.getContext()),
+                    Settings.RELOAD_VIDEO::get,
+                    v -> ReloadVideoPatch.reloadVideo(),
                     null
             );
         } catch (Exception ex) {
-            Logger.printException(() -> "initializeButton failure", ex);
+            Logger.printException(() -> "initialize failure", ex);
         }
     }
 
@@ -56,11 +50,5 @@ public class VotingButton {
      */
     public static void setVisibility(boolean visible, boolean animated) {
         if (instance != null) instance.setVisibility(visible, animated);
-    }
-
-    private static boolean isButtonEnabled() {
-        return Settings.SB_ENABLED.get() && Settings.SB_VOTING_BUTTON.get()
-                && SegmentPlaybackController.videoHasSegments()
-                && !SegmentPlaybackController.isAdProgressTextVisible();
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/LoopVideoButtonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/LoopVideoButtonPatch.kt
@@ -1,4 +1,4 @@
-package app.morphe.patches.youtube.misc.loopvideo.button
+package app.morphe.patches.youtube.interaction.loop
 
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/LoopVideoPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/LoopVideoPatch.kt
@@ -8,14 +8,13 @@
  * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to Morphe contributions.
  */
 
-package app.morphe.patches.youtube.misc.loopvideo
+package app.morphe.patches.youtube.interaction.loop
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
-import app.morphe.patches.youtube.misc.loopvideo.button.loopVideoButtonPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import app.morphe.patches.youtube.video.information.playerStatusMethodRef

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/reload/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/reload/Fingerprints.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to Morphe contributions.
+ */
+
+package app.morphe.patches.youtube.interaction.reload
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.opcode
+import app.morphe.patcher.string
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+internal object MiniAppOpenYtContentCommandEndpointFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf("L"),
+    filters = listOf(
+        string("no error message"),
+        opcode(Opcode.IF_EQZ),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            parameters = listOf(),
+            returnType = "V"
+        ),
+        string("InvalidProtocolBufferException while decoding MiniAppMetadata for MiniAppOpenYTContentCommand: ")
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/reload/ReloadVideoPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/reload/ReloadVideoPatch.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to Morphe contributions.
+ */
+
+package app.morphe.patches.youtube.interaction.reload
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
+import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import app.morphe.patches.youtube.misc.playercontrols.addTopControl
+import app.morphe.patches.youtube.misc.playercontrols.initializeTopControl
+import app.morphe.patches.youtube.misc.playercontrols.injectVisibilityCheckCall
+import app.morphe.patches.youtube.misc.playercontrols.playerControlsPatch
+import app.morphe.patches.youtube.misc.settings.PreferenceScreen
+import app.morphe.patches.youtube.misc.settings.settingsPatch
+import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
+import app.morphe.patches.youtube.shared.YouTubeActivityOnCreateFingerprint
+import app.morphe.patches.youtube.video.information.videoInformationPatch
+import app.morphe.util.ResourceGroup
+import app.morphe.util.copyResources
+import app.morphe.util.getReference
+import app.morphe.util.indexOfFirstInstructionReversedOrThrow
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
+import com.android.tools.smali.dexlib2.util.MethodUtil
+
+private val reloadVideoResourcePatch = resourcePatch {
+    dependsOn(
+        settingsPatch,
+        playerControlsPatch,
+    )
+
+    execute {
+        PreferenceScreen.PLAYER.addPreferences(
+            SwitchPreference("morphe_reload_video"),
+        )
+
+        copyResources(
+            "reloadbutton",
+            ResourceGroup(
+                resourceDirectoryName = "drawable",
+                "morphe_reload_video.xml",
+            ),
+        )
+    }
+}
+
+private const val EXTENSION_BUTTON_DESCRIPTOR =
+    "Lapp/morphe/extension/youtube/videoplayer/ReloadVideoButton;"
+
+private const val EXTENSION_CLASS_DESCRIPTOR =
+    "Lapp/morphe/extension/youtube/patches/ReloadVideoPatch;"
+
+private const val EXTENSION_PLAYER_INTERFACE =
+    "Lapp/morphe/extension/youtube/patches/ReloadVideoPatch\$PlayerInterface;"
+
+@Suppress("unused")
+val reloadVideoPatch = bytecodePatch(
+    name = "Reload video",
+    description = "Adds options to display buttons in the video player to reload video.",
+) {
+    dependsOn(
+        reloadVideoResourcePatch,
+        playerControlsPatch,
+        videoInformationPatch,
+    )
+
+    compatibleWith(COMPATIBILITY_YOUTUBE)
+
+    execute {
+        initializeTopControl(EXTENSION_BUTTON_DESCRIPTOR)
+        injectVisibilityCheckCall(EXTENSION_BUTTON_DESCRIPTOR)
+
+        // Main activity is used to launch downloader intent.
+        YouTubeActivityOnCreateFingerprint.method.addInstruction(
+            0,
+            "invoke-static/range { p0 .. p0 }, $EXTENSION_CLASS_DESCRIPTOR->setMainActivity(Landroid/app/Activity;)V"
+        )
+
+        val dismissPlayerInnerMethod = MiniAppOpenYtContentCommandEndpointFingerprint
+            .instructionMatches[2]
+            .getInstruction<ReferenceInstruction>()
+            .getReference<MethodReference>()!!
+
+        mutableClassDefBy(dismissPlayerInnerMethod.definingClass).apply {
+            // Add interface and helper methods to allow extension code to call obfuscated methods.
+            interfaces.add(EXTENSION_PLAYER_INTERFACE)
+            // Add methods to access obfuscated player methods.
+            methods.add(
+                ImmutableMethod(
+                    type,
+                    "patch_dismissPlayer",
+                    listOf(),
+                    "V",
+                    AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+                    null,
+                    null,
+                    MutableMethodImplementation(2),
+                ).toMutable().apply {
+                    addInstructions(
+                        0,
+                        """
+                            invoke-virtual { p0 }, $dismissPlayerInnerMethod
+                            return-void
+                        """
+                    )
+                }
+            )
+
+            methods.single { method ->
+                MethodUtil.isConstructor(method)
+            }.apply {
+                val index = indexOfFirstInstructionReversedOrThrow(Opcode.RETURN_VOID)
+
+                addInstruction(
+                    index,
+                    "invoke-static/range { p0 .. p0 }, $EXTENSION_CLASS_DESCRIPTOR->initialize($EXTENSION_PLAYER_INTERFACE)V"
+                )
+            }
+        }
+    }
+
+    finalize {
+        addTopControl(
+            "reloadbutton",
+            "@+id/morphe_reload_video_button",
+            "@+id/morphe_reload_video_button"
+        )
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/sponsorblock/SponsorBlockPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/sponsorblock/SponsorBlockPatch.kt
@@ -96,7 +96,11 @@ private val sponsorBlockResourcePatch = resourcePatch {
             copyResources("sponsorblock", resourceGroup)
         }
 
-        addTopControl("sponsorblock")
+        addTopControl(
+            "sponsorblock",
+            "@+id/morphe_sb_voting_button",
+            "@+id/morphe_sb_create_segment_button"
+        )
     }
 }
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/PlayerControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/PlayerControlsPatch.kt
@@ -44,8 +44,10 @@ import java.lang.ref.WeakReference
  */
 @Suppress("KDocUnresolvedReference")
 // Internal until this is modified to work with any patch (and not just SponsorBlock).
-internal lateinit var addTopControl: (String) -> Unit
+internal lateinit var addTopControl: (String, String, String) -> Unit
     private set
+
+private var insertElementId = "@id/player_video_heading"
 
 /**
  * Add a new bottom to the bottom of the YouTube player.
@@ -92,7 +94,7 @@ internal val playerControlsResourcePatch = resourcePatch {
             setAttribute("android:layout_width", "48.0dip")
         }
 
-        addTopControl = { resourceDirectoryName ->
+        addTopControl = { resourceDirectoryName, startElementId, endElementId ->
             val resourceFileName = "host/layout/youtube_controls_layout.xml"
             val hostingResourceStream = inputStreamFromBundledResource(
                 resourceDirectoryName,
@@ -100,21 +102,30 @@ internal val playerControlsResourcePatch = resourcePatch {
             ) ?: throw PatchException("Could not find $resourceFileName")
 
             val document = document("res/layout/youtube_controls_layout.xml")
+            val androidId = "android:id"
+            val androidLayoutToStartOf = "android:layout_toStartOf"
 
             "RelativeLayout".copyXmlNode(
                 document(hostingResourceStream),
                 document,
             ).use {
-                val element = document.childNodes.findElementByAttributeValueOrThrow(
-                    "android:id",
-                    "@id/player_video_heading",
+                val insertElement = document.childNodes.findElementByAttributeValueOrThrow(
+                    androidId,
+                    insertElementId,
                 )
+                val endElement = document.childNodes.findElementByAttributeValueOrThrow(
+                    androidId,
+                    endElementId,
+                )
+                val insertElementLayoutToStartOf =
+                    insertElement.attributes.getNamedItem(androidLayoutToStartOf).nodeValue!!
 
-                // FIXME: This uses hard coded values that only works with SponsorBlock.
-                // If other top buttons are added by other patches, this code must be changed.
-                // voting button id from the voting button view from the youtube_controls_layout.xml host file
-                val votingButtonId = "@+id/morphe_sb_voting_button"
-                element.attributes.getNamedItem("android:layout_toStartOf").nodeValue = votingButtonId
+                insertElement.attributes.getNamedItem(androidLayoutToStartOf).nodeValue =
+                    startElementId
+                endElement.attributes.getNamedItem(androidLayoutToStartOf).nodeValue =
+                    insertElementLayoutToStartOf
+
+                insertElementId = endElementId
             }
         }
 
@@ -174,7 +185,7 @@ internal val playerControlsResourcePatch = resourcePatch {
 internal fun initializeTopControl(descriptor: String) {
     inflateTopControlMethodRef.get()!!.addInstruction(
         inflateTopControlInsertIndex++,
-        "invoke-static { v$inflateTopControlRegister }, $descriptor->initialize(Landroid/view/View;)V",
+        "invoke-static { v$inflateTopControlRegister }, $descriptor->initializeButton(Landroid/view/View;)V",
     )
 }
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/information/VideoInformationPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/information/VideoInformationPatch.kt
@@ -32,6 +32,7 @@ import app.morphe.patches.youtube.video.playerresponse.Hook
 import app.morphe.patches.youtube.video.playerresponse.addPlayerResponseMethodHook
 import app.morphe.patches.youtube.video.playerresponse.playerResponseMethodHookPatch
 import app.morphe.patches.youtube.video.videoid.hookBackgroundPlayVideoId
+import app.morphe.patches.youtube.video.videoid.hookPlayerResponsePlaylistId
 import app.morphe.patches.youtube.video.videoid.hookPlayerResponseVideoId
 import app.morphe.patches.youtube.video.videoid.hookVideoId
 import app.morphe.patches.youtube.video.videoid.videoIdPatch
@@ -196,6 +197,9 @@ val videoInformationPatch = bytecodePatch(
         val videoIdMethodDescriptor = "$EXTENSION_CLASS_DESCRIPTOR->setVideoId(Ljava/lang/String;)V"
         hookVideoId(videoIdMethodDescriptor)
         hookBackgroundPlayVideoId(videoIdMethodDescriptor)
+        hookPlayerResponsePlaylistId(
+            "$EXTENSION_CLASS_DESCRIPTOR->setPlayerResponsePlaylistId(Ljava/lang/String;Z)V",
+        )
         hookPlayerResponseVideoId(
             "$EXTENSION_CLASS_DESCRIPTOR->setPlayerResponseVideoId(Ljava/lang/String;Z)V",
         )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/playerresponse/PlayerResponseMethodHookPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/playerresponse/PlayerResponseMethodHookPatch.kt
@@ -34,12 +34,14 @@ fun addPlayerResponseMethodHook(hook: Hook) {
 // Parameter numbers of the patched method.
 private const val PARAMETER_VIDEO_ID = 1
 private const val PARAMETER_PROTO_BUFFER = 3
+private const val PARAMETER_PLAYLIST_ID = 4
 private var parameterIsShortAndOpeningOrPlaying = -1
 
 // Registers used to pass the parameters to the extension.
 private var playerResponseMethodCopyRegisters = false
 private lateinit var registerVideoId: String
 private lateinit var registerProtoBuffer: String
+private lateinit var registerPlaylistId: String
 private lateinit var registerIsShortAndOpeningOrPlaying: String
 
 private lateinit var playerResponseMethodRef : WeakReference<MutableMethod>
@@ -86,15 +88,25 @@ val playerResponseMethodHookPatch = bytecodePatch {
         if (playerResponseMethodCopyRegisters) {
             registerVideoId = "v0"
             registerProtoBuffer = "v1"
-            registerIsShortAndOpeningOrPlaying = "v2"
+            registerPlaylistId = "v2"
+            registerIsShortAndOpeningOrPlaying = "v3"
         } else {
             registerVideoId = "p$PARAMETER_VIDEO_ID"
             registerProtoBuffer = "p$PARAMETER_PROTO_BUFFER"
+            registerPlaylistId = "p$PARAMETER_PLAYLIST_ID"
             registerIsShortAndOpeningOrPlaying = "p$parameterIsShortAndOpeningOrPlaying"
         }
     }
 
     finalize {
+        fun hookPlaylistId(hook: Hook) {
+            playerResponseMethodRef.get()!!.addInstruction(
+                0,
+                "invoke-static { $registerPlaylistId, $registerIsShortAndOpeningOrPlaying }, $hook",
+            )
+            numberOfInstructionsAdded++
+        }
+
         fun hookVideoId(hook: Hook) {
             playerResponseMethodRef.get()!!.addInstruction(
                 0,
@@ -116,11 +128,13 @@ val playerResponseMethodHookPatch = bytecodePatch {
 
         // Reverse the order in order to preserve insertion order of the hooks.
         val beforeVideoIdHooks = hooks.filterIsInstance<Hook.ProtoBufferParameterBeforeVideoId>().asReversed()
+        val playlistIdHooks = hooks.filterIsInstance<Hook.PlaylistId>().asReversed()
         val videoIdHooks = hooks.filterIsInstance<Hook.VideoId>().asReversed()
         val afterVideoIdHooks = hooks.filterIsInstance<Hook.ProtoBufferParameter>().asReversed()
 
         // Add the hooks in this specific order as they insert instructions at the beginning of the method.
         afterVideoIdHooks.forEach(::hookProtoBufferParameter)
+        playlistIdHooks.forEach(::hookPlaylistId)
         videoIdHooks.forEach(::hookVideoId)
         beforeVideoIdHooks.forEach(::hookProtoBufferParameter)
 
@@ -130,10 +144,11 @@ val playerResponseMethodHookPatch = bytecodePatch {
                 """
                     move-object/from16 $registerVideoId, p$PARAMETER_VIDEO_ID
                     move-object/from16 $registerProtoBuffer, p$PARAMETER_PROTO_BUFFER
+                    move-object/from16 $registerPlaylistId, p$PARAMETER_PLAYLIST_ID
                     move/from16        $registerIsShortAndOpeningOrPlaying, p$parameterIsShortAndOpeningOrPlaying
                 """
             )
-            numberOfInstructionsAdded += 3
+            numberOfInstructionsAdded += 4
 
             // Move the modified register back.
             playerResponseMethodRef.get()!!.addInstruction(
@@ -147,6 +162,7 @@ val playerResponseMethodHookPatch = bytecodePatch {
 }
 
 sealed class Hook(private val methodDescriptor: String) {
+    class PlaylistId(methodDescriptor: String) : Hook(methodDescriptor)
     class VideoId(methodDescriptor: String) : Hook(methodDescriptor)
 
     class ProtoBufferParameter(methodDescriptor: String) : Hook(methodDescriptor)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/videoid/VideoIdPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/videoid/VideoIdPatch.kt
@@ -58,6 +58,32 @@ fun hookBackgroundPlayVideoId(
 )
 
 /**
+ * Hooks the playlist ID of every video when loaded.
+ * Supports all videos and functions in all situations.
+ *
+ * First parameter is the playlist ID.
+ * Second parameter is if the video is a Short AND it is being opened or is currently playing.
+ *
+ * Hook is always called off the main thread.
+ *
+ * This hook is called as soon as the player response is parsed,
+ * and called before many other hooks are updated such as [playerTypeHookPatch].
+ *
+ * Note: The playlist ID returned here may not be the current video that's being played.
+ * It's common for multiple Shorts to load at once in preparation
+ * for the user swiping to the next Short.
+ *
+ * Be aware, this can be called multiple times for the same playlist ID.
+ *
+ * @param methodDescriptor which method to call. Params must be `Ljava/lang/String;Z`
+ */
+fun hookPlayerResponsePlaylistId(methodDescriptor: String) = addPlayerResponseMethodHook(
+    Hook.PlaylistId(
+        methodDescriptor,
+    ),
+)
+
+/**
  * Hooks the video ID of every video when loaded.
  * Supports all videos and functions in all situations.
  *

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -504,19 +504,19 @@ Limitations:
 Verify the package name is correct and the app is installed"</string>
     <string name="morphe_external_downloader_empty_warning">The package name cannot be empty</string>
 
-    <!-- misc.loop.loopVideoPatch -->
+    <!-- interaction.loop.loopVideoPatch -->
     <string name="morphe_loop_video_title">Enable loop video</string>
     <string name="morphe_loop_video_summary_on">Video will loop</string>
     <string name="morphe_loop_video_summary_off">Video will not loop</string>
 
-    <!-- misc.loop.loopVideoButtonPatch -->
+    <!-- interaction.loop.loopVideoButtonPatch -->
     <string name="morphe_loop_video_button_title">Show loop video button</string>
     <string name="morphe_loop_video_button_summary_on">Loop video button is shown</string>
     <string name="morphe_loop_video_button_summary_off">Loop video button is not shown</string>
     <string name="morphe_loop_video_button_toast_on">Loop video is on</string>
     <string name="morphe_loop_video_button_toast_off">Loop video is off</string>
 
-    <!-- misc.reload.reloadVideoPatch -->
+    <!-- interaction.reload.reloadVideoPatch -->
     <string name="morphe_reload_video_title">Show reload video button</string>
     <string name="morphe_reload_video_summary_on">Reload video button is shown</string>
     <string name="morphe_reload_video_summary_off">Reload video button is not shown</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -504,6 +504,24 @@ Limitations:
 Verify the package name is correct and the app is installed"</string>
     <string name="morphe_external_downloader_empty_warning">The package name cannot be empty</string>
 
+    <!-- misc.loop.loopVideoPatch -->
+    <string name="morphe_loop_video_title">Enable loop video</string>
+    <string name="morphe_loop_video_summary_on">Video will loop</string>
+    <string name="morphe_loop_video_summary_off">Video will not loop</string>
+
+    <!-- misc.loop.loopVideoButtonPatch -->
+    <string name="morphe_loop_video_button_title">Show loop video button</string>
+    <string name="morphe_loop_video_button_summary_on">Loop video button is shown</string>
+    <string name="morphe_loop_video_button_summary_off">Loop video button is not shown</string>
+    <string name="morphe_loop_video_button_toast_on">Loop video is on</string>
+    <string name="morphe_loop_video_button_toast_off">Loop video is off</string>
+
+    <!-- misc.reload.reloadVideoPatch -->
+    <string name="morphe_reload_video_title">Show reload video button</string>
+    <string name="morphe_reload_video_summary_on">Reload video button is shown</string>
+    <string name="morphe_reload_video_summary_off">Reload video button is not shown</string>
+    <string name="morphe_dismiss_player_not_available_toast">Video id is unavailable. Please manually reopen the video.</string>
+
     <!-- interaction.seekbar.disablePreciseSeekingGesturePatch -->
     <string name="morphe_disable_precise_seeking_gesture_title">Disable precise seeking gesture</string>
     <string name="morphe_disable_precise_seeking_gesture_summary_on">Precise seeking gesture is disabled</string>
@@ -1578,18 +1596,6 @@ Tap here to learn more about DeArrow"</string>
     <string name="morphe_announcements_enabled_summary" translatable="false">Show announcements on startup</string>
     <string name="morphe_announcements_connection_failed" translatable="false">Failed connecting to announcements provider</string>
     <string name="morphe_announcements_dialog_dismiss" translatable="false">Dismiss</string>
-
-    <!-- misc.loopvideo.loopVideoPatch -->
-    <string name="morphe_loop_video_title">Enable loop video</string>
-    <string name="morphe_loop_video_summary_on">Video will loop</string>
-    <string name="morphe_loop_video_summary_off">Video will not loop</string>
-
-    <!-- misc.loopvideo.button.loopVideoButtonPatch -->
-    <string name="morphe_loop_video_button_title">Show loop video button</string>
-    <string name="morphe_loop_video_button_summary_on">Loop video button is shown</string>
-    <string name="morphe_loop_video_button_summary_off">Loop video button is not shown</string>
-    <string name="morphe_loop_video_button_toast_on">Loop video is on</string>
-    <string name="morphe_loop_video_button_toast_off">Loop video is off</string>
 
     <!-- misc.dimensions.spoof.spoofDeviceDimensionsPatch -->
     <string name="morphe_spoof_device_dimensions_title">Spoof device dimensions</string>

--- a/patches/src/main/resources/reloadbutton/drawable/morphe_reload_video.xml
+++ b/patches/src/main/resources/reloadbutton/drawable/morphe_reload_video.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    https://github.com/google/material-design-icons/blob/c4daeb98d119754cc058ef366d69150fed76ec2d/symbols/android/restart_alt/materialsymbolsoutlined/restart_alt_gradN25_24px.xml
+    Changes made: Icon has been resized.
+
+    Copyright 2022 Google
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M449.04,813.96Q335.5,803.61 259.14,719.13Q182.77,634.65 182.77,520.31Q182.77,451.58 214,390.62Q245.23,329.66 300.69,288.69L332.19,319.89Q281.54,353.27 254.08,406.64Q226.62,460 226.62,520.31Q226.62,617.42 289.87,687.94Q353.12,758.46 449.04,770.11L449.04,813.96ZM512.88,814.73L512.88,770.88Q608.54,757.58 671.52,687.21Q734.5,616.85 734.5,520.31Q734.5,414.23 660.85,340.33Q587.19,266.42 480.62,266.42L453.46,266.42L519.85,332.81L488.65,364.69L368.81,244.85L488.65,125L519.85,156.19L453.46,222.58L480.62,222.58Q604.92,222.58 691.63,309.79Q778.34,397 778.34,520.31Q778.34,634.96 702.04,719.1Q625.73,803.23 512.88,814.73Z"/>
+</vector>

--- a/patches/src/main/resources/reloadbutton/host/layout/youtube_controls_layout.xml
+++ b/patches/src/main/resources/reloadbutton/host/layout/youtube_controls_layout.xml
@@ -1,0 +1,15 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <com.google.android.libraries.youtube.common.ui.TouchImageView
+        android:id="@+id/morphe_reload_video_button"
+        style="@style/YouTubePlayerButton"
+        android:layout_width="@dimen/controls_overlay_action_button_size"
+        android:layout_height="@dimen/controls_overlay_action_button_size"
+        android:layout_alignWithParentIfMissing="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginTop="2dp"
+        android:layout_marginEnd="4dp"
+        android:layout_toStartOf="@id/music_app_deeplink_button"
+        android:padding="@dimen/controls_overlay_action_button_padding"
+        android:src="@drawable/morphe_reload_video" />
+</RelativeLayout>


### PR DESCRIPTION
### Description

Closes https://github.com/MorpheApp/morphe-patches/issues/398.

### Additional context

The patch was implemented as an independent patch instead of relying on `Spoof video streams` for the following reasons:

1. Root users cannot use the `Spoof video streams` patch.
2. `Reload video` might be useful for someone who wants to refresh related videos.

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
