### PR TITLE
fix(YouTube - Override YouTube Music buttons): Support launching arbitrary third-party music clients

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/OverrideYouTubeMusicActionsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/OverrideYouTubeMusicActionsPatch.java
@@ -60,9 +60,7 @@ public class OverrideYouTubeMusicActionsPatch {
         }
 
         String uriString = uri.toString();
-        if (uriString.contains(YOUTUBE_MUSIC_PACKAGE_NAME) ||
-                (uriString.startsWith("market://") && uriString.contains(YOUTUBE_MUSIC_PACKAGE_NAME)) ||
-                (uriString.contains("play.google.com/store/apps") && uriString.contains(YOUTUBE_MUSIC_PACKAGE_NAME))) {
+        if (uriString.contains(YOUTUBE_MUSIC_PACKAGE_NAME)) {
 
             String target = Settings.MORPHE_MUSIC_PACKAGE_NAME.get().trim();
             if (Utils.isNotEmpty(target) && isAppInstalled(target)) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/OverrideYouTubeMusicActionsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/OverrideYouTubeMusicActionsPatch.java
@@ -8,6 +8,7 @@
 package app.morphe.extension.youtube.patches;
 
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.youtube.settings.Settings;
@@ -16,6 +17,7 @@ import app.morphe.extension.youtube.settings.Settings;
 public class OverrideYouTubeMusicActionsPatch {
 
     private static final String YOUTUBE_MUSIC_PACKAGE_NAME = "com.google.android.apps.youtube.music";
+    private static final String HIJACK_FLAG = "morphe_hijacked";
 
     public static Intent overrideSetPackage(Intent intent, String packageName) {
         if (intent == null) return null;
@@ -24,12 +26,26 @@ public class OverrideYouTubeMusicActionsPatch {
             return intent.setPackage(packageName);
         }
 
-        if (YOUTUBE_MUSIC_PACKAGE_NAME.equals(packageName)) {
-            String target = Settings.MORPHE_MUSIC_PACKAGE_NAME.get();
-            if (Utils.isNotEmpty(target) && Utils.isPackageEnabled(target)) {
-                return intent.setPackage(target);
-            }
+        if (intent.getBooleanExtra(HIJACK_FLAG, false)) {
+            return intent;
+        }
 
+        if (YOUTUBE_MUSIC_PACKAGE_NAME.equals(packageName)) {
+            String target = Settings.MORPHE_MUSIC_PACKAGE_NAME.get().trim();
+
+            if (Utils.isNotEmpty(target) && isAppInstalled(target)) {
+                PackageManager pm = Utils.getContext().getPackageManager();
+                Intent launchIntent = pm.getLaunchIntentForPackage(target);
+
+                if (launchIntent != null) {
+                    intent.setAction(launchIntent.getAction());
+                    intent.setComponent(launchIntent.getComponent());
+                    intent.setPackage(target);
+                    intent.putExtra(HIJACK_FLAG, true);
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    return intent;
+                }
+            }
             return intent.setPackage(null);
         }
 
@@ -44,22 +60,41 @@ public class OverrideYouTubeMusicActionsPatch {
         }
 
         String uriString = uri.toString();
-        if (uriString.contains(YOUTUBE_MUSIC_PACKAGE_NAME)) {
-            if (uriString.startsWith("market://") || uriString.contains("play.google.com/store/apps")) {
+        if (uriString.contains(YOUTUBE_MUSIC_PACKAGE_NAME) ||
+                (uriString.startsWith("market://") && uriString.contains(YOUTUBE_MUSIC_PACKAGE_NAME)) ||
+                (uriString.contains("play.google.com/store/apps") && uriString.contains(YOUTUBE_MUSIC_PACKAGE_NAME))) {
 
-                intent.setData(Uri.parse("https://music.youtube.com/"));
+            String target = Settings.MORPHE_MUSIC_PACKAGE_NAME.get().trim();
+            if (Utils.isNotEmpty(target) && isAppInstalled(target)) {
 
-                String target = Settings.MORPHE_MUSIC_PACKAGE_NAME.get();
-                if (Utils.isNotEmpty(target) && Utils.isPackageEnabled(target)) {
-
-                    intent.setPackage(target);
-                } else {
-                    intent.setPackage(null);
+                Uri musicUri = Uri.parse("https://music.youtube.com/");
+                if (!uriString.contains("play.google.com") && !uriString.startsWith("market://")) {
+                    musicUri = uri;
                 }
+
+                intent.setAction(Intent.ACTION_VIEW);
+                intent.setData(musicUri);
+                intent.setPackage(target);
+                intent.setComponent(null);
+                intent.putExtra(HIJACK_FLAG, true);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 return intent;
             }
+
+            intent.setData(Uri.parse("https://music.youtube.com/"));
+            intent.setPackage(null);
+            intent.setComponent(null);
+            return intent;
         }
 
         return intent.setData(uri);
+    }
+
+    private static boolean isAppInstalled(String packageName) {
+        try {
+            return Utils.getContext().getPackageManager().getLaunchIntentForPackage(packageName) != null;
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/OverrideYouTubeMusicButtonsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/OverrideYouTubeMusicButtonsPatch.java
@@ -14,7 +14,7 @@ import app.morphe.extension.shared.Utils;
 import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
-public class OverrideYouTubeMusicActionsPatch {
+public class OverrideYouTubeMusicButtonsPatch {
 
     private static final String YOUTUBE_MUSIC_PACKAGE_NAME = "com.google.android.apps.youtube.music";
     private static final String HIJACK_FLAG = "morphe_hijacked";
@@ -22,7 +22,7 @@ public class OverrideYouTubeMusicActionsPatch {
     public static Intent overrideSetPackage(Intent intent, String packageName) {
         if (intent == null) return null;
 
-        if (!Settings.OVERRIDE_YOUTUBE_MUSIC_BUTTON.get()) {
+        if (!Settings.OVERRIDE_YOUTUBE_MUSIC_BUTTONS.get()) {
             return intent.setPackage(packageName);
         }
 
@@ -55,7 +55,7 @@ public class OverrideYouTubeMusicActionsPatch {
     public static Intent overrideSetData(Intent intent, Uri uri) {
         if (intent == null) return null;
         if (uri == null) return intent.setData(null);
-        if (!Settings.OVERRIDE_YOUTUBE_MUSIC_BUTTON.get()) {
+        if (!Settings.OVERRIDE_YOUTUBE_MUSIC_BUTTONS.get()) {
             return intent.setData(uri);
         }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -541,6 +541,7 @@ public class Settings extends SharedYouTubeSettings {
     private static final BooleanSetting DEPRECATED_DISABLE_SIGNIN_TO_TV_POPUP = new BooleanSetting("morphe_disable_signin_to_tv_popup", FALSE);
     private static final BooleanSetting DEPRECATED_HIDE_ENDSCREEN_CARDS = new BooleanSetting("morphe_hide_endscreen_cards", FALSE);
     private static final BooleanSetting DEPRECATED_HIDE_DOODLES = new BooleanSetting("morphe_hide_doodles", FALSE);
+    private static final BooleanSetting DEPRECATED_OVERRIDE_YOUTUBE_MUSIC_BUTTON = new BooleanSetting("morphe_override_youtube_music_button", FALSE, true);
     private static final BooleanSetting DEPRECATED_SEEKBAR_TAPPING = new BooleanSetting("morphe_seekbar_tapping", FALSE);
 
     static {
@@ -550,6 +551,7 @@ public class Settings extends SharedYouTubeSettings {
         migrateOldSettingToNew(DEPRECATED_DISABLE_SIGNIN_TO_TV_POPUP, DISABLE_SIGN_IN_TO_TV_POPUP);
         migrateOldSettingToNew(DEPRECATED_HIDE_ENDSCREEN_CARDS, HIDE_END_SCREEN_CARDS);
         migrateOldSettingToNew(DEPRECATED_HIDE_DOODLES, HIDE_YOUTUBE_DOODLES);
+        migrateOldSettingToNew(DEPRECATED_OVERRIDE_YOUTUBE_MUSIC_BUTTON, OVERRIDE_YOUTUBE_MUSIC_BUTTONS);
         migrateOldSettingToNew(DEPRECATED_SEEKBAR_TAPPING, TAP_TO_SEEK);
 
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -332,8 +332,8 @@ public class Settings extends SharedYouTubeSettings {
             "morphe_remove_viewer_discretion_dialog_user_dialog_message");
     public static final BooleanSetting SPOOF_APP_VERSION = new BooleanSetting("morphe_spoof_app_version", FALSE, true, "morphe_spoof_app_version_user_dialog_message");
     public static final BooleanSetting OPEN_SYSTEM_SHARE_SHEET = new BooleanSetting("morphe_open_system_share_sheet", FALSE, true);
-    public static final BooleanSetting OVERRIDE_YOUTUBE_MUSIC_BUTTON = new BooleanSetting("morphe_override_youtube_music_button", FALSE, true);
-    public static final StringSetting MORPHE_MUSIC_PACKAGE_NAME = new StringSetting("morphe_music_package_name", "app.morphe.android.apps.youtube.music", true, parent(OVERRIDE_YOUTUBE_MUSIC_BUTTON));
+    public static final BooleanSetting OVERRIDE_YOUTUBE_MUSIC_BUTTONS = new BooleanSetting("morphe_override_youtube_music_buttons", FALSE, true);
+    public static final StringSetting MORPHE_MUSIC_PACKAGE_NAME = new StringSetting("morphe_music_package_name", "app.morphe.android.apps.youtube.music", true, parent(OVERRIDE_YOUTUBE_MUSIC_BUTTONS));
     public static final EnumSetting<StartPage> CHANGE_START_PAGE = new EnumSetting<>("morphe_change_start_page", StartPage.DEFAULT, true);
     public static final BooleanSetting CHANGE_START_PAGE_ALWAYS = new BooleanSetting("morphe_change_start_page_always", FALSE, true,
             new ChangeStartPageTypeAvailability());

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/music/OverrideYouTubeMusicActionsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/music/OverrideYouTubeMusicActionsPatch.kt
@@ -30,22 +30,17 @@ private fun overrideYouTubeMusicManifestPatch() = resourcePatch{
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {
-        val targetPackage = "app.morphe.android.apps.youtube.music"
         val manifestFile = get("AndroidManifest.xml")
         var manifestContent = manifestFile.readText()
+        val permissionTag = "<uses-permission android:name=\"android.permission.QUERY_ALL_PACKAGES\"/>"
 
-        manifestContent = if (manifestContent.contains("</queries>")) {
-            manifestContent.replace(
-                "</queries>",
-                "<package android:name=\"$targetPackage\"/></queries>"
+        if (!manifestContent.contains(permissionTag)) {
+            manifestContent = manifestContent.replace(
+                "<application",
+                "$permissionTag\n    <application"
             )
-        } else {
-            manifestContent.replace(
-                "</manifest>",
-                "<queries><package android:name=\"$targetPackage\"/></queries>\n</manifest>"
-            )
+            manifestFile.writeText(manifestContent)
         }
-        manifestFile.writeText(manifestContent)
     }
 }
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/music/OverrideYouTubeMusicButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/music/OverrideYouTubeMusicButtonsPatch.kt
@@ -24,7 +24,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
-private const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/OverrideYouTubeMusicActionsPatch;"
+private const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/OverrideYouTubeMusicButtonsPatch;"
 
 private fun overrideYouTubeMusicManifestPatch() = resourcePatch{
     compatibleWith(COMPATIBILITY_YOUTUBE)
@@ -45,9 +45,9 @@ private fun overrideYouTubeMusicManifestPatch() = resourcePatch{
 }
 
 @Suppress("unused")
-val overrideYouTubeMusicActionsPatch = bytecodePatch(
-    name = "Override YouTube Music actions",
-    description = "Overrides the YouTube Music button to open Morphe Music directly.",
+val overrideYouTubeMusicButtonsPatch = bytecodePatch(
+    name = "Override YouTube Music buttons",
+    description = "Overrides YouTube Music buttons to open Morphe Music or any compatible third-party client.",
 ) {
     dependsOn(settingsPatch)
     dependsOn(overrideYouTubeMusicManifestPatch())
@@ -60,7 +60,7 @@ val overrideYouTubeMusicActionsPatch = bytecodePatch(
                 sorting = Sorting.UNSORTED,
                 tag = "app.morphe.extension.shared.settings.preference.NoTitlePreferenceCategory",
                 preferences = setOf(
-                    SwitchPreference(key = "morphe_override_youtube_music_button"),
+                    SwitchPreference(key = "morphe_override_youtube_music_buttons"),
                     TextPreference(key = "morphe_music_package_name")
                 )
             )

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1469,12 +1469,12 @@ If later turned off, it is recommended to clear the app data to prevent UI bugs.
     <string name="morphe_open_system_share_sheet_summary_on">Opens system share sheet</string>
     <string name="morphe_open_system_share_sheet_summary_off">Opens in-app share sheet</string>
 
-    <!-- layout.music.overrideYouTubeMusicActionsPatch -->
-    <string name="morphe_override_youtube_music_button_title">Override YouTube Music button</string>
-    <string name="morphe_override_youtube_music_button_summary_on">YouTube Music button opens your target music app</string>
-    <string name="morphe_override_youtube_music_button_summary_off">YouTube Music button opens the native app</string>
-    <string name="morphe_music_package_name_title">Morphe Music package name</string>
-    <string name="morphe_music_package_name_summary">Package name of the target music app</string>
+    <!-- layout.music.overrideYouTubeMusicButtonsPatch -->
+    <string name="morphe_override_youtube_music_buttons_title">Override YouTube Music buttons</string>
+    <string name="morphe_override_youtube_music_buttons_summary_on">YouTube Music buttons open your target music app</string>
+    <string name="morphe_override_youtube_music_buttons_summary_off">YouTube Music buttons open the official app</string>
+    <string name="morphe_music_package_name_title">Target music app package name</string>
+    <string name="morphe_music_package_name_summary">Package name of your installed target music app</string>
 
     <!-- layout.startpage.changeStartPagePatch -->
     <string name="morphe_change_start_page_title">Change start page</string>


### PR DESCRIPTION
### Description

Closes #957.

### Additional context

Previously, the "Override YouTube Music actions" patch failed to launch custom FOSS clients (like ViMusic, InnerTune, or Metrolist) on Android 11+ due to package visibility rules, and would frequently redirect to a website. This PR fixes that issue.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
