### PR TITLE
feat: Set notification icon independently of the launcher icon

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/CustomBrandingPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/CustomBrandingPatch.java
@@ -16,6 +16,7 @@ import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.view.View;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
@@ -81,6 +82,38 @@ public class CustomBrandingPatch {
         }
     }
 
+    /**
+     * Notification icon theme - selected independently of the launcher icon.
+     */
+    public enum NotificationIconTheme {
+        /**  * Follow the currently selected launcher icon theme. */
+        FOLLOW,
+        ORIGINAL,
+        LIGHT,
+        DARK,
+        BLACK,
+        PLAY,
+        /** * User provided custom PNG notification icon. */
+        CUSTOM;
+
+        /**
+         * Resolves the effective {@link BrandingTheme} to use for the notification icon.
+         * When {@link #FOLLOW}, delegates to the current launcher icon setting.
+         */
+        @NonNull
+        BrandingTheme resolveNotificationBrandingTheme() {
+            if (this == FOLLOW) {
+                return SharedYouTubeSettings.CUSTOM_BRANDING_ICON.get();
+            }
+            // Map 1:1 to BrandingTheme by name (both enums share the same names except FOLLOW).
+            try {
+                return BrandingTheme.valueOf(name());
+            } catch (IllegalArgumentException e) {
+                return BrandingTheme.BLACK;
+            }
+        }
+    }
+
     @Nullable
     private static Integer notificationSmallIcon;
 
@@ -93,7 +126,9 @@ public class CustomBrandingPatch {
                 return notificationSmallIcon = 0;
             }
 
