### PR TITLE
feat(Spoof video streams): Default client maintenance

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/spoof/SpoofVideoStreamsPatch.java
@@ -1,8 +1,8 @@
 package app.morphe.extension.music.patches.spoof;
 
 import static app.morphe.extension.music.settings.Settings.SPOOF_VIDEO_STREAMS_CLIENT_TYPE;
-import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_47_48;
-import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_54_20;
+import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_64;
+import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_65;
 import static app.morphe.extension.shared.spoof.ClientType.TV;
 import static app.morphe.extension.shared.spoof.ClientType.VISIONOS;
 
@@ -20,9 +20,9 @@ public class SpoofVideoStreamsPatch {
         // For some users No SDK can fail at 1 minute. Only use it if the user has explicitly set it.
         List<ClientType> availableClients = List.of(
                 TV,
-                ANDROID_VR_1_47_48,
+                ANDROID_VR_1_64,
                 VISIONOS,
-                ANDROID_VR_1_54_20
+                ANDROID_VR_1_65
         );
 
         app.morphe.extension.shared.spoof.SpoofVideoStreamsPatch.setClientsToUse(

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/spoof/SpoofVideoStreamsPatch.java
@@ -1,6 +1,7 @@
 package app.morphe.extension.music.patches.spoof;
 
 import static app.morphe.extension.music.settings.Settings.SPOOF_VIDEO_STREAMS_CLIENT_TYPE;
+import static app.morphe.extension.shared.spoof.ClientType.ANDROID_REEL;
 import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_64;
 import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_65;
 import static app.morphe.extension.shared.spoof.ClientType.TV;
@@ -19,6 +20,7 @@ public class SpoofVideoStreamsPatch {
     public static void setClientOrderToUse() {
         // For some users No SDK can fail at 1 minute. Only use it if the user has explicitly set it.
         List<ClientType> availableClients = List.of(
+                ANDROID_REEL,
                 TV,
                 ANDROID_VR_1_64,
                 VISIONOS,

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -43,7 +43,7 @@ public class Settings extends SharedYouTubeSettings {
 
     // Miscellaneous
     public static final EnumSetting<ClientType> SPOOF_VIDEO_STREAMS_CLIENT_TYPE = new EnumSetting<>("morphe_spoof_video_streams_client_type",
-            ClientType.ANDROID_VR_1_64, true, parent(SPOOF_VIDEO_STREAMS));
+            ClientType.ANDROID_REEL, true, parent(SPOOF_VIDEO_STREAMS));
 
     public static final BooleanSetting FORCE_ORIGINAL_AUDIO = new BooleanSetting("morphe_force_original_audio", TRUE, true);
 

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -43,7 +43,7 @@ public class Settings extends SharedYouTubeSettings {
 
     // Miscellaneous
     public static final EnumSetting<ClientType> SPOOF_VIDEO_STREAMS_CLIENT_TYPE = new EnumSetting<>("morphe_spoof_video_streams_client_type",
-            ClientType.ANDROID_VR_1_47_48, true, parent(SPOOF_VIDEO_STREAMS));
+            ClientType.ANDROID_VR_1_64, true, parent(SPOOF_VIDEO_STREAMS));
 
     public static final BooleanSetting FORCE_ORIGINAL_AUDIO = new BooleanSetting("morphe_force_original_audio", TRUE, true);
 

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/oauth2/requests/OAuth2Routes.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/oauth2/requests/OAuth2Routes.java
@@ -20,7 +20,7 @@ final class OAuth2Routes {
     private static final String OAUTH2_GOOGLE_API_URL = "https://oauth2.googleapis.com/";
     private static final String OAUTH2_YOUTUBE_API_URL = "https://www.youtube.com/o/oauth2/";
     private static final String USER_AGENT =
-            "com.google.android.apps.youtube.vr.oculus/1.47.48(Linux; U; Android 10; en_US; Quest Build/QQ3A.200805.001) gzip";
+            "com.google.android.apps.youtube.vr.oculus/1.64.34(Linux; U; Android 10; en_US; Quest Build/QQ3A.200805.001) gzip";
 
     /**
      * TCP connection and HTTP read timeout.

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/ClientType.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/ClientType.java
@@ -85,7 +85,7 @@ public enum ClientType {
      * AV1 codec available.
      */
     // https://dumps.tadiphone.dev/dumps/oculus/eureka
-    ANDROID_VR_1_54_20(
+    ANDROID_VR_1_65(
             28,
             "ANDROID_VR",
             "com.google.android.apps.youtube.vr.oculus",
@@ -95,7 +95,7 @@ public enum ClientType {
             "14",
             "34",
             "UP1A.231005.007.A1",
-            "1.54.20",
+            "1.65.10",
             null,
             false,
             false,
@@ -103,32 +103,32 @@ public enum ClientType {
             true,
             false,
             true,
-            "Android VR 1.54"
+            "Android VR 1.65"
     ),
     /**
      * Uses non adaptive bitrate.
      * AV1 codec not available.
      */
     // https://dumps.tadiphone.dev/dumps/oculus/monterey
-    ANDROID_VR_1_47_48(
-            ANDROID_VR_1_54_20.id,
-            ANDROID_VR_1_54_20.clientName,
-            Objects.requireNonNull(ANDROID_VR_1_54_20.packageName),
-            ANDROID_VR_1_54_20.deviceMake,
+    ANDROID_VR_1_64(
+            ANDROID_VR_1_65.id,
+            ANDROID_VR_1_65.clientName,
+            Objects.requireNonNull(ANDROID_VR_1_65.packageName),
+            ANDROID_VR_1_65.deviceMake,
             "Quest",
-            ANDROID_VR_1_54_20.osName,
+            ANDROID_VR_1_65.osName,
             "10",
             "29",
             "QQ3A.200805.001",
-            "1.47.48",
-            ANDROID_VR_1_54_20.clientPlatform,
-            ANDROID_VR_1_54_20.canLogin,
-            ANDROID_VR_1_54_20.requireLogin,
-            ANDROID_VR_1_54_20.supportsMultiAudioTracks,
-            ANDROID_VR_1_54_20.supportsOAuth2,
-            ANDROID_VR_1_54_20.requireJS,
-            ANDROID_VR_1_54_20.usePlayerEndpoint,
-            "Android VR 1.47"
+            "1.64.34",
+            ANDROID_VR_1_65.clientPlatform,
+            ANDROID_VR_1_65.canLogin,
+            ANDROID_VR_1_65.requireLogin,
+            ANDROID_VR_1_65.supportsMultiAudioTracks,
+            ANDROID_VR_1_65.supportsOAuth2,
+            ANDROID_VR_1_65.requireJS,
+            ANDROID_VR_1_65.usePlayerEndpoint,
+            "Android VR 1.64"
     ),
     /**
      * Video not playable: Livestream.

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
@@ -71,7 +71,7 @@ public class SpoofVideoStreamsPatch {
     @Nullable
     private static volatile AppLanguage languageOverride;
 
-    private static volatile ClientType preferredClient = ClientType.ANDROID_VR_1_47_48;
+    private static volatile ClientType preferredClient = ClientType.ANDROID_VR_1_64;
 
     private static WeakReference<Application> mainActivityRef = new WeakReference<>(null);
 

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
@@ -71,7 +71,7 @@ public class SpoofVideoStreamsPatch {
     @Nullable
     private static volatile AppLanguage languageOverride;
 
-    private static volatile ClientType preferredClient = ClientType.ANDROID_VR_1_64;
+    private static volatile ClientType preferredClient = ClientType.ANDROID_REEL;
 
     private static WeakReference<Application> mainActivityRef = new WeakReference<>(null);
 

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/requests/StreamingDataRequest.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/requests/StreamingDataRequest.java
@@ -344,7 +344,7 @@ public class StreamingDataRequest {
         handleConnectionError(str("morphe_spoof_video_streams_no_clients_toast"), null, true);
 
         var preferredClient = clientOrderToUse[0];
-        if (preferredClient != ClientType.ANDROID_VR_1_47_48 && preferredClient != ClientType.ANDROID_VR_1_54_20
+        if (preferredClient != ClientType.ANDROID_VR_1_64 && preferredClient != ClientType.ANDROID_VR_1_65
                 && !SharedYouTubeSettings.OAUTH2_REFRESH_TOKEN.get().isBlank()) {
             handleConnectionError(str("morphe_spoof_video_streams_no_clients_suggest_vr_toast"), null, true);
         }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/spoof/SpoofVideoStreamsPatch.java
@@ -1,6 +1,7 @@
 package app.morphe.extension.youtube.patches.spoof;
 
 import static app.morphe.extension.shared.spoof.ClientType.ANDROID_CREATOR;
+import static app.morphe.extension.shared.spoof.ClientType.ANDROID_REEL;
 import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_64;
 import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_65;
 import static app.morphe.extension.shared.spoof.ClientType.TV;
@@ -44,6 +45,7 @@ public class SpoofVideoStreamsPatch {
 
         // For some users No SDK can fail at 1 minute. Only use it if the user has explicitly set it.
         List<ClientType> availableClients = List.of(
+                ANDROID_REEL,
                 TV,
                 ANDROID_VR_1_64,
                 VISIONOS,

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/spoof/SpoofVideoStreamsPatch.java
@@ -1,8 +1,8 @@
 package app.morphe.extension.youtube.patches.spoof;
 
 import static app.morphe.extension.shared.spoof.ClientType.ANDROID_CREATOR;
-import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_47_48;
-import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_54_20;
+import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_64;
+import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_65;
 import static app.morphe.extension.shared.spoof.ClientType.TV;
 import static app.morphe.extension.shared.spoof.ClientType.VISIONOS;
 
@@ -19,7 +19,7 @@ public class SpoofVideoStreamsPatch {
         @Override
         public boolean isAvailable() {
             return Settings.SPOOF_VIDEO_STREAMS_CLIENT_TYPE.isAvailable()
-                    && Settings.SPOOF_VIDEO_STREAMS_CLIENT_TYPE.get() == ANDROID_VR_1_47_48;
+                    && Settings.SPOOF_VIDEO_STREAMS_CLIENT_TYPE.get() == ANDROID_VR_1_64;
         }
 
         @Override
@@ -34,18 +34,18 @@ public class SpoofVideoStreamsPatch {
     public static void setClientOrderToUse() {
         ClientType client = Settings.SPOOF_VIDEO_STREAMS_CLIENT_TYPE.get();
 
-        // Use VR 1.54 client that has AV1 if user settings allow it.
-        // AVC cannot be forced with VR 1.54 because it uses VP9 and AV1.
-        // If both settings are on, then force AVC takes priority and VR 1.47 is used.
-        if (client == ANDROID_VR_1_47_48 && Settings.SPOOF_VIDEO_STREAMS_AV1.get()
+        // Use VR 1.65 client that has AV1 if user settings allow it.
+        // AVC cannot be forced with VR 1.65 because it uses VP9 and AV1.
+        // If both settings are on, then force AVC takes priority and VR 1.64 is used.
+        if (client == ANDROID_VR_1_64 && Settings.SPOOF_VIDEO_STREAMS_AV1.get()
                 && !Settings.FORCE_AVC_CODEC.get()) {
-            client = ANDROID_VR_1_54_20;
+            client = ANDROID_VR_1_65;
         }
 
         // For some users No SDK can fail at 1 minute. Only use it if the user has explicitly set it.
         List<ClientType> availableClients = List.of(
                 TV,
-                ANDROID_VR_1_47_48,
+                ANDROID_VR_1_64,
                 VISIONOS,
                 ANDROID_CREATOR
         );

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -428,7 +428,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting EXTERNAL_BROWSER = new BooleanSetting("morphe_external_browser", TRUE, true);
     public static final BooleanSetting SPOOF_DEVICE_DIMENSIONS = new BooleanSetting("morphe_spoof_device_dimensions", FALSE, true,
             "morphe_spoof_device_dimensions_user_dialog_message");
-    public static final EnumSetting<ClientType> SPOOF_VIDEO_STREAMS_CLIENT_TYPE = new EnumSetting<>("morphe_spoof_video_streams_client_type", ClientType.ANDROID_VR_1_47_48, true, parent(SPOOF_VIDEO_STREAMS));
+    public static final EnumSetting<ClientType> SPOOF_VIDEO_STREAMS_CLIENT_TYPE = new EnumSetting<>("morphe_spoof_video_streams_client_type", ClientType.ANDROID_VR_1_64, true, parent(SPOOF_VIDEO_STREAMS));
     public static final BooleanSetting SPOOF_VIDEO_STREAMS_AV1 = new BooleanSetting("morphe_spoof_video_streams_av1", FALSE, true,
             "morphe_spoof_video_streams_av1_user_dialog_message", new SpoofClientAv1Availability());
     public static final BooleanSetting DEBUG_PROTOBUFFER = new BooleanSetting("morphe_debug_protobuffer", FALSE, false,
@@ -554,8 +554,8 @@ public class Settings extends SharedYouTubeSettings {
             SPOOF_APP_VERSION.resetToDefault();
         }
 
-        // VR 1.54 is not selectable in the settings, and it's selected by spoof stream patch if needed.
-        if (SPOOF_VIDEO_STREAMS_CLIENT_TYPE.get() == ClientType.ANDROID_VR_1_54_20) {
+        // VR 1.65 is not selectable in the settings, and it's selected by spoof stream patch if needed.
+        if (SPOOF_VIDEO_STREAMS_CLIENT_TYPE.get() == ClientType.ANDROID_VR_1_65) {
             SPOOF_VIDEO_STREAMS_CLIENT_TYPE.resetToDefault();
         }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -428,7 +428,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting EXTERNAL_BROWSER = new BooleanSetting("morphe_external_browser", TRUE, true);
     public static final BooleanSetting SPOOF_DEVICE_DIMENSIONS = new BooleanSetting("morphe_spoof_device_dimensions", FALSE, true,
             "morphe_spoof_device_dimensions_user_dialog_message");
-    public static final EnumSetting<ClientType> SPOOF_VIDEO_STREAMS_CLIENT_TYPE = new EnumSetting<>("morphe_spoof_video_streams_client_type", ClientType.ANDROID_VR_1_64, true, parent(SPOOF_VIDEO_STREAMS));
+    public static final EnumSetting<ClientType> SPOOF_VIDEO_STREAMS_CLIENT_TYPE = new EnumSetting<>("morphe_spoof_video_streams_client_type", ClientType.ANDROID_REEL, true, parent(SPOOF_VIDEO_STREAMS));
     public static final BooleanSetting SPOOF_VIDEO_STREAMS_AV1 = new BooleanSetting("morphe_spoof_video_streams_av1", FALSE, true,
             "morphe_spoof_video_streams_av1_user_dialog_message", new SpoofClientAv1Availability());
     public static final BooleanSetting DEBUG_PROTOBUFFER = new BooleanSetting("morphe_debug_protobuffer", FALSE, false,

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/preference/SpoofVideoStreamsSideEffectsPreference.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/preference/SpoofVideoStreamsSideEffectsPreference.java
@@ -100,8 +100,8 @@ public class SpoofVideoStreamsSideEffectsPreference extends Preference {
                             + '\n' + str("morphe_spoof_video_streams_about_no_force_original_audio");
             case ANDROID_REEL ->
                     summary = str("morphe_spoof_video_streams_about_playback_failure");
-            // VR 1.54 is not exposed in the UI and should never be reached here.
-            case ANDROID_VR_1_47_48, ANDROID_VR_1_54_20 ->
+            // VR 1.65 is not exposed in the UI and should never be reached here.
+            case ANDROID_VR_1_64, ANDROID_VR_1_65 ->
                     summary = str("morphe_spoof_video_streams_about_no_audio_tracks")
                             + '\n' + str("morphe_spoof_video_streams_about_no_stable_volume");
             case TV ->

--- a/patches/src/main/resources/addresources/values/music/arrays.xml
+++ b/patches/src/main/resources/addresources/values/music/arrays.xml
@@ -86,7 +86,7 @@
     <string-array name="morphe_spoof_video_streams_client_type_entry_values">
         <item>ANDROID_REEL</item>
         <item>ANDROID_MUSIC_NO_SDK</item>
-        <item>ANDROID_VR_1_47_48</item>
+        <item>ANDROID_VR_1_64</item>
         <item>TV</item>
         <item>VISIONOS</item>
     </string-array>

--- a/patches/src/main/resources/addresources/values/youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/youtube/arrays.xml
@@ -78,7 +78,7 @@
     <string-array name="morphe_spoof_video_streams_client_type_entry_values">
         <item>ANDROID_REEL</item>
         <item>ANDROID_CREATOR</item>
-        <item>ANDROID_VR_1_47_48</item>
+        <item>ANDROID_VR_1_64</item>
         <item>TV</item>
         <item>VISIONOS</item>
     </string-array>


### PR DESCRIPTION
### `Android VR` client versions have been updated

- Google has recently discontinued support for clients released in 2023 and 2024.

- **YouTube Studio 23.47.101** and **YouTube 19.47.53**, released in 2023 and 2024, now show a **Playback error (App is outdated?)** toast message.

- Since YouTube VR 1.47.48 was released in **July 2023** and YouTube VR 1.54.20 in **February 2024**, it is highly likely that support will be discontinued in the near future.

- For this reason, the client versions of YouTube VR have been updated.

### Default client has been changed to `Android Reel`

- NewPipe has been using only **Android Reel** for two years and works for most users.

- I have tested it for a few weeks, and it seems there won't be any major issues even if it is used as the default client.

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
