### PR TITLE
refactor(YouTube - Hide video action buttons): Group player action button settings together into a single preference screen

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/QuickActionButtonsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/QuickActionButtonsFilter.java
@@ -103,22 +103,6 @@ public final class QuickActionButtonsFilter extends Filter {
         );
     }
 
-    /**
-     * Checks if all child elements of the Quick Actions menu are set to be hidden.
-     * If they are, we can just hide the parent container entirely.
-     */
-    private boolean isEveryFilterGroupEnabled() {
-        for (StringFilterGroup group : pathCallbacks) {
-            if (!group.isEnabled()) return false;
-        }
-
-        for (ByteArrayFilterGroup group : bufferButtonsGroupList) {
-            if (!group.isEnabled()) return false;
-        }
-
-        return true;
-    }
-
     @Override
     boolean isFiltered(ContextInterface contextInterface,
                        String identifier,
@@ -133,8 +117,8 @@ public final class QuickActionButtonsFilter extends Filter {
             return false;
         }
 
-        if (matchedGroup == quickActions && !isEveryFilterGroupEnabled()) {
-            return false;
+        if (matchedGroup == quickActions) {
+            return true;
         }
 
         if (matchedGroup == buttonFilterPath) {

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/HideVideoActionButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/HideVideoActionButtonsPatch.kt
@@ -14,6 +14,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.shared.misc.fix.proto.fixProtoLibraryPatch
+import app.morphe.patches.shared.misc.settings.preference.PreferenceCategory
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
@@ -36,7 +37,7 @@ private const val QUICK_ACTIONS_FILTER =
 @Suppress("unused")
 val hideVideoActionButtonsPatch = bytecodePatch(
     name = "Hide video action buttons",
-    description = "Adds options to hide quick actions and video action buttons (such as the Download button) under videos."
+    description = "Adds options to hide video action buttons in fullscreen and portrait modes."
 ) {
     dependsOn(
         settingsPatch,
@@ -52,41 +53,46 @@ val hideVideoActionButtonsPatch = bytecodePatch(
     execute {
         PreferenceScreen.PLAYER.addPreferences(
             PreferenceScreenPreference(
-                key = "morphe_hide_buttons_screen",
+                key = "morphe_action_buttons_screen",
                 preferences = setOf(
-                    SwitchPreference("morphe_disable_like_subscribe_glow"),
-                    SwitchPreference("morphe_hide_action_bar"),
-                    SwitchPreference("morphe_hide_ask_button"),
-                    SwitchPreference("morphe_hide_clip_button"),
-                    SwitchPreference("morphe_hide_comments_button"),
-                    SwitchPreference("morphe_hide_download_button"),
-                    SwitchPreference("morphe_hide_hype_button"),
-                    SwitchPreference("morphe_hide_like_dislike_button"),
-                    SwitchPreference("morphe_hide_promote_button"),
-                    SwitchPreference("morphe_hide_remix_button"),
-                    SwitchPreference("morphe_hide_report_button"),
-                    SwitchPreference("morphe_hide_save_button"),
-                    SwitchPreference("morphe_hide_share_button"),
-                    SwitchPreference("morphe_hide_shop_button"),
-                    SwitchPreference("morphe_hide_stop_ads_button"),
-                    SwitchPreference("morphe_hide_thanks_button"),
-                )
-            ),
-            PreferenceScreenPreference(
-                key = "morphe_quick_actions_screen",
-                preferences = setOf(
-                    SwitchPreference("morphe_hide_quick_actions_ask_button"),
-                    SwitchPreference("morphe_hide_quick_actions_comments_button"),
-                    SwitchPreference("morphe_hide_quick_actions_dislike_button"),
-                    SwitchPreference("morphe_hide_quick_actions_like_button"),
-                    SwitchPreference("morphe_hide_quick_actions_live_chat_button"),
-                    SwitchPreference("morphe_hide_quick_actions_mix_button"),
-                    SwitchPreference("morphe_hide_quick_actions_more_button"),
-                    SwitchPreference("morphe_hide_quick_actions_more_videos_button"),
-                    SwitchPreference("morphe_hide_quick_actions_playlist_button"),
-                    SwitchPreference("morphe_hide_quick_actions_save_button"),
-                    SwitchPreference("morphe_hide_quick_actions_share_button"),
-                    SwitchPreference("morphe_hide_quick_actions"),
+                    PreferenceCategory(
+                        titleKey = "morphe_portrait_buttons",
+                        preferences = setOf(
+                            SwitchPreference("morphe_disable_like_subscribe_glow"),
+                            SwitchPreference("morphe_hide_action_bar"),
+                            SwitchPreference("morphe_hide_ask_button"),
+                            SwitchPreference("morphe_hide_clip_button"),
+                            SwitchPreference("morphe_hide_comments_button"),
+                            SwitchPreference("morphe_hide_download_button"),
+                            SwitchPreference("morphe_hide_hype_button"),
+                            SwitchPreference("morphe_hide_like_dislike_button"),
+                            SwitchPreference("morphe_hide_promote_button"),
+                            SwitchPreference("morphe_hide_remix_button"),
+                            SwitchPreference("morphe_hide_report_button"),
+                            SwitchPreference("morphe_hide_save_button"),
+                            SwitchPreference("morphe_hide_share_button"),
+                            SwitchPreference("morphe_hide_shop_button"),
+                            SwitchPreference("morphe_hide_stop_ads_button"),
+                            SwitchPreference("morphe_hide_thanks_button"),
+                        )
+                    ),
+                    PreferenceCategory(
+                        titleKey = "morphe_fullscreen_buttons",
+                        preferences = setOf(
+                            SwitchPreference("morphe_hide_quick_actions"),
+                            SwitchPreference("morphe_hide_quick_actions_ask_button"),
+                            SwitchPreference("morphe_hide_quick_actions_comments_button"),
+                            SwitchPreference("morphe_hide_quick_actions_dislike_button"),
+                            SwitchPreference("morphe_hide_quick_actions_like_button"),
+                            SwitchPreference("morphe_hide_quick_actions_live_chat_button"),
+                            SwitchPreference("morphe_hide_quick_actions_mix_button"),
+                            SwitchPreference("morphe_hide_quick_actions_more_button"),
+                            SwitchPreference("morphe_hide_quick_actions_more_videos_button"),
+                            SwitchPreference("morphe_hide_quick_actions_playlist_button"),
+                            SwitchPreference("morphe_hide_quick_actions_save_button"),
+                            SwitchPreference("morphe_hide_quick_actions_share_button"),
+                        )
+                    )
                 )
             )
         )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/HideVideoActionButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/HideVideoActionButtonsPatch.kt
@@ -74,7 +74,6 @@ val hideVideoActionButtonsPatch = bytecodePatch(
             ),
             PreferenceScreenPreference(
                 key = "morphe_quick_actions_screen",
-                sorting = PreferenceScreenPreference.Sorting.UNSORTED,
                 preferences = setOf(
                     SwitchPreference("morphe_hide_quick_actions_ask_button"),
                     SwitchPreference("morphe_hide_quick_actions_comments_button"),

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -636,8 +636,9 @@ Adjust volume by swiping vertically on the right side of the screen"</string>
     <string name="morphe_swipe_change_video_summary_off">Swiping in fullscreen mode will not change to the next/previous video</string>
 
     <!-- layout.buttons.action.hideButtonsPatch -->
-    <string name="morphe_hide_buttons_screen_title">Action buttons</string>
-    <string name="morphe_hide_buttons_screen_summary">Hide or show action buttons under videos</string>
+    <string name="morphe_action_buttons_screen_title">Action buttons</string>
+    <string name="morphe_action_buttons_screen_summary">Hide or show action buttons in fullscreen and portrait</string>
+    <string name="morphe_portrait_buttons">Portrait buttons</string>
     <string name="morphe_disable_like_subscribe_glow_title">Disable Like and Subscribe glow</string>
     <string name="morphe_disable_like_subscribe_glow_summary_on">Like and Subscribe button will not glow when mentioned</string>
     <string name="morphe_disable_like_subscribe_glow_summary_off">Like and Subscribe button will glow when mentioned</string>
@@ -703,6 +704,44 @@ Adjust volume by swiping vertically on the right side of the screen"</string>
     <string name="morphe_hide_save_button_title">Hide Save</string>
     <string name="morphe_hide_save_button_summary_on">Save button is hidden</string>
     <string name="morphe_hide_save_button_summary_off">Save button is shown</string>
+
+    <string name="morphe_fullscreen_buttons">Fullscreen buttons</string>
+    <string name="morphe_hide_quick_actions_title">Hide action bar</string>
+    <string name="morphe_hide_quick_actions_summary_on">Action bar is hidden</string>
+    <string name="morphe_hide_quick_actions_summary_off">Action bar is shown</string>
+    <string name="morphe_hide_quick_actions_ask_button_title">Hide Ask</string>
+    <string name="morphe_hide_quick_actions_ask_button_summary_on">Ask button is hidden</string>
+    <string name="morphe_hide_quick_actions_ask_button_summary_off">Ask button is shown</string>
+    <string name="morphe_hide_quick_actions_comments_button_title">Hide Comments</string>
+    <string name="morphe_hide_quick_actions_comments_button_summary_on">Comments button is hidden</string>
+    <string name="morphe_hide_quick_actions_comments_button_summary_off">Comments button is shown</string>
+    <string name="morphe_hide_quick_actions_dislike_button_title">Hide Dislike</string>
+    <string name="morphe_hide_quick_actions_dislike_button_summary_on">Dislike button is hidden</string>
+    <string name="morphe_hide_quick_actions_dislike_button_summary_off">Dislike button is shown</string>
+    <string name="morphe_hide_quick_actions_like_button_title">Hide Like</string>
+    <string name="morphe_hide_quick_actions_like_button_summary_on">Like button is hidden</string>
+    <string name="morphe_hide_quick_actions_like_button_summary_off">Like button is shown</string>
+    <string name="morphe_hide_quick_actions_live_chat_button_title">Hide \'Live chat\'</string>
+    <string name="morphe_hide_quick_actions_live_chat_button_summary_on">Live chat button is hidden</string>
+    <string name="morphe_hide_quick_actions_live_chat_button_summary_off">Live chat button is shown</string>
+    <string name="morphe_hide_quick_actions_mix_button_title">Hide Mix</string>
+    <string name="morphe_hide_quick_actions_mix_button_summary_on">Mix button is hidden</string>
+    <string name="morphe_hide_quick_actions_mix_button_summary_off">Mix button is shown</string>
+    <string name="morphe_hide_quick_actions_more_button_title">Hide More</string>
+    <string name="morphe_hide_quick_actions_more_button_summary_on">More button is hidden</string>
+    <string name="morphe_hide_quick_actions_more_button_summary_off">More button is shown</string>
+    <string name="morphe_hide_quick_actions_more_videos_button_title">Hide \'More videos\'</string>
+    <string name="morphe_hide_quick_actions_more_videos_button_summary_on">More videos button is hidden</string>
+    <string name="morphe_hide_quick_actions_more_videos_button_summary_off">More videos button is shown</string>
+    <string name="morphe_hide_quick_actions_playlist_button_title">Hide Playlist</string>
+    <string name="morphe_hide_quick_actions_playlist_button_summary_on">Playlist button is hidden</string>
+    <string name="morphe_hide_quick_actions_playlist_button_summary_off">Playlist button is shown</string>
+    <string name="morphe_hide_quick_actions_save_button_title">Hide Save</string>
+    <string name="morphe_hide_quick_actions_save_button_summary_on">Save button is hidden</string>
+    <string name="morphe_hide_quick_actions_save_button_summary_off">Save button is shown</string>
+    <string name="morphe_hide_quick_actions_share_button_title">Hide Share</string>
+    <string name="morphe_hide_quick_actions_share_button_summary_on">Share button is hidden</string>
+    <string name="morphe_hide_quick_actions_share_button_summary_off">Share button is shown</string>
 
     <!-- layout.captions.captionsPatch -->
     <string name="morphe_captions_screen_title">Captions</string>
@@ -940,45 +979,6 @@ To show the Audio track menu, change \'Spoof video streams\' to \'Android Reel\'
     <string name="morphe_hide_settings_button_title">Hide Settings</string>
     <string name="morphe_hide_settings_button_summary_on">Settings button is hidden</string>
     <string name="morphe_hide_settings_button_summary_off">Settings button is shown</string>
-
-    <string name="morphe_quick_actions_screen_title">Quick actions</string>
-    <string name="morphe_quick_actions_screen_summary">Hide or show quick actions in fullscreen under seekbar</string>
-    <string name="morphe_hide_quick_actions_ask_button_title">Hide Ask</string>
-    <string name="morphe_hide_quick_actions_ask_button_summary_on">Ask button is hidden</string>
-    <string name="morphe_hide_quick_actions_ask_button_summary_off">Ask button is shown</string>
-    <string name="morphe_hide_quick_actions_comments_button_title">Hide Comments</string>
-    <string name="morphe_hide_quick_actions_comments_button_summary_on">Comments button is hidden</string>
-    <string name="morphe_hide_quick_actions_comments_button_summary_off">Comments button is shown</string>
-    <string name="morphe_hide_quick_actions_dislike_button_title">Hide Dislike</string>
-    <string name="morphe_hide_quick_actions_dislike_button_summary_on">Dislike button is hidden</string>
-    <string name="morphe_hide_quick_actions_dislike_button_summary_off">Dislike button is shown</string>
-    <string name="morphe_hide_quick_actions_like_button_title">Hide Like</string>
-    <string name="morphe_hide_quick_actions_like_button_summary_on">Like button is hidden</string>
-    <string name="morphe_hide_quick_actions_like_button_summary_off">Like button is shown</string>
-    <string name="morphe_hide_quick_actions_live_chat_button_title">Hide \'Live chat\'</string>
-    <string name="morphe_hide_quick_actions_live_chat_button_summary_on">Live chat button is hidden</string>
-    <string name="morphe_hide_quick_actions_live_chat_button_summary_off">Live chat button is shown</string>
-    <string name="morphe_hide_quick_actions_mix_button_title">Hide Mix</string>
-    <string name="morphe_hide_quick_actions_mix_button_summary_on">Mix button is hidden</string>
-    <string name="morphe_hide_quick_actions_mix_button_summary_off">Mix button is shown</string>
-    <string name="morphe_hide_quick_actions_more_button_title">Hide More</string>
-    <string name="morphe_hide_quick_actions_more_button_summary_on">More button is hidden</string>
-    <string name="morphe_hide_quick_actions_more_button_summary_off">More button is shown</string>
-    <string name="morphe_hide_quick_actions_more_videos_button_title">Hide \'More videos\'</string>
-    <string name="morphe_hide_quick_actions_more_videos_button_summary_on">More videos button is hidden</string>
-    <string name="morphe_hide_quick_actions_more_videos_button_summary_off">More videos button is shown</string>
-    <string name="morphe_hide_quick_actions_playlist_button_title">Hide Playlist</string>
-    <string name="morphe_hide_quick_actions_playlist_button_summary_on">Playlist button is hidden</string>
-    <string name="morphe_hide_quick_actions_playlist_button_summary_off">Playlist button is shown</string>
-    <string name="morphe_hide_quick_actions_title">Hide Quick actions</string>
-    <string name="morphe_hide_quick_actions_summary_on">Quick actions are hidden</string>
-    <string name="morphe_hide_quick_actions_summary_off">Quick actions are shown</string>
-    <string name="morphe_hide_quick_actions_save_button_title">Hide Save</string>
-    <string name="morphe_hide_quick_actions_save_button_summary_on">Save button is hidden</string>
-    <string name="morphe_hide_quick_actions_save_button_summary_off">Save button is shown</string>
-    <string name="morphe_hide_quick_actions_share_button_title">Hide Share</string>
-    <string name="morphe_hide_quick_actions_share_button_summary_on">Share button is hidden</string>
-    <string name="morphe_hide_quick_actions_share_button_summary_off">Share button is shown</string>
 
     <!-- layout.hide.endscreencards.hideEndScreenCardsPatch -->
     <string name="morphe_hide_end_screen_cards_title">Hide end screen cards</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -637,7 +637,7 @@ Adjust volume by swiping vertically on the right side of the screen"</string>
 
     <!-- layout.buttons.action.hideButtonsPatch -->
     <string name="morphe_hide_buttons_screen_title">Action buttons</string>
-    <string name="morphe_hide_buttons_screen_summary">Hide or show buttons under videos</string>
+    <string name="morphe_hide_buttons_screen_summary">Hide or show action buttons under videos</string>
     <string name="morphe_disable_like_subscribe_glow_title">Disable Like and Subscribe glow</string>
     <string name="morphe_disable_like_subscribe_glow_summary_on">Like and Subscribe button will not glow when mentioned</string>
     <string name="morphe_disable_like_subscribe_glow_summary_off">Like and Subscribe button will glow when mentioned</string>
@@ -808,7 +808,7 @@ To access Settings, enable the Settings button via General → Toolbar → Show 
     <string name="morphe_disable_translucent_navigation_bar_dark_summary_off">Dark mode navigation bar is opaque or translucent</string>
 
     <string name="morphe_toolbar_screen_title">Toolbar</string>
-    <string name="morphe_toolbar_screen_summary">Hide or change toolbar components</string>
+    <string name="morphe_toolbar_screen_summary">Hide or show toolbar components</string>
     <string name="morphe_hide_toolbar_create_button_title">Hide Create</string>
     <string name="morphe_hide_toolbar_create_button_summary_on">Create button is hidden</string>
     <string name="morphe_hide_toolbar_create_button_summary_off">Create button is shown</string>
@@ -942,7 +942,7 @@ To show the Audio track menu, change \'Spoof video streams\' to \'Android Reel\'
     <string name="morphe_hide_settings_button_summary_off">Settings button is shown</string>
 
     <string name="morphe_quick_actions_screen_title">Quick actions</string>
-    <string name="morphe_quick_actions_screen_summary">Hide or show fullscreen quick actions related components</string>
+    <string name="morphe_quick_actions_screen_summary">Hide or show quick actions in fullscreen under seekbar</string>
     <string name="morphe_hide_quick_actions_ask_button_title">Hide Ask</string>
     <string name="morphe_hide_quick_actions_ask_button_summary_on">Ask button is hidden</string>
     <string name="morphe_hide_quick_actions_ask_button_summary_off">Ask button is shown</string>


### PR DESCRIPTION
### Description

Closes #1262

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
