### PR TITLE
fix(Change package name): `DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION` is not updated correctly

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/all/misc/packagename/ChangePackageNamePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/all/misc/packagename/ChangePackageNamePatch.kt
@@ -273,12 +273,13 @@ val changePackageNamePatch = resourcePatch(
 
                 val receiverNotExported = "DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION"
                 val androidName = "android:name"
-                val newName = "$packageName.$receiverNotExported"
+                val oldName = "$packageName.$receiverNotExported"
+                val newName = "$newPackageName.$receiverNotExported"
 
                 (permissions + usesPermissions)
                     .map { it as Element }
                     .filter {
-                        it.getAttribute(androidName) == newName
+                        it.getAttribute(androidName) == oldName
                     }
                     .forEach {
                         it.setAttribute(androidName, newName)

--- a/patches/src/main/kotlin/app/morphe/patches/all/misc/packagename/ChangePackageNamePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/all/misc/packagename/ChangePackageNamePatch.kt
@@ -165,29 +165,29 @@ val changePackageNamePatch = resourcePatch(
         it == "Default" || it!!.matches(Regex("^[a-z]\\w*(\\.[a-z]\\w*)+\$"))
     }
 
-    val updatePermissions = booleanOption(
+    val updatePermissionsOption = booleanOption(
         key = "updatePermissions",
         default = false,
         title = "Update permissions",
         description = "Update compatibility receiver permissions. " +
             "Enabling this can fix installation errors, but this can also break features in certain apps.",
-    ).value
+    )
 
-    val updateProviders = booleanOption(
+    val updateProvidersOption = booleanOption(
         key = "updateProviders",
         default = false,
         title = "Update providers",
         description = "Update provider names declared by the app. " +
             "Enabling this can fix installation errors, but this can also break features in certain apps.",
-    ).value
+    )
 
-    val updateProvidersStrings = booleanOption(
+    val updateProvidersStringsOption = booleanOption(
         key = "updateProvidersStrings",
         default = false,
         title = "Update providers strings",
         description = "Update additional provider names declared by the app in the strings.xml file. " +
                 "Enabling this can fix installation errors, but this can also break features in certain apps.",
-    ).value
+    )
 
     fun getReplacementPackageName(originalPackageName: String) : String {
         val replacementPackageName = packageNameOption.value
@@ -245,9 +245,9 @@ val changePackageNamePatch = resourcePatch(
                 applyUpdateProvidersStrings = true
             }
             else -> {
-                applyUpdatePermissions = updatePermissions!!
-                applyUpdateProviders = updateProviders!!
-                applyUpdateProvidersStrings = updateProvidersStrings!!
+                applyUpdatePermissions = updatePermissionsOption.value!!
+                applyUpdateProviders = updateProvidersOption.value!!
+                applyUpdateProvidersStrings = updateProvidersStringsOption.value!!
             }
         }
 


### PR DESCRIPTION
### Description
Regression from 60a2f9e5b27ca126c4cce3a7207c197675f10d80
<!-- ADD DETAILED DESCRIPTION HERE -->

Closes #

### Additional context

<!-- ADD ADDITIONAL CONTEXT HERE -->

Found this while trying to debug why GmsCore patch wasn't updating C2D_MESSAGE permission package name in YT 21.x (which turned out to be just me forgetting to -f).
Note that GmsCore patch hid this issue because it would also make the same rename (but correctly).

### Test results
Verified manifest has the updated name on the receiverNotExported permission for 20.45.36. I don't think this needs testing on the other versions given it's a manifest-specific bugfix.
- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
