### PR TITLE
feat(YouTube - System media controls): Add options to hide prev/next and seekbar in notification media controls

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MediaNotificationControlsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MediaNotificationControlsPatch.java
@@ -1,0 +1,23 @@
+package app.morphe.extension.youtube.patches;
+
+import android.media.session.PlaybackState;
+import app.morphe.extension.youtube.settings.Settings;
+
+@SuppressWarnings("unused")
+public class MediaNotificationControlsPatch {
+
+    /** Injection point. */
+    public static PlaybackState filterPlaybackState(PlaybackState state) {
+        long actions = state.getActions();
+        long filtered = actions;
+        if (Settings.HIDE_NOTIFICATION_MEDIA_SEEKBAR.get()) {
+            filtered &= ~PlaybackState.ACTION_SEEK_TO;
+        }
+        if (Settings.HIDE_NOTIFICATION_MEDIA_PREV_NEXT.get()) {
+            filtered &= ~PlaybackState.ACTION_SKIP_TO_NEXT;
+            filtered &= ~PlaybackState.ACTION_SKIP_TO_PREVIOUS;
+        }
+        if (filtered == actions) return state;
+        return new PlaybackState.Builder(state).setActions(filtered).build();
+    }
+}

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MediaNotificationControlsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MediaNotificationControlsPatch.java
@@ -1,23 +1,38 @@
 package app.morphe.extension.youtube.patches;
 
 import android.media.session.PlaybackState;
