### PR TITLE
feat(YouTube - Hide layout components): Add "Hide Info button" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/CommentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/CommentsFilter.java
@@ -12,6 +12,9 @@ package app.morphe.extension.youtube.patches.components;
 
 import static app.morphe.extension.shared.Utils.getFilterStrings;
 
+import android.view.View;
+import android.widget.LinearLayout;
+
 import androidx.annotation.NonNull;
 
 import java.util.List;
@@ -34,7 +37,7 @@ public class CommentsFilter extends Filter {
 
     private final StringFilterGroup comments;
     private final StringFilterGroup emojiAndTimestampButtons;
-    
+
     public CommentsFilter() {
         var chatSummary = new StringFilterGroup(
                 Settings.HIDE_COMMENTS_AI_CHAT_SUMMARY,
@@ -193,6 +196,17 @@ public class CommentsFilter extends Filter {
         }
 
         return bytes;
+    }
+
+    /**
+     * Injection point.
+     */
+    public static void hideCommentsInfoButton(View view) {
+        if (Settings.HIDE_COMMENTS_INFO_BUTTON.get()) {
+            LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(0, 0);
+            view.setLayoutParams(lp);
+            view.setVisibility(View.GONE);
+        }
     }
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -238,6 +238,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_COMMENTS_COMMUNITY_GUIDELINES = new BooleanSetting("morphe_hide_comments_community_guidelines", TRUE);
     public static final BooleanSetting HIDE_COMMENTS_CREATE_A_SHORT_BUTTON = new BooleanSetting("morphe_hide_comments_create_a_short_button", TRUE);
     public static final BooleanSetting HIDE_COMMENTS_EMOJI_AND_TIMESTAMP_BUTTONS = new BooleanSetting("morphe_hide_comments_emoji_and_timestamp_buttons", FALSE);
+    public static final BooleanSetting HIDE_COMMENTS_INFO_BUTTON = new BooleanSetting("morphe_hide_comments_info_button", FALSE, true);
     public static final BooleanSetting HIDE_COMMENTS_PREVIEW_COMMENT = new BooleanSetting("morphe_hide_comments_preview_comment", FALSE);
     public static final BooleanSetting HIDE_COMMENTS_PROMPTS = new BooleanSetting("morphe_hide_comments_prompts", FALSE);
     public static final BooleanSetting HIDE_COMMENTS_SECTION = new BooleanSetting("morphe_hide_comments_section", FALSE);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
@@ -401,3 +401,13 @@ internal object ChannelTabRendererFingerprint : Fingerprint(
         "TabRenderer.content contains SectionListRenderer but the tab does not have a section list controller."
     )
 )
+
+internal object EngagementPanelInformationButtonFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf("Landroid/content/Context;"),
+    filters = listOf(
+        resourceLiteral(ResourceType.ID, "information_button"),
+        opcode(Opcode.CHECK_CAST)
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -153,6 +153,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
                     SwitchPreference("morphe_hide_comments_community_guidelines"),
                     SwitchPreference("morphe_hide_comments_create_a_short_button"),
                     SwitchPreference("morphe_hide_comments_emoji_and_timestamp_buttons"),
+                    SwitchPreference("morphe_hide_comments_info_button"),
                     SwitchPreference("morphe_hide_comments_preview_comment"),
                     SwitchPreference("morphe_hide_comments_thanks_button"),
                     SwitchPreference("morphe_sanitize_comments_category_bar"),
@@ -444,11 +445,27 @@ val hideLayoutComponentsPatch = bytecodePatch(
 
         // endregion
 
-        // region hide comment page
+        // region hide comments carousel
 
         hookElement("$COMMENTS_FILTER_CLASS_NAME->onCommentsLoaded([B)[B")
 
         // endregion
+
+        // region hide comments info button
+
+        EngagementPanelInformationButtonFingerprint.let {
+            it.method.apply {
+                val checkCastIndex = it.instructionMatches[1].index
+                val viewRegister = getInstruction<OneRegisterInstruction>(checkCastIndex).registerA
+
+                addInstruction(
+                    checkCastIndex + 1,
+                    "invoke-static { v$viewRegister }, $COMMENTS_FILTER_CLASS_NAME->hideCommentsInfoButton(Landroid/view/View;)V"
+                )
+            }
+        }
+
+        //endregion
 
         // region hide crowdfunding box
 

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -349,6 +349,9 @@ Changes include:
     <string name="morphe_hide_comments_emoji_and_timestamp_buttons_title">Hide Emoji and Timestamp buttons</string>
     <string name="morphe_hide_comments_emoji_and_timestamp_buttons_summary_on">Emoji and Timestamp buttons are hidden</string>
     <string name="morphe_hide_comments_emoji_and_timestamp_buttons_summary_off">Emoji and Timestamp buttons are shown</string>
+    <string name="morphe_hide_comments_info_button_title">Hide Info button</string>
+    <string name="morphe_hide_comments_info_button_summary_on">Info button is hidden</string>
+    <string name="morphe_hide_comments_info_button_summary_off">Info button is shown</string>
     <string name="morphe_hide_comments_preview_comment_title">Hide preview comment</string>
     <string name="morphe_hide_comments_preview_comment_summary_on">Preview comment is hidden</string>
     <string name="morphe_hide_comments_preview_comment_summary_off">Preview comment is shown</string>


### PR DESCRIPTION
### Description

Code adapted from @inotia00 https://github.com/inotia00/revanced-patches/

Closes #483.

### Additional context

<img width="1080" height="300" alt="Screenshot_20260321_024112" src="https://github.com/user-attachments/assets/78698d5b-a629-4a32-b082-872a3715c4de" />

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
