### PR TITLE
chore(YouTube - Seekbar): Add warning to "Enable livestream DVR" setting regarding "Spoof video streams"

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -421,7 +421,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_SEEKBAR_THUMBNAIL = new BooleanSetting("morphe_hide_seekbar_thumbnail", FALSE, true);
     public static final BooleanSetting FULLSCREEN_LARGE_SEEKBAR = new BooleanSetting("morphe_fullscreen_large_seekbar", FALSE);
     public static final BooleanSetting HIDE_TIMESTAMP = new BooleanSetting("morphe_hide_timestamp", FALSE);
-    public static final BooleanSetting LIVESTREAM_DVR = new BooleanSetting("morphe_livestream_dvr", FALSE);
+    public static final BooleanSetting LIVESTREAM_DVR = new BooleanSetting("morphe_livestream_dvr", FALSE, "morphe_livestream_dvr_user_dialog_message");
     public static final BooleanSetting SLIDE_TO_SEEK = new BooleanSetting("morphe_slide_to_seek", FALSE, true);
     public static final BooleanSetting TAP_TO_SEEK = new BooleanSetting("morphe_tap_to_seek", FALSE);
     public static final BooleanSetting SEEKBAR_CUSTOM_COLOR = new BooleanSetting("morphe_seekbar_custom_color", FALSE, true);

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -572,7 +572,7 @@ Info: May not work on live streams"</string>
     <string name="morphe_livestream_dvr_summary_on">Seeking is allowed on all livestreams</string>
     <string name="morphe_livestream_dvr_summary_off">Seeking may not be available on livestreams</string>
     <!-- 'Spoof video streams' should be the same translation used for 'morphe_spoof_video_streams_screen_title'. -->
-    <string name="morphe_livestream_dvr_user_dialog_message">This setting may cause unexpected behavior if \'Spoof video streams\' is not enabled.</string>
+    <string name="morphe_livestream_dvr_user_dialog_message">Enabling this may cause unexpected livestream seeking behavior if \'Spoof video streams\' is not enabled.</string>
 
     <!-- interaction.seekbar.enableSlideToSeekPatch -->
     <string name="morphe_slide_to_seek_title">Enable slide to seek</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -571,6 +571,8 @@ Info: May not work on live streams"</string>
     <string name="morphe_livestream_dvr_title">Enable livestream DVR</string>
     <string name="morphe_livestream_dvr_summary_on">Seeking is allowed on all livestreams</string>
     <string name="morphe_livestream_dvr_summary_off">Seeking may not be available on livestreams</string>
+    <!-- 'Spoof video streams' should be the same translation used for 'morphe_spoof_video_streams_screen_title'. -->
+    <string name="morphe_livestream_dvr_user_dialog_message">This setting may cause unexpected behavior if \'Spoof video streams\' is not enabled.</string>
 
     <!-- interaction.seekbar.enableSlideToSeekPatch -->
     <string name="morphe_slide_to_seek_title">Enable slide to seek</string>


### PR DESCRIPTION
<!-- ADD DETAILED DESCRIPTION HERE -->
Adds a warning to "Enable livestream DVR" that it may not function correctly unless "Spoof video streams" is also enabled.

### Additional context

<!-- ADD ADDITIONAL CONTEXT HERE -->
As with #1110, when the app is using SABR the feature may not work correctly because SABR doesn't send any data from before the user started viewing the stream, and "Spoof video streams" disables SABR as far as I can tell.
N/A

### Test results
Tested alongside #1110 
- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
