### PR TITLE
fix: Notification icon entries key mismatch

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
@@ -258,7 +258,7 @@ internal fun baseCustomBrandingPatch(
             )
             preferences += ListPreference(
                 key = "morphe_custom_branding_notification_icon",
-                entriesKey = "morphe_custom_branding_icon_custom_entries",
+                entriesKey = "morphe_custom_branding_notification_icon_custom_entries",
                 entryValuesKey = "morphe_custom_branding_notification_icon_custom_entry_values"
             )
         } else {

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
@@ -29,7 +29,6 @@ import app.morphe.patches.shared.misc.settings.preference.BasePreferenceScreen
 import app.morphe.patches.shared.misc.settings.preference.ListPreference
 import app.morphe.patches.shared.misc.settings.preference.PreferenceCategory
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference.Sorting
-import app.morphe.patches.youtube.video.speed.settingsMenuVideoSpeedGroup
 import app.morphe.util.ResourceGroup
 import app.morphe.util.copyResources
 import app.morphe.util.findElementByAttributeValueOrThrow


### PR DESCRIPTION
### Description

Fix the refactoring of notification icons.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
