### PR TITLE
fix(YouTube - Hide layout components): Resolve patch failing on `20.21.37` and `20.31.42`

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
@@ -408,8 +408,6 @@ internal object ChannelTabRendererFingerprint : Fingerprint(
 )
 
 internal object EngagementPanelInformationButtonFingerprint : Fingerprint(
-    accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.FINAL),
-    returnType = "V",
     parameters = listOf("Landroid/content/Context;"),
     filters = listOf(
         resourceLiteral(ResourceType.ID, "information_button"),


### PR DESCRIPTION
### Description

Closes #968.

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