-            BrandingTheme branding = SharedYouTubeSettings.CUSTOM_BRANDING_ICON.get();
+            // Resolve the effective BrandingTheme for the notification icon.
+            NotificationIconTheme notificationTheme = SharedYouTubeSettings.CUSTOM_BRANDING_NOTIFICATION_ICON.get();
+            BrandingTheme branding = notificationTheme.resolveNotificationBrandingTheme();
             String iconName = branding.notificationIconResourceName();
             if (iconName == null) {
                 notificationSmallIcon = 0;

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
@@ -3,6 +3,7 @@ package app.morphe.extension.shared.settings;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static app.morphe.extension.shared.patches.CustomBrandingPatch.BrandingTheme;
+import static app.morphe.extension.shared.patches.CustomBrandingPatch.NotificationIconTheme;
 import static app.morphe.extension.shared.settings.Setting.migrateOldSettingToNew;
 import static app.morphe.extension.shared.settings.Setting.parent;
 
@@ -45,6 +46,7 @@ public class SharedYouTubeSettings extends BaseSettings {
     public static final BooleanSetting CHECK_WATCH_HISTORY_DOMAIN_NAME = new BooleanSetting("morphe_check_watch_history_domain_name", TRUE, false, false);
 
     public static final EnumSetting<BrandingTheme> CUSTOM_BRANDING_ICON = new EnumSetting<>("morphe_custom_branding_icon", CustomBrandingPatch.getDefaultIconStyle(), true);
+    public static final EnumSetting<NotificationIconTheme> CUSTOM_BRANDING_NOTIFICATION_ICON = new EnumSetting<>("morphe_custom_branding_notification_icon", NotificationIconTheme.FOLLOW, true);
     public static final IntegerSetting CUSTOM_BRANDING_NAME = new IntegerSetting("morphe_custom_branding_name", CustomBrandingPatch.getDefaultAppNameIndex(), true);
 
     public static final StringSetting DISABLED_FEATURE_FLAGS = new StringSetting("morphe_disabled_feature_flags", "", true, parent(DEBUG));

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
@@ -24,8 +24,12 @@ import app.morphe.patcher.patch.stringOption
 import app.morphe.patches.all.misc.packagename.setOrGetFallbackPackageName
 import app.morphe.patches.shared.misc.fix.bitmap.fixRecycledBitmapPatch
 import app.morphe.patches.shared.misc.mapping.resourceMappingPatch
+import app.morphe.patches.shared.misc.settings.preference.BasePreference
 import app.morphe.patches.shared.misc.settings.preference.BasePreferenceScreen
 import app.morphe.patches.shared.misc.settings.preference.ListPreference
+import app.morphe.patches.shared.misc.settings.preference.PreferenceCategory
+import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference.Sorting
+import app.morphe.patches.youtube.video.speed.settingsMenuVideoSpeedGroup
 import app.morphe.util.ResourceGroup
 import app.morphe.util.copyResources
 import app.morphe.util.findElementByAttributeValueOrThrow
@@ -234,32 +238,42 @@ internal fun baseCustomBrandingPatch(
         val useCustomName = customName != null
         val useCustomIcon = customIcon != null
 
-        preferenceScreen.addPreferences(
-            if (useCustomName) {
-                ListPreference(
-                    key = "morphe_custom_branding_name",
-                    entriesKey = "morphe_custom_branding_name_custom_entries",
-                    entryValuesKey = "morphe_custom_branding_name_custom_entry_values"
-                )
-            } else {
-                ListPreference("morphe_custom_branding_name")
-            },
+        val preferences = mutableSetOf<BasePreference>()
 
-            if (useCustomIcon) {
-                ListPreference(
-                    key = "morphe_custom_branding_icon",
-                    entriesKey = "morphe_custom_branding_icon_custom_entries",
-                    entryValuesKey = "morphe_custom_branding_icon_custom_entry_values"
-                )
-                ListPreference(
-                    key = "morphe_custom_branding_notification_icon",
-                    entriesKey = "morphe_custom_branding_notification_icon_custom_entries",
-                    entryValuesKey = "morphe_custom_branding_notification_icon_custom_entry_values"
-                )
-            } else {
-                ListPreference("morphe_custom_branding_icon")
-                ListPreference("morphe_custom_branding_notification_icon")
-            }
+        preferences += if (useCustomName) {
+            ListPreference(
+                key = "morphe_custom_branding_name",
+                entriesKey = "morphe_custom_branding_name_custom_entries",
+                entryValuesKey = "morphe_custom_branding_name_custom_entry_values"
+            )
+        } else {
+            ListPreference("morphe_custom_branding_name")
+        }
+
+        if (useCustomIcon) {
+            preferences += ListPreference(
+                key = "morphe_custom_branding_icon",
+                entriesKey = "morphe_custom_branding_icon_custom_entries",
+                entryValuesKey = "morphe_custom_branding_icon_custom_entry_values"
+            )
+            preferences += ListPreference(
+                key = "morphe_custom_branding_notification_icon",
+                entriesKey = "morphe_custom_branding_icon_custom_entries",
+                entryValuesKey = "morphe_custom_branding_notification_icon_custom_entry_values"
+            )
+        } else {
+            preferences += ListPreference("morphe_custom_branding_icon")
+            preferences += ListPreference("morphe_custom_branding_notification_icon")
+        }
+
+        preferenceScreen.addPreferences(
+            PreferenceCategory(
+                key = null,
+                titleKey = null,
+                sorting = Sorting.UNSORTED,
+                tag = "app.morphe.extension.shared.settings.preference.NoTitlePreferenceCategory",
+                preferences = preferences
+            )
         )
 
         iconStyleNames.forEach { style ->

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
@@ -251,8 +251,14 @@ internal fun baseCustomBrandingPatch(
                     entriesKey = "morphe_custom_branding_icon_custom_entries",
                     entryValuesKey = "morphe_custom_branding_icon_custom_entry_values"
                 )
+                ListPreference(
+                    key = "morphe_custom_branding_notification_icon",
+                    entriesKey = "morphe_custom_branding_notification_icon_custom_entries",
+                    entryValuesKey = "morphe_custom_branding_notification_icon_custom_entry_values"
+                )
             } else {
                 ListPreference("morphe_custom_branding_icon")
+                ListPreference("morphe_custom_branding_notification_icon")
             }
         )
 

--- a/patches/src/main/resources/addresources/values/shared-youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/arrays.xml
@@ -31,4 +31,38 @@
         <item>PLAY</item>
         <item>CUSTOM</item>
     </string-array>
+    <string-array name="morphe_custom_branding_notification_icon_entries">
+        <item>@string/morphe_custom_branding_notification_icon_entry_1</item>
+        <item>@string/morphe_custom_branding_icon_entry_1</item>
+        <item>@string/morphe_custom_branding_icon_entry_2</item>
+        <item>@string/morphe_custom_branding_icon_entry_3</item>
+        <item>@string/morphe_custom_branding_icon_entry_4</item>
+        <item>@string/morphe_custom_branding_icon_entry_5</item>
+    </string-array>
+    <string-array name="morphe_custom_branding_notification_icon_entry_values">
+        <item>FOLLOW</item>
+        <item>ORIGINAL</item>
+        <item>BLACK</item>
+        <item>DARK</item>
+        <item>LIGHT</item>
+        <item>PLAY</item>
+    </string-array>
+    <string-array name="morphe_custom_branding_notification_icon_custom_entries">
+        <item>@string/morphe_custom_branding_notification_icon_entry_1</item>
+        <item>@string/morphe_custom_branding_icon_entry_1</item>
+        <item>@string/morphe_custom_branding_icon_entry_2</item>
+        <item>@string/morphe_custom_branding_icon_entry_3</item>
+        <item>@string/morphe_custom_branding_icon_entry_4</item>
+        <item>@string/morphe_custom_branding_icon_entry_5</item>
+        <item>@string/morphe_custom_branding_icon_entry_6</item>
+    </string-array>
+    <string-array name="morphe_custom_branding_notification_icon_custom_entry_values">
+        <item>FOLLOW</item>
+        <item>ORIGINAL</item>
+        <item>BLACK</item>
+        <item>DARK</item>
+        <item>LIGHT</item>
+        <item>PLAY</item>
+        <item>CUSTOM</item>
+    </string-array>
 </resources>

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -31,6 +31,8 @@ Second \"item\" text"</string>
     <string name="morphe_custom_branding_icon_entry_5">Morphe play</string>
     <!-- Translations of this should be identical to morphe_custom_branding_name_entry_5 -->
     <string name="morphe_custom_branding_icon_entry_6">Custom</string>
+    <string name="morphe_custom_branding_notification_icon_title">Notification icon</string>
+    <string name="morphe_custom_branding_notification_icon_entry_1">Follow app icon</string>
 
     <!-- If any of these experimental strings are changed then also change the hard coded values in the patch for Reddit -->
     <!-- misc.checks.experimentalAppNoticePatch -->


### PR DESCRIPTION
### Description

Allows to choose a notification icon independent of the application icon. By default, it follows the application icon.

Closes comment https://github.com/MorpheApp/morphe-patches/pull/978#issuecomment-4121441289
