### PR TITLE
feat(YouTube - Sanitize sharing links): Add setting to change Share links to shortened URLs

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/SanitizeSharingLinksPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/SanitizeSharingLinksPatch.java
@@ -1,6 +1,7 @@
 package app.morphe.extension.shared.patches;
 
 import android.net.Uri;
+import android.text.TextUtils;
 
 import java.util.List;
 
@@ -51,11 +52,11 @@ public final class SanitizeSharingLinksPatch {
                 return url;
             }
             String pathType = segments.get(0);
-            if (!pathType.equals("live") && !pathType.equals("shorts")) {
+            if (!"live".equals(pathType) && !"shorts".equals(pathType)) {
                 return url;
             }
             String videoId = segments.get(1);
-            if (videoId.isEmpty()) {
+            if (TextUtils.isEmpty(videoId)) {
                 return url;
             }
             return new Uri.Builder()

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/SanitizeSharingLinksPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/SanitizeSharingLinksPatch.java
@@ -1,5 +1,10 @@
 package app.morphe.extension.shared.patches;
 
+import android.net.Uri;
+
+import java.util.List;
+
+import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.privacy.LinkSanitizer;
 import app.morphe.extension.shared.settings.SharedYouTubeSettings;
 
@@ -27,6 +32,43 @@ public final class SanitizeSharingLinksPatch {
             url = url.replace("music.youtube.com", "youtube.com");
         }
 
+        if (SharedYouTubeSettings.REPLACE_LINKS_WITH_SHORTENER.get()) {
+            url = replaceWithShortenedUrl(url);
+        }
+
         return url;
+    }
+
+    private static String replaceWithShortenedUrl(String url) {
+        try {
+            Uri uri = Uri.parse(url);
+            String host = uri.getHost();
+            if (host == null || (!host.equals("youtube.com") && !host.endsWith(".youtube.com"))) {
+                return url;
+            }
+            List<String> segments = uri.getPathSegments();
+            if (segments.size() < 2) {
+                return url;
+            }
+            String pathType = segments.get(0);
+            if (!pathType.equals("live") && !pathType.equals("shorts")) {
+                return url;
+            }
+            String videoId = segments.get(1);
+            if (videoId.isEmpty()) {
+                return url;
+            }
+            return new Uri.Builder()
+                    .scheme("https")
+                    .authority("youtu.be")
+                    .appendPath(videoId)
+                    .encodedQuery(uri.getEncodedQuery())
+                    .encodedFragment(uri.getEncodedFragment())
+                    .build()
+                    .toString();
+        } catch (Exception ex) {
+            Logger.printException(() -> "replaceWithShortenedUrl failure: " + url, ex);
+            return url;
+        }
     }
 }

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
@@ -44,6 +44,7 @@ public class SharedYouTubeSettings extends BaseSettings {
 
     public static final BooleanSetting SANITIZE_SHARING_LINKS = new BooleanSetting("morphe_sanitize_sharing_links", TRUE);
     public static final BooleanSetting REPLACE_MUSIC_LINKS_WITH_YOUTUBE = new BooleanSetting("morphe_replace_music_with_youtube", FALSE);
+    public static final BooleanSetting REPLACE_LINKS_WITH_SHORTENER = new BooleanSetting("morphe_replace_links_with_shortener", FALSE);
 
     public static final BooleanSetting CHECK_WATCH_HISTORY_DOMAIN_NAME = new BooleanSetting("morphe_check_watch_history_domain_name", TRUE, false, false);
 

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/privacy/SanitizeSharingLinksPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/privacy/SanitizeSharingLinksPatch.kt
@@ -6,6 +6,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.BytecodePatchBuilder
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.misc.settings.preference.BasePreference
 import app.morphe.patches.shared.misc.settings.preference.BasePreferenceScreen
 import app.morphe.patches.shared.misc.settings.preference.PreferenceCategory
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference.Sorting
@@ -24,7 +25,8 @@ internal fun sanitizeSharingLinksPatch(
     block: BytecodePatchBuilder.() -> Unit = {},
     executeBlock: BytecodePatchContext.() -> Unit = {},
     preferenceScreen: BasePreferenceScreen.Screen,
-    replaceMusicLinksWithYouTube: Boolean = false
+    replaceMusicLinksWithYouTube: Boolean = false,
+    replaceLinksWithShortener: Boolean = false
 ) = bytecodePatch(
     name = "Sanitize sharing links",
     description = "Removes the tracking query parameters from shared links.",
@@ -37,15 +39,16 @@ internal fun sanitizeSharingLinksPatch(
         val sanitizePreference = SwitchPreference("morphe_sanitize_sharing_links")
 
         preferenceScreen.addPreferences(
-            if (replaceMusicLinksWithYouTube) {
+            if (replaceMusicLinksWithYouTube || replaceLinksWithShortener) {
+                val preferences = mutableSetOf<BasePreference>(sanitizePreference)
+                if (replaceMusicLinksWithYouTube) preferences += SwitchPreference("morphe_replace_music_with_youtube")
+                if (replaceLinksWithShortener) preferences += SwitchPreference("morphe_replace_links_with_shortener")
+
                 PreferenceCategory(
                     titleKey = null,
                     sorting = Sorting.UNSORTED,
                     tag = "app.morphe.extension.shared.settings.preference.NoTitlePreferenceCategory",
-                    preferences = setOf(
-                        sanitizePreference,
-                        SwitchPreference("morphe_replace_music_with_youtube")
-                    )
+                    preferences = preferences
                 )
             } else {
                 sanitizePreference

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/privacy/SanitizeSharingLinksPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/privacy/SanitizeSharingLinksPatch.kt
@@ -16,5 +16,6 @@ val sanitizeSharingLinksPatch = sanitizeSharingLinksPatch(
 
         compatibleWith(COMPATIBILITY_YOUTUBE)
     },
-    preferenceScreen = PreferenceScreen.MISC
+    preferenceScreen = PreferenceScreen.MISC,
+    replaceLinksWithShortener = true
 )

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -133,4 +133,7 @@ To sign in, press continue below"</string>
     <string name="morphe_replace_music_with_youtube_title">Change share links to youtube.com</string>
     <string name="morphe_replace_music_with_youtube_summary_on">Shared links use youtube.com</string>
     <string name="morphe_replace_music_with_youtube_summary_off">Shared links use music.youtube.com</string>
+    <string name="morphe_replace_links_with_shortener_title">Change share links to youtu.be</string>
+    <string name="morphe_replace_links_with_shortener_summary_on">Shared live stream and Shorts links use youtu.be</string>
+    <string name="morphe_replace_links_with_shortener_summary_off">Shared live stream and Shorts links use their original URLs</string>
 </resources>


### PR DESCRIPTION
### Description

<!-- ADD DETAILED DESCRIPTION HERE -->
Adds setting to replace `youtube.com/live/VIDEOID` and `youtube.com/shorts/VIDEOID` urls with `youtu.be/VIDEOID` urls.
This only affects live/shorts as normal links already get shortened by stock YT.
Closes #

### Additional context

<!-- ADD ADDITIONAL CONTEXT HERE -->
Motivation: YT recently introduced a bug where embed metadata for live urls (technically /e/ and /v/ urls too, but those aren't really used) doesn't work properly (at least in Discord). Adding this option so that shared livestreams can use the short link and get correct metadata that way.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions - 20.21.37, 20.47.62
- [x] Tested on **experimental** supported versions (Optional) - 21.17.480
