### PR TITLE
feat(YouTube): Add `Dim Shorts overlay` patch

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DimShortsOverlayPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DimShortsOverlayPatch.java
@@ -1,0 +1,186 @@
+package app.morphe.extension.youtube.patches;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.os.Build;
+import android.view.View;
+import android.view.ViewParent;
+import android.view.ViewTreeObserver;
+import android.view.Window;
+import android.view.WindowInsetsController;
+import android.widget.ImageView;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.youtube.settings.Settings;
+import app.morphe.extension.youtube.shared.NavigationBar.NavigationButton;
+import app.morphe.extension.youtube.shared.ShortsPlayerState;
+
+@SuppressWarnings("unused")
+public class DimShortsOverlayPatch {
+
+    private static int reelTimeBarId = 0;
+
+    /**
+     * Injection point.
+     */
+    public static void dimShortsPlayerOverlay(View shortsOverlayView) {
+        shortsOverlayView.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
+            private ViewTreeObserver registeredObserver;
+            private ViewTreeObserver.OnPreDrawListener preDrawListener;
+            private Window window;
+            private boolean wasImmersive = false;
+            private boolean reelTimeBarListenerAdded = false;
+
+            @Override
+            public void onViewAttachedToWindow(View v) {
+                ViewParent parent = v.getParent();
+                final View target = (parent instanceof View) ? (View) parent : v;
+
+                Logger.printDebug(() -> "DimShorts overlay: target=" + target.getClass().getName());
+
+                window = getWindow(target);
+
+                if (reelTimeBarId == 0) {
+                    reelTimeBarId = v.getContext().getResources()
+                            .getIdentifier("reel_time_bar", "id", v.getContext().getPackageName());
+                }
+
+                preDrawListener = () -> {
+                    int opacity = Settings.SHORTS_OVERLAY_OPACITY.get();
+                    if (opacity < 0 || opacity > 100) opacity = 100;
+                    final float alpha = opacity / 100.0f;
+                    if (target.getAlpha() != alpha) {
+                        target.setAlpha(alpha);
+                    }
+
+                    if (!reelTimeBarListenerAdded && window != null && reelTimeBarId != 0) {
+                        View rtb = window.getDecorView().findViewById(reelTimeBarId);
+                        if (rtb != null) {
+                            addShortsAwareDimListener(rtb);
+                            reelTimeBarListenerAdded = true;
+                        }
+                    }
+
+                    boolean shouldBeImmersive = Settings.SHORTS_IMMERSIVE_MODE.get();
+                    if (window != null && shouldBeImmersive != wasImmersive) {
+                        wasImmersive = shouldBeImmersive;
+                        setStatusBarHidden(window, shouldBeImmersive);
+                    }
+
+                    return true;
+                };
+                registeredObserver = target.getViewTreeObserver();
+                registeredObserver.addOnPreDrawListener(preDrawListener);
+            }
+
+            @Override
+            public void onViewDetachedFromWindow(View v) {
+                if (preDrawListener != null && registeredObserver != null
+                        && registeredObserver.isAlive()) {
+                    registeredObserver.removeOnPreDrawListener(preDrawListener);
+                }
+                if (window != null) {
+                    setStatusBarHidden(window, false);
+                    wasImmersive = false;
+                }
+                reelTimeBarListenerAdded = false;
+                preDrawListener = null;
+                registeredObserver = null;
+                window = null;
+            }
+        });
+    }
+
+    private static Window getWindow(View view) {
+        Context ctx = view.getContext();
+        while (ctx instanceof ContextWrapper) {
+            if (ctx instanceof Activity) {
+                return ((Activity) ctx).getWindow();
+            }
+            ctx = ((ContextWrapper) ctx).getBaseContext();
+        }
+        return null;
+    }
+
+    private static void setStatusBarHidden(Window window, boolean hide) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WindowInsetsController controller = window.getInsetsController();
+            if (controller == null) return;
+            if (hide) {
+                controller.hide(android.view.WindowInsets.Type.statusBars());
+                controller.setSystemBarsBehavior(
+                        WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+            } else {
+                controller.show(android.view.WindowInsets.Type.statusBars());
+            }
+        } else {
+            View decorView = window.getDecorView();
+            int flags = decorView.getSystemUiVisibility();
+            if (hide) {
+                flags |= View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
+            } else {
+                flags &= ~(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+            }
+            decorView.setSystemUiVisibility(flags);
+        }
+    }
+
+    /**
+     * Injection point.
+     */
+    public static void dimShortsToolbarButton(String enumString, View buttonView, ImageView imageView) {
+        Logger.printDebug(() -> "DimShorts toolbar: enum=" + enumString);
+        addShortsAwareDimListener(buttonView);
+    }
+
+    /**
+     * Injection point.
+     */
+    public static void navigationTabCreated(NavigationButton button, View tabView) {
+        addShortsAwareDimListener(tabView);
+    }
+
+    private static void addShortsAwareDimListener(View view) {
+        View.OnAttachStateChangeListener listener = new View.OnAttachStateChangeListener() {
+            private ViewTreeObserver registeredObserver;
+            private ViewTreeObserver.OnPreDrawListener preDrawListener;
+
+            @Override
+            public void onViewAttachedToWindow(View v) {
+                if (preDrawListener != null) return;
+                preDrawListener = () -> {
+                    final float targetAlpha;
+                    if (ShortsPlayerState.isOpen()) {
+                        int opacity = Settings.SHORTS_OVERLAY_OPACITY.get();
+                        if (opacity < 0 || opacity > 100) opacity = 100;
+                        targetAlpha = opacity / 100.0f;
+                    } else {
+                        targetAlpha = 1.0f;
+                    }
+                    if (v.getAlpha() != targetAlpha) {
+                        v.setAlpha(targetAlpha);
+                    }
+                    return true;
+                };
+                registeredObserver = v.getViewTreeObserver();
+                registeredObserver.addOnPreDrawListener(preDrawListener);
+            }
+
+            @Override
+            public void onViewDetachedFromWindow(View v) {
+                if (preDrawListener != null && registeredObserver != null
+                        && registeredObserver.isAlive()) {
+                    registeredObserver.removeOnPreDrawListener(preDrawListener);
+                }
+                preDrawListener = null;
+                registeredObserver = null;
+            }
+        };
+
+        view.addOnAttachStateChangeListener(listener);
+        if (view.isAttachedToWindow()) {
+            listener.onViewAttachedToWindow(view);
+        }
+    }
+}

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -439,6 +439,8 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_SHORTS_VIDEO_TITLE = new BooleanSetting("morphe_hide_shorts_video_title", FALSE);
     public static final BooleanSetting SHORTS_AUTOPLAY = new BooleanSetting("morphe_shorts_autoplay", FALSE);
     public static final BooleanSetting SHORTS_AUTOPLAY_BACKGROUND = new BooleanSetting("morphe_shorts_autoplay_background", TRUE);
