### PR TITLE
fix(YouTube - Hide layout components): Resolve "Hide How this was made" not working in Shorts description

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/DescriptionComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/DescriptionComponentsFilter.java
@@ -20,6 +20,7 @@ final class DescriptionComponentsFilter extends Filter {
     private final StringFilterGroup featuredLinksSection;
     private final StringFilterGroup featuredVideosSection;
     private final StringFilterGroup subscribeButton;
+    private final StringFilterGroup shortsHowThisWasMadeSection;
 
     public DescriptionComponentsFilter() {
         final StringFilterGroup aiGeneratedVideoSummarySection = new StringFilterGroup(
@@ -111,6 +112,12 @@ final class DescriptionComponentsFilter extends Filter {
                 )
         );
 
+        shortsHowThisWasMadeSection = new StringFilterGroup(
+                Settings.HIDE_HOW_THIS_WAS_MADE_SECTION,
+                "shelf_header.e",
+                "cell_video_attribute.e"
+        );
+
         addPathCallbacks(
                 aiGeneratedVideoSummarySection,
                 askSection,
@@ -122,6 +129,7 @@ final class DescriptionComponentsFilter extends Filter {
                 infoCardsSection,
                 macroMarkersCarousel,
                 playlistSection,
+                shortsHowThisWasMadeSection,
                 subscribeButton,
                 transcriptSection
         );
@@ -153,6 +161,10 @@ final class DescriptionComponentsFilter extends Filter {
 
         if (matchedGroup == macroMarkersCarousel) {
             return contentIndex == 0 && macroMarkersCarouselGroupList.check(buffer).isFiltered();
+        }
+
+        if (matchedGroup == shortsHowThisWasMadeSection) {
+            return ShortsPlayerState.isOpen() && EngagementPanel.isDescription();
         }
 
         return true;


### PR DESCRIPTION
### Description

Closes #1220.

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
