### PR TITLE
chore: Fix project-wide deprecation warnings

### DIFF
--- a/extensions/music/build.gradle.kts
+++ b/extensions/music/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.api.dsl.ApplicationExtension
+
 dependencies {
     compileOnly(libs.morphe.extensions.library)
     compileOnly(project(":extensions:shared-youtube:library"))
@@ -5,7 +7,7 @@ dependencies {
     compileOnly(libs.annotation)
 }
 
-android {
+configure<ApplicationExtension> {
     defaultConfig {
         minSdk = 26
     }

--- a/extensions/reddit/build.gradle.kts
+++ b/extensions/reddit/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.api.dsl.ApplicationExtension
+
 dependencies {
     compileOnly(project(":extensions:shared:library"))
     compileOnly(project(":extensions:reddit:stub"))
@@ -10,7 +12,7 @@ dependencies {
     implementation(libs.hiddenapi)
 }
 
-android {
+configure<ApplicationExtension> {
     compileSdk = 36
 
     defaultConfig {

--- a/extensions/reddit/stub/build.gradle.kts
+++ b/extensions/reddit/stub/build.gradle.kts
@@ -1,8 +1,10 @@
+import com.android.build.api.dsl.LibraryExtension
+
 plugins {
     alias(libs.plugins.android.library)
 }
 
-android {
+configure<LibraryExtension> {
     namespace = "app.morphe.extension"
     compileSdk = 36
 

--- a/extensions/shared-youtube/build.gradle.kts
+++ b/extensions/shared-youtube/build.gradle.kts
@@ -1,8 +1,10 @@
+import com.android.build.api.dsl.ApplicationExtension
+
 dependencies {
     implementation(project(":extensions:shared-youtube:library"))
 }
 
-android {
+configure<ApplicationExtension> {
     namespace = "app.morphe.extension"
     compileSdk = 36
 

--- a/extensions/shared-youtube/library/build.gradle.kts
+++ b/extensions/shared-youtube/library/build.gradle.kts
@@ -1,9 +1,11 @@
+import com.android.build.api.dsl.LibraryExtension
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.protobuf)
 }
 
-android {
+configure<LibraryExtension> {
     namespace = "app.morphe.extension.shared.youtube"
     compileSdk = 36
 

--- a/extensions/shared/build.gradle.kts
+++ b/extensions/shared/build.gradle.kts
@@ -1,8 +1,10 @@
+import com.android.build.api.dsl.ApplicationExtension
+
 dependencies {
     implementation(project(":extensions:shared:library"))
 }
 
-android {
+configure<ApplicationExtension> {
     namespace = "app.morphe.extension"
     compileSdk = 36
 

--- a/extensions/shared/library/build.gradle.kts
+++ b/extensions/shared/library/build.gradle.kts
@@ -1,8 +1,10 @@
+import com.android.build.api.dsl.LibraryExtension
+
 plugins {
     alias(libs.plugins.android.library)
 }
 
-android {
+configure<LibraryExtension> {
     namespace = "app.morphe.extension.shared"
     compileSdk = 36
 

--- a/extensions/youtube/build.gradle.kts
+++ b/extensions/youtube/build.gradle.kts
@@ -5,11 +5,12 @@ plugins {
 }
 
 dependencies {
+    compileOnly(libs.androidx.core)
+    compileOnly(libs.annotation)
     compileOnly(libs.morphe.extensions.library)
     compileOnly(project(":extensions:shared-youtube:library"))
     compileOnly(project(":extensions:shared:library"))
     compileOnly(project(":extensions:youtube:stub"))
-    compileOnly(libs.annotation)
 
     implementation(libs.protobuf.javalite)
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableVideoCodecsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableVideoCodecsPatch.java
@@ -4,7 +4,7 @@ import android.view.Display;
 
 import app.morphe.extension.youtube.settings.Settings;
 
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "deprecation"})
 public class DisableVideoCodecsPatch {
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
@@ -20,7 +20,6 @@ import android.graphics.Canvas;
 import android.graphics.ColorFilter;
 import android.graphics.Paint;
 import android.graphics.PixelFormat;
-import android.graphics.PorterDuff;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -37,6 +36,9 @@ import android.widget.GridLayout;
 import android.widget.LinearLayout;
 import android.widget.SeekBar;
 import android.widget.TextView;
+
+import androidx.core.graphics.BlendModeColorFilterCompat;
+import androidx.core.graphics.BlendModeCompat;
 
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
@@ -345,9 +347,11 @@ public class CustomPlaybackSpeedPatch {
             speedSlider.setMax(speedToProgressValue(customPlaybackSpeedsMax));
             speedSlider.setProgress(speedToProgressValue(currentSpeed));
             speedSlider.getProgressDrawable().setColorFilter(
-                    Utils.getAppForegroundColor(), PorterDuff.Mode.SRC_IN); // Theme progress bar.
+                    BlendModeColorFilterCompat.createBlendModeColorFilterCompat(
+                            Utils.getAppForegroundColor(), BlendModeCompat.SRC_IN)); // Theme progress bar.
             speedSlider.getThumb().setColorFilter(
-                    Utils.getAppForegroundColor(), PorterDuff.Mode.SRC_IN); // Theme slider thumb.
+                    BlendModeColorFilterCompat.createBlendModeColorFilterCompat(
+                            Utils.getAppForegroundColor(), BlendModeCompat.SRC_IN)); // Theme slider thumb.
             LinearLayout.LayoutParams sliderParams = new LinearLayout.LayoutParams(
                     0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f);
             speedSlider.setLayoutParams(sliderParams);

--- a/extensions/youtube/stub/build.gradle.kts
+++ b/extensions/youtube/stub/build.gradle.kts
@@ -1,8 +1,10 @@
+import com.android.build.api.dsl.LibraryExtension
+
 plugins {
     alias(libs.plugins.android.library)
 }
 
-android {
+configure<LibraryExtension> {
     namespace = "app.morphe.extension"
     compileSdk = 36
 


### PR DESCRIPTION
### Description

- Migrated all `build.gradle.kts` files to use `configure<LibraryExtension>` and `configure<ApplicationExtension>` to fix AGP 9.0 DSL deprecations.

- Replaced deprecated `PorterDuff API` with `BlendModeColorFilterCompat` in `CustomPlaybackSpeedPatch`.

- Added necessary `@SuppressWarnings("deprecation")` to legacy injection targets like `Display.HdrCapabilities` to ensure clean -`Xlint:deprecation` compilation.

### Additional context

<!-- ADD ADDITIONAL CONTEXT HERE -->

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