+    public static final IntegerSetting SHORTS_OVERLAY_OPACITY = new IntegerSetting("morphe_shorts_overlay_opacity", 90, false);
+    public static final BooleanSetting SHORTS_IMMERSIVE_MODE = new BooleanSetting("morphe_shorts_immersive_mode", TRUE);
 
     // Seekbar
     public static final BooleanSetting DISABLE_PRECISE_SEEKING_GESTURE = new BooleanSetting("morphe_disable_precise_seeking_gesture", FALSE);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/shortsplayer/DimShortsOverlayPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/shortsplayer/DimShortsOverlayPatch.kt
@@ -1,0 +1,62 @@
+package app.morphe.patches.youtube.layout.shortsplayer
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.misc.settings.preference.InputType
+import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import app.morphe.patches.shared.misc.settings.preference.TextPreference
+import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
+import app.morphe.patches.youtube.misc.navigation.hookNavigationButtonCreated
+import app.morphe.patches.youtube.misc.navigation.navigationBarHookPatch
+import app.morphe.patches.youtube.misc.playertype.ReelWatchPagerFingerprint
+import app.morphe.patches.youtube.misc.playertype.playerTypeHookPatch
+import app.morphe.patches.youtube.misc.settings.PreferenceScreen
+import app.morphe.patches.youtube.misc.settings.settingsPatch
+import app.morphe.patches.youtube.misc.toolbar.hookToolBar
+import app.morphe.patches.youtube.misc.toolbar.toolBarHookPatch
+import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+
+private const val EXTENSION_CLASS =
+    "Lapp/morphe/extension/youtube/patches/DimShortsOverlayPatch;"
+
+@Suppress("unused")
+val dimShortsOverlayPatch = bytecodePatch(
+    name = "Dim Shorts overlay",
+    description = "Adds an option to reduce the brightness of the Shorts overlay to prevent OLED burn-in.",
+) {
+    dependsOn(
+        sharedExtensionPatch,
+        settingsPatch,
+        playerTypeHookPatch,
+        toolBarHookPatch,
+        navigationBarHookPatch,
+    )
+
+    compatibleWith(COMPATIBILITY_YOUTUBE)
+
+    execute {
+        PreferenceScreen.SHORTS.addPreferences(
+            TextPreference("morphe_shorts_overlay_opacity", inputType = InputType.NUMBER),
+            SwitchPreference("morphe_shorts_immersive_mode"),
+        )
+
+        hookToolBar("$EXTENSION_CLASS->dimShortsToolbarButton")
+
+        hookNavigationButtonCreated(EXTENSION_CLASS)
+
+        ReelWatchPagerFingerprint.let {
+            it.method.apply {
+                val index = it.instructionMatches.last().index
+                val register = getInstruction<OneRegisterInstruction>(index).registerA
+
+                addInstruction(
+                    index + 1,
+                    "invoke-static { v$register }, " +
+                            "$EXTENSION_CLASS->dimShortsPlayerOverlay(Landroid/view/View;)V",
+                )
+            }
+        }
+    }
+}

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1574,6 +1574,14 @@ Limitation: Using the back button on the toolbar may not work"</string>
     <string name="morphe_shorts_player_type_regular_player_fullscreen">Regular player fullscreen</string>
 
     <!-- layout.shortsautoplay.shortsAutoplayPatch -->
