### PR TITLE
feat(YouTube - Hide layout components): Add "Hide search term thumbnails" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -764,6 +764,13 @@ public final class LayoutComponentsFilter extends Filter {
 
     /**
      * Injection point.
+     */
+    public static boolean hideSearchTermThumbnails() {
+        return Settings.HIDE_SEARCH_TERM_THUMBNAILS.get();
+    }
+
+    /**
+     * Injection point.
      *
      * @param typedString   Keywords typed in the search bar.
      * @return              Whether the setting is enabled and the typed string is empty.

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -114,6 +114,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_MOVIES_SECTION = new BooleanSetting("morphe_hide_movies_section", TRUE);
     public static final BooleanSetting HIDE_NOTIFY_ME_BUTTON = new BooleanSetting("morphe_hide_notify_me_button", TRUE);
     public static final BooleanSetting HIDE_PLAYABLES = new BooleanSetting("morphe_hide_playables", TRUE);
+    public static final BooleanSetting HIDE_SEARCH_TERM_THUMBNAILS = new BooleanSetting("morphe_hide_search_term_thumbnails", FALSE, true);
     public static final BooleanSetting HIDE_SHOW_MORE_BUTTON = new BooleanSetting("morphe_hide_show_more_button", TRUE, true);
     public static final BooleanSetting HIDE_SUBSCRIBED_CHANNELS_BAR = new BooleanSetting("morphe_hide_subscribed_channels_bar", FALSE, true);
     public static final BooleanSetting HIDE_SURVEYS = new BooleanSetting("morphe_hide_surveys", TRUE);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
@@ -400,3 +400,16 @@ internal object EngagementPanelInformationButtonFingerprint : Fingerprint(
         opcode(Opcode.CHECK_CAST)
     )
 )
+
+internal object CreateSearchSuggestionsFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf("L", "I"),
+    filters = listOf(
+        string("ss_rds"),
+        methodCall(
+            opcode = Opcode.INVOKE_INTERFACE,
+            smali = "Ljava/util/Iterator;->next()Ljava/lang/Object;"
+        )
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
@@ -406,10 +406,35 @@ internal object CreateSearchSuggestionsFingerprint : Fingerprint(
     returnType = "V",
     parameters = listOf("L", "I"),
     filters = listOf(
-        string("ss_rds"),
         methodCall(
-            opcode = Opcode.INVOKE_INTERFACE,
             smali = "Ljava/util/Iterator;->next()Ljava/lang/Object;"
+        ),
+        literal(
+            0,
+            location = MatchAfterWithin(30)
+        ),
+        methodCall(
+            smali = "Landroid/widget/ImageView;->setVisibility(I)V",
+            location = MatchAfterWithin(10)
+        ),
+        literal(
+            8,
+            location = MatchAfterWithin(10)
+        ),
+        methodCall(
+            smali = "Landroid/widget/ImageView;->setVisibility(I)V",
+            location = MatchAfterWithin(10)
+        ),
+        methodCall(
+            smali = "Landroid/widget/ImageView;->setImageDrawable(Landroid/graphics/drawable/Drawable;)V",
+        ),
+        methodCall(
+            smali = "Landroid/net/Uri;->parse(Ljava/lang/String;)Landroid/net/Uri;",
+        ),
+        literal(
+            0,
+            location = MatchAfterWithin(20)
         )
-    )
+    ),
+    strings = listOf("ss_rds")
 )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -48,7 +48,6 @@ import app.morphe.util.addInstructionsAtControlFlowLabel
 import app.morphe.util.findFreeRegister
 import app.morphe.util.findInstructionIndicesReversedOrThrow
 import app.morphe.util.getReference
-import app.morphe.util.indexOfFirstInstructionOrThrow
 import app.morphe.util.indexOfFirstInstructionReversedOrThrow
 import app.morphe.util.injectHideViewCall
 import app.morphe.util.insertLiteralOverride
@@ -767,14 +766,14 @@ val hideLayoutComponentsPatch = bytecodePatch(
                 addInstructionsWithLabels(
                     objectIndex + 1,
                     """
-                invoke-static { v${objectInstruction.registerA} }, $LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR->hideChannelTab(Ljava/lang/String;)Z
-                move-result v${objectInstruction.registerA}
-                if-eqz v${objectInstruction.registerA}, :ignore
-                invoke-interface { v$iteratorRegister }, Ljava/util/Iterator;->remove()V
-                goto :next_iterator
-                :ignore
-                iget-object v${objectInstruction.registerA}, v${objectInstruction.registerB}, $objectReference
-                """,
+                        invoke-static { v${objectInstruction.registerA} }, $LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR->hideChannelTab(Ljava/lang/String;)Z
+                        move-result v${objectInstruction.registerA}
+                        if-eqz v${objectInstruction.registerA}, :ignore
+                        invoke-interface { v$iteratorRegister }, Ljava/util/Iterator;->remove()V
+                        goto :next_iterator
+                        :ignore
+                        iget-object v${objectInstruction.registerA}, v${objectInstruction.registerB}, $objectReference
+                    """,
                     ExternalLabel("next_iterator", getInstruction(iteratorIndex))
                 )
             }
@@ -786,33 +785,19 @@ val hideLayoutComponentsPatch = bytecodePatch(
 
         CreateSearchSuggestionsFingerprint.let {
             it.method.apply {
-                val iteratorIndex = indexOfFirstInstructionReversedOrThrow {
-                    opcode == Opcode.INVOKE_INTERFACE &&
-                            getReference<MethodReference>()?.name == "next" &&
-                            getReference<MethodReference>()?.definingClass == "Ljava/util/Iterator;"
-                }
-
-                val insertIndex = indexOfFirstInstructionOrThrow(iteratorIndex) {
-                    opcode == Opcode.INVOKE_VIRTUAL &&
-                            getReference<MethodReference>()?.toString() == "Landroid/widget/ImageView;->setVisibility(I)V"
-                } - 1
-
-                val freeRegister = getInstruction<OneRegisterInstruction>(insertIndex).registerA
-                val uriIndex = indexOfFirstInstructionOrThrow(insertIndex) {
-                    opcode == Opcode.INVOKE_STATIC &&
-                            getReference<MethodReference>()?.toString() == "Landroid/net/Uri;->parse(Ljava/lang/String;)Landroid/net/Uri;"
-                }
-
-                val jumpIndex = indexOfFirstInstructionOrThrow(uriIndex, Opcode.CONST_4)
+                val insertIndex = it.instructionMatches[2].index - 1
+                val freeRegister = findFreeRegister(insertIndex)
+                val jumpIndex = it.instructionMatches.last().index
 
                 addInstructionsWithLabels(
-                    insertIndex, """
+                    insertIndex,
+                    """
                         invoke-static { }, $LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR->hideSearchTermThumbnails()Z
                         move-result v$freeRegister
                         
-                        # if-nez means "if not zero". Since boolean true is 1, this jumps if the setting is enabled.
                         if-nez v$freeRegister, :hidden
-                        """, ExternalLabel("hidden", getInstruction(jumpIndex))
+                    """,
+                    ExternalLabel("hidden", getInstruction(jumpIndex))
                 )
             }
         }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -48,6 +48,7 @@ import app.morphe.util.addInstructionsAtControlFlowLabel
 import app.morphe.util.findFreeRegister
 import app.morphe.util.findInstructionIndicesReversedOrThrow
 import app.morphe.util.getReference
+import app.morphe.util.indexOfFirstInstructionOrThrow
 import app.morphe.util.indexOfFirstInstructionReversedOrThrow
 import app.morphe.util.injectHideViewCall
 import app.morphe.util.insertLiteralOverride
@@ -255,6 +256,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
             SwitchPreference("morphe_hide_movies_section"),
             SwitchPreference("morphe_hide_notify_me_button"),
             SwitchPreference("morphe_hide_playables"),
+            SwitchPreference("morphe_hide_search_term_thumbnails"),
             SwitchPreference("morphe_hide_show_more_button"),
             SwitchPreference("morphe_hide_subscribed_channels_bar"),
             SwitchPreference("morphe_hide_surveys"),
@@ -774,6 +776,43 @@ val hideLayoutComponentsPatch = bytecodePatch(
                 iget-object v${objectInstruction.registerA}, v${objectInstruction.registerB}, $objectReference
                 """,
                     ExternalLabel("next_iterator", getInstruction(iteratorIndex))
+                )
+            }
+        }
+
+        // endregion
+
+        // region hide search term thumbnails
+
+        CreateSearchSuggestionsFingerprint.let {
+            it.method.apply {
+                val iteratorIndex = indexOfFirstInstructionReversedOrThrow {
+                    opcode == Opcode.INVOKE_INTERFACE &&
+                            getReference<MethodReference>()?.name == "next" &&
+                            getReference<MethodReference>()?.definingClass == "Ljava/util/Iterator;"
+                }
+
+                val insertIndex = indexOfFirstInstructionOrThrow(iteratorIndex) {
+                    opcode == Opcode.INVOKE_VIRTUAL &&
+                            getReference<MethodReference>()?.toString() == "Landroid/widget/ImageView;->setVisibility(I)V"
+                } - 1
+
+                val freeRegister = getInstruction<OneRegisterInstruction>(insertIndex).registerA
+                val uriIndex = indexOfFirstInstructionOrThrow(insertIndex) {
+                    opcode == Opcode.INVOKE_STATIC &&
+                            getReference<MethodReference>()?.toString() == "Landroid/net/Uri;->parse(Ljava/lang/String;)Landroid/net/Uri;"
+                }
+
+                val jumpIndex = indexOfFirstInstructionOrThrow(uriIndex, Opcode.CONST_4)
+
+                addInstructionsWithLabels(
+                    insertIndex, """
+                        invoke-static { }, $LAYOUT_COMPONENTS_FILTER_CLASS_DESCRIPTOR->hideSearchTermThumbnails()Z
+                        move-result v$freeRegister
+                        
+                        # if-nez means "if not zero". Since boolean true is 1, this jumps if the setting is enabled.
+                        if-nez v$freeRegister, :hidden
+                        """, ExternalLabel("hidden", getInstruction(jumpIndex))
                 )
             }
         }

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -126,6 +126,9 @@ Changes include:
     <string name="morphe_hide_playables_title">Hide Playables</string>
     <string name="morphe_hide_playables_summary_on">Playables are hidden</string>
     <string name="morphe_hide_playables_summary_off">Playables are shown</string>
+    <string name="morphe_hide_search_term_thumbnails_title">Hide search term thumbnails</string>
+    <string name="morphe_hide_search_term_thumbnails_summary_on">Search term thumbnails are hidden</string>
+    <string name="morphe_hide_search_term_thumbnails_summary_off">Search term thumbnails are shown</string>
     <!-- 'Show more' should be translated using the same localized wording YouTube displays for the button.
           This button usually appears when searching for a YouTube creator. -->
     <string name="morphe_hide_show_more_button_title">Hide \'Show more\' button</string>


### PR DESCRIPTION
### Description

Code adapted from @inotia00 https://github.com/inotia00/revanced-patches/

Closes #1015.

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
