### PR TITLE
fix(YouTube - Captions): Captions disabled due to incorrect hooking

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AutoCaptionsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AutoCaptionsPatch.java
@@ -10,6 +10,9 @@
 
 package app.morphe.extension.youtube.patches;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import app.morphe.extension.shared.Utils;
 import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
@@ -22,7 +25,7 @@ public class AutoCaptionsPatch {
         WITHOUT_VOLUME_ONLY
     }
 
-    private static volatile boolean captionsButtonStatus;
+    private static final AtomicBoolean captionsButtonStatus = new AtomicBoolean(false);
 
     /**
      * Injection point.
@@ -36,7 +39,7 @@ public class AutoCaptionsPatch {
             // Disable auto-captioning only
             // when 'withVolumeAutoCaptioningEnabled'
             // field is false
-            return !captionsButtonStatus || original;
+            return !captionsButtonStatus.get() || original;
         }
 
         return original;
@@ -58,15 +61,17 @@ public class AutoCaptionsPatch {
 
     /**
      * Injection point.
+     * Called before {@link #disableAutoCaptions(boolean)}.
      */
-    public static void preFetchVideo() {
-        captionsButtonStatus = false;
+    public static void newVideoStarted(VideoInformation.PlaybackController ignoredPlayerController) {
+        captionsButtonStatus.set(false);
     }
 
     /**
      * Injection point.
+     * Called after {@link #disableAutoCaptions(boolean)}.
      */
-    public static void newVideoStarted(VideoInformation.PlaybackController ignoredPlayerController) {
-        captionsButtonStatus = true;
+    public static void videoInformationLoaded() {
+        Utils.runOnMainThreadDelayed(() -> captionsButtonStatus.compareAndSet(false, true), 150);
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/captions/AutoCaptionsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/captions/AutoCaptionsPatch.kt
@@ -66,12 +66,12 @@ internal val autoCaptionsPatch = bytecodePatch(
             }
         }
 
+        onCreateHook(EXTENSION_CLASS_DESCRIPTOR, "newVideoStarted")
+
         StartVideoInformerFingerprint.method.addInstruction(
             0,
-            "invoke-static { }, $EXTENSION_CLASS_DESCRIPTOR->preFetchVideo()V"
+            "invoke-static { }, $EXTENSION_CLASS_DESCRIPTOR->videoInformationLoaded()V"
         )
-
-        onCreateHook(EXTENSION_CLASS_DESCRIPTOR, "newVideoStarted")
 
         if (is_20_26_or_greater) {
             NoVolumeCaptionsFeatureFlagFingerprint.method.apply {


### PR DESCRIPTION
### Description

Closes https://github.com/MorpheApp/morphe-patches/issues/879.

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