+
+import app.morphe.extension.shared.Logger;
 import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
 public class MediaNotificationControlsPatch {
 
-    /** Injection point. */
-    public static PlaybackState filterPlaybackState(PlaybackState state) {
-        long actions = state.getActions();
-        long filtered = actions;
-        if (Settings.HIDE_NOTIFICATION_MEDIA_SEEKBAR.get()) {
-            filtered &= ~PlaybackState.ACTION_SEEK_TO;
+    public static final Boolean HIDE_NOTIFICATIONS_MEDIA_SEEKBAR = Settings.HIDE_NOTIFICATION_MEDIA_SEEKBAR.get();
+    public static final Boolean HIDE_NOTIFICATION_MEDIA_PREV_NEXT = Settings.HIDE_NOTIFICATION_MEDIA_PREV_NEXT.get();
+
+    /**
+     * Injection point.
+     */
+    public static PlaybackState changePlaybackState(PlaybackState state) {
+        try {
+            if (HIDE_NOTIFICATIONS_MEDIA_SEEKBAR || HIDE_NOTIFICATION_MEDIA_PREV_NEXT) {
+                long filtered = state.getActions();
+
+                if (HIDE_NOTIFICATIONS_MEDIA_SEEKBAR) {
+                    filtered &= ~PlaybackState.ACTION_SEEK_TO;
+                }
+                if (HIDE_NOTIFICATION_MEDIA_PREV_NEXT) {
+                    filtered &= ~PlaybackState.ACTION_SKIP_TO_NEXT;
+                    filtered &= ~PlaybackState.ACTION_SKIP_TO_PREVIOUS;
+                }
+
+                return new PlaybackState.Builder(state).setActions(filtered).build();
+            }
+        } catch (Exception ex) {
+            Logger.printException(() -> "changePlaybackState failure", ex);
         }
-        if (Settings.HIDE_NOTIFICATION_MEDIA_PREV_NEXT.get()) {
-            filtered &= ~PlaybackState.ACTION_SKIP_TO_NEXT;
-            filtered &= ~PlaybackState.ACTION_SKIP_TO_PREVIOUS;
-        }
-        if (filtered == actions) return state;
-        return new PlaybackState.Builder(state).setActions(filtered).build();
+
+        return state;
     }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MediaNotificationControlsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MediaNotificationControlsPatch.java
@@ -8,7 +8,7 @@ import app.morphe.extension.youtube.settings.Settings;
 @SuppressWarnings("unused")
 public class MediaNotificationControlsPatch {
 
-    public static final Boolean HIDE_NOTIFICATIONS_MEDIA_SEEKBAR = Settings.HIDE_NOTIFICATION_MEDIA_SEEKBAR.get();
+    public static final Boolean HIDE_NOTIFICATIONS_MEDIA_SEEKBAR = Settings.DISABLE_NOTIFICATION_MEDIA_SEEKBAR.get();
     public static final Boolean HIDE_NOTIFICATION_MEDIA_PREV_NEXT = Settings.HIDE_NOTIFICATION_MEDIA_PREV_NEXT.get();
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -181,6 +181,8 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_LIVE_CHAT_DONATORS_BAR = new BooleanSetting("morphe_hide_live_chat_donators_bar", FALSE, true);
     public static final BooleanSetting HIDE_LIVE_CHAT_REPLAY_BUTTON = new BooleanSetting("morphe_hide_live_chat_replay_button", FALSE);
     public static final BooleanSetting HIDE_MEDICAL_PANELS = new BooleanSetting("morphe_hide_medical_panels", TRUE);
+    public static final BooleanSetting HIDE_NOTIFICATION_MEDIA_SEEKBAR = new BooleanSetting("morphe_hide_notification_media_seekbar", FALSE, true);
+    public static final BooleanSetting HIDE_NOTIFICATION_MEDIA_PREV_NEXT = new BooleanSetting("morphe_hide_notification_media_prev_next", FALSE, true);
     public static final BooleanSetting HIDE_PLAYER_RELATED_VIDEOS = new BooleanSetting("morphe_hide_player_related_videos", FALSE, true);
     public static final BooleanSetting HIDE_PLAYER_RELATED_VIDEOS_OVERLAY = new BooleanSetting("morphe_hide_player_related_videos_overlay", FALSE, true);
     public static final BooleanSetting HIDE_SETTINGS_BUTTON = new BooleanSetting("morphe_hide_settings_button", FALSE, true);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -181,7 +181,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_LIVE_CHAT_DONATORS_BAR = new BooleanSetting("morphe_hide_live_chat_donators_bar", FALSE, true);
     public static final BooleanSetting HIDE_LIVE_CHAT_REPLAY_BUTTON = new BooleanSetting("morphe_hide_live_chat_replay_button", FALSE);
     public static final BooleanSetting HIDE_MEDICAL_PANELS = new BooleanSetting("morphe_hide_medical_panels", TRUE);
-    public static final BooleanSetting HIDE_NOTIFICATION_MEDIA_SEEKBAR = new BooleanSetting("morphe_hide_notification_media_seekbar", FALSE, true);
+    public static final BooleanSetting DISABLE_NOTIFICATION_MEDIA_SEEKBAR = new BooleanSetting("morphe_disable_notification_media_seekbar", FALSE, true);
     public static final BooleanSetting HIDE_NOTIFICATION_MEDIA_PREV_NEXT = new BooleanSetting("morphe_hide_notification_media_prev_next", FALSE, true);
     public static final BooleanSetting HIDE_PLAYER_RELATED_VIDEOS = new BooleanSetting("morphe_hide_player_related_videos", FALSE, true);
     public static final BooleanSetting HIDE_PLAYER_RELATED_VIDEOS_OVERLAY = new BooleanSetting("morphe_hide_player_related_videos_overlay", FALSE, true);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/overlay/HidePlayerOverlayButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/overlay/HidePlayerOverlayButtonsPatch.kt
@@ -61,8 +61,6 @@ val hidePlayerOverlayButtonsPatch = bytecodePatch(
                     SwitchPreference("morphe_hide_fullscreen_button"),
                     SwitchPreference("morphe_hide_player_control_buttons_background"),
                     SwitchPreference("morphe_hide_player_previous_next_buttons"),
-                    SwitchPreference("morphe_hide_notification_media_prev_next"),
-                    SwitchPreference("morphe_hide_notification_media_seekbar"),
                     SwitchPreference("morphe_hide_settings_button"),
                 )
             )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/overlay/HidePlayerOverlayButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/overlay/HidePlayerOverlayButtonsPatch.kt
@@ -61,6 +61,8 @@ val hidePlayerOverlayButtonsPatch = bytecodePatch(
                     SwitchPreference("morphe_hide_fullscreen_button"),
                     SwitchPreference("morphe_hide_player_control_buttons_background"),
                     SwitchPreference("morphe_hide_player_previous_next_buttons"),
+                    SwitchPreference("morphe_hide_notification_media_prev_next"),
+                    SwitchPreference("morphe_hide_notification_media_seekbar"),
                     SwitchPreference("morphe_hide_settings_button"),
                 )
             )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/medianotification/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/medianotification/Fingerprints.kt
@@ -1,0 +1,13 @@
+package app.morphe.patches.youtube.misc.medianotification
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.methodCall
+
+internal object MediaSessionSetPlaybackStateFingerprint : Fingerprint(
+    filters = listOf(
+        methodCall(
+            definingClass = "Landroid/media/session/MediaSession;",
+            name = "setPlaybackState",
+        ),
+    ),
+)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/medianotification/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/medianotification/Fingerprints.kt
@@ -8,6 +8,7 @@ internal object MediaSessionSetPlaybackStateFingerprint : Fingerprint(
         methodCall(
             definingClass = "Landroid/media/session/MediaSession;",
             name = "setPlaybackState",
-        ),
-    ),
+            parameters = listOf("Landroid/media/session/PlaybackState;")
+        )
+    )
 )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/medianotification/MediaNotificationControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/medianotification/MediaNotificationControlsPatch.kt
