### PR TITLE
fix(YouTube - Remove background playback restrictions): Add in-app setting to manually turn off the patch

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/BackgroundPlaybackPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/BackgroundPlaybackPatch.java
@@ -7,10 +7,41 @@ import app.morphe.extension.youtube.shared.ShortsPlayerState;
 @SuppressWarnings("unused")
 public class BackgroundPlaybackPatch {
 
+    private static final boolean REMOVE_BACKGROUND_PLAYBACK_RESTRICTIONS
+            = Settings.REMOVE_BACKGROUND_PLAYBACK_RESTRICTIONS.get();
+
+    private static final boolean REMOVE_BACKGROUND_PLAYBACK_RESTRICTIONS_SHORTS
+            = !Settings.DISABLE_SHORTS_BACKGROUND_PLAYBACK.get();
+
+    /**
+     * Injection point.
+     */
+    public static boolean isPatchEnabled() {
+        return REMOVE_BACKGROUND_PLAYBACK_RESTRICTIONS;
+    }
+
+    /**
+     * Injection point.
+     */
+    public static boolean enableFeatureFlag(boolean original) {
+        if (REMOVE_BACKGROUND_PLAYBACK_RESTRICTIONS) return true;
+        return original;
+    }
+
+    /**
+     * Injection point.
+     */
+    public static boolean disableFeatureFlag(boolean original) {
+        if (REMOVE_BACKGROUND_PLAYBACK_RESTRICTIONS) return false;
+        return original;
+    }
+
     /**
      * Injection point.
      */
     public static boolean isBackgroundPlaybackAllowed(boolean original) {
+        if (!REMOVE_BACKGROUND_PLAYBACK_RESTRICTIONS) return original;
+
         if (original) return true;
 
         // Steps to verify most edge cases (with Shorts background playback set to off):
@@ -37,6 +68,6 @@ public class BackgroundPlaybackPatch {
      * Injection point.
      */
     public static boolean isBackgroundShortsPlaybackAllowed(boolean original) {
-        return !Settings.DISABLE_SHORTS_BACKGROUND_PLAYBACK.get();
+        return REMOVE_BACKGROUND_PLAYBACK_RESTRICTIONS_SHORTS;
     }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -391,7 +391,7 @@ public class Settings extends SharedYouTubeSettings {
 
     // Shorts
     public static final BooleanSetting DISABLE_SHORTS_RESUMING_ON_STARTUP = new BooleanSetting("morphe_disable_shorts_resuming_on_startup", FALSE);
-    public static final BooleanSetting DISABLE_SHORTS_BACKGROUND_PLAYBACK = new BooleanSetting("morphe_shorts_disable_background_playback", FALSE);
+    public static final BooleanSetting DISABLE_SHORTS_BACKGROUND_PLAYBACK = new BooleanSetting("morphe_shorts_disable_background_playback", FALSE, true);
     public static final EnumSetting<ShortsPlayerType> SHORTS_PLAYER_TYPE = new EnumSetting<>("morphe_shorts_player_type", ShortsPlayerType.SHORTS_PLAYER);
     public static final BooleanSetting DISABLE_SHORTS_DOUBLE_TAP_TO_LIKE = new BooleanSetting("morphe_disable_shorts_double_tap_to_like", FALSE);
     public static final BooleanSetting HIDE_SHORTS_AI_BUTTON = new BooleanSetting("morphe_hide_shorts_ai_button", FALSE);
@@ -453,6 +453,7 @@ public class Settings extends SharedYouTubeSettings {
     // Miscellaneous
     public static final BooleanSetting ANNOUNCEMENTS = new BooleanSetting("morphe_announcements", TRUE);
     public static final IntegerSetting ANNOUNCEMENT_LAST_ID = new IntegerSetting("morphe_announcement_last_id", -1, false, false);
+    public static final BooleanSetting REMOVE_BACKGROUND_PLAYBACK_RESTRICTIONS = new BooleanSetting("morphe_remove_background_playback_restrictions", TRUE, true);
     public static final BooleanSetting BYPASS_URL_REDIRECTS = new BooleanSetting("morphe_bypass_url_redirects", TRUE);
     public static final BooleanSetting EXTERNAL_BROWSER = new BooleanSetting("morphe_external_browser", TRUE, true);
     public static final BooleanSetting SPOOF_DEVICE_DIMENSIONS = new BooleanSetting("morphe_spoof_device_dimensions", FALSE, true,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/backgroundplayback/BackgroundPlaybackPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/backgroundplayback/BackgroundPlaybackPatch.kt
@@ -1,12 +1,13 @@
 package app.morphe.patches.youtube.misc.backgroundplayback
 
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.patches.shared.misc.fix.bitmap.fixRecycledBitmapPatch
-import app.morphe.patches.all.misc.resources.ResourceType
-import app.morphe.patches.all.misc.resources.getResourceId
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
+import app.morphe.patches.shared.misc.fix.bitmap.fixRecycledBitmapPatch
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.playertype.playerTypeHookPatch
@@ -19,10 +20,9 @@ import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import app.morphe.patches.youtube.video.information.videoInformationPatch
 import app.morphe.util.addInstructionsAtControlFlowLabel
 import app.morphe.util.findInstructionIndicesReversedOrThrow
+import app.morphe.util.getMutableMethod
 import app.morphe.util.getReference
 import app.morphe.util.insertLiteralOverride
-import app.morphe.util.returnEarly
-import app.morphe.util.returnLate
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
@@ -51,6 +51,10 @@ val backgroundPlaybackPatch = bytecodePatch(
             SwitchPreference("morphe_shorts_disable_background_playback")
         )
 
+        PreferenceScreen.MISC.addPreferences(
+            SwitchPreference("morphe_remove_background_playback_restrictions")
+        )
+
         arrayOf(
             BackgroundPlaybackManagerFingerprint to "isBackgroundPlaybackAllowed",
             BackgroundPlaybackManagerShortsFingerprint to "isBackgroundShortsPlaybackAllowed",
@@ -70,36 +74,53 @@ val backgroundPlaybackPatch = bytecodePatch(
             }
         }
 
-        // Enable background playback option in YouTube settings
-        BackgroundPlaybackSettingsFingerprint.originalMethod.apply {
-            val booleanCalls = instructions.withIndex().filter {
-                it.value.getReference<MethodReference>()?.returnType == "Z"
-            }
+        fun MutableMethod.addBackgroundPlaybackIsPatchEnabledHook() {
+            val returnInstruction = if (returnType == "Z") "return v0" else "return-void"
 
-            val settingsBooleanIndex = booleanCalls.elementAt(1).index
-            val settingsBooleanMethod by navigate(this).to(settingsBooleanIndex)
-
-            settingsBooleanMethod.returnEarly(true)
-        }
-
-        // Force allowing background play for Shorts.
-        ShortsBackgroundPlaybackFeatureFlagFingerprint.method.returnEarly(true)
-
-        // Force allowing background play for videos labeled for kids.
-        KidsBackgroundPlaybackPolicyControllerFingerprint.method.returnEarly()
-
-        // Fix PiP buttons not working after locking/unlocking device screen.
-        PipInputConsumerFeatureFlagFingerprint.let {
-            it.method.insertLiteralOverride(
-                it.instructionMatches.first().index,
-                false
+            addInstructionsWithLabels(
+                0,
+                """
+                    invoke-static { }, $EXTENSION_CLASS->isPatchEnabled()Z
+                    move-result v0
+                    if-eqz v0, :disabled
+                    $returnInstruction
+                    :disabled
+                    nop
+                """
             )
         }
+
+        fun Fingerprint.addBackgroundPlaybackFeatureFlagHook(enable: Boolean) {
+            val methodName = if (enable) "enableFeatureFlag" else "disableFeatureFlag"
+            method.insertLiteralOverride(
+                instructionMatches.first().index,
+                "$EXTENSION_CLASS->$methodName(Z)Z"
+            )
+        }
+
+        // Enable background playback option in YouTube settings
+        BackgroundPlaybackSettingsFingerprint.originalMethod.apply {
+            val booleanCalls = instructions.filter {
+                it.getReference<MethodReference>()?.returnType == "Z"
+            }
+
+            booleanCalls[1].getReference<MethodReference>()!!
+                .getMutableMethod().addBackgroundPlaybackIsPatchEnabledHook()
+        }
+
+        // Force allowing background play for videos labeled for kids.
+        KidsBackgroundPlaybackPolicyControllerFingerprint.method.addBackgroundPlaybackIsPatchEnabledHook()
+
+        // Force allowing background play for Shorts.
+        ShortsBackgroundPlaybackFeatureFlagFingerprint.addBackgroundPlaybackFeatureFlagHook(true)
+
+        // Fix PiP buttons not working after locking/unlocking device screen.
+        PipInputConsumerFeatureFlagFingerprint.addBackgroundPlaybackFeatureFlagHook(false)
 
         if (is_20_29_or_greater) {
             // Client flag that interferes with background playback of some video types.
             // Exact purpose is not clear and it's used in ~ 100 locations.
-            NewPlayerTypeEnumFeatureFlag.method.returnLate(false)
+            NewPlayerTypeEnumFeatureFlag.addBackgroundPlaybackFeatureFlagHook(false)
         }
     }
 }

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -35,6 +35,9 @@ Second \"item\" text"</string>
     <string name="morphe_restore_old_settings_menus_summary_off">Old settings menus are not shown</string>
 
     <!-- misc.backgroundplayback.backgroundPlaybackPatch -->
+    <string name="morphe_remove_background_playback_restrictions_title">Remove background play restrictions</string>
+    <string name="morphe_remove_background_playback_restrictions_summary_on">Background playback is unrestricted</string>
+    <string name="morphe_remove_background_playback_restrictions_summary_off">Background playback is restricted</string>
     <string name="morphe_shorts_disable_background_playback_title">Disable Shorts background play</string>
     <string name="morphe_shorts_disable_background_playback_summary_on">Shorts background play is disabled</string>
     <string name="morphe_shorts_disable_background_playback_summary_off">Shorts background play is enabled</string>


### PR DESCRIPTION
### Description

Adds an in-app setting to disable the patch functionality.

This is intended to help troubleshoot why including the playback can break playback for some users without needing to repatch.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
