### PR TITLE
fix(YouTube - Hide ads): Resolve "Hide YouTube Premium promotions" affecting YouTube Doodles

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AdsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AdsFilter.java
@@ -35,12 +35,12 @@ public final class AdsFilter extends Filter {
     private static final boolean HIDE_END_SCREEN_STORE_BANNER =
             Settings.HIDE_END_SCREEN_STORE_BANNER.get();
 
+    private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+
     private final StringTrieSearch exceptions = new StringTrieSearch();
 
     private final StringFilterGroup buyMovieAd;
     private final ByteArrayFilterGroup buyMovieAdBuffer;
-    private final StringFilterGroup promotionBanner;
-    private final ByteArrayFilterGroup promotionBannerBuffer;
 
     public AdsFilter() {
         exceptions.addPatterns(
@@ -133,16 +133,6 @@ public final class AdsFilter extends Filter {
                 "shopping_carousel.e" // Channel profile shopping shelf.
         );
 
-        promotionBanner = new StringFilterGroup(
-                null,
-                "statement_banner"
-        );
-
-        promotionBannerBuffer = new ByteArrayFilterGroup(
-                null,
-                "EgliaWd5b29kbGU" // Base64 chunk that decodes to 'bigyoodle'
-        );
-
         final var selfSponsor = new StringFilterGroup(
                 Settings.HIDE_SELF_SPONSOR,
                 "cta_shelf_card"
@@ -153,7 +143,6 @@ public final class AdsFilter extends Filter {
                 generalAds,
                 merchandise,
                 movieAds,
-                promotionBanner,
                 selfSponsor,
                 shoppingLinks,
                 viewProducts
@@ -173,17 +162,37 @@ public final class AdsFilter extends Filter {
             return contentIndex == 0 && buyMovieAdBuffer.check(buffer).isFiltered();
         }
 
-        if (matchedGroup == promotionBanner) {
-            if (contentIndex == 0) {
-                if (promotionBannerBuffer.check(buffer).isFiltered()) {
-                    return Settings.HIDE_YOUTUBE_DOODLES.get();
+        return !exceptions.matches(path);
+    }
+
+    /**
+     * Injection point.
+     */
+    public static byte[] hideStatementBanner(byte[] bytes) {
+        try {
+            String payload = new String(bytes);
+
+            if (payload.contains("statement_banner")) {
+
+                boolean isDoodle = payload.contains("EgliaWd5b29kbGU"); // Base64 chunk that decodes to 'bigyoodle'
+
+                if (isDoodle) {
+                    if (Settings.HIDE_YOUTUBE_DOODLES.get()) {
+                        Logger.printDebug(() -> "Hiding YouTube Doodles");
+                        return EMPTY_BYTE_ARRAY;
+                    }
+                } else {
+                    if (Settings.HIDE_YOUTUBE_PREMIUM_PROMOTIONS.get()) {
+                        Logger.printDebug(() -> "Hiding YouTube Premium promotions");
+                        return EMPTY_BYTE_ARRAY;
+                    }
                 }
-                return Settings.HIDE_YOUTUBE_PREMIUM_PROMOTIONS.get();
             }
-            return false;
+        } catch (Exception ex) {
+            Logger.printException(() -> "hideStatementBanner failure", ex);
         }
 
-        return !exceptions.matches(path);
+        return bytes;
     }
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AdsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AdsFilter.java
@@ -1,5 +1,7 @@
 package app.morphe.extension.youtube.patches.components;
 
+import static app.morphe.extension.shared.ByteTrieSearch.convertStringsToBytes;
+
 import android.app.Dialog;
 import android.view.View;
 import android.view.Window;
@@ -9,6 +11,7 @@ import androidx.annotation.Nullable;
 
 import java.util.List;
 
+import app.morphe.extension.shared.ByteTrieSearch;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.StringTrieSearch;
 import app.morphe.extension.shared.Utils;
@@ -36,6 +39,10 @@ public final class AdsFilter extends Filter {
             Settings.HIDE_END_SCREEN_STORE_BANNER.get();
 
     private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+    private static final ByteTrieSearch statementBannerSearch = new ByteTrieSearch(
+            convertStringsToBytes("statement_banner"));
+    private static final ByteTrieSearch yoodleSearch = new ByteTrieSearch(
+            convertStringsToBytes("EgliaWd5b29kbGU")); // Base64 chunk that decodes to 'bigyoodle'
 
     private final StringTrieSearch exceptions = new StringTrieSearch();
 
@@ -170,11 +177,8 @@ public final class AdsFilter extends Filter {
      */
     public static byte[] hideStatementBanner(byte[] bytes) {
         try {
-            String payload = new String(bytes);
-
-            if (payload.contains("statement_banner")) {
-
-                boolean isDoodle = payload.contains("EgliaWd5b29kbGU"); // Base64 chunk that decodes to 'bigyoodle'
+            if (statementBannerSearch.matches(bytes)) {
+                final boolean isDoodle = yoodleSearch.matches(bytes);
 
                 if (isDoodle) {
                     if (Settings.HIDE_YOUTUBE_DOODLES.get()) {

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/ad/general/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/ad/general/HideAdsPatch.kt
@@ -18,6 +18,8 @@ import app.morphe.patches.youtube.misc.engagement.engagementPanelHookPatch
 import app.morphe.patches.youtube.misc.litho.filter.addLithoFilter
 import app.morphe.patches.youtube.misc.litho.filter.lithoFilterPatch
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
+import app.morphe.patches.youtube.misc.proto.elementProtoParserHookPatch
+import app.morphe.patches.youtube.misc.proto.hookElement
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
@@ -79,12 +81,14 @@ val hideAdsPatch = bytecodePatch(
 ) {
     dependsOn(
         hideAdsResourcePatch,
+        elementProtoParserHookPatch,
         versionCheckPatch
     )
 
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {
+        hookElement("$EXTENSION_CLASS_DESCRIPTOR->hideStatementBanner([B)[B")
         // Hide end screen store banner
 
         FullScreenEngagementAdContainerFingerprint.let {

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/ad/general/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/ad/general/HideAdsPatch.kt
@@ -88,7 +88,10 @@ val hideAdsPatch = bytecodePatch(
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {
+        // Hide YouTube Premium promotions
+
         hookElement("$EXTENSION_CLASS_DESCRIPTOR->hideStatementBanner([B)[B")
+
         // Hide end screen store banner
 
         FullScreenEngagementAdContainerFingerprint.let {


### PR DESCRIPTION
### Description

To prevent this from happening:

<img width="1080" height="516" alt="image" src="https://github.com/user-attachments/assets/368ebc31-9d63-4212-bb62-c8125c25f612" />

### Additional context

<!-- ADD ADDITIONAL CONTEXT HERE -->

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
