### PR TITLE
fix(YouTube): Resolve Shorts playback failing

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/Fingerprints.kt
@@ -144,3 +144,11 @@ internal object RenderNextUIFeatureFlagFingerprint : Fingerprint(
         literal(45649743L)
     )
 )
+
+internal object ShortsPlaybackStartDescriptorFeatureFlagFingerprint : Fingerprint(
+    parameters = listOf(),
+    returnType = "Z",
+    filters = listOf(
+        literal(45665455L)
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
@@ -17,6 +17,7 @@ import app.morphe.patches.youtube.misc.litho.filter.addLithoFilter
 import app.morphe.patches.youtube.misc.litho.filter.lithoFilterPatch
 import app.morphe.patches.youtube.misc.navigation.navigationBarHookPatch
 import app.morphe.patches.youtube.misc.playservice.is_19_41_or_greater
+import app.morphe.patches.youtube.misc.playservice.is_20_03_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_20_07_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_20_22_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_20_45_or_greater
@@ -290,6 +291,11 @@ val hideShortsComponentsPatch = bytecodePatch(
         // Flags might be present in earlier targets, but they are not found in 19.47.53.
         // If these flags are forced on, the experimental layout is still not used and
         // it appears the features requires additional server side data to fully use.
+        if (is_20_03_or_greater) {
+            // Flag breaks Shorts playback when enabled via A/B test.
+            ShortsPlaybackStartDescriptorFeatureFlagFingerprint.method.returnLate(false)
+        }
+
         if (is_20_07_or_greater) {
             // Experimental Shorts player uses Android native buttons and not Litho,
             // and the layout is provided by the server.


### PR DESCRIPTION
### Description

A feature flag in YouTube 20.03+ breaks Shorts when it gets enabled via A/B test. Added the fingerprint to identify it and force it off for affected versions.

Closes #1198

### Additional context

N/A

### Test results

- [ ] Tested on both the **minimum** and **maximum** supported versions
- [ ] Tested on **experimental** supported versions (Optional)