+    <!-- layout.shortsplayer.dimShortsOverlayPatch -->
+    <string name="morphe_shorts_overlay_opacity_title">Shorts overlay opacity</string>
+    <string name="morphe_shorts_overlay_opacity_summary">Opacity of the Shorts overlay (0-100), where 0 is transparent. Reducing this prevents OLED burn-in.</string>
+    <string name="morphe_shorts_overlay_opacity_invalid_toast">Shorts overlay opacity must be between 0-100</string>
+    <string name="morphe_shorts_immersive_mode_title">Immersive Shorts</string>
+    <string name="morphe_shorts_immersive_mode_summary_on">Status bar is hidden when watching Shorts</string>
+    <string name="morphe_shorts_immersive_mode_summary_off">Status bar is visible when watching Shorts</string>
+
     <string name="morphe_shorts_autoplay_title">Autoplay Shorts</string>
     <string name="morphe_shorts_autoplay_summary_on">Shorts will autoplay</string>
     <string name="morphe_shorts_autoplay_summary_off">Shorts will repeat</string>


### PR DESCRIPTION
Adds a new **Dim Shorts overlay** patch that reduces the brightness of the Shorts UI to help prevent OLED burn-in. Dims the overlay, toolbar buttons, nav bar tabs, and seekbar based on a configurable opacity setting. Also includes an immersive mode option that hides the status bar while Shorts is open.

| 100% (no patch) | 50% opacity + Immersive | 20% opacity + Immersive |
|-----------------|-------------|-------------|
| <img width="270" src="https://github.com/user-attachments/assets/5ae3c80e-0ad4-4811-81eb-64d693aae7e0" /> | <img width="270" src="https://github.com/user-attachments/assets/f4f4ad4a-18ea-48fc-a0c8-0c7ffede9304" /> | <img width="270" src="https://github.com/user-attachments/assets/d0a99920-8207-4e09-a69b-fa42c3fcf84e" /> |