### PR TITLE
fix(YouTube - Hide ads): Hide new type of product sticker

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
@@ -1370,6 +1370,7 @@ public class CrossfadeManager {
         return sessionPaused.get();
     }
 
+    @SuppressWarnings("deprecation")
     @SuppressLint("MissingPermission")
     public static void toggleSessionPause() {
         boolean current;

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/search/MusicSearchResultsAdapter.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/search/MusicSearchResultsAdapter.java
@@ -20,6 +20,7 @@ public class MusicSearchResultsAdapter extends BaseSearchResultsAdapter {
         super(context, items, fragment, searchViewController);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected PreferenceScreen getMainPreferenceScreen() {
         return fragment.getPreferenceScreenForSearch();

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/LicensesDialog.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/LicensesDialog.java
@@ -75,6 +75,7 @@ public class LicensesDialog extends Dialog {
         super(context, android.R.style.Theme_DeviceDefault_NoActionBar);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AdsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AdsFilter.java
@@ -121,7 +121,7 @@ public final class AdsFilter extends Filter {
         );
 
         final var viewProducts = new StringFilterGroup(
-                Settings.HIDE_VIEW_PRODUCTS_BANNER,
+                Settings.HIDE_PLAYER_POPUP_ADS,
                 "product_item",
                 "products_in_video",
                 "shopping_overlay.e" // Video player overlay shopping links.
@@ -138,10 +138,17 @@ public final class AdsFilter extends Filter {
                 "shopping_carousel.e" // Channel profile shopping shelf.
         );
 
+        final var paidPromotionLabel = new StringFilterGroup(
+                Settings.HIDE_PAID_PROMOTION_LABEL,
+                "paid_content_overlay",
+                "reel_player_disclosure.e",
+                "shorts_disclosures.e"
+        );
+
         final var productSticker = new StringFilterGroup(
-                Settings.HIDE_PRODUCT_STICKER,
+                Settings.HIDE_PLAYER_POPUP_ADS,
                 "stickers_layer.e",
-                "product_sticker.e"
+                "product_sticker.e" // Product sticker that appears on Shorts.
         );
 
         final var selfSponsor = new StringFilterGroup(
@@ -154,6 +161,7 @@ public final class AdsFilter extends Filter {
                 generalAds,
                 merchandise,
                 movieAds,
+                paidPromotionLabel,
                 productSticker,
                 selfSponsor,
                 shoppingLinks,

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AdsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AdsFilter.java
@@ -138,6 +138,12 @@ public final class AdsFilter extends Filter {
                 "shopping_carousel.e" // Channel profile shopping shelf.
         );
 
+        final var productSticker = new StringFilterGroup(
+                Settings.HIDE_PRODUCT_STICKER,
+                "stickers_layer.e",
+                "product_sticker.e"
+        );
+
         final var selfSponsor = new StringFilterGroup(
                 Settings.HIDE_SELF_SPONSOR,
                 "cta_shelf_card"
@@ -148,6 +154,7 @@ public final class AdsFilter extends Filter {
                 generalAds,
                 merchandise,
                 movieAds,
+                productSticker,
                 selfSponsor,
                 shoppingLinks,
                 viewProducts

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -183,11 +183,6 @@ public final class LayoutComponentsFilter extends Filter {
                 "medical_panel"
         );
 
-        final var paidPromotion = new StringFilterGroup(
-                Settings.HIDE_PAID_PROMOTION_LABEL,
-                "paid_content_overlay"
-        );
-
         final var infoPanel = new StringFilterGroup(
                 Settings.HIDE_INFO_PANELS,
                 "publisher_transparency_panel"
@@ -379,7 +374,6 @@ public final class LayoutComponentsFilter extends Filter {
                 infoPanel,
                 medicalPanel,
                 notifyMe,
-                paidPromotion,
                 playables,
                 postsShelf,
                 searchFriction,

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/ShortsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/ShortsFilter.java
@@ -81,7 +81,6 @@ public final class ShortsFilter extends Filter {
     private final StringFilterGroup autoDubbedLabel;
     private final StringFilterGroup subscribeButton;
     private final StringFilterGroup joinButton;
-    private final StringFilterGroup paidPromotionLabel;
     private final StringFilterGroup shelfHeaderIdentifier;
     private final StringFilterGroup shelfHeaderPath;
 
@@ -239,12 +238,6 @@ public final class ShortsFilter extends Filter {
                 "subscribe_button"
         );
 
-        paidPromotionLabel = new StringFilterGroup(
-                Settings.HIDE_PAID_PROMOTION_LABEL,
-                "reel_player_disclosure.e",
-                "shorts_disclosures.e"
-        );
-
         shortsActionBar = new StringFilterGroup(
                 null,
                 "shorts_action_bar.e",
@@ -305,8 +298,8 @@ public final class ShortsFilter extends Filter {
         );
 
         addPathCallbacks(
-                shortsCompactFeedVideo, shelfHeaderPath, joinButton, subscribeButton, paidPromotionLabel,
-                livePreview, suggestedAction, pausedOverlayButtons, channelBar, infoPanel, previewComment,
+                shortsCompactFeedVideo, shelfHeaderPath, joinButton, subscribeButton, livePreview,
+                suggestedAction, pausedOverlayButtons, channelBar, infoPanel, previewComment,
                 autoDubbedLabel, fullVideoLinkLabel, videoTitle, soundButton, useButtons, likeFountain,
                 reelCarousel, reelSoundMetadata, likeButton, dislikeButton, shortsActionBar
         );
@@ -446,8 +439,7 @@ public final class ShortsFilter extends Filter {
         }
 
         if (contentType == FilterContentType.PATH) {
-            if (matchedGroup == subscribeButton || matchedGroup == joinButton
-                    || matchedGroup == paidPromotionLabel || matchedGroup == autoDubbedLabel) {
+            if (matchedGroup == subscribeButton || matchedGroup == joinButton || matchedGroup == autoDubbedLabel) {
                 // Selectively filter to avoid false positive filtering of other subscribe/join buttons.
                 return path.startsWith(REEL_CHANNEL_BAR_PATH) || path.startsWith(REEL_METAPANEL_PATH)
                         || path.startsWith(REEL_PLAYER_OVERLAY_PATH);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/ShortsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/ShortsFilter.java
@@ -191,11 +191,6 @@ public final class ShortsFilter extends Filter {
                 "shorts_info_panel_overview"
         );
 
-        StringFilterGroup stickers = new StringFilterGroup(
-                Settings.HIDE_SHORTS_STICKERS,
-                "stickers_layer.e"
-        );
-
         StringFilterGroup likeFountain = new StringFilterGroup(
                 Settings.HIDE_SHORTS_LIKE_FOUNTAIN,
                 "like_fountain.e"
@@ -312,8 +307,8 @@ public final class ShortsFilter extends Filter {
         addPathCallbacks(
                 shortsCompactFeedVideo, shelfHeaderPath, joinButton, subscribeButton, paidPromotionLabel,
                 livePreview, suggestedAction, pausedOverlayButtons, channelBar, infoPanel, previewComment,
-                autoDubbedLabel, fullVideoLinkLabel, videoTitle, soundButton, stickers, useButtons,
-                reelCarousel, reelSoundMetadata, likeFountain, likeButton, dislikeButton, shortsActionBar
+                autoDubbedLabel, fullVideoLinkLabel, videoTitle, soundButton, useButtons, likeFountain,
+                reelCarousel, reelSoundMetadata, likeButton, dislikeButton, shortsActionBar
         );
 
         //

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
@@ -21,6 +21,7 @@ import android.graphics.ColorFilter;
 import android.graphics.Paint;
 import android.graphics.PixelFormat;
 import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -345,9 +346,9 @@ public class CustomPlaybackSpeedPatch {
             speedSlider.setMax(speedToProgressValue(customPlaybackSpeedsMax));
             speedSlider.setProgress(speedToProgressValue(currentSpeed));
             speedSlider.getProgressDrawable().setColorFilter(
-                    Utils.getAppForegroundColor(), PorterDuff.Mode.SRC_IN); // Theme progress bar.
+                    new PorterDuffColorFilter(Utils.getAppForegroundColor(), PorterDuff.Mode.SRC_IN)); // Theme progress bar.
             speedSlider.getThumb().setColorFilter(
-                    Utils.getAppForegroundColor(), PorterDuff.Mode.SRC_IN); // Theme slider thumb.
+                    new PorterDuffColorFilter(Utils.getAppForegroundColor(), PorterDuff.Mode.SRC_IN)); // Theme slider thumb.
             LinearLayout.LayoutParams sliderParams = new LinearLayout.LayoutParams(
                     0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f);
             speedSlider.setLayoutParams(sliderParams);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -85,10 +85,11 @@ public class Settings extends SharedYouTubeSettings {
     // Ads
     public static final BooleanSetting HIDE_CREATOR_STORE_SHELF = new BooleanSetting("morphe_hide_creator_store_shelf", TRUE);
     public static final BooleanSetting HIDE_END_SCREEN_STORE_BANNER = new BooleanSetting("morphe_hide_end_screen_store_banner", TRUE, true);
-    public static final BooleanSetting HIDE_PLAYER_POPUP_ADS = new BooleanSetting("morphe_hide_player_popup_ads", TRUE);
     public static final BooleanSetting HIDE_GENERAL_ADS = new BooleanSetting("morphe_hide_general_ads", TRUE);
     public static final BooleanSetting HIDE_MERCHANDISE_BANNERS = new BooleanSetting("morphe_hide_merchandise_banners", TRUE);
     public static final BooleanSetting HIDE_PAID_PROMOTION_LABEL = new BooleanSetting("morphe_hide_paid_promotion_label", TRUE);
+    public static final BooleanSetting HIDE_PLAYER_POPUP_ADS = new BooleanSetting("morphe_hide_player_popup_ads", TRUE);
+    public static final BooleanSetting HIDE_PRODUCT_STICKER = new BooleanSetting("morphe_hide_product_sticker", TRUE);
     public static final BooleanSetting HIDE_SELF_SPONSOR = new BooleanSetting("morphe_hide_self_sponsor_ads", TRUE);
     public static final BooleanSetting HIDE_SHOPPING_LINKS = new BooleanSetting("morphe_hide_shopping_links", TRUE);
     public static final BooleanSetting HIDE_VIDEO_ADS = new BooleanSetting("morphe_hide_video_ads", TRUE, true);
@@ -434,7 +435,6 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_SHORTS_SHOP_BUTTON = new BooleanSetting("morphe_hide_shorts_shop_button", TRUE);
     public static final BooleanSetting HIDE_SHORTS_SOUND_BUTTON = new BooleanSetting("morphe_hide_shorts_sound_button", FALSE);
     public static final BooleanSetting HIDE_SHORTS_SOUND_METADATA_LABEL = new BooleanSetting("morphe_hide_shorts_sound_metadata_label", FALSE);
-    public static final BooleanSetting HIDE_SHORTS_STICKERS = new BooleanSetting("morphe_hide_shorts_stickers", TRUE);
     public static final BooleanSetting HIDE_SHORTS_SUBSCRIBE_BUTTON = new BooleanSetting("morphe_hide_shorts_subscribe_button", TRUE);
     public static final BooleanSetting HIDE_SHORTS_SUBSCRIPTIONS = new BooleanSetting("morphe_hide_shorts_subscriptions", FALSE);
     public static final BooleanSetting HIDE_SHORTS_SUPER_THANKS_BUTTON = new BooleanSetting("morphe_hide_shorts_super_thanks_button", TRUE);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -89,11 +89,9 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_MERCHANDISE_BANNERS = new BooleanSetting("morphe_hide_merchandise_banners", TRUE);
     public static final BooleanSetting HIDE_PAID_PROMOTION_LABEL = new BooleanSetting("morphe_hide_paid_promotion_label", TRUE);
     public static final BooleanSetting HIDE_PLAYER_POPUP_ADS = new BooleanSetting("morphe_hide_player_popup_ads", TRUE);
-    public static final BooleanSetting HIDE_PRODUCT_STICKER = new BooleanSetting("morphe_hide_product_sticker", TRUE);
     public static final BooleanSetting HIDE_SELF_SPONSOR = new BooleanSetting("morphe_hide_self_sponsor_ads", TRUE);
     public static final BooleanSetting HIDE_SHOPPING_LINKS = new BooleanSetting("morphe_hide_shopping_links", TRUE);
     public static final BooleanSetting HIDE_VIDEO_ADS = new BooleanSetting("morphe_hide_video_ads", TRUE, true);
-    public static final BooleanSetting HIDE_VIEW_PRODUCTS_BANNER = new BooleanSetting("morphe_hide_view_products_banner", TRUE);
     public static final BooleanSetting HIDE_YOUTUBE_PREMIUM_PROMOTIONS = new BooleanSetting("morphe_hide_youtube_premium_promotions", TRUE);
 
     // Feed

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/ad/general/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/ad/general/HideAdsPatch.kt
@@ -60,6 +60,7 @@ private val hideAdsResourcePatch = resourcePatch {
             SwitchPreference("morphe_hide_merchandise_banners", summaryKey = null),
             SwitchPreference("morphe_hide_paid_promotion_label", summaryKey = null),
             SwitchPreference("morphe_hide_player_popup_ads", summaryKey = null),
+            SwitchPreference("morphe_hide_product_sticker", summaryKey = null),
             SwitchPreference("morphe_hide_self_sponsor_ads", summaryKey = null),
             SwitchPreference("morphe_hide_shopping_links", summaryKey = null),
             SwitchPreference("morphe_hide_view_products_banner", summaryKey = null),

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/ad/general/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/ad/general/HideAdsPatch.kt
@@ -60,10 +60,8 @@ private val hideAdsResourcePatch = resourcePatch {
             SwitchPreference("morphe_hide_merchandise_banners", summaryKey = null),
             SwitchPreference("morphe_hide_paid_promotion_label", summaryKey = null),
             SwitchPreference("morphe_hide_player_popup_ads", summaryKey = null),
-            SwitchPreference("morphe_hide_product_sticker", summaryKey = null),
             SwitchPreference("morphe_hide_self_sponsor_ads", summaryKey = null),
             SwitchPreference("morphe_hide_shopping_links", summaryKey = null),
-            SwitchPreference("morphe_hide_view_products_banner", summaryKey = null),
             SwitchPreference("morphe_hide_youtube_premium_promotions", summaryKey = null),
         )
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
@@ -114,7 +114,6 @@ private val hideShortsComponentsResourcePatch = resourcePatch {
                     SwitchPreference("morphe_hide_shorts_tagged_products", summaryKey = null),
                     SwitchPreference("morphe_hide_shorts_search_suggestions", summaryKey = null),
                     SwitchPreference("morphe_hide_shorts_super_thanks_button", summaryKey = null),
-                    SwitchPreference("morphe_hide_shorts_stickers", summaryKey = null),
 
                     // Bottom of the screen.
                     SwitchPreference("morphe_hide_shorts_ai_button", summaryKey = null),

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -267,6 +267,7 @@ Limitations:
     <string name="morphe_hide_merchandise_banners_title">Hide merchandise banners</string>
     <string name="morphe_hide_paid_promotion_label_title">Hide paid promotion label</string>
     <string name="morphe_hide_player_popup_ads_title">Hide player popup ads</string>
+    <string name="morphe_hide_product_sticker_title">Hide product sticker</string>
     <string name="morphe_hide_self_sponsor_ads_title">Hide self sponsored cards</string>
     <string name="morphe_hide_shopping_links_title">Hide shopping links</string>
     <string name="morphe_hide_view_products_banner_title">Hide view products banner</string>
@@ -670,7 +671,6 @@ To show the \'Audio Track\' menu, change \'Spoof video streams\' to \'Android Re
     <string name="morphe_hide_shorts_save_sound_button_title">Hide \'Save music\' button</string>
     <string name="morphe_hide_shorts_search_suggestions_title">Hide search suggestions</string>
     <string name="morphe_hide_shorts_shop_button_title">Hide Shop button</string>
-    <string name="morphe_hide_shorts_stickers_title">Hide stickers</string>
     <string name="morphe_hide_shorts_subscribe_button_title">Hide Subscribe button</string>
     <string name="morphe_hide_shorts_tagged_products_title">Hide tagged products</string>
     <string name="morphe_hide_shorts_upcoming_button_title">Hide Upcoming button</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -267,7 +267,6 @@ Limitations:
     <string name="morphe_hide_merchandise_banners_title">Hide merchandise banners</string>
     <string name="morphe_hide_paid_promotion_label_title">Hide paid promotion label</string>
     <string name="morphe_hide_player_popup_ads_title">Hide player popup ads</string>
-    <string name="morphe_hide_product_sticker_title">Hide product sticker</string>
     <string name="morphe_hide_self_sponsor_ads_title">Hide self sponsored cards</string>
     <string name="morphe_hide_shopping_links_title">Hide shopping links</string>
     <string name="morphe_hide_view_products_banner_title">Hide view products banner</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -269,7 +269,6 @@ Limitations:
     <string name="morphe_hide_player_popup_ads_title">Hide player popup ads</string>
     <string name="morphe_hide_self_sponsor_ads_title">Hide self sponsored cards</string>
     <string name="morphe_hide_shopping_links_title">Hide shopping links</string>
-    <string name="morphe_hide_view_products_banner_title">Hide view products banner</string>
     <string name="morphe_hide_youtube_premium_promotions_title">Hide YouTube Premium promotions</string>
 
     <!-- ad.video.videoAdsPatch -->


### PR DESCRIPTION
### Description

Closes #1481.

### Additional context

Since the sticker only shows product ads, moved the setting into "Hide ads" patch.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
