### PR TITLE
feat(YouTube - Miniplayer): Add "Disable resuming miniplayer" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MiniplayerPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MiniplayerPatch.java
@@ -115,6 +115,9 @@ public final class MiniplayerPatch {
         MINIPLAYER_SIZE = dipWidth;
     }
 
+    private static final boolean DISABLE_RESUMING_MINIPLAYER =
+            Settings.DISABLE_RESUMING_MINIPLAYER.get();
+
     private static final MiniplayerType CURRENT_TYPE = Settings.MINIPLAYER_TYPE.get();
 
     /**
@@ -227,6 +230,13 @@ public final class MiniplayerPatch {
         public List<Setting<?>> getParentSettings() {
             return List.of(Settings.MINIPLAYER_TYPE);
         }
+    }
+
+    /**
+     * Injection point.
+     */
+    public static boolean disableResumingStartupMiniPlayer(boolean original) {
+        return !DISABLE_RESUMING_MINIPLAYER && original;
     }
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MiniplayerPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MiniplayerPatch.java
@@ -116,7 +116,7 @@ public final class MiniplayerPatch {
     }
 
     private static final boolean DISABLE_RESUMING_MINIPLAYER =
-            Settings.DISABLE_RESUMING_MINIPLAYER.get();
+            Settings.MINIPLAYER_DISABLE_RESUMING.get();
 
     private static final MiniplayerType CURRENT_TYPE = Settings.MINIPLAYER_TYPE.get();
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -237,7 +237,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting FIX_TRANSCRIPT = new BooleanSetting("morphe_fix_transcript", TRUE, true);
 
     // Miniplayer
-    public static final BooleanSetting DISABLE_RESUMING_MINIPLAYER = new BooleanSetting("morphe_disable_resuming_miniplayer", FALSE, true, "morphe_disable_resuming_miniplayer_user_dialog_message");
+    public static final BooleanSetting MINIPLAYER_DISABLE_RESUMING = new BooleanSetting("morphe_miniplayer_disable_resuming", FALSE, true, "morphe_miniplayer_disable_resuming_user_dialog_message");
     public static final EnumSetting<MiniplayerType> MINIPLAYER_TYPE = new EnumSetting<>("morphe_miniplayer_type", MiniplayerType.DEFAULT, true);
     public static final BooleanSetting MINIPLAYER_DISABLE_DRAG_AND_DROP = new BooleanSetting("morphe_miniplayer_disable_drag_and_drop", FALSE, true, new MiniplayerAnyModernAvailability());
     public static final BooleanSetting MINIPLAYER_DISABLE_HORIZONTAL_DRAG = new BooleanSetting("morphe_miniplayer_disable_horizontal_drag", FALSE, true, new MiniplayerHorizontalDragAvailability());

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -237,7 +237,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting FIX_TRANSCRIPT = new BooleanSetting("morphe_fix_transcript", TRUE, true);
 
     // Miniplayer
-    public static final BooleanSetting DISABLE_RESUMING_MINIPLAYER = new BooleanSetting("morphe_disable_resuming_miniplayer", FALSE, true);
+    public static final BooleanSetting DISABLE_RESUMING_MINIPLAYER = new BooleanSetting("morphe_disable_resuming_miniplayer", FALSE, true, "morphe_disable_resuming_miniplayer_user_dialog_message");
     public static final EnumSetting<MiniplayerType> MINIPLAYER_TYPE = new EnumSetting<>("morphe_miniplayer_type", MiniplayerType.DEFAULT, true);
     public static final BooleanSetting MINIPLAYER_DISABLE_DRAG_AND_DROP = new BooleanSetting("morphe_miniplayer_disable_drag_and_drop", FALSE, true, new MiniplayerAnyModernAvailability());
     public static final BooleanSetting MINIPLAYER_DISABLE_HORIZONTAL_DRAG = new BooleanSetting("morphe_miniplayer_disable_horizontal_drag", FALSE, true, new MiniplayerHorizontalDragAvailability());

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -237,6 +237,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting FIX_TRANSCRIPT = new BooleanSetting("morphe_fix_transcript", TRUE, true);
 
     // Miniplayer
