### PR TITLE
fix: Hardcoded OAuth client secret in distributed Android code

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/oauth2/requests/OAuth2Requester.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/oauth2/requests/OAuth2Requester.java
@@ -51,11 +51,6 @@ public class OAuth2Requester {
     private static final String CLIENT_ID =
             "652469312169-4lvs9bnhr9lpns9v451j5oivd81vjvu1.apps.googleusercontent.com";
 
-    /**
-     * The client secret of the Android YouTube VR client.
-     * This value is unique and does not change.
-     */
-    private static final String CLIENT_SECRET = "3fTWrBJI5Uojm1TK7_iJCW5Z";
 
     /**
      * Device model enum name for the Android YouTube VR app.
@@ -250,7 +245,7 @@ public class OAuth2Requester {
 
                 JSONObject jsonObject = new JSONObject();
                 jsonObject.put("client_id", CLIENT_ID);
-                jsonObject.put("client_secret", CLIENT_SECRET);
+                jsonObject;
                 jsonObject.put("code", activationCodeData.deviceCode);
                 jsonObject.put("grant_type", GRANT_TYPE_DEFAULT);
 
@@ -303,8 +298,7 @@ public class OAuth2Requester {
 
             JSONObject jsonObject = new JSONObject();
             jsonObject.put("client_id", CLIENT_ID);
-            jsonObject.put("client_secret", CLIENT_SECRET);
-            jsonObject.put("refresh_token", refreshToken);
+                        jsonObject.put("refresh_token", refreshToken);
             jsonObject.put("grant_type", GRANT_TYPE_REFRESH);
 
             byte[] body = jsonObject.toString().getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
## 🔒 Security Fix

### Problem
`CLIENT_SECRET` is embedded directly in app code. In an Android/library distribution model, this value is trivially recoverable from the APK (decompilation/string extraction), so it is not a secret in practice. An attacker can reuse this credential to abuse OAuth token endpoints as your client (quota abuse, automated token requests, potential client revocation/blacklisting), which can disrupt legitimate users.


**Severity**: `high`
**File**: `extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/oauth2/requests/OAuth2Requester.java`

### Solution
Remove `CLIENT_SECRET` from client-side code and stop sending it from the app. Treat this app as a public OAuth client. Concretely: 1) Delete `private static final String CLIENT_SECRET = "...";` 2) Remove all request parameters/JSON fields that send `client_secret` in `OAuth2Requester`. 3) If the provider requires a confidential client secret, move token exchange to a backend you
   control and keep the secret in server environment variables; the app should call only your
   backend endpoint (authenticated) instead of Google token endpoints directly.

### Changes
- `extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/oauth2/requests/OAuth2Requester.java` (modified)

### Description



Closes #1055

### Additional context



N/A

### Test results

- [ ] Tested on both the **minimum** and **maximum** supported versions
- [ ] Tested on **experimental** supported versions (Optional)
