### PR TITLE
chore(Settings): Additional strings improvements

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/privacy/SanitizeSharingLinksPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/privacy/SanitizeSharingLinksPatch.kt
@@ -41,7 +41,7 @@ internal fun sanitizeSharingLinksPatch(
         preferenceScreen.addPreferences(
             if (replaceMusicLinksWithYouTube || replaceLinksWithShortener) {
                 val preferences = mutableSetOf<BasePreference>(sanitizePreference)
-                if (replaceMusicLinksWithYouTube) preferences += SwitchPreference("morphe_replace_music_with_youtube", summaryKey = null)
+                if (replaceMusicLinksWithYouTube) preferences += SwitchPreference("morphe_replace_music_with_youtube")
                 if (replaceLinksWithShortener) preferences += SwitchPreference("morphe_replace_links_with_shortener")
 
                 PreferenceCategory(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/ad/general/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/ad/general/HideAdsPatch.kt
@@ -55,6 +55,7 @@ private val hideAdsResourcePatch = resourcePatch {
 
     execute {
         PreferenceScreen.ADS.addPreferences(
+            SwitchPreference("morphe_hide_creator_store_shelf", summaryKey = null),
             SwitchPreference("morphe_hide_end_screen_store_banner", summaryKey = null),
             SwitchPreference("morphe_hide_general_ads", summaryKey = null),
             SwitchPreference("morphe_hide_merchandise_banners", summaryKey = null),

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/downloads/DownloadsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/downloads/DownloadsPatch.kt
@@ -32,7 +32,7 @@ private val downloadsResourcePatch = resourcePatch {
                 key = "morphe_external_downloader_screen",
                 sorting = Sorting.UNSORTED,
                 preferences = setOf(
-                    SwitchPreference("morphe_external_downloader", summaryKey = null),
+                    SwitchPreference("morphe_external_downloader"),
                     SwitchPreference("morphe_external_downloader_action_button"),
                     TextPreference(
                         "morphe_external_downloader_name",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/EnableSlideToSeekPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/EnableSlideToSeekPatch.kt
@@ -12,7 +12,6 @@ import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.util.findInstructionIndicesReversed
 import app.morphe.util.getReference
-import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
@@ -30,7 +29,7 @@ val enableSlideToSeekPatch = bytecodePatch(
 
     execute {
         PreferenceScreen.SEEKBAR.addPreferences(
-            SwitchPreference("morphe_slide_to_seek", summaryKey = null),
+            SwitchPreference("morphe_slide_to_seek"),
         )
 
         var modifiedMethods = false

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/EnableTapToSeekPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/EnableTapToSeekPatch.kt
@@ -25,7 +25,7 @@ val enableTapToSeekPatch = bytecodePatch(
 
     execute {
         PreferenceScreen.SEEKBAR.addPreferences(
-            SwitchPreference("morphe_tap_to_seek", summaryKey = null),
+            SwitchPreference("morphe_tap_to_seek"),
         )
 
         // Find the required methods to tap the seekbar.

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/endscreensuggestedvideo/HideEndScreenSuggestedVideoPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/endscreensuggestedvideo/HideEndScreenSuggestedVideoPatch.kt
@@ -29,7 +29,7 @@ val hideEndScreenSuggestedVideoPatch = bytecodePatch(
 
     execute {
         PreferenceScreen.PLAYER.addPreferences(
-            SwitchPreference("morphe_hide_end_screen_suggested_video", summaryKey = null),
+            SwitchPreference("morphe_hide_end_screen_suggested_video"),
         )
 
         val autoNavStatusMethod = AutoNavStatusFingerprint.method

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -100,12 +100,6 @@ val hideLayoutComponentsPatch = bytecodePatch(
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {
-        PreferenceScreen.ADS.addPreferences(
-            // Uses horizontal shelf and a buffer, which requires managing in a single place in the code
-            // to ensure the generic "hide horizontal shelves" doesn't hide when it should show.
-            SwitchPreference("morphe_hide_creator_store_shelf", summaryKey = null)
-        )
-
         PreferenceScreen.PLAYER.addPreferences(
             PreferenceScreenPreference(
                 key = "morphe_hide_description_components_screen",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -252,10 +252,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
                 )
             ),
             SwitchPreference("morphe_hide_floating_microphone_button"),
-            SwitchPreference(
-                key = "morphe_hide_horizontal_shelves",
-                tag = "app.morphe.extension.shared.settings.preference.BulletPointSwitchPreference"
-            ),
+            SwitchPreference("morphe_hide_horizontal_shelves"),
             SwitchPreference("morphe_hide_hyped_label", summaryKey = null),
             SwitchPreference("morphe_hide_image_shelf"),
             SwitchPreference("morphe_hide_latest_videos_button"),

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -272,12 +272,12 @@ val hideLayoutComponentsPatch = bytecodePatch(
             SwitchPreference("morphe_hide_search_term_thumbnails"),
             SwitchPreference("morphe_hide_show_more_button"),
             SwitchPreference("morphe_hide_subscribed_channels_bar", summaryKey = null),
-            SwitchPreference("morphe_hide_surveys", summaryKey = null),
+            SwitchPreference("morphe_hide_surveys"),
             SwitchPreference("morphe_hide_ticket_shelf", summaryKey = null),
             SwitchPreference("morphe_hide_upload_time", summaryKey = null),
             SwitchPreference("morphe_hide_video_recommendation_labels"),
             SwitchPreference("morphe_hide_view_count", summaryKey = null),
-            SwitchPreference("morphe_hide_web_search_results", summaryKey = null),
+            SwitchPreference("morphe_hide_web_search_results"),
             SwitchPreference("morphe_hide_youtube_doodles"),
         )
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
@@ -19,6 +19,7 @@ import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.all.misc.resources.ResourceType
 import app.morphe.patches.all.misc.resources.getResourceId
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
+import app.morphe.patches.shared.misc.settings.preference.PreferenceCategory
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.engagement.engagementPanelHookPatch
@@ -69,14 +70,18 @@ private val hideShortsComponentsResourcePatch = resourcePatch {
         val hideShortsWidget by hideShortsWidgetOption
 
         PreferenceScreen.SHORTS.addPreferences(
-            SwitchPreference("morphe_hide_shorts_channel", summaryKey = null),
-            SwitchPreference("morphe_hide_shorts_home", summaryKey = null),
-            SwitchPreference("morphe_hide_shorts_search", summaryKey = null),
-            SwitchPreference("morphe_hide_shorts_subscriptions", summaryKey = null),
-            SwitchPreference("morphe_hide_shorts_video_description", summaryKey = null),
-            SwitchPreference("morphe_hide_shorts_history", summaryKey = null),
+            PreferenceCategory(
+                titleKey = "morphe_preference_category_hide_shorts",
+                preferences = setOf(
+                    SwitchPreference("morphe_hide_shorts_channel", summaryKey = null),
+                    SwitchPreference("morphe_hide_shorts_home", summaryKey = null),
+                    SwitchPreference("morphe_hide_shorts_search", summaryKey = null),
+                    SwitchPreference("morphe_hide_shorts_subscriptions", summaryKey = null),
+                    SwitchPreference("morphe_hide_shorts_video_description", summaryKey = null),
+                    SwitchPreference("morphe_hide_shorts_history", summaryKey = null),
+                )
+            ),
             SwitchPreference("morphe_disable_shorts_double_tap_to_like", summaryKey = null),
-
             PreferenceScreenPreference(
                 key = "morphe_shorts_player_screen",
                 sorting = PreferenceScreenPreference.Sorting.UNSORTED,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
@@ -71,7 +71,7 @@ private val hideShortsComponentsResourcePatch = resourcePatch {
 
         PreferenceScreen.SHORTS.addPreferences(
             PreferenceCategory(
-                titleKey = "morphe_preference_category_hide_shorts",
+                titleKey = "morphe_hide_shorts_category_title",
                 preferences = setOf(
                     SwitchPreference("morphe_hide_shorts_channel", summaryKey = null),
                     SwitchPreference("morphe_hide_shorts_home", summaryKey = null),

--- a/patches/src/main/resources/addresources/values/music/strings.xml
+++ b/patches/src/main/resources/addresources/values/music/strings.xml
@@ -121,7 +121,7 @@ Feature implementation by VazerOG"</string>
 
     <!-- layout.navigationbar.navigationBarPatch -->
     <string name="morphe_music_navigation_bar_screen_title">Navigation bar</string>
-    <string name="morphe_music_navigation_bar_screen_summary">Choose which buttons appear in the navigation bar</string>
+    <string name="morphe_music_navigation_bar_screen_summary">Choose which buttons appear in the bottom navigation bar</string>
     <!-- 'Home' should be translated using the same localized wording YouTube Music displays for the tab. -->
     <string name="morphe_music_hide_navigation_bar_home_button_title">Hide Home button</string>
     <!-- 'Samples' should be translated using the same localized wording YouTube Music displays for the tab. -->

--- a/patches/src/main/resources/addresources/values/music/strings.xml
+++ b/patches/src/main/resources/addresources/values/music/strings.xml
@@ -43,7 +43,7 @@ Second \"item\" text"</string>
 
     <!-- interaction.crossfade.crossfadePatch -->
     <string name="morphe_music_crossfade_screen_title">Crossfade</string>
-    <string name="morphe_music_crossfade_screen_summary">Customize how tracks smoothly blend into each other</string>
+    <string name="morphe_music_crossfade_screen_summary">Smoothly blend tracks into each other</string>
     <string name="morphe_music_crossfade_enabled_title">Enable crossfade</string>
     <string name="morphe_music_crossfade_curve_title">Fade curve</string>
     <string name="morphe_music_crossfade_curve_entry_equal_power">Equal power</string>

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -119,7 +119,7 @@ To sign in, press continue below"</string>
     <string name="morphe_sanitize_sharing_links_title">Sanitize sharing links</string>
     <string name="morphe_sanitize_sharing_links_summary">Removes tracking query parameters from shared links</string>
     <string name="morphe_replace_music_with_youtube_title">Change share links to youtube.com</string>
-    <string name="morphe_replace_music_with_youtube_summary">Changes music.youtube.com to youtube.com in shared links</string>
+    <string name="morphe_replace_music_with_youtube_summary">Replaces music.youtube.com to youtube.com in shared links</string>
     <string name="morphe_replace_links_with_shortener_title">Change share links to youtu.be</string>
     <string name="morphe_replace_links_with_shortener_summary">Forces live streams and Shorts to use the shortened youtu.be URL format</string>
 </resources>

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -119,6 +119,7 @@ To sign in, press continue below"</string>
     <string name="morphe_sanitize_sharing_links_title">Sanitize sharing links</string>
     <string name="morphe_sanitize_sharing_links_summary">Removes tracking query parameters from shared links</string>
     <string name="morphe_replace_music_with_youtube_title">Change share links to youtube.com</string>
+    <string name="morphe_replace_music_with_youtube_summary">Changes music.youtube.com to youtube.com in shared links</string>
     <string name="morphe_replace_links_with_shortener_title">Change share links to youtu.be</string>
     <string name="morphe_replace_links_with_shortener_summary">Forces live streams and Shorts to use the shortened youtu.be URL format</string>
 </resources>

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -43,7 +43,7 @@ Second \"item\" text"</string>
     <string name="morphe_spoof_video_streams_screen_title">Spoof video streams</string>
     <string name="morphe_spoof_video_streams_screen_summary">Configure client spoofing to prevent playback issues</string>
     <string name="morphe_spoof_video_streams_title">Spoof video streams</string>
-    <string name="morphe_spoof_video_streams_summary">"Tricks YouTube into sending a compatible video stream, which fixes playback for most users
+    <string name="morphe_spoof_video_streams_summary">"Fixes playback issues for most users by requesting a compatible video stream
 
 If you are a YouTube Premium user, this setting may not be required"</string>
     <string name="morphe_spoof_video_streams_no_clients_toast">Could not fetch any client streams</string>

--- a/patches/src/main/resources/addresources/values/shared/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared/strings.xml
@@ -146,7 +146,7 @@ If battery optimizations are not changed then you may experience:
 
     <!-- misc.gms.linkHandlingPatch -->
     <string name="morphe_link_handling_title">App link handling</string>
-    <string name="morphe_link_handling_summary">Configure which app opens links</string>
+    <string name="morphe_link_handling_summary">Configure links to open in this app</string>
     <string name="morphe_link_handling_step1_title">Step 1: Disable original app links</string>
     <string name="morphe_link_handling_step1_message">Open the original app\'s settings and disable all domain links</string>
     <string name="morphe_link_handling_step2_title">Step 2: Enable patched app links</string>

--- a/patches/src/main/resources/addresources/values/shared/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared/strings.xml
@@ -136,7 +136,7 @@ Disabling battery optimizations for MicroG will not negatively affect battery us
 
 Tap the continue button and allow optimization changes."</string>
     <string name="gms_core_dialog_continue_text">Continue</string>
-    <string name="morphe_gms_core_battery_optimization_dialog_title">Show battery optimization dialog</string>
+    <string name="morphe_gms_core_battery_optimization_dialog_title">Show MicroG battery optimization dialog</string>
     <string name="morphe_gms_core_battery_optimization_dialog_user_dialog_message">"Disabling this will hide the MicroG battery optimization prompt.
 
 If battery optimizations are not changed then you may experience:

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -61,7 +61,6 @@ Changes include:
 • Account switch button may not appear on the Library tab."</string>
 
     <!-- layout.hide.general.hideLayoutComponentsPatch -->
-    <string name="morphe_hide_creator_store_shelf_title">Hide creator store shelf</string>
     <string name="morphe_hide_feed_flyout_menu_title">Enable feed flyout menu filter</string>
     <string name="morphe_hide_feed_flyout_menu_filter_strings_title">Feed flyout menu filter</string>
     <string name="morphe_hide_feed_flyout_menu_filter_strings_summary">Enter the flyout menu names to filter by, separated by new lines</string>
@@ -268,6 +267,7 @@ Limitations:
     <string name="morphe_hide_keyword_toast_invalid_broad">Keyword will hide all videos: %s</string>
 
     <!-- ad.general.hideAdsPatch -->
+    <string name="morphe_hide_creator_store_shelf_title">Hide creator store shelf</string>
     <string name="morphe_hide_end_screen_store_banner_title">Hide end screen store banner</string>
     <string name="morphe_hide_general_ads_title">Hide general ads</string>
     <string name="morphe_hide_merchandise_banners_title">Hide merchandise banners</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -315,13 +315,13 @@ Limitations:
 
     <!-- interaction.downloads.downloadsPatch -->
     <string name="morphe_external_downloader_screen_title">External downloads</string>
-    <string name="morphe_external_downloader_screen_summary">Configure an external downloader app for downloading videos</string>
+    <string name="morphe_external_downloader_screen_summary">Download videos with third-party downloading apps</string>
     <string name="morphe_external_downloader_title">Show external download button</string>
-    <string name="morphe_external_downloader_summary">Shows a download button in video player that opens your external downloader</string>
+    <string name="morphe_external_downloader_summary">Shows an overlay button in video player that opens your external downloader</string>
     <!-- 'Download action button' should match the language used in 'morphe_hide_download_button_title'. -->
     <string name="morphe_external_downloader_action_button_title">Override Download action button</string>
     <string name="morphe_external_downloader_action_button_summary">Replaces YouTube\'s built-in download function with your external downloader</string>
-    <string name="morphe_external_downloader_name_title">External downloader package name</string>
+    <string name="morphe_external_downloader_name_title">Downloader package name</string>
     <string name="morphe_external_downloader_name_summary">Package name of your installed external downloader app</string>
     <string name="morphe_external_downloader_other_item_hint">Enter the package name</string>
     <string name="morphe_external_downloader_other_item">Other</string>
@@ -1202,7 +1202,7 @@ Tap here to learn more about DeArrow"</string>
 
     <!-- misc.dimensions.spoof.spoofDeviceDimensionsPatch -->
     <string name="morphe_spoof_device_dimensions_title">Spoof device dimensions</string>
-    <string name="morphe_spoof_device_dimensions_summary">May unlock higher video qualities</string>
+    <string name="morphe_spoof_device_dimensions_summary">Enabling this can unlock higher video qualities</string>
     <string name="morphe_spoof_device_dimensions_user_dialog_message">Enabling this can cause video playback stuttering, worse battery life, and unknown side effects.</string>
 
     <!-- misc.hapticfeedback.disableHapticFeedbackPatch -->

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -30,7 +30,7 @@ Second \"item\" text"</string>
     <string name="morphe_settings_screen_09_return_youtube_dislike_title" translatable="false">Return YouTube Dislike</string>
     <string name="morphe_settings_screen_11_misc_title">Miscellaneous</string>
     <string name="morphe_settings_screen_12_video_title">Video</string>
-    <string name="morphe_restore_old_settings_menus_title">Restore old settings menus</string>
+    <string name="morphe_restore_old_settings_menus_title">Restore old YouTube settings screen</string>
 
     <!-- misc.backgroundplayback.backgroundPlaybackPatch -->
     <string name="morphe_remove_background_playback_restrictions_title">Remove background play restrictions</string>
@@ -61,6 +61,7 @@ Changes include:
 • Account switch button may not appear on the Library tab."</string>
 
     <!-- layout.hide.general.hideLayoutComponentsPatch -->
+    <string name="morphe_hide_creator_store_shelf_title">Hide creator store shelf</string>
     <string name="morphe_hide_feed_flyout_menu_title">Enable feed flyout menu filter</string>
     <string name="morphe_hide_feed_flyout_menu_filter_strings_title">Feed flyout menu filter</string>
     <string name="morphe_hide_feed_flyout_menu_filter_strings_summary">Enter the flyout menu names to filter by, separated by new lines</string>
@@ -81,7 +82,7 @@ Changes include:
     <string name="morphe_hide_floating_microphone_button_title">Hide floating microphone button</string>
     <string name="morphe_hide_floating_microphone_button_summary">Hides floating microphone button in the lower-right corner of search suggestions screen</string>
     <string name="morphe_hide_horizontal_shelves_title">Hide horizontal shelves</string>
-    <string name="morphe_hide_horizontal_shelves_summary">Hides horizontal shelves such as Breaking news, Community posts you may like, Continue watching, Explore more channels, Explore more topics, For You, Latest videos, Most relevant, Posts from Creator\'s Community, Shopping and Watch it again</string>
+    <string name="morphe_hide_horizontal_shelves_summary">Hides horizontal shelves such as Breaking news, Community posts you may like, Continue watching, Explore more channels, Explore more topics, For You, Latest videos, Most relevant, Posts from Creator\'s Community, Shopping, and Watch it again</string>
     <string name="morphe_hide_hyped_label_title">Hide Hyped label</string>
     <string name="morphe_hide_image_shelf_title">Hide image shelf</string>
     <string name="morphe_hide_image_shelf_summary">Hides image shelves in search results</string>
@@ -94,7 +95,7 @@ Changes include:
     <!-- 'Notify me' should be translated using the same localized wording YouTube displays for the button.
           This button usually appears in the Subscriptions feed for future livestreams or unreleased videos. -->
     <string name="morphe_hide_notify_me_button_title">Hide \'Notify me\' button</string>
-    <string name="morphe_hide_notify_me_button_summary">Hides the reminder button for upcoming livestreams and premieres</string>
+    <string name="morphe_hide_notify_me_button_summary">Hides the reminder button for scheduled livestreams and premieres</string>
     <string name="morphe_hide_playables_title">Hide Playables</string>
     <string name="morphe_hide_playables_summary">Hides the feature that allows you to play games</string>
     <string name="morphe_hide_search_term_thumbnails_title">Hide search term thumbnails</string>
@@ -105,11 +106,13 @@ Changes include:
     <string name="morphe_hide_show_more_button_summary">Hides the expand button under videos in the search results</string>
     <string name="morphe_hide_subscribed_channels_bar_title">Hide subscribed channels bar</string>
     <string name="morphe_hide_surveys_title">Hide surveys</string>
+    <string name="morphe_hide_surveys_summary">Hides surveys such as \'Is the above video a good recommendation for you?\'</string>
     <string name="morphe_hide_ticket_shelf_title">Hide ticket shelf</string>
     <!-- 'People also watched' and 'You might also like' should be translated using the same localized wording YouTube displays for the label. -->
     <string name="morphe_hide_video_recommendation_labels_title">Hide video recommendation labels</string>
     <string name="morphe_hide_video_recommendation_labels_summary">Hides \'People also watched\' and \'You might also like\' labels in search results</string>
     <string name="morphe_hide_web_search_results_title">Hide web search results</string>
+    <string name="morphe_hide_web_search_results_summary">Hides \'Result from the web\' section from search results</string>
     <string name="morphe_hide_you_may_like_section_title">Hide \'You may like\' section</string>
     <!-- https://logos.fandom.com/wiki/YouTube/Yoodles -->
     <string name="morphe_hide_youtube_doodles_title">Hide YouTube Doodles</string>
@@ -242,7 +245,11 @@ Showing YouTube Doodles may prevent custom headers from displaying."</string>
     <string name="morphe_hide_keyword_content_phrases_title">Keywords to hide</string>
     <!-- For localization, it is preferred, but not required, if 'LeBlanc' is replaced with a localized name or a familiar word that has upper case letters in the middle of the word.
          This is because keywords can be in any language, and showing an example in the localized script helps convey this. -->
-    <string name="morphe_hide_keyword_content_phrases_summary">Enter keywords or channel names, separated by new lines. Words with uppercase letters in the middle must match exactly (ie: iPhone, TikTok, LeBlanc)</string>
+    <string name="morphe_hide_keyword_content_phrases_summary">"Enter keywords and phrases to hide, separated by new lines
+
+Keywords can be any text shown in video titles or channel names
+
+Words with uppercase letters in the middle must match exactly (ie: iPhone, TikTok, LeBlanc)"</string>
     <string name="morphe_hide_keyword_content_about_title">About keyword filtering</string>
     <string name="morphe_hide_keyword_content_about_summary">"Home / Subscriptions / Search results are filtered to hide content that matches keyword phrases
 
@@ -261,11 +268,11 @@ Limitations:
     <string name="morphe_hide_keyword_toast_invalid_broad">Keyword will hide all videos: %s</string>
 
     <!-- ad.general.hideAdsPatch -->
-    <string name="morphe_hide_creator_store_shelf_title">Hide creator store shelf</string>
     <string name="morphe_hide_end_screen_store_banner_title">Hide end screen store banner</string>
     <string name="morphe_hide_general_ads_title">Hide general ads</string>
     <string name="morphe_hide_merchandise_banners_title">Hide merchandise banners</string>
-    <string name="morphe_hide_paid_promotion_label_title">Hide paid promotion label</string>
+    <!-- 'Includes paid promotion' should be translated using the same localized wording YouTube displays for the label. -->
+    <string name="morphe_hide_paid_promotion_label_title">Hide \'Includes paid promotion\' label</string>
     <string name="morphe_hide_player_popup_ads_title">Hide player popup ads</string>
     <string name="morphe_hide_self_sponsor_ads_title">Hide self sponsored cards</string>
     <string name="morphe_hide_shopping_links_title">Hide shopping links</string>
@@ -335,8 +342,8 @@ Verify the package name is correct and the app is installed"</string>
 
     <!-- interaction.playall.playAllButtonPatch -->
     <string name="morphe_play_all_button_title">Show Play all button</string>
-    <string name="morphe_play_all_button_summary">"Tap to generate a playlist, tap and hold to undo
-
+    <string name="morphe_play_all_button_summary">"Tap to generate a playlist of all videos from channel
+Tap and hold to undo
 Info: May not work on live streams"</string>
     <string name="morphe_play_all_button_type_title">Generate playlist mode</string>
     <string name="morphe_play_all_button_type_entry_0">All contents (Sort by time, Ascending)</string>
@@ -365,12 +372,12 @@ Info: May not work on live streams"</string>
     <string name="morphe_save_to_watch_later_error_toast">Cannot save this video in watch later playlist</string>
 
     <!-- interaction.livering.openChannelOfLiveAvatarPatch -->
-    <string name="morphe_open_channel_of_live_avatar_title">Live avatar tap action</string>
-    <string name="morphe_open_channel_of_live_avatar_summary">Opens the channel page when enabled, or the live stream when disabled</string>
+    <string name="morphe_open_channel_of_live_avatar_title">Open channel of live avatar</string>
+    <string name="morphe_open_channel_of_live_avatar_summary">Prevents the live stream from opening when tapping the channel\'s avatar</string>
 
     <!-- interaction.seekbar.disablePreciseSeekingGesturePatch -->
     <string name="morphe_disable_precise_seeking_gesture_title">Disable precise seeking gesture</string>
-    <string name="morphe_disable_precise_seeking_gesture_summary">Disables the precise seeking mode that activates when holding a seek position</string>
+    <string name="morphe_disable_precise_seeking_gesture_summary">Disables the precise seeking mode that activates when pulling up the seekbar</string>
 
     <!-- interaction.seekbar.livestreamDvrPatch -->
     <string name="morphe_livestream_dvr_title">Enable livestream DVR</string>
@@ -380,6 +387,7 @@ Info: May not work on live streams"</string>
 
     <!-- interaction.seekbar.enableSlideToSeekPatch -->
     <string name="morphe_slide_to_seek_title">Enable slide to seek</string>
+    <string name="morphe_slide_to_seek_summary">Enables slide to seek instead of playing at 2x speed when pressing and holding the video player</string>
 
     <!-- interaction.seekbar.enableTapToSeekPatch -->
     <string name="morphe_tap_to_seek_title">Enable tap to seek</string>
@@ -412,7 +420,7 @@ Info: May not work on live streams"</string>
     <string name="morphe_swipe_threshold_title">Swipe magnitude threshold</string>
     <string name="morphe_swipe_threshold_summary">Set the required swipe distance before an adjustment triggers</string>
     <string name="morphe_swipe_volume_sensitivity_title">Volume swipe sensitivity</string>
-    <string name="morphe_swipe_volume_sensitivity_summary">Adjust how the volume changes during a swipe</string>
+    <string name="morphe_swipe_volume_sensitivity_summary">Adjust how much the volume changes per swipe</string>
     <string name="morphe_swipe_overlay_style_title">Swipe overlay style</string>
     <string name="morphe_swipe_overlay_style_entry_1">Horizontal overlay</string>
     <string name="morphe_swipe_overlay_style_entry_2">Horizontal overlay (minimal - top)</string>
@@ -491,12 +499,14 @@ Info: May not work on live streams"</string>
     <string name="morphe_auto_captions_style_legacy_entry_2">Hide auto captions</string>
 
     <!-- layout.captions.captionCookiesPatch -->
-    <string name="morphe_set_caption_cookies_title">Enable caption cookies</string>
-    <string name="morphe_set_caption_cookies_summary">Required for auto-translate captions to work correctly</string>
+    <string name="morphe_set_caption_cookies_title">Set caption cookies</string>
+    <string name="morphe_set_caption_cookies_summary">"Fixes a stock YouTube's bug where the auto-translate captions may not be available due to missing cookies
+
+\'Caption cookies\' must be provided"</string>
     <string name="morphe_caption_cookies_title">Caption cookies</string>
-    <string name="morphe_caption_cookies_summary">Cookies used to authenticate Timed Text API requests for captions</string>
+    <string name="morphe_caption_cookies_summary">Cookies to be set in Timed Text API (Caption Data API) requests</string>
     <string name="morphe_get_caption_cookies_title">Get caption cookies</string>
-    <string name="morphe_get_caption_cookies_summary">Fetches and saves cookies automatically if they are valid</string>
+    <string name="morphe_get_caption_cookies_summary">Click here to fetch cookies</string>
     <string name="morphe_get_caption_cookies_failed">Failed to fetch cookies</string>
     <string name="morphe_get_caption_cookies_duplicate">Cookies already exist</string>
     <string name="morphe_get_caption_cookies_success">Cookies were successfully updated</string>
@@ -523,8 +533,9 @@ Info: May not work on live streams"</string>
     <string name="morphe_show_settings_button_title">Show Settings button</string>
     <string name="morphe_show_settings_button_index_title">Settings button position</string>
     <string name="morphe_show_settings_button_type_title">Settings button action</string>
-    <string name="morphe_show_settings_button_type_summary">Opens Morphe settings when enabled, or YouTube settings when disabled</string>
-    <string name="morphe_swap_create_with_notifications_button_title">Swap Create with Notifications</string>
+    <string name="morphe_show_settings_button_type_summary">"OFF: Open YouTube settings
+ON: Open Morphe settings"</string>
+    <string name="morphe_swap_create_with_notifications_button_title">Swap Create button with Notifications button</string>
     <string name="morphe_swap_create_with_notifications_button_user_dialog_message">If changing this setting does not take effect, try switching to Incognito mode.</string>
     <string name="morphe_hide_navigation_button_labels_title">Hide navigation button labels</string>
     <string name="morphe_hide_navigation_bar_title">Hide navigation bar</string>
@@ -557,7 +568,8 @@ To access Settings, enable the Settings button via General → Toolbar → Show 
     <string name="morphe_show_toolbar_settings_button_title">Show Settings button</string>
     <string name="morphe_show_toolbar_settings_button_index_title">Settings button position</string>
     <string name="morphe_show_toolbar_settings_button_type_title">Settings button action</string>
-    <string name="morphe_show_toolbar_settings_button_type_summary">When enabled, tap opens Morphe settings and long press opens YouTube settings, disable to swap</string>
+    <string name="morphe_show_toolbar_settings_button_type_summary">"OFF: Tap opens YouTube settings and long press opens Morphe settings
+ON: Tap opens Morphe settings and long press opens YouTube settings"</string>
 
     <!-- layout.hide.player.flyoutmenupanel.hidePlayerFlyoutMenuPatch -->
     <string name="morphe_hide_player_flyout_title">Flyout menu</string>
@@ -638,9 +650,8 @@ To show the \'Audio Track\' menu, change \'Spoof video streams\' to \'Android Re
 
     <!-- layout.hide.seekbar.hideSeekbarPatch -->
     <string name="morphe_hide_seekbar_title">Hide video player seekbar</string>
-    <!-- Seekbar shown inside video thumbnails found on the Home / Subscriptions / Search / History.  The seekbar shows the prior watch progress from when the video was last opened. -->
     <string name="morphe_hide_seekbar_thumbnail_title">Hide video thumbnails seekbar</string>
-    <string name="morphe_hide_seekbar_thumbnail_summary">Hides the watch progress bar shown on video thumbnails in feeds and search results</string>
+    <string name="morphe_hide_seekbar_thumbnail_summary">Hides the watch progress bar shown on thumbnails of videos you have already watched</string>
     <string name="morphe_fullscreen_large_seekbar_title">Enable fullscreen large seekbar</string>
 
     <!-- layout.hide.shorts.hideShortsComponentsPatch -->
@@ -696,6 +707,7 @@ To show the \'Audio Track\' menu, change \'Spoof video streams\' to \'Android Re
 
     <!-- layout.hide.endscreensuggestedvideo.hideEndScreenSuggestedVideoPatch -->
     <string name="morphe_hide_end_screen_suggested_video_title">Hide end screen suggested video</string>
+    <string name="morphe_hide_end_screen_suggested_video_summary">Hides the suggested video overlay that appear after the video ends</string>
     <string name="morphe_hide_end_screen_suggested_video_user_dialog_message">"This setting only works if 'Autoplay next video' is turned off.
 
 You can change this in YouTube:
@@ -706,7 +718,7 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
 
     <!-- layout.hide.relatedvideooverlay.hideRelatedVideoOverlayPatch -->
     <string name="morphe_hide_player_related_videos_overlay_title">Hide related videos overlay</string>
-    <string name="morphe_hide_player_related_videos_overlay_summary">Hides recommended videos shown in the fullscreen mode</string>
+    <string name="morphe_hide_player_related_videos_overlay_summary">Hides \'More videos\' overlay shown when swiping up in the fullscreen mode</string>
 
     <!-- layout.hide.time.hideTimestampPatch -->
     <string name="morphe_hide_timestamp_title">Hide video timestamp</string>
@@ -816,7 +828,7 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
     <string name="morphe_sb_guidelines_preference_title">Submission guidelines</string>
     <string name="morphe_sb_guidelines_preference_summary">Guidelines contain rules and tips for creating new segments</string>
     <string name="morphe_sb_guidelines_popup_title">Follow the guidelines</string>
-    <string name="morphe_sb_guidelines_popup_content">View the rules and tips for creating new segments</string>
+    <string name="morphe_sb_guidelines_popup_content">Read the SponsorBlock guidelines before creating new segments</string>
     <string name="morphe_sb_guidelines_popup_already_read">Already read</string>
     <string name="morphe_sb_guidelines_popup_open">Show me</string>
     <string name="morphe_sb_general">General</string>
@@ -825,7 +837,7 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
     <string name="morphe_sb_general_skipcount">Enable skip count tracking</string>
     <string name="morphe_sb_general_skipcount_summary">Sends skip counts to the SponsorBlock leaderboard to track how much time is saved</string>
     <string name="morphe_sb_general_min_duration">Minimum segment duration</string>
-    <string name="morphe_sb_general_min_duration_summary">Set the minimum length required for a segment to be skipped, in seconds</string>
+    <string name="morphe_sb_general_min_duration_summary">Segments shorter than this value (in seconds) will not be shown or skipped</string>
     <string name="morphe_sb_general_min_duration_invalid">Invalid time duration</string>
     <string name="morphe_sb_general_uuid">Your private user ID</string>
     <string name="morphe_sb_general_uuid_summary">This should be kept private. This is like a password and should not be shared with anyone. If someone has this, they can impersonate you</string>
@@ -839,7 +851,7 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
     <string name="morphe_sb_settings_copy">Copy</string>
     <string name="morphe_sb_settings_ie_summary">Your SponsorBlock JSON configuration that can be imported / exported to Morphe and other SponsorBlock platforms</string>
     <string name="morphe_sb_settings_ie_summary_warning">"Your SponsorBlock JSON configuration that can be imported / exported to Morphe and other SponsorBlock platforms
-    
+
 This includes your private user ID. Be sure to share this wisely"</string>
     <string name="morphe_sb_settings_import_successful">Settings imported successfully</string>
     <string name="morphe_sb_settings_import_failed">Failed to import: %s</string>
@@ -1214,7 +1226,7 @@ Tap here to learn more about DeArrow"</string>
 
     <!-- misc.links.bypassURLRedirectsPatch -->
     <string name="morphe_bypass_url_redirects_title">Bypass URL redirects</string>
-    <string name="morphe_bypass_url_redirects_summary">Opens destination URLs directly, bypassing redirect tracking links</string>
+    <string name="morphe_bypass_url_redirects_summary">Opens the original URL directly, bypassing the tracking link (youtube.com/redirect)</string>
 
     <!-- misc.links.openLinksExternallyPatch -->
     <string name="morphe_external_browser_title">Open links in browser</string>
@@ -1226,7 +1238,7 @@ Tap here to learn more about DeArrow"</string>
     <string name="morphe_remember_video_quality_last_selected_title">Remember video quality</string>
     <string name="morphe_remember_video_quality_last_selected_summary">Applies your manual quality selection to all future videos</string>
     <string name="morphe_remember_video_quality_last_selected_toast_title">Quality change notifications</string>
-    <string name="morphe_remember_video_quality_last_selected_toast_summary">Shows a notification when the default video quality changes</string>
+    <string name="morphe_remember_video_quality_last_selected_toast_summary">Shows a notification when a new default quality is saved</string>
     <string name="morphe_video_quality_default_wifi_title">Default video quality on Wi-Fi network</string>
     <string name="morphe_video_quality_default_mobile_title">Default video quality on mobile network</string>
     <string name="morphe_remember_shorts_quality_last_selected_title">Remember Shorts quality</string>
@@ -1261,7 +1273,7 @@ Tap here to learn more about DeArrow"</string>
     <string name="morphe_remember_playback_speed_last_selected_title">Remember playback speed</string>
     <string name="morphe_remember_playback_speed_last_selected_summary">Applies your manual speed selection to all future videos</string>
     <string name="morphe_remember_playback_speed_last_selected_toast_title">Speed change notifications</string>
-    <string name="morphe_remember_playback_speed_last_selected_toast_summary">Shows a notification when the default playback speed changes</string>
+    <string name="morphe_remember_playback_speed_last_selected_toast_summary">Shows a notification when a new default playback speed is saved</string>
     <string name="morphe_playback_speed_default_title">Default playback speed</string>
     <string name="morphe_remember_playback_speed_toast">Changed default playback speed to: %s</string>
 

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1034,7 +1034,7 @@ If later turned off, it is recommended to clear the app data to prevent UI bugs.
     <string name="morphe_spoof_app_version_target_title">Spoof app version target</string>
     <string name="morphe_spoof_app_version_target_entry_20_39">20.39.41 - Restore old save to playlist</string>
     <string name="morphe_spoof_app_version_target_entry_20_28">20.28.41 - Disable bold icons</string>
-    <string name="morphe_spoof_app_version_target_entry_20_13">20.13.41 - Restore non collapsed video action bar</string>
+    <string name="morphe_spoof_app_version_target_entry_20_13">20.13.41 - Show channel name below video player</string>
 
     <!-- misc.sharesheet.openSystemShareSheetPatch -->
     <string name="morphe_open_system_share_sheet_title">Open system share sheet</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -311,7 +311,7 @@ Limitations:
 
     <!-- interaction.doubletap.disableDoubleTapActionsPatch -->
     <string name="morphe_disable_chapter_skip_double_tap_title">Disable double-tap chapter skip</string>
-    <string name="morphe_disable_chapter_skip_double_tap_summary">Disables the two-finger double-tap gesture that skips to the next or previous chapter, which can sometimes be accidentally triggered with a single finger</string>
+    <string name="morphe_disable_chapter_skip_double_tap_summary">Disables the two-finger double-tap gesture that skips chapters, which may be accidentally triggered with one finger</string>
 
     <!-- interaction.downloads.downloadsPatch -->
     <string name="morphe_external_downloader_screen_title">External downloads</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -658,6 +658,7 @@ To show the \'Audio Track\' menu, change \'Spoof video streams\' to \'Android Re
     <!-- layout.hide.shorts.hideShortsComponentsPatch -->
     <string name="morphe_shorts_player_screen_title">Shorts player</string>
     <string name="morphe_shorts_player_screen_summary">Choose which components appear in the Shorts player</string>
+    <string name="morphe_preference_category_hide_shorts">Hide Shorts</string>
     <string name="morphe_hide_shorts_channel_title">Hide in channel page</string>
     <!-- 'Home' should be translated using the same localized wording YouTube displays for the tab. -->
     <string name="morphe_hide_shorts_home_title">Hide in Home feed &amp; related videos</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -311,7 +311,7 @@ Limitations:
 
     <!-- interaction.doubletap.disableDoubleTapActionsPatch -->
     <string name="morphe_disable_chapter_skip_double_tap_title">Disable double-tap chapter skip</string>
-    <string name="morphe_disable_chapter_skip_double_tap_summary">Prevents double-tapping from accidentally skipping to the next or previous chapter</string>
+    <string name="morphe_disable_chapter_skip_double_tap_summary">Disables the two-finger double-tap gesture that skips to the next or previous chapter, which can sometimes be accidentally triggered with a single finger</string>
 
     <!-- interaction.downloads.downloadsPatch -->
     <string name="morphe_external_downloader_screen_title">External downloads</string>
@@ -1032,7 +1032,7 @@ If later turned off, it is recommended to clear the app data to prevent UI bugs.
     <string name="morphe_spoof_app_version_target_title">Spoof app version target</string>
     <string name="morphe_spoof_app_version_target_entry_20_39">20.39.41 - Restore old save to playlist</string>
     <string name="morphe_spoof_app_version_target_entry_20_28">20.28.41 - Disable bold icons</string>
-    <string name="morphe_spoof_app_version_target_entry_20_13">20.13.41 - Show channel name below video player</string>
+    <string name="morphe_spoof_app_version_target_entry_20_13">20.13.41 - Restore channel name below video player</string>
 
     <!-- misc.sharesheet.openSystemShareSheetPatch -->
     <string name="morphe_open_system_share_sheet_title">Open system share sheet</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -72,8 +72,8 @@ Changes include:
     <string name="morphe_hide_community_posts_title">Hide community posts</string>
     <string name="morphe_hide_compact_banner_title">Hide compact banners</string>
     <string name="morphe_hide_compact_banner_summary">Hides compact banners and spacing between some components</string>
-    <string name="morphe_hide_expandable_card_title">Expandable cards under videos</string>
-    <string name="morphe_hide_expandable_card_entry_1">Show all</string>
+    <string name="morphe_hide_expandable_card_title">Hide expandable cards under videos</string>
+    <string name="morphe_hide_expandable_card_entry_1">Disabled</string>
     <string name="morphe_hide_expandable_card_entry_2">Hide product card only</string>
     <string name="morphe_hide_expandable_card_entry_3">Hide summary card only</string>
     <string name="morphe_hide_expandable_card_entry_4">Hide product and summary cards</string>
@@ -220,7 +220,7 @@ Showing YouTube Doodles may prevent custom headers from displaying."</string>
     <string name="morphe_sanitize_comments_category_bar_title">Sanitize category bar</string>
     <string name="morphe_sanitize_comments_category_bar_summary">Hides all comment sorting options except \'Top\' and \'Newest\'</string>
     <string name="morphe_custom_filter_screen_title">Custom filter</string>
-    <string name="morphe_custom_filter_screen_summary">Choose which components to hide using custom filters</string>
+    <string name="morphe_custom_filter_screen_summary">Configure custom filters to hide any component</string>
     <string name="morphe_custom_filter_title">Enable custom filter</string>
     <string name="morphe_custom_filter_strings_title">Custom filter</string>
     <!-- 'Component path builder strings' is the technical name for identifying the Litho UI layout items to hide. This is an advanced feature and most users will never use this. -->
@@ -299,8 +299,8 @@ Limitations:
     <string name="morphe_share_copy_url_button_timestamp_success">URL with timestamp copied to clipboard</string>
     <string name="morphe_copy_video_url_button_title">Show Copy video URL button</string>
     <string name="morphe_copy_video_url_button_summary">Tap to copy the video URL, tap and hold to copy with timestamp</string>
-    <string name="morphe_copy_video_url_button_timestamp_title">Copy timestamp</string>
-    <string name="morphe_copy_video_url_button_timestamp_summary">When on, tap copies the URL with timestamp and hold copies without. When off, the behavior is reversed</string>
+    <string name="morphe_copy_video_url_button_timestamp_title">Copy timestamp by default</string>
+    <string name="morphe_copy_video_url_button_timestamp_summary">Reverses the tap and tap-and-hold actions of \'Copy video URL\' button</string>
 
     <!-- interaction.dialog.removeViewerDiscretionDialogPatch -->
     <string name="morphe_remove_viewer_discretion_dialog_title">Remove viewer discretion dialog</string>
@@ -315,14 +315,14 @@ Limitations:
 
     <!-- interaction.downloads.downloadsPatch -->
     <string name="morphe_external_downloader_screen_title">External downloads</string>
-    <string name="morphe_external_downloader_screen_summary">Choose which external app handles your downloads</string>
+    <string name="morphe_external_downloader_screen_summary">Configure an external downloader app for downloading videos</string>
     <string name="morphe_external_downloader_title">Show external download button</string>
-
+    <string name="morphe_external_downloader_summary">Shows a download button in video player that opens your external downloader</string>
     <!-- 'Download action button' should match the language used in 'morphe_hide_download_button_title'. -->
     <string name="morphe_external_downloader_action_button_title">Override Download action button</string>
-    <string name="morphe_external_downloader_action_button_summary">Replaces YouTube\'s built-in download function with your chosen third-party downloading app</string>
-    <string name="morphe_external_downloader_name_title">Downloader package name</string>
-    <string name="morphe_external_downloader_name_summary">Package name of your installed external downloader app</string>
+    <string name="morphe_external_downloader_action_button_summary">Replaces YouTube\'s built-in download function with your external downloader</string>
+    <string name="morphe_external_downloader_name_title">External downloader package name</string>
+    <string name="morphe_external_downloader_name_summary">Package name of your installed third-party downloading app</string>
     <string name="morphe_external_downloader_other_item_hint">Enter the package name</string>
     <string name="morphe_external_downloader_other_item">Other</string>
     <string name="morphe_external_downloader_not_found_title">App not installed</string>
@@ -391,6 +391,7 @@ Info: May not work on live streams"</string>
 
     <!-- interaction.seekbar.enableTapToSeekPatch -->
     <string name="morphe_tap_to_seek_title">Enable tap to seek</string>
+    <string name="morphe_tap_to_seek_summary">Just tap the seekbar to jump to that position without dragging it</string>
 
     <!-- interaction.swipecontrols.swipeControlsPatch -->
     <string name="morphe_swipe_brightness_title">Enable brightness gesture</string>
@@ -822,8 +823,8 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
     <string name="morphe_sb_create_segment_category">Creating new segments</string>
     <string name="morphe_sb_enable_create_segment">Show \'Create new segment\' button</string>
     <string name="morphe_sb_enable_create_segment_summary">Adds a button to the video player allowing you to submit new SponsorBlock segments</string>
-    <string name="morphe_sb_general_adjusting">Adjust new segment step</string>
-    <string name="morphe_sb_general_adjusting_summary">Set the number of milliseconds for the time adjustment buttons when creating new segments</string>
+    <string name="morphe_sb_general_adjusting">Time adjustment buttons step</string>
+    <string name="morphe_sb_general_adjusting_summary">Number of milliseconds the time adjustment buttons move</string>
     <string name="morphe_sb_general_adjusting_invalid">Value must be a positive number</string>
     <string name="morphe_sb_guidelines_preference_title">Submission guidelines</string>
     <string name="morphe_sb_guidelines_preference_summary">Guidelines contain rules and tips for creating new segments</string>
@@ -1201,7 +1202,7 @@ Tap here to learn more about DeArrow"</string>
 
     <!-- misc.dimensions.spoof.spoofDeviceDimensionsPatch -->
     <string name="morphe_spoof_device_dimensions_title">Spoof device dimensions</string>
-    <string name="morphe_spoof_device_dimensions_summary">Tricks the server into providing higher quality options by spoofing device dimensions</string>
+    <string name="morphe_spoof_device_dimensions_summary">May unlock higher video qualities</string>
     <string name="morphe_spoof_device_dimensions_user_dialog_message">Enabling this can cause video playback stuttering, worse battery life, and unknown side effects.</string>
 
     <!-- misc.hapticfeedback.disableHapticFeedbackPatch -->
@@ -1230,7 +1231,7 @@ Tap here to learn more about DeArrow"</string>
 
     <!-- misc.links.openLinksExternallyPatch -->
     <string name="morphe_external_browser_title">Open links in browser</string>
-    <string name="morphe_external_browser_summary">Opens links in your browser instead of the in-app browser</string>
+    <string name="morphe_external_browser_summary">Disables the in-app browser (Custom Tabs)</string>
 
     <!-- video.quality.rememberVideoQualityPatch -->
     <!-- Translations should match the language used in 'morphe_custom_playback_speeds_auto'. -->

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -322,7 +322,7 @@ Limitations:
     <string name="morphe_external_downloader_action_button_title">Override Download action button</string>
     <string name="morphe_external_downloader_action_button_summary">Replaces YouTube\'s built-in download function with your external downloader</string>
     <string name="morphe_external_downloader_name_title">External downloader package name</string>
-    <string name="morphe_external_downloader_name_summary">Package name of your installed third-party downloading app</string>
+    <string name="morphe_external_downloader_name_summary">Package name of your installed external downloader app</string>
     <string name="morphe_external_downloader_other_item_hint">Enter the package name</string>
     <string name="morphe_external_downloader_other_item">Other</string>
     <string name="morphe_external_downloader_not_found_title">App not installed</string>
@@ -342,8 +342,8 @@ Verify the package name is correct and the app is installed"</string>
 
     <!-- interaction.playall.playAllButtonPatch -->
     <string name="morphe_play_all_button_title">Show Play all button</string>
-    <string name="morphe_play_all_button_summary">"Tap to generate a playlist of all videos from channel
-Tap and hold to undo
+    <string name="morphe_play_all_button_summary">"Tap to generate a playlist of all videos from channel, tap and hold to undo
+
 Info: May not work on live streams"</string>
     <string name="morphe_play_all_button_type_title">Generate playlist mode</string>
     <string name="morphe_play_all_button_type_entry_0">All contents (Sort by time, Ascending)</string>
@@ -372,7 +372,7 @@ Info: May not work on live streams"</string>
     <string name="morphe_save_to_watch_later_error_toast">Cannot save this video in watch later playlist</string>
 
     <!-- interaction.livering.openChannelOfLiveAvatarPatch -->
-    <string name="morphe_open_channel_of_live_avatar_title">Open channel of live avatar</string>
+    <string name="morphe_open_channel_of_live_avatar_title">Open channel from live avatar</string>
     <string name="morphe_open_channel_of_live_avatar_summary">Prevents the live stream from opening when tapping the channel\'s avatar</string>
 
     <!-- interaction.seekbar.disablePreciseSeekingGesturePatch -->
@@ -733,7 +733,7 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
     <string name="morphe_exit_fullscreen_entry_1">Disabled</string>
     <string name="morphe_exit_fullscreen_entry_2">Portrait only</string>
     <string name="morphe_exit_fullscreen_entry_3">Landscape only</string>
-    <string name="morphe_exit_fullscreen_entry_4">Both</string>
+    <string name="morphe_exit_fullscreen_entry_4">Portrait and landscape</string>
 
     <!-- layout.player.fullscreen.openVideosFullscreen -->
     <string name="morphe_open_videos_fullscreen_portrait_title">Open videos in fullscreen portrait</string>
@@ -1231,7 +1231,7 @@ Tap here to learn more about DeArrow"</string>
 
     <!-- misc.links.openLinksExternallyPatch -->
     <string name="morphe_external_browser_title">Open links in browser</string>
-    <string name="morphe_external_browser_summary">Disables the in-app browser (Custom Tabs)</string>
+    <string name="morphe_external_browser_summary">Opens links in external browser instead of the in-app browser</string>
 
     <!-- video.quality.rememberVideoQualityPatch -->
     <!-- Translations should match the language used in 'morphe_custom_playback_speeds_auto'. -->

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -72,8 +72,8 @@ Changes include:
     <string name="morphe_hide_community_posts_title">Hide community posts</string>
     <string name="morphe_hide_compact_banner_title">Hide compact banners</string>
     <string name="morphe_hide_compact_banner_summary">Hides compact banners and spacing between some components</string>
-    <string name="morphe_hide_expandable_card_title">Hide expandable cards under videos</string>
-    <string name="morphe_hide_expandable_card_entry_1">Disabled</string>
+    <string name="morphe_hide_expandable_card_title">Expandable cards under videos</string>
+    <string name="morphe_hide_expandable_card_entry_1">Show all</string>
     <string name="morphe_hide_expandable_card_entry_2">Hide product card only</string>
     <string name="morphe_hide_expandable_card_entry_3">Hide summary card only</string>
     <string name="morphe_hide_expandable_card_entry_4">Hide product and summary cards</string>
@@ -105,7 +105,7 @@ Changes include:
     <string name="morphe_hide_show_more_button_summary">Hides the expand button under videos in the search results</string>
     <string name="morphe_hide_subscribed_channels_bar_title">Hide subscribed channels bar</string>
     <string name="morphe_hide_surveys_title">Hide surveys</string>
-    <string name="morphe_hide_surveys_summary">Hides surveys such as \'Is the above video a good recommendation for you?\'</string>
+    <string name="morphe_hide_surveys_summary">Hide surveys and nudges about feed recommendation accuracy</string>
     <string name="morphe_hide_ticket_shelf_title">Hide ticket shelf</string>
     <!-- 'People also watched' and 'You might also like' should be translated using the same localized wording YouTube displays for the label. -->
     <string name="morphe_hide_video_recommendation_labels_title">Hide video recommendation labels</string>
@@ -534,8 +534,7 @@ Info: May not work on live streams"</string>
     <string name="morphe_show_settings_button_title">Show Settings button</string>
     <string name="morphe_show_settings_button_index_title">Settings button position</string>
     <string name="morphe_show_settings_button_type_title">Settings button action</string>
-    <string name="morphe_show_settings_button_type_summary">"OFF: Open YouTube settings
-ON: Open Morphe settings"</string>
+    <string name="morphe_show_settings_button_type_summary">Opens Morphe settings when enabled, or YouTube settings when disabled</string>
     <string name="morphe_swap_create_with_notifications_button_title">Swap Create button with Notifications button</string>
     <string name="morphe_swap_create_with_notifications_button_user_dialog_message">If changing this setting does not take effect, try switching to Incognito mode.</string>
     <string name="morphe_hide_navigation_button_labels_title">Hide navigation button labels</string>
@@ -569,8 +568,7 @@ To access Settings, enable the Settings button via General → Toolbar → Show 
     <string name="morphe_show_toolbar_settings_button_title">Show Settings button</string>
     <string name="morphe_show_toolbar_settings_button_index_title">Settings button position</string>
     <string name="morphe_show_toolbar_settings_button_type_title">Settings button action</string>
-    <string name="morphe_show_toolbar_settings_button_type_summary">"OFF: Tap opens YouTube settings and long press opens Morphe settings
-ON: Tap opens Morphe settings and long press opens YouTube settings"</string>
+    <string name="morphe_show_toolbar_settings_button_type_summary">When enabled, tap opens Morphe settings and long press opens YouTube settings, disable to swap</string>
 
     <!-- layout.hide.player.flyoutmenupanel.hidePlayerFlyoutMenuPatch -->
     <string name="morphe_hide_player_flyout_title">Flyout menu</string>
@@ -658,7 +656,7 @@ To show the \'Audio Track\' menu, change \'Spoof video streams\' to \'Android Re
     <!-- layout.hide.shorts.hideShortsComponentsPatch -->
     <string name="morphe_shorts_player_screen_title">Shorts player</string>
     <string name="morphe_shorts_player_screen_summary">Choose which components appear in the Shorts player</string>
-    <string name="morphe_preference_category_hide_shorts">Hide Shorts</string>
+    <string name="morphe_hide_shorts_category_title">Hide Shorts</string>
     <string name="morphe_hide_shorts_channel_title">Hide in channel page</string>
     <!-- 'Home' should be translated using the same localized wording YouTube displays for the tab. -->
     <string name="morphe_hide_shorts_home_title">Hide in Home feed &amp; related videos</string>
@@ -824,8 +822,8 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
     <string name="morphe_sb_create_segment_category">Creating new segments</string>
     <string name="morphe_sb_enable_create_segment">Show \'Create new segment\' button</string>
     <string name="morphe_sb_enable_create_segment_summary">Adds a button to the video player allowing you to submit new SponsorBlock segments</string>
-    <string name="morphe_sb_general_adjusting">Time adjustment buttons step</string>
-    <string name="morphe_sb_general_adjusting_summary">Number of milliseconds the time adjustment buttons move</string>
+    <string name="morphe_sb_general_adjusting">Time adjustment step</string>
+    <string name="morphe_sb_general_adjusting_summary">Seek amount of the time adjustment buttons (in milliseconds)</string>
     <string name="morphe_sb_general_adjusting_invalid">Value must be a positive number</string>
     <string name="morphe_sb_guidelines_preference_title">Submission guidelines</string>
     <string name="morphe_sb_guidelines_preference_summary">Guidelines contain rules and tips for creating new segments</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -719,7 +719,7 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
     <string name="morphe_hide_player_related_videos_title">Hide related videos</string>
 
     <!-- layout.hide.relatedvideooverlay.hideRelatedVideoOverlayPatch -->
-    <string name="morphe_hide_player_related_videos_overlay_title">Hide related videos overlay</string>
+    <string name="morphe_hide_player_related_videos_overlay_title">Hide \'More videos\' overlay</string>
     <string name="morphe_hide_player_related_videos_overlay_summary">Hides \'More videos\' overlay shown when swiping up in the fullscreen mode</string>
 
     <!-- layout.hide.time.hideTimestampPatch -->
@@ -1232,7 +1232,7 @@ Tap here to learn more about DeArrow"</string>
 
     <!-- misc.links.openLinksExternallyPatch -->
     <string name="morphe_external_browser_title">Open links in browser</string>
-    <string name="morphe_external_browser_summary">Opens links in external browser instead of the in-app browser</string>
+    <string name="morphe_external_browser_summary">Opens links in an external browser instead of the in-app browser</string>
 
     <!-- video.quality.rememberVideoQualityPatch -->
     <!-- Translations should match the language used in 'morphe_custom_playback_speeds_auto'. -->


### PR DESCRIPTION
@krvstek

Additional follow-up string improvements to #1366.

These are all just suggestions. Please feel free to share your opinions.

Notable changes:

- `morphe_hide_creator_store_shelf_title`: Moved to the correct patch section
- `morphe_restore_old_settings_menus_title`: Because it was unclear whether this was a Morphe setting or a YouTube setting, I have clarified that it is YouTube. I have also emphasized that it restores the old "screen." I think the word "menu" can be confused with any menus such as old quality setting menu.
- `morphe_hide_surveys_summary`: Added a example of surveys. This is needed because in my language, "survey" was being confused with polls in a community post by a creator.
- `morphe_show_settings_button_type_summary` and `morphe_show_toolbar_settings_button_type_summary`: I used a new expression here. The meanings of ON and OFF are now listed separately.
- `morphe_sb_guidelines_popup_content`: This is reverted to the previous string. Since reading the guidelines is an obligation for everyone submitting a segment, I felt that "Read" sounds stronger and is more appropriate than "View."
- `morphe_sb_general_min_duration_summary`: The information that the segment was not being shown was lost, so I reverted to the previous string.

I'm creating this pull request as a draft because I might add more changes later.