### PR TITLE
fix(YouTube - Hide layout components): "Hide info panel" does not work in search results

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -33,8 +33,6 @@ import app.morphe.extension.shared.Utils;
 import app.morphe.extension.youtube.patches.ChangeHeaderPatch;
 import app.morphe.extension.youtube.settings.Settings;
 import app.morphe.extension.youtube.shared.ConversionContext.ContextInterface;
-import app.morphe.extension.youtube.shared.NavigationBar;
-import app.morphe.extension.youtube.shared.PlayerType;
 
 @SuppressWarnings("unused")
 public final class LayoutComponentsFilter extends Filter {
@@ -55,6 +53,9 @@ public final class LayoutComponentsFilter extends Filter {
     private final StringFilterGroup communityPosts;
     private final StringFilterGroup surveys;
     private final StringFilterGroup notifyMe;
+    private final StringFilterGroup searchFriction;
+    private final StringFilterGroup singleItemInformationPanel;
+    private static int singleItemInformationPanelIndex = -1;
     private final StringFilterGroup expandableMetadata;
     private final ByteArrayFilterGroup productCardBuffer;
     private final ByteArrayFilterGroup summaryCardBuffer;
@@ -185,7 +186,12 @@ public final class LayoutComponentsFilter extends Filter {
                 "publisher_transparency_panel"
         );
 
-        final var singleItemInformationPanel = new StringFilterGroup(
+        searchFriction = new StringFilterGroup(
+                Settings.HIDE_INFO_PANELS,
+                "search_friction"
+        );
+
+        singleItemInformationPanel = new StringFilterGroup(
                 Settings.HIDE_INFO_PANELS,
                 "single_item_information_panel"
         );
@@ -363,6 +369,7 @@ public final class LayoutComponentsFilter extends Filter {
                 postsShelf,
                 quickActions,
                 relatedVideos,
+                searchFriction,
                 singleItemInformationPanel,
                 subscribedChannelsBar,
                 subscribersCommunityGuidelines,
@@ -384,6 +391,27 @@ public final class LayoutComponentsFilter extends Filter {
                        StringFilterGroup matchedGroup,
                        FilterContentType contentType,
                        int contentIndex) {
+        // This identifier is used not only in players but also in search results:
+        // Until 2024, medical information panels such as Covid-19 also used this identifier and were shown in the search results.
+        // From 2025, the medical information panel is no longer shown in the search results.
+        // Therefore, this identifier does not filter when the search bar is activated.
+        if (matchedGroup == searchFriction) {
+            singleItemInformationPanelIndex = 0;
+            return false;
+        }
+        if (matchedGroup == singleItemInformationPanel) {
+            if (singleItemInformationPanelIndex >= 0) {
+                if (singleItemInformationPanelIndex < 9) {
+                    singleItemInformationPanelIndex++;
+                } else {
+                    singleItemInformationPanelIndex = -1;
+                }
+                return false;
+            } else {
+                return true;
+            }
+        }
+
         // The groups are excluded from the filter due to the exceptions list below.
         // Filter them separately here.
         if (matchedGroup == notifyMe || matchedGroup == surveys) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -55,7 +55,7 @@ public final class LayoutComponentsFilter extends Filter {
     private final StringFilterGroup notifyMe;
     private final StringFilterGroup searchFriction;
     private final StringFilterGroup singleItemInformationPanel;
-    private static int singleItemInformationPanelIndex = -1;
+    private static volatile int singleItemInformationPanelIndex = -1;
     private final StringFilterGroup expandableMetadata;
     private final ByteArrayFilterGroup productCardBuffer;
     private final ByteArrayFilterGroup summaryCardBuffer;

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -55,7 +55,6 @@ public final class LayoutComponentsFilter extends Filter {
     private final StringFilterGroup communityPosts;
     private final StringFilterGroup surveys;
     private final StringFilterGroup notifyMe;
-    private final StringFilterGroup singleItemInformationPanel;
     private final StringFilterGroup expandableMetadata;
     private final ByteArrayFilterGroup productCardBuffer;
     private final ByteArrayFilterGroup summaryCardBuffer;
@@ -186,7 +185,7 @@ public final class LayoutComponentsFilter extends Filter {
                 "publisher_transparency_panel"
         );
 
-        singleItemInformationPanel = new StringFilterGroup(
+        final var singleItemInformationPanel = new StringFilterGroup(
                 Settings.HIDE_INFO_PANELS,
                 "single_item_information_panel"
         );
@@ -385,14 +384,6 @@ public final class LayoutComponentsFilter extends Filter {
                        StringFilterGroup matchedGroup,
                        FilterContentType contentType,
                        int contentIndex) {
-        // This identifier is used not only in players but also in search results:
-        // Until 2024, medical information panels such as Covid-19 also used this identifier and were shown in the search results.
-        // From 2025, the medical information panel is no longer shown in the search results.
-        // Therefore, this identifier does not filter when the search bar is activated.
-        if (matchedGroup == singleItemInformationPanel) {
-            return PlayerType.getCurrent().isMaximizedOrFullscreen() || !NavigationBar.isSearchBarActive();
-        }
-
         // The groups are excluded from the filter due to the exceptions list below.
         // Filter them separately here.
         if (matchedGroup == notifyMe || matchedGroup == surveys) {


### PR DESCRIPTION
### Description

This panel was partially hidden, because of the hiding of other items with the same name, including the informative help message that appears when searching for "forbidden" terms. With this PR all will be hidden, included the top message after performed a search.

<img width="1440" height="2920" alt="Screenshot_20260419_094838" src="https://github.com/user-attachments/assets/54a63cf1-16b0-4da8-bf70-af7062889792" />

### Additional context

<!-- ADD ADDITIONAL CONTEXT HERE -->

To hide this information panel only on the medical help screen, I calculated the amount of ```single_information_panel``` items present after the medical help screen elements (marked as ```search_friction```) are detected. In this way the button to continue to see the search results will not be hidden.

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
