### PR TITLE
fix(YouTube - Swipe controls): 2x speed action is triggered when the status bar is visible on Android 15+

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/SwipeControlsHostActivity.kt
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/SwipeControlsHostActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.ViewGroup
+import android.view.WindowInsets
 import app.morphe.extension.shared.Logger.printDebug
 import app.morphe.extension.shared.Logger.printException
 import app.morphe.extension.youtube.patches.VersionCheckPatch
@@ -21,6 +22,7 @@ import app.morphe.extension.youtube.swipecontrols.controller.gesture.core.Gestur
 import app.morphe.extension.youtube.swipecontrols.misc.Rectangle
 import app.morphe.extension.youtube.swipecontrols.views.SwipeControlsOverlayLayout
 import java.lang.ref.WeakReference
+import kotlin.concurrent.Volatile
 
 /**
  * The main controller for volume and brightness swipe controls.
@@ -67,6 +69,12 @@ class SwipeControlsHostActivity : Activity() {
      */
     private val contentRoot
         get() = window.decorView.findViewById<ViewGroup>(android.R.id.content)
+
+    /**
+     * whether the status bar is visible on Android 15+ (edge-to-edge display)
+     */
+    @Volatile
+    var statusBarVisible: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -155,6 +163,18 @@ class SwipeControlsHostActivity : Activity() {
 
         // set current instance reference
         currentHost = WeakReference(this)
+
+        // fix edge-to-edge display
+        // see: https://github.com/MorpheApp/morphe-patches/issues/658
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            val rootView = contentRoot.parent
+            if (rootView is ViewGroup) {
+                rootView.setOnApplyWindowInsetsListener { _, insets ->
+                    statusBarVisible = insets.isVisible(WindowInsets.Type.statusBars())
+                    insets
+                }
+            }
+        }
     }
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/controller/gesture/core/BaseGestureController.kt
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/controller/gesture/core/BaseGestureController.kt
@@ -44,6 +44,11 @@ abstract class BaseGestureController(
             return false
         }
 
+        // ignore if status bar is visible
+        if (controller.statusBarVisible) {
+            return false
+        }
+
         // create a copy of the event so we can modify it
         // without causing any issues downstream
         val me = MotionEvent.obtain(motionEvent)


### PR DESCRIPTION
### Description

Closes #658.

### Additional context

To ignore the swiping down notification gesture (when showing the status bar via a swipe in the fullscreen), the patch raises a Motion event.

This MotionEvent triggers tap and hold playback speed, which does not occur on unpatched YouTube.

This PR prevents MotionEvent from occurring when the status bar is made visible via swiping in the fullscreen.

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
