### PR TITLE
fix(YouTube - PlayerOverlayButton): Video heading margin not applied when no bottom buttons present

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LegacyPlayerControlButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LegacyPlayerControlButton.java
@@ -83,8 +83,6 @@ public class LegacyPlayerControlButton {
                                      PlayerControlButtonStatus enabledStatus,
                                      View.OnClickListener onClickListener,
                                      @Nullable View.OnLongClickListener longClickListener) {
-        PlayerOverlayButton.initializeHeadingFromUpperButton(controlsViewGroup);
-        
         View containerView = Utils.getChildViewByResourceName(controlsViewGroup, viewToHide);
         containerView.setVisibility(View.GONE);
         containerRef = new WeakReference<>(containerView);
@@ -274,6 +272,8 @@ public class LegacyPlayerControlButton {
         if (container == null) {
             return;
         }
+
+        PlayerOverlayButton.initializeHeadingFromUpperButton(container);
 
         container.animate().cancel();
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LegacyPlayerControlButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LegacyPlayerControlButton.java
@@ -83,6 +83,8 @@ public class LegacyPlayerControlButton {
                                      PlayerControlButtonStatus enabledStatus,
                                      View.OnClickListener onClickListener,
                                      @Nullable View.OnLongClickListener longClickListener) {
+        PlayerOverlayButton.initializeHeadingFromUpperButton(controlsViewGroup);
+        
         View containerView = Utils.getChildViewByResourceName(controlsViewGroup, viewToHide);
         containerView.setVisibility(View.GONE);
         containerRef = new WeakReference<>(containerView);
@@ -115,7 +117,6 @@ public class LegacyPlayerControlButton {
         }
 
         buttonRef = new WeakReference<>(button);
-        PlayerOverlayButton.initializeHeadingFromUpperButton(button);
 
         TextView tempTextOverlay = null;
         if (textOverlayId != null) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LegacyPlayerControlButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LegacyPlayerControlButton.java
@@ -83,6 +83,8 @@ public class LegacyPlayerControlButton {
                                      PlayerControlButtonStatus enabledStatus,
                                      View.OnClickListener onClickListener,
                                      @Nullable View.OnLongClickListener longClickListener) {
+        PlayerOverlayButton.initializeHeadingFromUpperButton(controlsViewGroup);
+
         View containerView = Utils.getChildViewByResourceName(controlsViewGroup, viewToHide);
         containerView.setVisibility(View.GONE);
         containerRef = new WeakReference<>(containerView);
@@ -272,8 +274,6 @@ public class LegacyPlayerControlButton {
         if (container == null) {
             return;
         }
-
-        PlayerOverlayButton.initializeHeadingFromUpperButton(container);
 
         container.animate().cancel();
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LegacyPlayerControlButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LegacyPlayerControlButton.java
@@ -115,6 +115,7 @@ public class LegacyPlayerControlButton {
         }
 
         buttonRef = new WeakReference<>(button);
+        PlayerOverlayButton.initializeHeadingFromUpperButton(button);
 
         TextView tempTextOverlay = null;
         if (textOverlayId != null) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlayerOverlayButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlayerOverlayButton.java
@@ -237,7 +237,6 @@ public class PlayerOverlayButton {
         videoHeadingContainer.updateMargin(LegacyPlayerControlButton.buttonWidth, getTotalUpperButtonCount());
     }
 
-    //
     private static boolean skipCallOnce = true;
     /**
      * Called from each {@link LegacyPlayerControlButton} constructor so that the
@@ -245,6 +244,7 @@ public class PlayerOverlayButton {
      * overlay buttons (speed, quality, etc.) have been added.
      */
     public static void initializeHeadingFromUpperButton(View sourceButton) {
+        // Useful to prevent initial null error in updateContainerRef() method
         if (skipCallOnce) {
             skipCallOnce = false;
             return;

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlayerOverlayButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlayerOverlayButton.java
@@ -243,8 +243,6 @@ public class PlayerOverlayButton {
      * overlay buttons (speed, quality, etc.) have been added.
      */
     public static void initializeHeadingFromUpperButton(View sourceButton) {
-        Utils.verifyOnMainThread();
-
         if (!(sourceButton.getParent() instanceof ViewGroup sourceButtonViewGroup)) return;
 
         videoHeadingContainer.updateContainerRef(sourceButtonViewGroup);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlayerOverlayButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlayerOverlayButton.java
@@ -242,9 +242,12 @@ public class PlayerOverlayButton {
      * video-heading end margin is initialized and kept correct even when no lower
      * overlay buttons (speed, quality, etc.) have been added.
      */
-    public static void initializeHeadingFromUpperButton(View upperButtonView) {
-        if (!(upperButtonView.getParent() instanceof ViewGroup parent)) return;
-        videoHeadingContainer.updateContainerRef(parent);
+    public static void initializeHeadingFromUpperButton(View sourceButton) {
+        Utils.verifyOnMainThread();
+
+        if (!(sourceButton.getParent() instanceof ViewGroup sourceButtonViewGroup)) return;
+
+        videoHeadingContainer.updateContainerRef(sourceButtonViewGroup);
         videoHeadingContainer.updateMargin(LegacyPlayerControlButton.buttonWidth, getTotalUpperButtonCount());
     }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlayerOverlayButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlayerOverlayButton.java
@@ -237,12 +237,21 @@ public class PlayerOverlayButton {
         videoHeadingContainer.updateMargin(LegacyPlayerControlButton.buttonWidth, getTotalUpperButtonCount());
     }
 
+    //
+    private static boolean skipCallOnce = true;
     /**
      * Called from each {@link LegacyPlayerControlButton} constructor so that the
      * video-heading end margin is initialized and kept correct even when no lower
      * overlay buttons (speed, quality, etc.) have been added.
      */
     public static void initializeHeadingFromUpperButton(View sourceButton) {
+        if (skipCallOnce) {
+            skipCallOnce = false;
+            return;
+        }
+
+        Utils.verifyOnMainThread();
+
         if (!(sourceButton.getParent() instanceof ViewGroup sourceButtonViewGroup)) return;
 
         videoHeadingContainer.updateContainerRef(sourceButtonViewGroup);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlayerOverlayButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlayerOverlayButton.java
@@ -55,6 +55,7 @@ public class PlayerOverlayButton {
          */
         void updateContainerRef(ViewGroup sourceButtonViewGroup) {
             if (containerRef.get() != null) return;
+            lastMarginEnd = -1;
 
             final int id = ResourceUtils.getIdentifier(ResourceType.ID, resourceName);
             if (id != 0) {
@@ -142,7 +143,7 @@ public class PlayerOverlayButton {
                     // Fullscreen button has a custom margin layout parameters class
                     // and if used directly causes a broken layout with 21.15+
                     // if quality and speed button are shown. Older app targets
-                    // must use the original layut otherwise app crashes with a cast exception.
+                    // must use the original layout otherwise app crashes with a cast exception.
                     layoutParams = new ViewGroup.MarginLayoutParams(layoutParams);
                 }
                 button.setLayoutParams(layoutParams);
@@ -236,6 +237,16 @@ public class PlayerOverlayButton {
         videoHeadingContainer.updateMargin(LegacyPlayerControlButton.buttonWidth, getTotalUpperButtonCount());
     }
 
+    /**
+     * Called from each {@link LegacyPlayerControlButton} constructor so that the
+     * video-heading end margin is initialized and kept correct even when no lower
+     * overlay buttons (speed, quality, etc.) have been added.
+     */
+    public static void initializeHeadingFromUpperButton(View upperButtonView) {
+        if (!(upperButtonView.getParent() instanceof ViewGroup parent)) return;
+        videoHeadingContainer.updateContainerRef(parent);
+        videoHeadingContainer.updateMargin(LegacyPlayerControlButton.buttonWidth, getTotalUpperButtonCount());
+    }
 
     @Nullable
     private static ViewGroup updateRefsFromSourceButton(View sourceButton) {


### PR DESCRIPTION
### Description

The video heading end margin was only updated inside the OnPreDrawListener of lower overlay buttons (speed, quality, etc.). When none of those buttons were added, the listener never fired, so player_video_heading never received its margin and overlapped the upper custom buttons.

### Test results

- [ ] Tested on both the **minimum** and **maximum** supported versions
- [ ] Tested on **experimental** supported versions (Optional)