+    public static final BooleanSetting DISABLE_RESUMING_MINIPLAYER = new BooleanSetting("morphe_disable_resuming_miniplayer", FALSE, true);
     public static final EnumSetting<MiniplayerType> MINIPLAYER_TYPE = new EnumSetting<>("morphe_miniplayer_type", MiniplayerType.DEFAULT, true);
     public static final BooleanSetting MINIPLAYER_DISABLE_DRAG_AND_DROP = new BooleanSetting("morphe_miniplayer_disable_drag_and_drop", FALSE, true, new MiniplayerAnyModernAvailability());
     public static final BooleanSetting MINIPLAYER_DISABLE_HORIZONTAL_DRAG = new BooleanSetting("morphe_miniplayer_disable_horizontal_drag", FALSE, true, new MiniplayerHorizontalDragAvailability());

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/Fingerprints.kt
@@ -3,6 +3,7 @@
 package app.morphe.patches.youtube.layout.miniplayer
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation.MatchAfterImmediately
 import app.morphe.patcher.InstructionLocation.MatchAfterWithin
 import app.morphe.patcher.OpcodesFilter
 import app.morphe.patcher.anyInstruction
@@ -204,5 +205,20 @@ internal object MiniplayerSetIconsFingerprint : Fingerprint(
     filters = listOf(
         resourceLiteral(ResourceType.DRAWABLE, "yt_fill_pause_white_36"),
         resourceLiteral(ResourceType.DRAWABLE, "yt_fill_pause_black_36")
+    )
+)
+
+internal object ShowMiniplayerCommandFingerprint: Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf("L", "Ljava/util/Map;"),
+    filters = listOf(
+        opcode(Opcode.IF_NEZ),
+        opcode(
+            opcode = Opcode.IF_EQZ,
+            location = MatchAfterImmediately()
+        ),
+        literal(164817L),
+        literal(121253L)
     )
 )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/MiniplayerPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/MiniplayerPatch.kt
