### PR TITLE
feat(YouTube): Add experimental support for `21.12.521`

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/PlayerControlsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/PlayerControlsPatch.java
@@ -7,6 +7,7 @@ import android.widget.ImageView;
 import java.lang.ref.WeakReference;
 
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
 
 @SuppressWarnings("unused")
 public class PlayerControlsPatch {
@@ -15,6 +16,18 @@ public class PlayerControlsPatch {
 
     private static boolean fullscreenButtonVisibilityCallbacksExist() {
         return false; // Modified during patching if needed.
+    }
+
+    /**
+     * Injection point.
+     */
+    public static void hideBottomGradientScrim(ImageView bottomGradientScrim) {
+        if (bottomGradientScrim != null) {
+            Utils.runOnMainThread(() -> {
+                bottomGradientScrim.setImageAlpha(0);
+                bottomGradientScrim.setVisibility(View.GONE);
+            });
+        }
     }
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VersionCheckPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VersionCheckPatch.java
@@ -19,8 +19,8 @@ public class VersionCheckPatch {
     public static final boolean IS_19_29_OR_GREATER = isVersionOrGreater("19.29.00");
     @Deprecated
     public static final boolean IS_19_34_OR_GREATER = isVersionOrGreater("19.34.00");
-
-    public static final boolean IS_20_21_OR_GREATER = isVersionOrGreater("20.21.00");
+    @Deprecated
+    public static final boolean IS_20_10_OR_GREATER = isVersionOrGreater("20.10.00");
 
     public static final boolean IS_20_22_OR_GREATER = isVersionOrGreater("20.22.00");
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -458,7 +458,6 @@ public final class LayoutComponentsFilter extends Filter {
      * Injection point.
      */
     public static boolean hideFloatingMicrophoneButton(final boolean original) {
-        // FIXME? Is this feature still relevant? When/where does this microphone appear?
         return original || Settings.HIDE_FLOATING_MICROPHONE_BUTTON.get();
     }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -11,7 +11,7 @@
 package app.morphe.extension.youtube.patches.components;
 
 import static app.morphe.extension.shared.Utils.getFilterStrings;
-import static app.morphe.extension.youtube.patches.VersionCheckPatch.IS_20_21_OR_GREATER;
+import static app.morphe.extension.youtube.patches.VersionCheckPatch.IS_20_10_OR_GREATER;
 import static app.morphe.extension.youtube.shared.NavigationBar.NavigationButton;
 
 import android.graphics.drawable.Drawable;
@@ -493,13 +493,24 @@ public final class LayoutComponentsFilter extends Filter {
     /**
      * Injection point.
      */
+    public static int hideInRelatedVideos(int height) {
+        return HIDE_FILTER_BAR_FEED_IN_RELATED_VIDEOS_ENABLED
+                ? 0
+                : height;
+    }
+
+    /**
+     * Injection point.
+     */
+    public static boolean hideInRelatedVideos(boolean original) {
+        return HIDE_FILTER_BAR_FEED_IN_RELATED_VIDEOS_ENABLED || original;
+    }
+
+    /**
+     * Injection point.
+     */
     public static void hideInRelatedVideos(View chipView) {
-        // Cannot use 0dp hide with later targets, otherwise the suggested videos
-        // can be shown in full screen mode.
-        // This behavior may also be present in earlier app targets.
-        if (IS_20_21_OR_GREATER) {
-            // FIXME: The filter bar is still briefly shown when dragging the suggested videos
-            //        below the video player.
+        if (IS_20_10_OR_GREATER) {
             Utils.hideViewUnderCondition(HIDE_FILTER_BAR_FEED_IN_RELATED_VIDEOS_ENABLED, chipView);
         } else {
             Utils.hideViewBy0dpUnderCondition(HIDE_FILTER_BAR_FEED_IN_RELATED_VIDEOS_ENABLED, chipView);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/PlayerFlyoutMenuItemsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/PlayerFlyoutMenuItemsFilter.java
@@ -76,8 +76,8 @@ public class PlayerFlyoutMenuItemsFilter extends Filter {
                 ),
                 new ByteArrayFilterGroup(
                         Settings.HIDE_PLAYER_FLYOUT_AUDIO_TRACK,
-                        "yt_outline_person_radar_",
-                        "yt_outline_experimental_person_radar_"
+                        "yt_outline_person_",
+                        "yt_outline_experimental_person_"
                 ),
                 new ByteArrayFilterGroup(
                         Settings.HIDE_PLAYER_FLYOUT_ADDITIONAL_SETTINGS,
@@ -92,11 +92,13 @@ public class PlayerFlyoutMenuItemsFilter extends Filter {
                 new ByteArrayFilterGroup(
                         Settings.HIDE_PLAYER_FLYOUT_LOOP_VIDEO,
                         "yt_outline_arrow_repeat_1_",
-                        "yt_outline_experimental_repeat1_"
+                        "yt_outline_experimental_repeat1_",
+                        "yt_outline_experimental_play_circle"
                 ),
                 new ByteArrayFilterGroup(
                         Settings.HIDE_PLAYER_FLYOUT_STABLE_VOLUME,
                         "volume_stable_",
+                        "yt_fill_experimental_stable_volume_",
                         "yt_outline_experimental_stable_volume_"
                 ),
                 new ByteArrayFilterGroup(

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/quality/AdvancedVideoQualityMenuPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/quality/AdvancedVideoQualityMenuPatch.java
@@ -3,7 +3,6 @@ package app.morphe.extension.youtube.patches.playback.quality;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewParent;
 import android.widget.ListView;
 
 import app.morphe.extension.shared.Logger;

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/quality/AdvancedVideoQualityMenuPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/quality/AdvancedVideoQualityMenuPatch.java
@@ -31,13 +31,11 @@ public final class AdvancedVideoQualityMenuPatch {
                 }
                 AdvancedVideoQualityMenuFilter.isVideoQualityMenuVisible = false;
 
-                ViewParent quickQualityViewParent = Utils.getParentView(recyclerView, 3);
-                if (!(quickQualityViewParent instanceof ViewGroup)) {
+                if (!(Utils.getParentView(recyclerView, 3) instanceof ViewGroup quickQualityViewParent)) {
                     return;
                 }
 
-                View firstChild = recyclerView.getChildAt(0);
-                if (!(firstChild instanceof ViewGroup firstChildGroup)) {
+                if (!(recyclerView.getChildAt(0) instanceof ViewGroup firstChildGroup)) {
                     return;
                 }
 
@@ -45,16 +43,14 @@ public final class AdvancedVideoQualityMenuPatch {
                     return;
                 }
 
-                View advancedQualityView = firstChildGroup.getChildAt(3);
-                if (advancedQualityView == null) {
+                if (!(firstChildGroup.getChildAt(3) instanceof ViewGroup advancedQualityView)) {
                     return;
                 }
 
-                ((ViewGroup) quickQualityViewParent).setVisibility(View.GONE);
+                quickQualityViewParent.setVisibility(View.GONE);
 
                 // Click the "Advanced" quality menu to show the "old" quality menu.
-                advancedQualityView.setSoundEffectsEnabled(false);
-                advancedQualityView.performClick();
+                advancedQualityView.callOnClick();
             } catch (Exception ex) {
                 Logger.printException(() -> "onFlyoutMenuCreate failure", ex);
             }
@@ -63,7 +59,7 @@ public final class AdvancedVideoQualityMenuPatch {
 
     /**
      * Injection point.
-     *
+     * <p>
      * Shorts video quality flyout.
      */
     public static void addVideoQualityListMenuListener(ListView listView) {
@@ -94,7 +90,7 @@ public final class AdvancedVideoQualityMenuPatch {
 
     /**
      * Injection point.
-     *
+     * <p>
      * Used to force the creation of the advanced menu item for the Shorts quality flyout.
      */
     public static boolean forceAdvancedVideoQualityMenuCreation(boolean original) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
@@ -263,12 +263,12 @@ public class CustomPlaybackSpeedPatch {
         lastTimePlaybackMenuInvoked = now;
 
         // Dismiss View [R.id.touch_outside] is the 1st ChildView of the 4th ParentView.
-        // This only shows in phone layout.
-        var touchInsidedView = parentView4th.getChildAt(0);
-        touchInsidedView.setSoundEffectsEnabled(false);
-        touchInsidedView.performClick();
+        // This only shows in phone layout of YouTube 21.11 or lower.
+        View touchInsidedView = parentView4th.getChildAt(0);
+        touchInsidedView.callOnClick();
 
-        // In tablet layout there is no Dismiss View, instead we just hide all two parent views.
+        // In tablet layout and phone layout of YouTube 21.12 or higher,
+        // there no Dismiss View, so instead just hide two parent views.
         parentView3rd.setVisibility(View.GONE);
         parentView4th.setVisibility(View.GONE);
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
@@ -144,6 +144,13 @@ public class CustomPlaybackSpeedPatch {
     /**
      * Injection point.
      */
+    public static boolean restoreOldPlaybackSpeedMenu() {
+        return Settings.RESTORE_OLD_SPEED_MENU.get();
+    }
+
+    /**
+     * Injection point.
+     */
     public static boolean useNewFlyoutMenu(boolean useNewFlyout) {
         // If using old speed Turn off A/B flyout that breaks old playback speed menu.
         return useNewFlyout && !Settings.RESTORE_OLD_SPEED_MENU.get();

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
@@ -268,7 +268,7 @@ public class CustomPlaybackSpeedPatch {
         touchInsidedView.callOnClick();
 
         // In tablet layout and phone layout of YouTube 21.12 or higher,
-        // there no Dismiss View, so instead just hide two parent views.
+        // there no Dismiss View. Just hide two parent views.
         parentView3rd.setVisibility(View.GONE);
         parentView4th.setVisibility(View.GONE);
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
@@ -13,10 +13,11 @@ package app.morphe.patches.youtube.layout.hide.general
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.InstructionLocation.MatchAfterImmediately
 import app.morphe.patcher.InstructionLocation.MatchAfterWithin
-import app.morphe.patcher.OpcodesFilter
+import app.morphe.patcher.OpcodesFilter.Companion.opcodesToFilters
 import app.morphe.patcher.StringComparisonType
 import app.morphe.patcher.checkCast
 import app.morphe.patcher.fieldAccess
+import app.morphe.patcher.literal
 import app.morphe.patcher.methodCall
 import app.morphe.patcher.newInstance
 import app.morphe.patcher.opcode
@@ -24,7 +25,6 @@ import app.morphe.patcher.string
 import app.morphe.patches.shared.misc.mapping.ResourceType
 import app.morphe.patches.shared.misc.mapping.resourceLiteral
 import app.morphe.patches.youtube.layout.buttons.navigation.WideSearchbarLayoutFingerprint
-import app.morphe.util.customLiteral
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 
@@ -145,60 +145,92 @@ internal object YouTubeDoodlesImageViewFingerprint : Fingerprint(
     )
 )
 
-internal object CrowdfundingBoxFingerprint : Fingerprint(
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
-    filters = OpcodesFilter.opcodesToFilters(
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.MOVE_RESULT_OBJECT,
-        Opcode.IPUT_OBJECT,
-    ),
-    custom = customLiteral { crowdfundingBoxId } // TODO: Convert this to an instruction filter
-)
-
 internal object AlbumCardsFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
-    filters = OpcodesFilter.opcodesToFilters(
-        Opcode.MOVE_RESULT_OBJECT,
-        Opcode.CONST,
-        Opcode.CONST_4,
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.MOVE_RESULT_OBJECT,
-        Opcode.CHECK_CAST,
-    ),
-    custom = customLiteral { albumCardId } // TODO: Convert this to an instruction filter
+    filters = listOf(
+        resourceLiteral(ResourceType.LAYOUT, "album_card"),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            name = "inflate",
+            returnType = "Landroid/view/View;",
+            location = MatchAfterWithin(5)
+        ),
+        opcode(Opcode.MOVE_RESULT_OBJECT, location = MatchAfterImmediately())
+    )
+)
+
+internal object CrowdfundingBoxFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
+    filters = listOf(
+        resourceLiteral(ResourceType.LAYOUT, "donation_companion"),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            name = "inflate",
+            returnType = "Landroid/view/View;",
+        ),
+        opcode(Opcode.MOVE_RESULT_OBJECT, location = MatchAfterImmediately())
+    )
 )
 
 internal object FilterBarHeightFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
-    filters = OpcodesFilter.opcodesToFilters(
-        Opcode.CONST,
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.MOVE_RESULT,
-        Opcode.IPUT,
-    ),
-    custom = customLiteral { filterBarHeightId } // TODO: Convert this to an instruction filter
+    filters = listOf(
+        resourceLiteral(ResourceType.DIMEN, "filter_bar_height"),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            name = "getDimensionPixelSize",
+            returnType = "I",
+        ),
+        opcode(Opcode.MOVE_RESULT, location = MatchAfterImmediately())
+    )
 )
 
+/**
+ * 20.10+
+ */
 internal object RelatedChipCloudFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
-    filters = OpcodesFilter.opcodesToFilters(
-        Opcode.CONST,
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.MOVE_RESULT_OBJECT,
-    ),
-    custom = customLiteral { relatedChipCloudMarginId } // TODO: Convert this to an instruction filter
+    filters = listOf(
+        resourceLiteral(ResourceType.ID, "related_chip_cloud"),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            name = "findViewById"
+        ),
+        literal(45682279L),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            name = "getDimensionPixelSize",
+            returnType = "I",
+        ),
+        opcode(Opcode.MOVE_RESULT, location = MatchAfterImmediately())
+    )
+)
+
+/**
+ * ~ 20.09
+ */
+internal object RelatedChipCloudLegacyFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
+    filters = listOf(
+        resourceLiteral(ResourceType.ID, "related_chip_cloud"),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            name = "findViewById"
+        )
+    )
 )
 
 internal object SearchResultsChipBarFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
-    filters = OpcodesFilter.opcodesToFilters(
-        Opcode.CONST,
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.MOVE_RESULT,
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.MOVE_RESULT_OBJECT,
-    ),
-    custom = customLiteral { barContainerHeightId } // TODO: Convert this to an instruction filter
+    filters = listOf(
+        resourceLiteral(ResourceType.DIMEN, "bar_container_height"),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            name = "getDimensionPixelSize",
+            returnType = "I",
+        ),
+        opcode(Opcode.MOVE_RESULT, location = MatchAfterImmediately())
+    )
 )
 
 internal object ShowFloatingMicrophoneButtonFingerprint : Fingerprint(
@@ -215,8 +247,7 @@ internal object ShowFloatingMicrophoneButtonFingerprint : Fingerprint(
 internal object HideViewCountFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
     returnType = "Ljava/lang/CharSequence;",
-
-    filters = OpcodesFilter.opcodesToFilters(
+    filters = opcodesToFilters(
         Opcode.RETURN_OBJECT,
         Opcode.CONST_STRING,
         Opcode.RETURN_OBJECT,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
@@ -233,7 +233,37 @@ internal object SearchResultsChipBarFingerprint : Fingerprint(
     )
 )
 
+/**
+ * 21.11+
+ *
+ * Resolves using the method found in [ShowFloatingMicrophoneButtonParentFingerprint]
+ */
 internal object ShowFloatingMicrophoneButtonFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf("Landroid/view/View;", "Lcom/google/android/libraries/quantum/fab/FloatingActionButton;", "Landroid/view/ViewStub;"),
+    filters = listOf(
+        opcode(Opcode.IGET_BOOLEAN)
+    )
+)
+
+/**
+ * 21.11+
+ */
+internal object ShowFloatingMicrophoneButtonParentFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf("Z"),
+    strings = listOf("Current FAB View Wrapper does not support this operation. Text: "),
+    custom = { _, classDef ->
+        !classDef.interfaces.contains("Landroid/view/View\$OnClickListener;")
+    }
+)
+
+/**
+ * ~ 21.10
+ */
+internal object ShowFloatingMicrophoneButtonLegacyFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "V",
     parameters = listOf(),

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -10,8 +10,6 @@
 
 package app.morphe.patches.youtube.layout.hide.general
 
-import app.morphe.patcher.Fingerprint
-import app.morphe.patcher.Match.InstructionMatch
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
@@ -19,12 +17,9 @@ import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.removeInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
 import app.morphe.patcher.util.smali.ExternalLabel
 import app.morphe.patches.shared.misc.fix.proto.fixProtoLibraryPatch
-import app.morphe.patches.shared.misc.mapping.ResourceType
-import app.morphe.patches.shared.misc.mapping.getResourceId
 import app.morphe.patches.shared.misc.mapping.resourceMappingPatch
 import app.morphe.patches.shared.misc.settings.preference.InputType
 import app.morphe.patches.shared.misc.settings.preference.NonInteractivePreference
@@ -41,6 +36,7 @@ import app.morphe.patches.youtube.misc.litho.filter.lithoFilterPatch
 import app.morphe.patches.youtube.misc.litho.lazily.hookTreeNodeResult
 import app.morphe.patches.youtube.misc.litho.lazily.lazilyConvertedElementHookPatch
 import app.morphe.patches.youtube.misc.navigation.navigationBarHookPatch
+import app.morphe.patches.youtube.misc.playservice.is_20_10_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_20_21_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_21_11_or_greater
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
@@ -54,10 +50,11 @@ import app.morphe.util.findFreeRegister
 import app.morphe.util.findInstructionIndicesReversedOrThrow
 import app.morphe.util.getReference
 import app.morphe.util.indexOfFirstInstructionReversedOrThrow
+import app.morphe.util.injectHideViewCall
+import app.morphe.util.insertLiteralOverride
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
-import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
@@ -66,48 +63,6 @@ import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
 import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
-
-internal var albumCardId = -1L
-    private set
-internal var crowdfundingBoxId = -1L
-    private set
-internal var filterBarHeightId = -1L
-    private set
-internal var relatedChipCloudMarginId = -1L
-    private set
-internal var barContainerHeightId = -1L
-    private set
-
-private val hideLayoutComponentsResourcePatch = resourcePatch {
-    dependsOn(resourceMappingPatch)
-
-    execute {
-        albumCardId = getResourceId(
-            ResourceType.LAYOUT,
-            "album_card",
-        )
-
-        crowdfundingBoxId = getResourceId(
-            ResourceType.LAYOUT,
-            "donation_companion",
-        )
-
-        relatedChipCloudMarginId = getResourceId(
-            ResourceType.LAYOUT,
-            "related_chip_cloud_reduced_margins",
-        )
-
-        filterBarHeightId = getResourceId(
-            ResourceType.DIMEN,
-            "filter_bar_height",
-        )
-
-        barContainerHeightId = getResourceId(
-            ResourceType.DIMEN,
-            "bar_container_height",
-        )
-    }
-}
 
 private const val LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR =
     "Lapp/morphe/extension/youtube/patches/components/LayoutComponentsFilter;"
@@ -129,7 +84,6 @@ val hideLayoutComponentsPatch = bytecodePatch(
         lithoFilterPatch,
         settingsPatch,
         engagementPanelHookPatch,
-        hideLayoutComponentsResourcePatch,
         navigationBarHookPatch,
         versionCheckPatch,
         resourceMappingPatch,
@@ -456,16 +410,11 @@ val hideLayoutComponentsPatch = bytecodePatch(
         else HideSubscribedChannelsBarConstructorLegacyFingerprint
 
         constructorFingerprint.let {
-            it.method.apply {
-                val index = it.instructionMatches[1].index
-                val register = getInstruction<OneRegisterInstruction>(index).registerA
-
-                addInstruction(
-                    index + 1,
-                    "invoke-static { v$register }, $LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR" +
-                            "->hideSubscribedChannelsBar(Landroid/view/View;)V",
-                )
-            }
+            it.method.injectHideViewCall(
+                it.instructionMatches[1].index,
+                LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR,
+                "hideSubscribedChannelsBar"
+            )
         }
 
         // Phone (landscape mode)
@@ -488,37 +437,14 @@ val hideLayoutComponentsPatch = bytecodePatch(
 
         // endregion
 
-        // region hide crowdfunding box
-
-        CrowdfundingBoxFingerprint.let {
-            it.method.apply {
-                val insertIndex = it.instructionMatches.last().index
-                val objectRegister = getInstruction<TwoRegisterInstruction>(insertIndex).registerA
-
-                addInstruction(
-                    insertIndex,
-                    "invoke-static {v$objectRegister}, $LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR" +
-                        "->hideCrowdfundingBox(Landroid/view/View;)V",
-                )
-            }
-        }
-
-        // endregion
-
         // region hide album cards
 
         AlbumCardsFingerprint.let {
-            it.method.apply {
-                val checkCastAnchorIndex = it.instructionMatches.last().index
-                val insertIndex = checkCastAnchorIndex + 1
-                val register = getInstruction<OneRegisterInstruction>(checkCastAnchorIndex).registerA
-
-                addInstruction(
-                    insertIndex,
-                    "invoke-static { v$register }, $LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR" +
-                        "->hideAlbumCard(Landroid/view/View;)V",
-                )
-            }
+            it.method.injectHideViewCall(
+                it.instructionMatches.last().index,
+                LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR,
+                "hideAlbumCard"
+            )
         }
 
         // endregion
@@ -526,6 +452,18 @@ val hideLayoutComponentsPatch = bytecodePatch(
         // region hide comment page
 
         hookElement("$COMMENTS_FILTER_CLASS_NAME->onCommentsLoaded([B)[B")
+
+        // endregion
+
+        // region hide crowdfunding box
+
+        CrowdfundingBoxFingerprint.let {
+            it.method.injectHideViewCall(
+                it.instructionMatches.last().index,
+                LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR,
+                "hideCrowdfundingBox"
+            )
+        }
 
         // endregion
 
@@ -558,14 +496,11 @@ val hideLayoutComponentsPatch = bytecodePatch(
             LatestVideosContentPillFingerprint,
             LatestVideosBarFingerprint,
         ).forEach { fingerprint ->
-            fingerprint.method.apply {
-                val moveIndex = fingerprint.instructionMatches.last().index
-                val viewRegister = getInstruction<OneRegisterInstruction>(moveIndex).registerA
-
-                addInstruction(
-                    moveIndex + 1,
-                    "invoke-static { v$viewRegister }, $LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR" +
-                            "->hideLatestVideosButton(Landroid/view/View;)V"
+            fingerprint.let {
+                it.method.injectHideViewCall(
+                    it.instructionMatches.last().index,
+                    LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR,
+                    "hideLatestVideosButton"
                 )
             }
         }
@@ -625,43 +560,58 @@ val hideLayoutComponentsPatch = bytecodePatch(
 
         // region hide filter bar
 
-        /**
-         * Patch a [Method] with a given [instructions].
-         *
-         * @param RegisterInstruction The type of instruction to get the register from.
-         * @param insertIndexOffset The offset to add to the end index of the [InstructionMatch].
-         * @param hookRegisterOffset The offset to add to the register of the hook.
-         * @param instructions The instructions to add with the register as a parameter.
-         */
-        fun <RegisterInstruction : OneRegisterInstruction> Fingerprint.patch(
-            insertIndexOffset: Int = 0,
-            hookRegisterOffset: Int = 0,
-            instructions: (Int) -> String,
-        ) = method.apply {
-            val endIndex = instructionMatches.last().index
-            val insertIndex = endIndex + insertIndexOffset
-            val register = getInstruction<RegisterInstruction>(endIndex + hookRegisterOffset).registerA
-
-            addInstructions(insertIndex, instructions(register))
+        val filterBars = mutableMapOf(
+            FilterBarHeightFingerprint to "hideInFeed",
+            SearchResultsChipBarFingerprint to "hideInSearch",
+        )
+        if (is_20_10_or_greater) {
+            filterBars += Pair(RelatedChipCloudFingerprint, "hideInRelatedVideos")
         }
 
-        FilterBarHeightFingerprint.patch<TwoRegisterInstruction> { register ->
-            """
-                invoke-static { v$register }, $LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR->hideInFeed(I)I
-                move-result v$register
-            """
+        filterBars.forEach { (fingerprint, methodName) ->
+            fingerprint.method.apply {
+                val moveIndex = fingerprint.instructionMatches.last().index
+                val sizeRegister = getInstruction<OneRegisterInstruction>(moveIndex).registerA
+
+                addInstructions(
+                    moveIndex + 1,
+                    """
+                        invoke-static { v$sizeRegister }, $LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR->$methodName(I)I
+                        move-result v$sizeRegister
+                    """
+                )
+            }
         }
 
-        SearchResultsChipBarFingerprint.patch<OneRegisterInstruction>(-1, -2) { register ->
-            """
-                invoke-static { v$register }, $LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR->hideInSearch(I)I
-                move-result v$register
-            """
+        if (is_20_10_or_greater) {
+            RelatedChipCloudFingerprint.let {
+                it.clearMatch()
+                it.method.apply {
+                    insertLiteralOverride(
+                        it.instructionMatches[2].index,
+                        "$LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR->hideInRelatedVideos(Z)Z"
+                    )
+                }
+            }
         }
 
-        RelatedChipCloudFingerprint.patch<OneRegisterInstruction>(1) { register ->
-            "invoke-static { v$register }, " +
-                "$LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR->hideInRelatedVideos(Landroid/view/View;)V"
+        val relatedChipCloudFingerprintMatch = if (is_20_10_or_greater)
+            RelatedChipCloudFingerprint
+        else RelatedChipCloudLegacyFingerprint
+
+        relatedChipCloudFingerprintMatch.let {
+            it.clearMatch()
+            it.method.apply {
+                val viewIndex = it.instructionMatches[1].index
+                val viewRegister = getInstruction<FiveRegisterInstruction>(viewIndex).registerC
+
+                injectHideViewCall(
+                    viewIndex,
+                    viewRegister,
+                    LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR,
+                    "hideInRelatedVideos"
+                )
+            }
         }
 
         // endregion

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -243,6 +243,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
                     ),
                 )
             ),
+            SwitchPreference("morphe_hide_floating_microphone_button"),
             SwitchPreference(
                 key = "morphe_hide_horizontal_shelves",
                 tag = "app.morphe.extension.shared.settings.preference.BulletPointSwitchPreference"
@@ -268,12 +269,6 @@ val hideLayoutComponentsPatch = bytecodePatch(
         if (is_20_21_or_greater) {
             PreferenceScreen.FEED.addPreferences(
                 SwitchPreference("morphe_hide_you_may_like_section")
-            )
-        }
-
-        if (!is_21_11_or_greater) {
-            PreferenceScreen.FEED.addPreferences(
-                SwitchPreference("morphe_hide_floating_microphone_button")
             )
         }
 
@@ -469,22 +464,24 @@ val hideLayoutComponentsPatch = bytecodePatch(
 
         // region hide floating microphone
 
-        if (!is_21_11_or_greater) {
-            // Code has moved in 21.11+, but it's not clear when/where this
-            // floating microphone can show or if this patch is still relevant.
-            ShowFloatingMicrophoneButtonFingerprint.let {
-                it.method.apply {
-                    val index = it.instructionMatches.last().index
-                    val register = getInstruction<TwoRegisterInstruction>(index).registerA
+        val showFloatingMicrophoneButtonFingerprintMatch = if (is_21_11_or_greater)
+            ShowFloatingMicrophoneButtonFingerprint.match(
+                ShowFloatingMicrophoneButtonParentFingerprint.originalClassDef
+            )
+        else ShowFloatingMicrophoneButtonLegacyFingerprint.match()
 
-                    addInstructions(
-                        index + 1,
-                        """
-                            invoke-static { v$register }, $LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR->hideFloatingMicrophoneButton(Z)Z
-                            move-result v$register
-                        """
-                    )
-                }
+        showFloatingMicrophoneButtonFingerprintMatch.let {
+            it.method.apply {
+                val index = it.instructionMatches.last().index
+                val register = getInstruction<TwoRegisterInstruction>(index).registerA
+
+                addInstructions(
+                    index + 1,
+                    """
+                        invoke-static { v$register }, $LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR->hideFloatingMicrophoneButton(Z)Z
+                        move-result v$register
+                    """
+                )
             }
         }
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/overlay/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/overlay/Fingerprints.kt
@@ -5,7 +5,12 @@ import app.morphe.patcher.InstructionLocation.MatchAfterWithin
 import app.morphe.patcher.checkCast
 import app.morphe.patches.shared.misc.mapping.ResourceType
 import app.morphe.patches.shared.misc.mapping.resourceLiteral
+import app.morphe.patches.youtube.layout.sponsorblock.ControlsOverlayFingerprint
+import app.morphe.patches.youtube.misc.playercontrols.PlayerBottomGradientScrimFingerprint
 
+/**
+ * Matches same method as [ControlsOverlayFingerprint] and [PlayerBottomGradientScrimFingerprint].
+ */
 internal object CreatePlayerOverviewFingerprint : Fingerprint(
     returnType = "V",
     filters = listOf(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/sponsorblock/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/sponsorblock/Fingerprints.kt
@@ -8,6 +8,9 @@ import app.morphe.patcher.methodCall
 import app.morphe.patcher.opcode
 import app.morphe.patches.shared.misc.mapping.ResourceType
 import app.morphe.patches.shared.misc.mapping.resourceLiteral
+import app.morphe.patches.youtube.layout.player.overlay.CreatePlayerOverviewFingerprint
+import app.morphe.patches.youtube.misc.playercontrols.PlayerBottomGradientScrimFingerprint
+import app.morphe.patches.youtube.shared.SeekbarFingerprint
 import app.morphe.util.getReference
 import app.morphe.util.indexOfFirstInstructionReversed
 import com.android.tools.smali.dexlib2.AccessFlags
@@ -27,6 +30,9 @@ internal object AppendTimeFingerprint : Fingerprint(
     )
 )
 
+/**
+ * Matches same method as [CreatePlayerOverviewFingerprint] and [PlayerBottomGradientScrimFingerprint].
+ */
 internal object ControlsOverlayFingerprint : Fingerprint(
     returnType = "V",
     parameters = listOf(),
@@ -37,7 +43,7 @@ internal object ControlsOverlayFingerprint : Fingerprint(
 )
 
 /**
- * Resolves to the class found in [seekbarFingerprint].
+ * Resolves to the class found in [SeekbarFingerprint].
  */
 internal object RectangleFieldInvalidatorFingerprint : Fingerprint(
     returnType = "V",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/sponsorblock/SponsorBlockPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/sponsorblock/SponsorBlockPatch.kt
@@ -234,8 +234,8 @@ val sponsorBlockPatch = bytecodePatch(
 
         // Initialize the SponsorBlock view.
         ControlsOverlayFingerprint.match(LayoutConstructorFingerprint.originalClassDef).let {
-            val checkCastIndex = it.instructionMatches.last().index
             it.method.apply {
+                val checkCastIndex = it.instructionMatches.last().index
                 val frameLayoutRegister = getInstruction<OneRegisterInstruction>(checkCastIndex).registerA
                 addInstruction(
                     checkCastIndex + 1,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/Fingerprints.kt
@@ -1,7 +1,9 @@
 package app.morphe.patches.youtube.misc.playercontrols
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation.MatchAfterAtLeast
 import app.morphe.patcher.InstructionLocation.MatchAfterImmediately
+import app.morphe.patcher.InstructionLocation.MatchAfterWithin
 import app.morphe.patcher.OpcodesFilter
 import app.morphe.patcher.checkCast
 import app.morphe.patcher.literal
@@ -9,6 +11,8 @@ import app.morphe.patcher.methodCall
 import app.morphe.patcher.opcode
 import app.morphe.patches.shared.misc.mapping.ResourceType
 import app.morphe.patches.shared.misc.mapping.resourceLiteral
+import app.morphe.patches.youtube.layout.player.overlay.CreatePlayerOverviewFingerprint
+import app.morphe.patches.youtube.layout.sponsorblock.ControlsOverlayFingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 
@@ -78,6 +82,22 @@ internal object PlayerBottomControlsInflateFingerprint : Fingerprint(
     )
 )
 
+/**
+ * Matches same method as [ControlsOverlayFingerprint] and [CreatePlayerOverviewFingerprint].
+ */
+internal object PlayerBottomGradientScrimFingerprint : Fingerprint(
+    returnType = "V",
+    parameters = listOf(),
+    filters = listOf(
+        resourceLiteral(ResourceType.ID, "bottom_gradient_scrim_overlay"),
+        checkCast("Landroid/widget/ImageView;", MatchAfterWithin(10)),
+        opcode(Opcode.NEW_INSTANCE),
+        opcode(Opcode.IPUT_OBJECT),
+        opcode(Opcode.IPUT_OBJECT, MatchAfterImmediately()),
+        opcode(Opcode.IPUT_OBJECT, MatchAfterImmediately()),
+    )
+)
+
 internal object OverlayViewInflateFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "V",
@@ -90,7 +110,7 @@ internal object OverlayViewInflateFingerprint : Fingerprint(
 )
 
 /**
- * Resolves to the class found in [playerTopControlsInflateFingerprint].
+ * Resolves to the class found in [PlayerTopControlsInflateFingerprint].
  */
 internal object ControlsOverlayVisibilityFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.FINAL),
@@ -140,14 +160,5 @@ internal object PlayerControlsButtonStrokeFeatureFlagFingerprint : Fingerprint(
     parameters = listOf(),
     filters = listOf(
         literal(45713296)
-    )
-)
-
-internal object PlayerOverlayOpacityGradientFeatureFlagFingerprint : Fingerprint(
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
-    returnType = "Z",
-    parameters = listOf(),
-    filters = listOf(
-        literal(45729621)
     )
 )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/Fingerprints.kt
@@ -1,7 +1,6 @@
 package app.morphe.patches.youtube.misc.playercontrols
 
 import app.morphe.patcher.Fingerprint
-import app.morphe.patcher.InstructionLocation.MatchAfterAtLeast
 import app.morphe.patcher.InstructionLocation.MatchAfterImmediately
 import app.morphe.patcher.InstructionLocation.MatchAfterWithin
 import app.morphe.patcher.OpcodesFilter

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/PlayerControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/PlayerControlsPatch.kt
@@ -25,6 +25,7 @@ import app.morphe.patches.youtube.misc.playservice.is_20_19_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_20_20_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_20_28_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_20_30_or_greater
+import app.morphe.patches.youtube.misc.playservice.is_20_40_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_21_03_or_greater
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
 import app.morphe.util.copyXmlNode
@@ -36,6 +37,7 @@ import app.morphe.util.returnEarly
 import app.morphe.util.returnLate
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import org.w3c.dom.Node
 import java.lang.ref.WeakReference
 
@@ -341,17 +343,37 @@ val playerControlsPatch = bytecodePatch(
 
             if (is_20_28_or_greater) {
                 PlayerControlsLargeOverlayButtonsFeatureFlagFingerprint.method.returnLate(false)
-            }
 
-            if (is_20_30_or_greater) {
-                PlayerControlsButtonStrokeFeatureFlagFingerprint.method.returnLate(false)
-            }
-        }
+                if (is_20_30_or_greater) {
+                    PlayerControlsButtonStrokeFeatureFlagFingerprint.method.returnLate(false)
 
-        if (is_21_03_or_greater) {
-            // If enabled it can show a black gradient on lower part of screen in fullscreen mode.
-            // This override may not be needed if the new bold player overlay icons are in use.
-            PlayerOverlayOpacityGradientFeatureFlagFingerprint.method.returnLate(false)
+                    if (is_20_40_or_greater) {
+                        // Clear bottom gradient.
+                        // This may not be needed if the new bold player overlay icons are in use.
+                        PlayerBottomGradientScrimFingerprint.let {
+                            it.method.apply {
+                                val gradientHelperIndex = it.instructionMatches.last().index
+                                val gradientHelperRegister =
+                                    getInstruction<TwoRegisterInstruction>(gradientHelperIndex).registerA
+
+                                val gradientViewIndex = it.instructionMatches[1].index
+                                val gradientViewRegister =
+                                    getInstruction<OneRegisterInstruction>(gradientViewIndex).registerA
+
+                                addInstruction(
+                                    gradientHelperIndex,
+                                    "const/4 v$gradientHelperRegister, 0x0"
+                                )
+                                addInstruction(
+                                    gradientViewIndex + 1,
+                                    "invoke-static { v$gradientViewRegister }, " +
+                                            "$EXTENSION_CLASS_DESCRIPTOR->hideBottomGradientScrim(Landroid/widget/ImageView;)V"
+                                )
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/PlayerControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/PlayerControlsPatch.kt
@@ -352,18 +352,21 @@ val playerControlsPatch = bytecodePatch(
                         // This may not be needed if the new bold player overlay icons are in use.
                         PlayerBottomGradientScrimFingerprint.let {
                             it.method.apply {
-                                val gradientHelperIndex = it.instructionMatches.last().index
-                                val gradientHelperRegister =
-                                    getInstruction<TwoRegisterInstruction>(gradientHelperIndex).registerA
+                                val gradientFieldIndex = it.instructionMatches.last().index
+                                val gradientFieldRegister =
+                                    getInstruction<TwoRegisterInstruction>(gradientFieldIndex).registerA
 
                                 val gradientViewIndex = it.instructionMatches[1].index
                                 val gradientViewRegister =
                                     getInstruction<OneRegisterInstruction>(gradientViewIndex).registerA
 
+                                // This field is Nullable, and if null, the bottom gradient is not set.
                                 addInstruction(
-                                    gradientHelperIndex,
-                                    "const/4 v$gradientHelperRegister, 0x0"
+                                    gradientFieldIndex,
+                                    "const/4 v$gradientFieldRegister, 0x0"
                                 )
+
+                                // Make the bottom gradient transparent and hide it.
                                 addInstruction(
                                     gradientViewIndex + 1,
                                     "invoke-static { v$gradientViewRegister }, " +

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playservice/VersionCheckPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playservice/VersionCheckPatch.kt
@@ -136,6 +136,8 @@ var is_21_10_or_greater : Boolean by Delegates.notNull()
     private set
 var is_21_11_or_greater : Boolean by Delegates.notNull()
     private set
+var is_21_12_or_greater : Boolean by Delegates.notNull()
+    private set
 
 
 val versionCheckPatch = resourcePatch(
@@ -199,5 +201,6 @@ val versionCheckPatch = resourcePatch(
         is_21_08_or_greater = 260905000 <= playStoreServicesVersion
         is_21_10_or_greater = 261080000 <= playStoreServicesVersion
         is_21_11_or_greater = 261205000 <= playStoreServicesVersion
+        is_21_12_or_greater = 261305000 <= playStoreServicesVersion
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/proto/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/proto/Fingerprints.kt
@@ -19,12 +19,15 @@ import com.android.tools.smali.dexlib2.Opcode
  * Resolves using the method found in [ProtoStuffReflectionFingerprint].
  */
 internal object NewElementProtoParserFingerprint : Fingerprint(
-    accessFlags = listOf(AccessFlags.STATIC),
     parameters = listOf("L"),
     returnType = "[B",
     filters = listOf(
         checkCast("[B")
-    )
+    ),
+    custom = { method, _ ->
+        // 'static' or 'public static'
+        AccessFlags.STATIC.isSet(method.accessFlags)
+    }
 )
 
 internal object ProtoStuffReflectionFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/shared/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/shared/Fingerprints.kt
@@ -177,6 +177,27 @@ internal object ToolBarButtonFingerprint : Fingerprint(
     )
 )
 
+internal object PlaybackSpeedOnItemClickParentFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
+    returnType = "L",
+    parameters = listOf("L", "Ljava/lang/String;"),
+    filters = listOf(
+        methodCall(name = "getSupportFragmentManager", location = MatchFirst()),
+        opcode(Opcode.MOVE_RESULT_OBJECT, location = MatchAfterImmediately()),
+        methodCall(
+            returnType = "L",
+            parameters = listOf("Ljava/lang/String;"),
+            location = MatchAfterImmediately()
+        ),
+        opcode(Opcode.MOVE_RESULT_OBJECT, location = MatchAfterImmediately()),
+        opcode(Opcode.IF_EQZ, location = MatchAfterImmediately()),
+        opcode(Opcode.CHECK_CAST, location = MatchAfterImmediately()),
+    ),
+    custom = { _, classDef ->
+        classDef.methods.count() == 8
+    }
+)
+
 internal object VideoQualityChangedFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "L",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/information/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/information/Fingerprints.kt
@@ -1,15 +1,13 @@
 package app.morphe.patches.youtube.video.information
 
 import app.morphe.patcher.Fingerprint
-import app.morphe.patcher.InstructionLocation.MatchAfterImmediately
-import app.morphe.patcher.InstructionLocation.MatchFirst
 import app.morphe.patcher.OpcodesFilter
 import app.morphe.patcher.StringComparisonType
 import app.morphe.patcher.anyInstruction
 import app.morphe.patcher.fieldAccess
 import app.morphe.patcher.methodCall
-import app.morphe.patcher.opcode
 import app.morphe.patcher.string
+import app.morphe.patches.youtube.shared.PlaybackSpeedOnItemClickParentFingerprint
 import app.morphe.patches.youtube.shared.VideoQualityChangedFingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
@@ -21,31 +19,10 @@ internal object CreateVideoPlayerSeekbarFingerprint : Fingerprint(
     )
 )
 
-internal object OnPlaybackSpeedItemClickParentFingerprint : Fingerprint(
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
-    returnType = "L",
-    parameters = listOf("L", "Ljava/lang/String;"),
-    filters = listOf(
-        methodCall(name = "getSupportFragmentManager", location = MatchFirst()),
-        opcode(Opcode.MOVE_RESULT_OBJECT, location = MatchAfterImmediately()),
-        methodCall(
-            returnType = "L",
-            parameters = listOf("Ljava/lang/String;"),
-            location = MatchAfterImmediately()
-        ),
-        opcode(Opcode.MOVE_RESULT_OBJECT, location = MatchAfterImmediately()),
-        opcode(Opcode.IF_EQZ, location = MatchAfterImmediately()),
-        opcode(Opcode.CHECK_CAST, location = MatchAfterImmediately()),
-    ),
-    custom = { _, classDef ->
-        classDef.methods.count() == 8
-    }
-)
-
 /**
- * Resolves using the method found in [OnPlaybackSpeedItemClickParentFingerprint].
+ * Resolves using the method found in [PlaybackSpeedOnItemClickParentFingerprint].
  */
-internal object OnPlaybackSpeedItemClickFingerprint : Fingerprint(
+internal object PlaybackSpeedOnItemClickFingerprint : Fingerprint(
     name = "onItemClick",
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "V",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/information/VideoInformationPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/information/VideoInformationPatch.kt
@@ -27,6 +27,7 @@ import app.morphe.patches.youtube.misc.playservice.is_20_19_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_20_20_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_20_49_or_greater
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
+import app.morphe.patches.youtube.shared.PlaybackSpeedOnItemClickParentFingerprint
 import app.morphe.patches.youtube.shared.VideoQualityChangedFingerprint
 import app.morphe.patches.youtube.video.playerresponse.Hook
 import app.morphe.patches.youtube.video.playerresponse.addPlayerResponseMethodHook
@@ -232,7 +233,7 @@ val videoInformationPatch = bytecodePatch(
         /*
          * Hook the user playback speed selection.
          */
-        OnPlaybackSpeedItemClickFingerprint.match(OnPlaybackSpeedItemClickParentFingerprint.classDef).method.apply {
+        PlaybackSpeedOnItemClickFingerprint.match(PlaybackSpeedOnItemClickParentFingerprint.classDef).method.apply {
             val speedSelectionValueInstructionIndex = indexOfFirstInstructionOrThrow(Opcode.IGET)
 
             legacySpeedSelectionInsertMethodRef = WeakReference(this)
@@ -297,7 +298,7 @@ val videoInformationPatch = bytecodePatch(
             setPlaybackSpeedMethodIndex = 0
 
             // Add override playback speed method.
-            OnPlaybackSpeedItemClickFingerprint.classDef.methods.add(
+            PlaybackSpeedOnItemClickParentFingerprint.classDef.methods.add(
                 ImmutableMethod(
                     definingClass,
                     "overridePlaybackSpeed",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/custom/CustomPlaybackSpeedPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/custom/CustomPlaybackSpeedPatch.kt
@@ -165,7 +165,7 @@ internal val customPlaybackSpeedPatch = bytecodePatch(
             )
         }
 
-        // FIXME: Restore the old playback speed menu in YouTube 21.12+.
+        // FIXME: Restore old playback speed menu in YouTube 21.12+.
         if (is_21_02_or_greater && !is_21_12_or_greater) {
             FlyoutMenuNonLegacyFeatureFlagFingerprint.let {
                 it.method.insertLiteralOverride(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/custom/CustomPlaybackSpeedPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/custom/CustomPlaybackSpeedPatch.kt
@@ -17,7 +17,9 @@ import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableField
 import app.morphe.patcher.util.proxy.mutableTypes.MutableField.Companion.toMutable
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
 import app.morphe.patches.shared.misc.mapping.resourceMappingPatch
 import app.morphe.patches.shared.misc.settings.preference.InputType
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
@@ -33,13 +35,20 @@ import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
 import app.morphe.patches.youtube.misc.recyclerviewtree.hook.addRecyclerViewTreeHook
 import app.morphe.patches.youtube.misc.recyclerviewtree.hook.recyclerViewTreeHookPatch
 import app.morphe.patches.youtube.misc.settings.settingsPatch
+import app.morphe.patches.youtube.shared.PlaybackSpeedOnItemClickParentFingerprint
 import app.morphe.patches.youtube.video.speed.settingsMenuVideoSpeedGroup
+import app.morphe.util.addInstructionsAtControlFlowLabel
+import app.morphe.util.getReference
 import app.morphe.util.indexOfFirstLiteralInstructionOrThrow
 import app.morphe.util.insertLiteralOverride
 import app.morphe.util.returnEarly
 import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.immutable.ImmutableField
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
 
 private const val FILTER_CLASS_DESCRIPTOR =
     "Lapp/morphe/extension/youtube/patches/components/PlaybackSpeedMenuFilter;"
@@ -165,8 +174,128 @@ internal val customPlaybackSpeedPatch = bytecodePatch(
             )
         }
 
-        // FIXME: Restore old playback speed menu in YouTube 21.12+.
-        if (is_21_02_or_greater && !is_21_12_or_greater) {
+        if (is_21_12_or_greater) {
+            val onItemClickClass: String
+            val fragmentIdField: MutableField
+            val fragmentManagerMethod : MethodReference
+
+            PlaybackSpeedOnItemClickParentFingerprint.let {
+                it.method.apply {
+                    // Add a fragment id instance field to the class.
+                    fragmentIdField = ImmutableField(
+                        definingClass,
+                        "INSTANCE",
+                        "Ljava/lang/String;",
+                        AccessFlags.PUBLIC.value,
+                        null,
+                        null,
+                        null,
+                    ).toMutable()
+                    it.classDef.instanceFields.add(fragmentIdField)
+
+                    onItemClickClass = definingClass
+                    fragmentManagerMethod = it.instructionMatches.first()
+                        .instruction.getReference<MethodReference>()!!
+
+                    val insertIndex = implementation!!.instructions.lastIndex
+
+                    addInstruction(
+                        insertIndex,
+                        "iput-object p1, p0, $fragmentIdField"
+                    )
+                }
+            }
+
+            val bottomSheetAvailabilityPrimaryMethodCall : String
+            val bottomSheetAvailabilitySecondaryMethodCall : String
+            val bottomSheetBuilderMethodCall : String
+            AudioTrackOldBottomSheetFingerprint.instructionMatches.apply {
+                fun getMethodCall(offset: Int):String {
+                    val methodReference =
+                        this[offset].instruction.getReference<MethodReference>()!!
+
+                    return methodReference.toString()
+                        .replace(methodReference.definingClass, onItemClickClass)
+                }
+                bottomSheetAvailabilityPrimaryMethodCall = getMethodCall(0)
+                bottomSheetAvailabilitySecondaryMethodCall = getMethodCall(1)
+                bottomSheetBuilderMethodCall = getMethodCall(3)
+            }
+
+            ShowOldPlaybackSpeedMenuFingerprint.let {
+                it.classDef.apply {
+                    val onItemClickField = fields.single { field ->
+                        field.type == onItemClickClass
+                    }
+                    val fragmentManagerField = fields.single { field ->
+                        field.type == fragmentManagerMethod.definingClass
+                    }
+                    val helperMethod = ImmutableMethod(
+                        type,
+                        "patch_showOldPlaybackSpeedMenu",
+                        listOf(),
+                        "V",
+                        AccessFlags.PRIVATE.value or AccessFlags.FINAL.value,
+                        null,
+                        null,
+                        MutableMethodImplementation(4),
+                    ).toMutable().apply {
+                        addInstructions(
+                            0,
+                            """
+                                # Check if it is enabled.
+                                invoke-static { }, $EXTENSION_CLASS_DESCRIPTOR->restoreOldPlaybackSpeedMenu()Z
+                                move-result v0
+                                if-eqz v0, :ignore
+                                
+                                # Check if the bottom sheet is available.
+                                iget-object v0, p0, $onItemClickField
+                                invoke-virtual { v0 }, $bottomSheetAvailabilityPrimaryMethodCall
+                                move-result v1
+                                if-nez v1, :ignore
+
+                                # Check if the bottom sheet is available.
+                                invoke-virtual { v0 }, $bottomSheetAvailabilitySecondaryMethodCall
+                                move-result v1
+                                if-nez v1, :ignore
+
+                                # Check if the fragment ID is not null.
+                                iget-object v2, v0, $fragmentIdField
+                                if-eqz v2, :ignore
+
+                                # Shows the bottom sheet dialog.
+                                iget-object v1, p0, $fragmentManagerField
+                                invoke-virtual { v1 }, $fragmentManagerMethod
+                                move-result-object v1
+                                invoke-virtual { v0, v1, v2 }, $bottomSheetBuilderMethodCall
+
+                                :ignore
+                                return-void
+                            """
+                        )
+                    }
+                    methods.add(helperMethod)
+
+                    it.method.apply {
+                        val index = it.instructionMatches.last().index
+                        val register = getInstruction<TwoRegisterInstruction>(index).registerA
+
+                        addInstructionsAtControlFlowLabel(
+                            index,
+                            """
+                                invoke-static { }, $EXTENSION_CLASS_DESCRIPTOR->restoreOldPlaybackSpeedMenu()Z
+                                move-result v$register
+                                if-eqz v$register, :ignore
+                                invoke-direct { p0 }, $helperMethod
+                                return-void
+                                :ignore
+                                nop
+                            """
+                        )
+                    }
+                }
+            }
+        } else if (is_21_02_or_greater) {
             FlyoutMenuNonLegacyFeatureFlagFingerprint.let {
                 it.method.insertLiteralOverride(
                     it.instructionMatches.first().index,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/custom/CustomPlaybackSpeedPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/custom/CustomPlaybackSpeedPatch.kt
@@ -28,6 +28,7 @@ import app.morphe.patches.youtube.misc.litho.filter.lithoFilterPatch
 import app.morphe.patches.youtube.misc.playservice.is_19_47_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_20_34_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_21_02_or_greater
+import app.morphe.patches.youtube.misc.playservice.is_21_12_or_greater
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
 import app.morphe.patches.youtube.misc.recyclerviewtree.hook.addRecyclerViewTreeHook
 import app.morphe.patches.youtube.misc.recyclerviewtree.hook.recyclerViewTreeHookPatch
@@ -164,7 +165,8 @@ internal val customPlaybackSpeedPatch = bytecodePatch(
             )
         }
 
-        if (is_21_02_or_greater) {
+        // FIXME: Restore the old playback speed menu in YouTube 21.12+.
+        if (is_21_02_or_greater && !is_21_12_or_greater) {
             FlyoutMenuNonLegacyFeatureFlagFingerprint.let {
                 it.method.insertLiteralOverride(
                     it.instructionMatches.first().index,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/custom/CustomPlaybackSpeedPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/custom/CustomPlaybackSpeedPatch.kt
@@ -174,11 +174,11 @@ internal val customPlaybackSpeedPatch = bytecodePatch(
             )
         }
 
+        // Fix restore old playback speed menu.
         if (is_21_12_or_greater) {
             val onItemClickClass: String
             val fragmentIdField: MutableField
             val fragmentManagerMethod : MethodReference
-
             PlaybackSpeedOnItemClickParentFingerprint.let {
                 it.method.apply {
                     // Add a fragment id instance field to the class.
@@ -243,11 +243,6 @@ internal val customPlaybackSpeedPatch = bytecodePatch(
                         addInstructions(
                             0,
                             """
-                                # Check if it is enabled.
-                                invoke-static { }, $EXTENSION_CLASS_DESCRIPTOR->restoreOldPlaybackSpeedMenu()Z
-                                move-result v0
-                                if-eqz v0, :ignore
-                                
                                 # Check if the bottom sheet is available.
                                 iget-object v0, p0, $onItemClickField
                                 invoke-virtual { v0 }, $bottomSheetAvailabilityPrimaryMethodCall

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/custom/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/custom/Fingerprints.kt
@@ -13,6 +13,28 @@ import app.morphe.patches.shared.misc.mapping.resourceLiteral
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 
+internal object AudioTrackOldBottomSheetFingerprint : Fingerprint(
+    returnType = "V",
+    filters = listOf(
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            parameters = listOf(),
+            returnType = "Z"
+        ),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            parameters = listOf(),
+            returnType = "Z"
+        ),
+        string("AUDIO_TRACKS_MENU_BOTTOM_SHEET_FRAGMENT"),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            parameters = listOf("L", "Ljava/lang/String;"),
+            returnType = "V"
+        ),
+    )
+)
+
 internal object GetOldPlaybackSpeedsFingerprint : Fingerprint(
     parameters = listOf("[L", "I"),
     strings = listOf("menu_item_playback_speed")
@@ -20,7 +42,12 @@ internal object GetOldPlaybackSpeedsFingerprint : Fingerprint(
 
 internal object ShowOldPlaybackSpeedMenuFingerprint : Fingerprint(
     filters = listOf(
-        resourceLiteral(ResourceType.STRING, "varispeed_unavailable_message")
+        resourceLiteral(ResourceType.STRING, "varispeed_unavailable_message"),
+        opcode(Opcode.RETURN_VOID),
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            definingClass = "this"
+        )
     )
 )
 

--- a/patches/src/main/kotlin/app/morphe/util/BytecodeUtils.kt
+++ b/patches/src/main/kotlin/app/morphe/util/BytecodeUtils.kt
@@ -235,6 +235,24 @@ fun MutableMethod.injectHideViewCall(
 )
 
 /**
+ * Inject a call to a method that hides a view.
+ *
+ * @param moveIndex The index of MOVE_RESULT_OBJECT.
+ * @param classDescriptor The descriptor of the class that contains the method.
+ * @param targetMethod The name of the method to call.
+ */
+fun MutableMethod.injectHideViewCall(
+    moveIndex: Int,
+    classDescriptor: String,
+    targetMethod: String,
+) = injectHideViewCall(
+    moveIndex + 1,
+    getInstruction<OneRegisterInstruction>(moveIndex).registerA,
+    classDescriptor,
+    targetMethod
+)
+
+/**
  * Inserts instructions at a given index, using the existing control flow label at that index.
  * Inserted instructions can have its own control flow labels as well.
  *


### PR DESCRIPTION
### Description

Closes https://github.com/MorpheApp/morphe-patches/issues/147 and https://github.com/MorpheApp/morphe-patches/issues/888.

### Additional context

[Can I patch newer than the recommended version?](https://github.com/MorpheApp/morphe-documentation/blob/main/docs/morphe-resources/questions.md#20-can-i-patch-the-latest-youtube-version-can-i-patch-newer-than-the-recommended-version)

### TODO
- [X] The experimental flag related to `Restore old playback speed menu` was removed in YouTube 21.12, implement a patch to restore it

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
