### PR TITLE
fix(YouTube - Playback speed): Playback speed menu opens from the feed flyout menu when `Restore old playback speed menu` is off

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
@@ -96,9 +96,9 @@ public class CustomPlaybackSpeedPatch {
     private static final float customPlaybackSpeedsMin, customPlaybackSpeedsMax;
 
     /**
-     * The last time the old playback menu was forcefully called.
+     * The last time the playback menu was forcefully called.
      */
-    private static volatile long lastTimeOldPlaybackMenuInvoked;
+    private static volatile long lastTimePlaybackMenuInvoked;
 
     /**
      * Formats speeds to UI strings.
@@ -253,6 +253,15 @@ public class CustomPlaybackSpeedPatch {
             return false;
         }
 
+        // This method is sometimes used multiple times.
+        // To prevent this, ignore method reuse within 1 second.
+        final long now = System.currentTimeMillis();
+        if (now - lastTimePlaybackMenuInvoked < 1000) {
+            Logger.printDebug(() -> "Ignoring call to hideLithoMenuAndShowSpeedMenu");
+            return true;
+        }
+        lastTimePlaybackMenuInvoked = now;
+
         // Dismiss View [R.id.touch_outside] is the 1st ChildView of the 4th ParentView.
         // This only shows in phone layout.
         var touchInsidedView = parentView4th.getChildAt(0);
@@ -276,16 +285,8 @@ public class CustomPlaybackSpeedPatch {
     }
 
     public static void showOldPlaybackSpeedMenu() {
-        // This method is sometimes used multiple times.
-        // To prevent this, ignore method reuse within 1 second.
-        final long now = System.currentTimeMillis();
-        if (now - lastTimeOldPlaybackMenuInvoked < 1000) {
-            Logger.printDebug(() -> "Ignoring call to showOldPlaybackSpeedMenu");
-            return;
-        }
-        lastTimeOldPlaybackMenuInvoked = now;
-
         // Rest of the implementation added by patch.
+        Logger.printDebug(() -> "showOldPlaybackSpeedMenu");
     }
 
     /**


### PR DESCRIPTION
### Description

Closes https://github.com/MorpheApp/morphe-patches/issues/877.

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
