### PR TITLE
fix(YouTube): Bold player buttons break under certain conditions

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LegacyPlayerControlsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LegacyPlayerControlsPatch.java
@@ -13,6 +13,7 @@ import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.Setting;
 import app.morphe.extension.youtube.settings.Settings;
+import app.morphe.extension.youtube.settings.YouTubeActivityHook;
 
 @SuppressWarnings("unused")
 public class LegacyPlayerControlsPatch {
@@ -25,7 +26,7 @@ public class LegacyPlayerControlsPatch {
     }
 
     public static final boolean RESTORE_OLD_PLAYER_BUTTONS =
-            Settings.RESTORE_OLD_PLAYER_BUTTONS.get() || !IS_20_31_OR_GREATER || isSpoofingToLessThan("20.31.00");
+            Settings.RESTORE_OLD_PLAYER_BUTTONS.get() || !YouTubeActivityHook.useBoldIcons(true);
 
     public static WeakReference<View> fullscreenButtonRef = new WeakReference<>(null);
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LegacyPlayerControlsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LegacyPlayerControlsPatch.java
@@ -1,5 +1,8 @@
 package app.morphe.extension.youtube.patches;
 
+import static app.morphe.extension.youtube.patches.VersionCheckPatch.IS_20_31_OR_GREATER;
+import static app.morphe.extension.youtube.patches.spoof.SpoofAppVersionPatch.isSpoofingToLessThan;
+
 import android.view.View;
 import android.view.ViewTreeObserver;
 import android.widget.ImageView;
@@ -8,14 +11,21 @@ import java.lang.ref.WeakReference;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.settings.Setting;
 import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
 public class LegacyPlayerControlsPatch {
 
-    // 20.31 is first version with working buttons, but the layout is weird with oval-shaped player buttons.
-    public static final boolean RESTORE_OLD_PLAYER_BUTTONS = Settings.RESTORE_OLD_PLAYER_BUTTONS.get()
-            || !VersionCheckPatch.IS_20_31_OR_GREATER;
+    public static final class RestoreOldPlayerButtonsAvailability implements Setting.Availability {
+        @Override
+        public boolean isAvailable() {
+            return IS_20_31_OR_GREATER && !isSpoofingToLessThan("20.31.00");
+        }
+    }
+
+    public static final boolean RESTORE_OLD_PLAYER_BUTTONS =
+            Settings.RESTORE_OLD_PLAYER_BUTTONS.get() || !IS_20_31_OR_GREATER || isSpoofingToLessThan("20.31.00");
 
     public static WeakReference<View> fullscreenButtonRef = new WeakReference<>(null);
 
@@ -84,9 +94,6 @@ public class LegacyPlayerControlsPatch {
      * Injection point.
      */
     public static boolean usePlayerBottomControlsExploderLayout(boolean original) {
-        if (RESTORE_OLD_PLAYER_BUTTONS) {
-            return false;
-        }
-        return original;
+        return !RESTORE_OLD_PLAYER_BUTTONS;
     }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -201,7 +201,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting LOOP_VIDEO = new BooleanSetting("morphe_loop_video", FALSE);
 
     // Player overlay buttons
-    public static final BooleanSetting RESTORE_OLD_PLAYER_BUTTONS = new BooleanSetting("morphe_restore_old_player_buttons", TRUE, true, new RestoreOldPlayerButtonsAvailability());
+    public static final BooleanSetting RESTORE_OLD_PLAYER_BUTTONS = new BooleanSetting("morphe_restore_old_player_buttons", FALSE, true, new RestoreOldPlayerButtonsAvailability());
     public static final BooleanSetting COPY_VIDEO_URL = new BooleanSetting("morphe_copy_video_url", FALSE, true);
     public static final BooleanSetting COPY_VIDEO_URL_TIMESTAMP = new BooleanSetting("morphe_copy_video_url_timestamp", TRUE, true, parent(COPY_VIDEO_URL));
     public static final BooleanSetting LOOP_VIDEO_BUTTON = new BooleanSetting("morphe_loop_video_button", FALSE);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -46,6 +46,7 @@ import app.morphe.extension.youtube.patches.AlternativeThumbnailsPatch.StillImag
 import app.morphe.extension.youtube.patches.AlternativeThumbnailsPatch.ThumbnailOption;
 import app.morphe.extension.youtube.patches.AlternativeThumbnailsPatch.ThumbnailStillTime;
 import app.morphe.extension.youtube.patches.AutoCaptionsPatch.AutoCaptionsStyle;
+import app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch.RestoreOldPlayerButtonsAvailability;
 import app.morphe.extension.youtube.patches.VersionCheckPatch;
 import app.morphe.extension.youtube.sponsorblock.SponsorBlockSettings;
 import app.morphe.extension.youtube.swipecontrols.SwipeControlsConfigurationProvider.SwipeOverlayStyle;
@@ -200,7 +201,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting LOOP_VIDEO = new BooleanSetting("morphe_loop_video", FALSE);
 
     // Player overlay buttons
-    public static final BooleanSetting RESTORE_OLD_PLAYER_BUTTONS = new BooleanSetting("morphe_restore_old_player_buttons", FALSE, true);
+    public static final BooleanSetting RESTORE_OLD_PLAYER_BUTTONS = new BooleanSetting("morphe_restore_old_player_buttons", TRUE, true, new RestoreOldPlayerButtonsAvailability());
     public static final BooleanSetting COPY_VIDEO_URL = new BooleanSetting("morphe_copy_video_url", FALSE, true);
     public static final BooleanSetting COPY_VIDEO_URL_TIMESTAMP = new BooleanSetting("morphe_copy_video_url_timestamp", TRUE, true, parent(COPY_VIDEO_URL));
     public static final BooleanSetting LOOP_VIDEO_BUTTON = new BooleanSetting("morphe_loop_video_button", FALSE);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/YouTubeActivityHook.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/YouTubeActivityHook.java
@@ -32,7 +32,6 @@ import app.morphe.extension.youtube.settings.search.YouTubeSearchViewController;
  * Hooks {@link GoogleApiActivity} to inject a custom {@link YouTubePreferenceFragment}
  * with a toolbar and search functionality.
  */
-@SuppressWarnings("deprecation")
 public class YouTubeActivityHook extends BaseActivityHook {
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/ui/NewSegmentLayout.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/ui/NewSegmentLayout.java
@@ -2,6 +2,7 @@ package app.morphe.extension.youtube.sponsorblock.ui;
 
 import static app.morphe.extension.shared.ResourceUtils.getColor;
 import static app.morphe.extension.shared.ResourceUtils.getDimensionPixelSize;
+import static app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS;
 import static app.morphe.extension.youtube.sponsorblock.ui.SkipSponsorButton.SB_BUTTON_EXTRA_VERTICAL_PADDING;
 
 import android.content.Context;
@@ -18,7 +19,6 @@ import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.ui.Dim;
-import app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch;
 import app.morphe.extension.youtube.patches.VideoInformation;
 import app.morphe.extension.youtube.settings.Settings;
 import app.morphe.extension.youtube.sponsorblock.SponsorBlockUtils;
@@ -123,7 +123,7 @@ public final class NewSegmentLayout extends FrameLayout {
 
         final int background = ResourceUtils.getIdentifierOrThrow(
                 ResourceType.DRAWABLE,
-                LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS
+                RESTORE_OLD_PLAYER_BUTTONS
                         ? imageResourceName
                         : imageResourceName + "_bold");
         button.setImageResource(background);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/ui/SkipSponsorButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/ui/SkipSponsorButton.java
@@ -3,6 +3,7 @@ package app.morphe.extension.youtube.sponsorblock.ui;
 import static app.morphe.extension.shared.ResourceUtils.getColor;
 import static app.morphe.extension.shared.ResourceUtils.getDimension;
 import static app.morphe.extension.shared.ResourceUtils.getDimensionPixelSize;
+import static app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS;
 
 import android.content.Context;
 import android.graphics.Canvas;
@@ -22,7 +23,6 @@ import java.util.Objects;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.ui.Dim;
-import app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch;
 import app.morphe.extension.youtube.settings.Settings;
 import app.morphe.extension.youtube.sponsorblock.SegmentPlaybackController;
 import app.morphe.extension.youtube.sponsorblock.objects.SponsorSegment;
@@ -30,7 +30,7 @@ import app.morphe.extension.youtube.sponsorblock.objects.SponsorSegment;
 public class SkipSponsorButton extends FrameLayout {
     /**
      * Adds a high contrast border around the skip button.
-     *
+     * <p>
      * This feature is not currently used.
      * If this is added, it needs an additional button width change because
      * as-is the skip button text is clipped when this is on.
@@ -43,7 +43,7 @@ public class SkipSponsorButton extends FrameLayout {
      * the bold player buttons.
      */
     public static final int SB_BUTTON_EXTRA_VERTICAL_PADDING =
-            LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS
+            RESTORE_OLD_PLAYER_BUTTONS
             ? 0
             : Dim.dp10;
     private final LinearLayout skipSponsorBtnContainer;

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/CopyVideoURLButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/CopyVideoURLButton.java
@@ -11,6 +11,7 @@
 package app.morphe.extension.youtube.videoplayer;
 
 import static app.morphe.extension.shared.StringRef.str;
+import static app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS;
 
 import android.os.Build;
 import android.view.View;
@@ -19,7 +20,6 @@ import androidx.annotation.Nullable;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
-import app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch;
 import app.morphe.extension.youtube.patches.VideoInformation;
 import app.morphe.extension.youtube.settings.Settings;
 
@@ -35,8 +35,7 @@ public class CopyVideoURLButton {
      */
     public static void initializeButton(View controlsView) {
         try {
-            if (LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS
-                    || !Settings.COPY_VIDEO_URL.get()) {
+            if (RESTORE_OLD_PLAYER_BUTTONS || !Settings.COPY_VIDEO_URL.get()) {
                 return;
             }
 
@@ -59,7 +58,7 @@ public class CopyVideoURLButton {
      */
     public static void initializeLegacyButton(View controlsView) {
         try {
-            if (!LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS) {
+            if (!RESTORE_OLD_PLAYER_BUTTONS) {
                 return;
             }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LegacyPlayerControlButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LegacyPlayerControlButton.java
@@ -10,6 +10,8 @@
 
 package app.morphe.extension.youtube.videoplayer;
 
+import static app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS;
+
 import android.graphics.drawable.AnimatedVectorDrawable;
 import android.graphics.drawable.Drawable;
 import android.view.View;
@@ -25,7 +27,6 @@ import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
-import app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch;
 import app.morphe.extension.youtube.shared.PlayerControlsVisibility;
 import app.morphe.extension.youtube.shared.PlayerType;
 import kotlin.Unit;
@@ -90,7 +91,7 @@ public class LegacyPlayerControlButton {
 
         if (imageResourceName != null) {
             final int iconResourceId = ResourceUtils.getIdentifierOrThrow(ResourceType.DRAWABLE,
-                    LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS
+                    RESTORE_OLD_PLAYER_BUTTONS
                             ? imageResourceName
                             : imageResourceName + "_bold"
             );

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LoopVideoButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LoopVideoButton.java
@@ -11,6 +11,7 @@
 package app.morphe.extension.youtube.videoplayer;
 
 import static app.morphe.extension.shared.StringRef.str;
+import static app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS;
 
 import android.view.View;
 import android.widget.ImageView;
@@ -21,7 +22,6 @@ import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
-import app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch;
 import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
@@ -38,12 +38,12 @@ public class LoopVideoButton {
 
     private static final int LOOP_VIDEO_ON = ResourceUtils.getIdentifierOrThrow(
             ResourceType.DRAWABLE,
-            LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS
+            RESTORE_OLD_PLAYER_BUTTONS
                     ? "morphe_loop_video_button_on"
                     : "morphe_loop_video_button_on_bold");
     private static final int LOOP_VIDEO_OFF = ResourceUtils.getIdentifierOrThrow(
             ResourceType.DRAWABLE,
-            LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS
+            RESTORE_OLD_PLAYER_BUTTONS
                     ? "morphe_loop_video_button_off"
                     : "morphe_loop_video_button_off_bold");
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlaybackSpeedDialogButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlaybackSpeedDialogButton.java
@@ -10,6 +10,8 @@
 
 package app.morphe.extension.youtube.videoplayer;
 
+import static app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS;
+
 import android.view.View;
 import android.widget.TextView;
 
@@ -20,7 +22,6 @@ import java.text.DecimalFormat;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
-import app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch;
 import app.morphe.extension.youtube.patches.VideoInformation;
 import app.morphe.extension.youtube.patches.playback.speed.CustomPlaybackSpeedPatch;
 import app.morphe.extension.youtube.settings.Settings;
@@ -44,8 +45,7 @@ public class PlaybackSpeedDialogButton {
      */
     public static void initializeButton(View controlsView) {
         try {
-            if (LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS
-                    || !Settings.PLAYBACK_SPEED_DIALOG_BUTTON.get()) {
+            if (RESTORE_OLD_PLAYER_BUTTONS || !Settings.PLAYBACK_SPEED_DIALOG_BUTTON.get()) {
                 return;
             }
 
@@ -64,7 +64,7 @@ public class PlaybackSpeedDialogButton {
 
     public static void initializeLegacyButton(View controlsView) {
         try {
-            if (!LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS) {
+            if (!RESTORE_OLD_PLAYER_BUTTONS) {
                 return;
             }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/VideoQualityDialogButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/VideoQualityDialogButton.java
@@ -15,6 +15,7 @@ import static app.morphe.extension.shared.settings.preference.CustomDialogListPr
 import static app.morphe.extension.shared.settings.preference.CustomDialogListPreference.ID_MORPHE_CHECK_ICON_PLACEHOLDER;
 import static app.morphe.extension.shared.settings.preference.CustomDialogListPreference.ID_MORPHE_ITEM_TEXT;
 import static app.morphe.extension.shared.settings.preference.CustomDialogListPreference.LAYOUT_MORPHE_CUSTOM_LIST_ITEM_CHECKED;
+import static app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS;
 import static app.morphe.extension.youtube.patches.VideoInformation.AUTOMATIC_VIDEO_QUALITY_VALUE;
 import static app.morphe.extension.youtube.patches.VideoInformation.isPremiumVideoQuality;
 import static app.morphe.extension.youtube.videoplayer.LegacyPlayerControlButton.fadeInDuration;
@@ -45,7 +46,6 @@ import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.shared.ui.SheetBottomDialog;
-import app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch;
 import app.morphe.extension.youtube.patches.VideoInformation;
 import app.morphe.extension.youtube.patches.VideoInformation.VideoQualityInterface;
 import app.morphe.extension.youtube.patches.playback.quality.RememberVideoQualityPatch;
@@ -82,8 +82,7 @@ public class VideoQualityDialogButton {
      */
     public static void initializeButton(View controlsView) {
         try {
-            if (LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS
-                    || !Settings.VIDEO_QUALITY_DIALOG_BUTTON.get()) {
+            if (RESTORE_OLD_PLAYER_BUTTONS || !Settings.VIDEO_QUALITY_DIALOG_BUTTON.get()) {
                 return;
             }
 
@@ -105,7 +104,7 @@ public class VideoQualityDialogButton {
      */
     public static void initializeLegacyButton(View controlsView) {
         try {
-            if (!LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS) {
+            if (!RESTORE_OLD_PLAYER_BUTTONS) {
                 return;
             }
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/buttons/PlayerOverlayButtonsHookPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/buttons/PlayerOverlayButtonsHookPatch.kt
@@ -17,8 +17,6 @@ import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import java.lang.ref.WeakReference
 
-private const val PLAYER_BUTTON_OVERLAY_CLASS_DESCRIPTOR = "Lapp/morphe/extension/youtube/videoplayer/PlayerOverlayButton;"
-
 private lateinit var exploderButtonMethodRef : WeakReference<MutableMethod>
 private var exploderButtonInsertIndex = -1
 private var exploderButtonInsertRegister = -1

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/LegacyPlayerControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/LegacyPlayerControlsPatch.kt
@@ -23,6 +23,7 @@ import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.playservice.is_20_28_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_20_30_or_greater
+import app.morphe.patches.youtube.misc.playservice.is_20_31_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_20_40_or_greater
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
@@ -261,7 +262,7 @@ val legacyPlayerControlsPatch = bytecodePatch(
     )
 
     execute {
-        if (is_20_30_or_greater) {
+        if (is_20_31_or_greater) {
             PreferenceScreen.PLAYER.addPreferences(
                 SwitchPreference("morphe_restore_old_player_buttons")
             )


### PR DESCRIPTION
### Description

Closes #1125.

### Additional context

~~The default value for `Restore old player button style` has been changed to **TRUE**.~~

~~Unpatched YouTube also does not use bold icons when the app is first installed.~~

~~To minimize unintended issues, it is better to allow users to manually disable `Restore old player button style`.~~

`Restore old player button style` setting is no longer available if the app version is spoofed to **20.28** or earlier.

According to the description in the `Spoof app version target`, the bold icon should not be used in YouTube 20.28 or earlier:

```
20.28.41 - Disable bold icons
```

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