@@ -1,0 +1,45 @@
+package app.morphe.patches.youtube.misc.medianotification
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
+import app.morphe.patches.youtube.misc.settings.settingsPatch
+import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
+import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
+
+private const val EXTENSION_CLASS =
+    "Lapp/morphe/extension/youtube/patches/MediaNotificationControlsPatch;"
+
+val mediaNotificationControlsPatch = bytecodePatch(
+    name = "Media notification controls",
+    description = "Adds options to disable the seekbar and next/previous buttons in the media notification and headphone controls.",
+) {
+    dependsOn(
+        sharedExtensionPatch,
+        settingsPatch,
+    )
+
+    compatibleWith(COMPATIBILITY_YOUTUBE)
+
+    execute {
+        // Intercept every setPlaybackState call site so all playback states
+        // (playing, paused, buffering) have their action flags filtered.
+        MediaSessionSetPlaybackStateFingerprint.matchAll().forEach { match ->
+            match.method.apply {
+                val matchIndex = match.instructionMatches.first().index
+                // invoke-virtual {vC=session, vD=playbackState} — vD is the argument to filter.
+                val playbackStateReg = getInstruction<FiveRegisterInstruction>(matchIndex).registerD
+
+                addInstructions(
+                    matchIndex,
+                    """
+                        invoke-static { v$playbackStateReg }, $EXTENSION_CLASS->filterPlaybackState(Landroid/media/session/PlaybackState;)Landroid/media/session/PlaybackState;
+                        move-result-object v$playbackStateReg
+                    """,
+                )
+            }
+        }
+
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/medianotification/MediaNotificationControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/medianotification/MediaNotificationControlsPatch.kt
@@ -3,6 +3,9 @@ package app.morphe.patches.youtube.misc.medianotification
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import app.morphe.patches.youtube.layout.buttons.overlay.addPlayerOverlayPreferences
+import app.morphe.patches.youtube.layout.buttons.overlay.playerOverlayButtonsSettingsPatch
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
@@ -13,33 +16,36 @@ private const val EXTENSION_CLASS =
 
 val mediaNotificationControlsPatch = bytecodePatch(
     name = "Media notification controls",
-    description = "Adds options to disable the seekbar and next/previous buttons in the media notification and headphone controls.",
+    description = "Adds options to disable the seekbar and previous/next buttons in the " +
+            "media notification and headphone controls.",
 ) {
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,
+        playerOverlayButtonsSettingsPatch
     )
 
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {
-        // Intercept every setPlaybackState call site so all playback states
-        // (playing, paused, buffering) have their action flags filtered.
-        MediaSessionSetPlaybackStateFingerprint.matchAll().forEach { match ->
-            match.method.apply {
-                val matchIndex = match.instructionMatches.first().index
-                // invoke-virtual {vC=session, vD=playbackState} — vD is the argument to filter.
-                val playbackStateReg = getInstruction<FiveRegisterInstruction>(matchIndex).registerD
+        addPlayerOverlayPreferences(
+            SwitchPreference("morphe_hide_notification_media_prev_next"),
+            SwitchPreference("morphe_hide_notification_media_seekbar"),
+        )
+
+        MediaSessionSetPlaybackStateFingerprint.let {
+            it.method.apply {
+                val index = it.instructionMatches.first().index
+                val register = getInstruction<FiveRegisterInstruction>(index).registerD
 
                 addInstructions(
-                    matchIndex,
+                    index,
                     """
-                        invoke-static { v$playbackStateReg }, $EXTENSION_CLASS->filterPlaybackState(Landroid/media/session/PlaybackState;)Landroid/media/session/PlaybackState;
-                        move-result-object v$playbackStateReg
-                    """,
+                        invoke-static { v$register }, $EXTENSION_CLASS->changePlaybackState(Landroid/media/session/PlaybackState;)Landroid/media/session/PlaybackState;
+                        move-result-object v$register
+                    """
                 )
             }
         }
-
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/medianotification/MediaNotificationControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/medianotification/MediaNotificationControlsPatch.kt
@@ -3,11 +3,10 @@ package app.morphe.patches.youtube.misc.medianotification
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.patches.shared.misc.settings.preference.PreferenceCategory
+import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
-import app.morphe.patches.youtube.layout.buttons.overlay.addPlayerOverlayPreferences
-import app.morphe.patches.youtube.layout.buttons.overlay.playerOverlayButtonsSettingsPatch
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
+import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
@@ -23,20 +22,18 @@ val mediaNotificationControlsPatch = bytecodePatch(
 ) {
     dependsOn(
         sharedExtensionPatch,
-        settingsPatch,
-        playerOverlayButtonsSettingsPatch
+        settingsPatch
     )
 
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {
-        addPlayerOverlayPreferences(
-            PreferenceCategory(
-                titleKey = null,
-                tag = "app.morphe.extension.shared.settings.preference.NoTitlePreferenceCategory",
+        PreferenceScreen.PLAYER.addPreferences(
+            PreferenceScreenPreference(
+                key = "morphe_notification_media_screen",
                 preferences = setOf(
                     SwitchPreference("morphe_hide_notification_media_prev_next"),
-                    SwitchPreference("morphe_hide_notification_media_seekbar"),
+                    SwitchPreference("morphe_disable_notification_media_seekbar"),
                 )
             )
         )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/medianotification/MediaNotificationControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/medianotification/MediaNotificationControlsPatch.kt
@@ -3,6 +3,7 @@ package app.morphe.patches.youtube.misc.medianotification
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.misc.settings.preference.PreferenceCategory
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.layout.buttons.overlay.addPlayerOverlayPreferences
 import app.morphe.patches.youtube.layout.buttons.overlay.playerOverlayButtonsSettingsPatch
@@ -14,6 +15,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 private const val EXTENSION_CLASS =
     "Lapp/morphe/extension/youtube/patches/MediaNotificationControlsPatch;"
 
+@Suppress("unused")
 val mediaNotificationControlsPatch = bytecodePatch(
     name = "Media notification controls",
     description = "Adds options to disable the seekbar and previous/next buttons in the " +
@@ -29,8 +31,14 @@ val mediaNotificationControlsPatch = bytecodePatch(
 
     execute {
         addPlayerOverlayPreferences(
-            SwitchPreference("morphe_hide_notification_media_prev_next"),
-            SwitchPreference("morphe_hide_notification_media_seekbar"),
+            PreferenceCategory(
+                titleKey = null,
+                tag = "app.morphe.extension.shared.settings.preference.NoTitlePreferenceCategory",
+                preferences = setOf(
+                    SwitchPreference("morphe_hide_notification_media_prev_next"),
+                    SwitchPreference("morphe_hide_notification_media_seekbar"),
+                )
+            )
         )
 
         MediaSessionSetPlaybackStateFingerprint.let {

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1737,12 +1737,14 @@ Enabling this can unlock higher video qualities"</string>
     <string name="morphe_disable_haptic_feedback_zoom_summary_off">Zoom haptics is enabled</string>
 
     <!-- misc.medianotification.mediaNotificationControlsPatch -->
-    <string name="morphe_hide_notification_media_prev_next_title">Hide Prev/Next in notification</string>
-    <string name="morphe_hide_notification_media_prev_next_summary_on">Previous &amp; Next buttons are disabled in media notification, lockscreen, and headphone controls</string>
-    <string name="morphe_hide_notification_media_prev_next_summary_off">Previous &amp; Next buttons are enabled in notification, lockscreen, and headphone controls</string>
-    <string name="morphe_hide_notification_media_seekbar_title">Disable Seekbar in notification</string>
-    <string name="morphe_hide_notification_media_seekbar_summary_on">Seekbar in media notification and lockscreen is read-only</string>
-    <string name="morphe_hide_notification_media_seekbar_summary_off">Seekbar in media notification and lockscreen is draggable</string>
+    <string name="morphe_notification_media_screen_title">Notification media controls</string>
+    <string name="morphe_notification_media_screen_summary">Hide lock screen media control components</string>
+    <string name="morphe_hide_notification_media_prev_next_title">Hide Prev &amp; Next buttons</string>
+    <string name="morphe_hide_notification_media_prev_next_summary_on">Previous &amp; Next buttons are hidden in media notification, lockscreen, and headphone controls</string>
+    <string name="morphe_hide_notification_media_prev_next_summary_off">Previous &amp; Next buttons are shown in notification, lockscreen, and headphone controls</string>
+    <string name="morphe_disable_notification_media_seekbar_title">Disable seekbar</string>
+    <string name="morphe_disable_notification_media_seekbar_summary_on">Seekbar in media notification and lockscreen is read-only</string>
+    <string name="morphe_disable_notification_media_seekbar_summary_off">Seekbar in media notification and lockscreen is draggable</string>
 
     <!-- misc.gms.accountCredentialsInvalidTextPatch -->
     <string name="microg_offline_account_login_error">If you recently changed your account login details, then uninstall and reinstall MicroG.</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1736,6 +1736,14 @@ Enabling this can unlock higher video qualities"</string>
     <string name="morphe_disable_haptic_feedback_zoom_summary_on">Zoom haptics is disabled</string>
     <string name="morphe_disable_haptic_feedback_zoom_summary_off">Zoom haptics is enabled</string>
 
+    <!-- misc.medianotification.mediaNotificationControlsPatch -->
+    <string name="morphe_hide_notification_media_prev_next_title">Hide Prev/Next in notification</string>
+    <string name="morphe_hide_notification_media_prev_next_summary_on">Previous &amp; Next buttons are disabled in media notification, lockscreen, and headphone controls</string>
+    <string name="morphe_hide_notification_media_prev_next_summary_off">Previous &amp; Next buttons are enabled in notification, lockscreen, and headphone controls</string>
+    <string name="morphe_hide_notification_media_seekbar_title">Disable Seekbar in notification</string>
+    <string name="morphe_hide_notification_media_seekbar_summary_on">Seekbar in media notification and lockscreen is read-only</string>
+    <string name="morphe_hide_notification_media_seekbar_summary_off">Seekbar in media notification and lockscreen is draggable</string>
+
     <!-- misc.gms.accountCredentialsInvalidTextPatch -->
     <string name="microg_offline_account_login_error">If you recently changed your account login details, then uninstall and reinstall MicroG.</string>
 


### PR DESCRIPTION

### Description

2 new settings for YouTube under Player - > System media controls (new section): 

1.  Hide Prev/Next in notification
- Previous and next buttons will be removed in the persistent media notification and lock screen
- Previous and next headphone controls have no effect
- Setting turned off by default. Both these effects are mentioned in the setting description
- Requires media to stop/start or restart app to apply changes. Prompts user to restart app when toggling on/off

2. Disable Seekbar in notification
- Seekbar is disabled in the persistent media notification and lock screen. It becomes a read-only progress bar instead.
- Requires media to stop/start media or restart app to apply changes. Prompts user to restart app when toggling on/off



### Test results

Tested on 20.21.37 and 20.47.62 with Samsung S23 Ultra, Android 14. Builds fine, works as intended

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