@@ -62,6 +62,8 @@ val miniplayerPatch = bytecodePatch(
 
         val preferences = mutableSetOf<BasePreference>()
 
+        preferences += SwitchPreference("morphe_disable_resuming_miniplayer")
+
         preferences +=
             if (is_20_37_or_greater) {
                 ListPreference("morphe_miniplayer_type")
@@ -159,6 +161,25 @@ val miniplayerPatch = bytecodePatch(
                 """
             )
         }
+
+        // region Disable resuming miniplayer (Continue watching)
+
+        ShowMiniplayerCommandFingerprint.let {
+            it.method.apply {
+                val index = it.instructionMatches[1].index
+                val register = getInstruction<OneRegisterInstruction>(index).registerA
+
+                addInstructions(
+                    index,
+                    """
+                        invoke-static { v$register }, $EXTENSION_CLASS->disableResumingStartupMiniPlayer(Z)Z
+                        move-result v$register
+                    """
+                )
+            }
+        }
+
+        // endregion
 
         // region Enable tablet miniplayer.
         // Parts of the YT code is removed in 20.37+ and the legacy player no longer works.

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/MiniplayerPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/MiniplayerPatch.kt
@@ -73,7 +73,7 @@ val miniplayerPatch = bytecodePatch(
                 )
             }
 
-        preferences += SwitchPreference("morphe_disable_resuming_miniplayer")
+        preferences += SwitchPreference("morphe_miniplayer_disable_resuming")
         preferences += SwitchPreference("morphe_miniplayer_disable_drag_and_drop")
         preferences += SwitchPreference("morphe_miniplayer_disable_horizontal_drag")
         preferences += SwitchPreference("morphe_miniplayer_disable_rounded_corners")

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/MiniplayerPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/MiniplayerPatch.kt
@@ -62,8 +62,6 @@ val miniplayerPatch = bytecodePatch(
 
         val preferences = mutableSetOf<BasePreference>()
 
-        preferences += SwitchPreference("morphe_disable_resuming_miniplayer")
-
         preferences +=
             if (is_20_37_or_greater) {
                 ListPreference("morphe_miniplayer_type")
@@ -75,7 +73,7 @@ val miniplayerPatch = bytecodePatch(
                 )
             }
 
-
+        preferences += SwitchPreference("morphe_disable_resuming_miniplayer")
         preferences += SwitchPreference("morphe_miniplayer_disable_drag_and_drop")
         preferences += SwitchPreference("morphe_miniplayer_disable_horizontal_drag")
         preferences += SwitchPreference("morphe_miniplayer_disable_rounded_corners")

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1583,11 +1583,10 @@ Limitation: Using the back button on the toolbar may not work"</string>
 
     <!-- layout.miniplayer.miniplayerPatch -->
     <string name="morphe_disable_resuming_miniplayer_title">Disable resuming miniplayer</string>
-    <string name="morphe_disable_resuming_miniplayer_summary_on">"'Continue watching' will not resume on app startup"</string>
-    <string name="morphe_disable_resuming_miniplayer_summary_off">"'Continue watching' will resume on app startup
-
-• 'Continue watching' is the YouTube Premium feature
-• This setting does not force 'Continue watching' to be enabled"</string>
+    <string name="morphe_disable_resuming_miniplayer_summary_on">\'Continue watching\' will not show on app startup</string>
+    <string name="morphe_disable_resuming_miniplayer_summary_off">\'Continue watching\' can show on app startup</string>
+    <string name="morphe_disable_resuming_miniplayer_user_dialog_message">"• 'Continue watching' is a YouTube Premium feature
+• This setting cannot force on this Premium feature"</string>
     <string name="morphe_miniplayer_screen_title">Miniplayer</string>
     <string name="morphe_miniplayer_screen_summary">Change the style of the in-app minimized player</string>
     <string name="morphe_miniplayer_type_title">Miniplayer type</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1582,10 +1582,10 @@ Limitation: Using the back button on the toolbar may not work"</string>
     <string name="morphe_shorts_autoplay_background_summary_off">Shorts background play will repeat</string>
 
     <!-- layout.miniplayer.miniplayerPatch -->
-    <string name="morphe_disable_resuming_miniplayer_title">Disable resuming miniplayer</string>
-    <string name="morphe_disable_resuming_miniplayer_summary_on">\'Continue watching\' will not show on app startup</string>
-    <string name="morphe_disable_resuming_miniplayer_summary_off">\'Continue watching\' can show on app startup</string>
-    <string name="morphe_disable_resuming_miniplayer_user_dialog_message">"• 'Continue watching' is a YouTube Premium feature
+    <string name="morphe_miniplayer_disable_resuming_title">Disable resuming miniplayer</string>
+    <string name="morphe_miniplayer_disable_resuming_summary_on">\'Continue watching\' will not show on app startup</string>
+    <string name="morphe_miniplayer_disable_resuming_summary_off">\'Continue watching\' can show on app startup</string>
+    <string name="morphe_miniplayer_disable_resuming_user_dialog_message">"• 'Continue watching' is a YouTube Premium feature
 • This setting cannot force on this Premium feature"</string>
     <string name="morphe_miniplayer_screen_title">Miniplayer</string>
     <string name="morphe_miniplayer_screen_summary">Change the style of the in-app minimized player</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1582,6 +1582,12 @@ Limitation: Using the back button on the toolbar may not work"</string>
     <string name="morphe_shorts_autoplay_background_summary_off">Shorts background play will repeat</string>
 
     <!-- layout.miniplayer.miniplayerPatch -->
+    <string name="morphe_disable_resuming_miniplayer_title">Disable resuming miniplayer</string>
+    <string name="morphe_disable_resuming_miniplayer_summary_on">"'Continue watching' will not resume on app startup"</string>
+    <string name="morphe_disable_resuming_miniplayer_summary_off">"'Continue watching' will resume on app startup
+
+• 'Continue watching' is the YouTube Premium feature
+• This setting does not force 'Continue watching' to be enabled"</string>
     <string name="morphe_miniplayer_screen_title">Miniplayer</string>
     <string name="morphe_miniplayer_screen_summary">Change the style of the in-app minimized player</string>
     <string name="morphe_miniplayer_type_title">Miniplayer type</string>


### PR DESCRIPTION
### Description

<img width="810" height="855" alt="continue-watching-miniplayer" src="https://github.com/user-attachments/assets/5dafe41d-ec96-42ee-856e-0cbe771823a7" />

YouTube Premium users can use a feature called `Continue watching` (a feature that opens the last video being watched when the app cold starts).

This feature cannot be turned off, and some YouTube Premium users want to disable it.

This PR adds an option to turn off this feature via `Disable resuming miniplayer`.

Since this patch targets YouTube Premium users, it is not necessary for most users.

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
