### PR TITLE
feat(Custom branding): Add icon previews to branding selectors and new play black icon

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/CustomBrandingPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/CustomBrandingPatch.java
@@ -28,6 +28,7 @@ import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.SharedYouTubeSettings;
+import app.morphe.extension.shared.settings.preference.IconListPreference;
 
 /**
  * Patch shared by YouTube and YT Music.
@@ -209,6 +210,17 @@ public class CustomBrandingPatch {
     /**
      * Injection point.
      * <p>
+     * The mipmap resource name of the original unpatched launcher icon.
+     * Differs per app: YouTube uses "ic_launcher", YT Music uses "ic_launcher_release".
+     */
+    private static String originalLauncherIconName() {
+        // Modified during patching.
+        return "";
+    }
+
+    /**
+     * Injection point.
+     * <p>
      * If a custom name was provided during patching.
      */
     private static boolean userProvidedCustomName() {
@@ -281,6 +293,8 @@ public class CustomBrandingPatch {
                 componentToEnable = defaultComponent;
                 componentsToDisable.remove(defaultComponent);
             }
+
+            IconListPreference.setOriginalLauncherIconName(originalLauncherIconName());
 
             // Reset cached notification icon so it is re-resolved with the current theme
             // on the next notification. This handles the case where setBranding() is called

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/CustomBrandingPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/CustomBrandingPatch.java
@@ -221,6 +221,18 @@ public class CustomBrandingPatch {
     /**
      * Injection point.
      * <p>
+     * The drawable resource name of the original notification icon.
+     * Differs per app: YouTube uses "ic_stat_yt_notification_logo",
+     * YT Music uses "music_push_notification_white".
+     */
+    private static String originalNotificationIconName() {
+        // Modified during patching.
+        return "";
+    }
+
+    /**
+     * Injection point.
+     * <p>
      * If a custom name was provided during patching.
      */
     private static boolean userProvidedCustomName() {
@@ -295,6 +307,7 @@ public class CustomBrandingPatch {
             }
 
             IconListPreference.setOriginalLauncherIconName(originalLauncherIconName());
+            IconListPreference.setOriginalNotificationIconName(originalNotificationIconName());
 
             // Reset cached notification icon so it is re-resolved with the current theme
             // on the next notification. This handles the case where setBranding() is called

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/CustomBrandingPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/CustomBrandingPatch.java
@@ -51,6 +51,7 @@ public class CustomBrandingPatch {
         DARK,
         BLACK,
         PLAY,
+        PLAY_BLACK,
         /**  User provided custom icon. */
         CUSTOM;
 
@@ -93,6 +94,7 @@ public class CustomBrandingPatch {
         DARK,
         BLACK,
         PLAY,
+        PLAY_BLACK,
         /** * User provided custom PNG notification icon. */
         CUSTOM;
 

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/CustomDialogListPreference.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/CustomDialogListPreference.java
@@ -92,7 +92,7 @@ public class CustomDialogListPreference extends ListPreference {
      * Returns entries for display in the dialog.
      * If highlighted entries exist, they are used; otherwise, the original entries are returned.
      */
-    private CharSequence[] getEntriesForDialog() {
+    protected CharSequence[] getEntriesForDialog() {
         return highlightedEntriesForDialog != null ? highlightedEntriesForDialog : getEntries();
     }
 

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/IconListPreference.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/IconListPreference.java
@@ -60,8 +60,8 @@ public class IconListPreference extends CustomDialogListPreference {
     public static final int ID_MORPHE_ITEM_ICON = getIdentifierOrThrow(
             ResourceType.ID, "morphe_item_icon");
 
-    private static final float ICON_SIZE_DP = 48f;
-    private static final float ICON_CORNER_RADIUS_FRACTION = 0.22f;
+    static final float ICON_SIZE_DP = 48f;
+    static final float ICON_CORNER_RADIUS_FRACTION = 0.22f;
 
     @Nullable
     private Drawable[] iconDrawables;
@@ -146,14 +146,14 @@ public class IconListPreference extends CustomDialogListPreference {
         }
     }
 
-    private static int resolveResId(String name) {
+    static int resolveResId(String name) {
         int resId = ResourceUtils.getIdentifier(ResourceType.DRAWABLE, name);
         if (resId == 0) resId = ResourceUtils.getIdentifier(ResourceType.MIPMAP, name);
         return resId;
     }
 
     @NonNull
-    private static Drawable renderToRounded(
+    static Drawable renderToRounded(
             Resources res, Drawable source, int sizePx, float cornerRadius, boolean isAdaptive) {
         Bitmap bmp = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(bmp);

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/IconListPreference.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/IconListPreference.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.settings.preference;
+
+import static app.morphe.extension.shared.ResourceUtils.getIdentifierOrThrow;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.Canvas;
+import android.graphics.Path;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.LayerDrawable;
+import android.os.Bundle;
+import android.util.AttributeSet;
+import android.util.DisplayMetrics;
+import android.util.Pair;
+import android.util.TypedValue;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Locale;
+import java.util.Objects;
+
+import app.morphe.extension.shared.ResourceType;
+import app.morphe.extension.shared.ResourceUtils;
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.ui.CustomDialog;
+
+/**
+ * A {@link CustomDialogListPreference} that shows a full adaptive-icon preview
+ * (background + foreground, rounded) next to each list entry.
+ * <p>
+ * Icons are resolved by convention:
+ * {@code morphe_adaptive_background_{value}} and {@code morphe_adaptive_foreground_{value}}
+ * are layered and rendered to a rounded bitmap. Entries with no matching resources
+ * fall back to the app's launcher icon.
+ */
+@SuppressWarnings({"unused", "deprecation"})
+public class IconListPreference extends CustomDialogListPreference {
+
+    public static final int LAYOUT_MORPHE_ICON_LIST_ITEM = getIdentifierOrThrow(
+            ResourceType.LAYOUT, "morphe_icon_list_item");
+    public static final int ID_MORPHE_ITEM_ICON = getIdentifierOrThrow(
+            ResourceType.ID, "morphe_item_icon");
+
+    private static final float ICON_SIZE_DP = 48f;
+    private static final float ICON_CORNER_RADIUS_FRACTION = 0.22f;
+
+    @Nullable
+    private Drawable[] iconDrawables;
+
+    public IconListPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    public IconListPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public IconListPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public IconListPreference(Context context) {
+        super(context);
+    }
+
+    /**
+     * Overrides the automatically resolved drawables.
+     * Must be the same length as {@link #getEntryValues()}.
+     * Pass {@code null} to revert to convention-based resolution.
+     */
+    public void setIconDrawables(@Nullable Drawable[] drawables) {
+        this.iconDrawables = drawables;
+    }
+
+    /**
+     * Builds a rounded icon drawable for each entry by combining
+     * {@code morphe_adaptive_background_{value}} and {@code morphe_adaptive_foreground_{value}}.
+     * Falls back to the app's launcher icon for unrecognized entries (e.g. ORIGINAL).
+     */
+    @NonNull
+    protected Drawable[] resolveIconDrawables() {
+        CharSequence[] values = getEntryValues();
+        if (values == null) return new Drawable[0];
+
+        Context context = getContext();
+        DisplayMetrics dm = context.getResources().getDisplayMetrics();
+        int sizePx = Math.round(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, ICON_SIZE_DP, dm));
+        float cornerRadius = sizePx * ICON_CORNER_RADIUS_FRACTION;
+
+        Drawable[] drawables = new Drawable[values.length];
+        for (int i = 0; i < values.length; i++) {
+            String suffix = values[i].toString().toLowerCase(Locale.US);
+            drawables[i] = buildIconDrawable(context, suffix, sizePx, cornerRadius);
+        }
+        return drawables;
+    }
+
+    /**
+     * Combines background + foreground for a given style suffix into a single
+     * rounded-corner drawable rendered at {@code sizePx}.
+     */
+    @Nullable
+    private static Drawable buildIconDrawable(
+            Context context, String suffix, int sizePx, float cornerRadius) {
+        try {
+            int bgResId = resolveResId("morphe_adaptive_background_" + suffix);
+            int fgResId = resolveResId("morphe_adaptive_foreground_" + suffix);
+
+            Drawable bg = bgResId != 0 ? context.getDrawable(bgResId) : null;
+            Drawable fg = fgResId != 0 ? context.getDrawable(fgResId) : null;
+
+            // Morphe assets are adaptive icon layers (108dp canvas, 72dp safe zone).
+            boolean isAdaptive = (bg != null || fg != null);
+            Drawable source;
+            if (bg != null && fg != null) {
+                source = new LayerDrawable(new Drawable[]{bg, fg});
+            } else {
+                // No morphe assets (e.g. ORIGINAL) — use the app's current launcher icon.
+                source = Objects.requireNonNullElseGet(fg,
+                        () -> Objects.requireNonNullElseGet(bg,
+                                () -> context.getPackageManager().getApplicationIcon(context.getApplicationInfo())));
+            }
+
+            return renderToRounded(context.getResources(), source, sizePx, cornerRadius, isAdaptive);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static int resolveResId(String name) {
+        int resId = ResourceUtils.getIdentifier(ResourceType.DRAWABLE, name);
+        if (resId == 0) resId = ResourceUtils.getIdentifier(ResourceType.MIPMAP, name);
+        return resId;
+    }
+
+    @NonNull
+    private static Drawable renderToRounded(
+            Resources res, Drawable source, int sizePx, float cornerRadius, boolean isAdaptive) {
+        Bitmap bmp = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bmp);
+        Path clip = new Path();
+        clip.addRoundRect(0, 0, sizePx, sizePx, cornerRadius, cornerRadius, Path.Direction.CW);
+        canvas.clipPath(clip);
+        if (isAdaptive) {
+            // Adaptive icon layers use a 108dp canvas with a 72dp safe zone.
+            // Scale so the safe-zone content fills the full bitmap.
+            int scaledSize = Math.round(sizePx * (108f / 72f));
+            int offset = (scaledSize - sizePx) / 2;
+            source.setBounds(-offset, -offset, sizePx + offset, sizePx + offset);
+        } else {
+            source.setBounds(0, 0, sizePx, sizePx);
+        }
+        source.draw(canvas);
+        return new BitmapDrawable(res, bmp);
+    }
+
+    @Override
+    protected void showDialog(Bundle state) {
+        if (iconDrawables == null) {
+            iconDrawables = resolveIconDrawables();
+        }
+
+        // Fall back to parent if no drawables could be resolved.
+        boolean hasAnyIcon = false;
+        for (Drawable d : iconDrawables) {
+            if (d != null) { hasAnyIcon = true; break; }
+        }
+        if (!hasAnyIcon) {
+            super.showDialog(state);
+            return;
+        }
+
+        Context context = getContext();
+        CharSequence[] entriesToShow = getEntriesForDialog();
+        CharSequence[] entryValues = getEntryValues();
+
+        ListView listView = new ListView(context);
+        listView.setId(android.R.id.list);
+        listView.setChoiceMode(ListView.CHOICE_MODE_SINGLE);
+
+        IconListPreferenceAdapter adapter = new IconListPreferenceAdapter(
+                context,
+                LAYOUT_MORPHE_ICON_LIST_ITEM,
+                entriesToShow,
+                entryValues,
+                getValue(),
+                iconDrawables
+        );
+        listView.setAdapter(adapter);
+
+        String currentValue = getValue();
+        if (currentValue != null) {
+            for (int i = 0, length = entryValues.length; i < length; i++) {
+                if (currentValue.equals(entryValues[i].toString())) {
+                    listView.setItemChecked(i, true);
+                    listView.setSelection(i);
+                    break;
+                }
+            }
+        }
+
+        Pair<Dialog, LinearLayout> dialogPair = CustomDialog.create(
+                context,
+                getTitle() != null ? getTitle().toString() : "",
+                null, null, null, null,
+                this::clearHighlightedEntriesForDialog,
+                null, null,
+                true
+        );
+
+        Dialog dialog = dialogPair.first;
+        dialog.setOnDismissListener(d -> clearHighlightedEntriesForDialog());
+
+        LinearLayout mainLayout = dialogPair.second;
+        mainLayout.addView(listView, mainLayout.getChildCount() - 1, new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT, 0, 1.0f));
+
+        listView.setOnItemClickListener((parent, view, position, id) -> {
+            String selected = entryValues[position].toString();
+            if (callChangeListener(selected)) {
+                setValue(selected);
+                if (getStaticSummary() == null) {
+                    CharSequence[] originalEntries = getEntries();
+                    if (originalEntries != null && position < originalEntries.length) {
+                        setSummary(originalEntries[position]);
+                    }
+                }
+                adapter.setSelectedValue(selected);
+                adapter.notifyDataSetChanged();
+            }
+            clearHighlightedEntriesForDialog();
+            dialog.dismiss();
+        });
+
+        dialog.show();
+    }
+
+    /**
+     * Adapter that renders each list row with a checkmark, an adaptive icon preview,
+     * and a text label.
+     */
+    public static class IconListPreferenceAdapter extends ArrayAdapter<CharSequence> {
+
+        private static class ViewHolder {
+            ImageView checkIcon;
+            View placeholder;
+            ImageView itemIcon;
+            TextView itemText;
+        }
+
+        private final int layoutResourceId;
+        private final CharSequence[] entryValues;
+        private final Drawable[] iconDrawables;
+        private String selectedValue;
+
+        public IconListPreferenceAdapter(
+                Context context,
+                int resource,
+                CharSequence[] entries,
+                CharSequence[] entryValues,
+                String selectedValue,
+                Drawable[] iconDrawables) {
+            super(context, resource, entries);
+            this.layoutResourceId = resource;
+            this.entryValues = entryValues;
+            this.selectedValue = selectedValue;
+            this.iconDrawables = iconDrawables;
+        }
+
+        @NonNull
+        @Override
+        public View getView(int position, View convertView, @NonNull ViewGroup parent) {
+            View view = convertView;
+            ViewHolder holder;
+
+            if (view == null) {
+                view = LayoutInflater.from(getContext()).inflate(layoutResourceId, parent, false);
+                holder = new ViewHolder();
+                holder.placeholder = view.findViewById(CustomDialogListPreference.ID_MORPHE_CHECK_ICON_PLACEHOLDER);
+                holder.itemText = view.findViewById(CustomDialogListPreference.ID_MORPHE_ITEM_TEXT);
+                holder.checkIcon = view.findViewById(CustomDialogListPreference.ID_MORPHE_CHECK_ICON);
+                holder.checkIcon.setImageResource(Utils.appIsUsingBoldIcons()
+                        ? CustomDialogListPreference.DRAWABLE_CHECKMARK_BOLD
+                        : CustomDialogListPreference.DRAWABLE_CHECKMARK);
+                holder.itemIcon = view.findViewById(ID_MORPHE_ITEM_ICON);
+                view.setTag(holder);
+            } else {
+                holder = (ViewHolder) view.getTag();
+            }
+
+            holder.itemText.setText(getItem(position));
+            holder.itemText.setTextColor(Utils.getAppForegroundColor());
+
+            boolean isSelected = entryValues[position].toString().equals(selectedValue);
+            holder.checkIcon.setVisibility(isSelected ? View.VISIBLE : View.GONE);
+            holder.checkIcon.setColorFilter(Utils.getAppForegroundColor());
+            holder.placeholder.setVisibility(isSelected ? View.GONE : View.VISIBLE);
+
+            if (holder.itemIcon != null) {
+                Drawable icon = (iconDrawables != null && position < iconDrawables.length)
+                        ? iconDrawables[position] : null;
+                if (icon != null) {
+                    holder.itemIcon.setImageDrawable(icon);
+                    holder.itemIcon.setVisibility(View.VISIBLE);
+                } else {
+                    holder.itemIcon.setVisibility(View.INVISIBLE);
+                }
+            }
+
+            return view;
+        }
+
+        public void setSelectedValue(String value) {
+            this.selectedValue = value;
+        }
+    }
+}

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/IconListPreference.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/IconListPreference.java
@@ -64,6 +64,31 @@ public class IconListPreference extends CustomDialogListPreference {
     static final float ICON_CORNER_RADIUS_FRACTION = 0.22f;
 
     @Nullable
+    private static String originalLauncherIconName;
+
+    /** Called from CustomBrandingPatch.setBranding() at app startup. */
+    public static void setOriginalLauncherIconName(@Nullable String name) {
+        originalLauncherIconName = name;
+    }
+
+    /**
+     * Resolves the original unpatched launcher icon drawable.
+     * Uses the resource name injected at patch time; falls back to the current app icon.
+     */
+    static Drawable resolveOriginalIconDrawable(Context context) {
+        try {
+            if (originalLauncherIconName != null && !originalLauncherIconName.isEmpty()) {
+                int resId = ResourceUtils.getIdentifier(ResourceType.MIPMAP, originalLauncherIconName);
+                if (resId != 0) {
+                    Drawable drawable = context.getDrawable(resId);
+                    if (drawable != null) return drawable;
+                }
+            }
+        } catch (Exception ignored) {}
+        return context.getPackageManager().getApplicationIcon(context.getApplicationInfo());
+    }
+
+    @Nullable
     private Drawable[] iconDrawables;
 
     public IconListPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
@@ -134,10 +159,10 @@ public class IconListPreference extends CustomDialogListPreference {
             if (bg != null && fg != null) {
                 source = new LayerDrawable(new Drawable[]{bg, fg});
             } else {
-                // No morphe assets (e.g. ORIGINAL) — use the app's current launcher icon.
+                // No morphe assets (e.g. ORIGINAL) - use the original unpatched launcher icon.
                 source = Objects.requireNonNullElseGet(fg,
                         () -> Objects.requireNonNullElseGet(bg,
-                                () -> context.getPackageManager().getApplicationIcon(context.getApplicationInfo())));
+                                () -> resolveOriginalIconDrawable(context)));
             }
 
             return renderToRounded(context.getResources(), source, sizePx, cornerRadius, isAdaptive);

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/IconListPreference.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/IconListPreference.java
@@ -66,9 +66,22 @@ public class IconListPreference extends CustomDialogListPreference {
     @Nullable
     private static String originalLauncherIconName;
 
+    @Nullable
+    private static String originalNotificationIconName;
+
     /** Called from CustomBrandingPatch.setBranding() at app startup. */
     public static void setOriginalLauncherIconName(@Nullable String name) {
         originalLauncherIconName = name;
+    }
+
+    /** Called from CustomBrandingPatch.setBranding() at app startup. */
+    public static void setOriginalNotificationIconName(@Nullable String name) {
+        originalNotificationIconName = name;
+    }
+
+    @Nullable
+    static String getOriginalNotificationIconName() {
+        return originalNotificationIconName;
     }
 
     /**

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/NotificationIconListPreference.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/NotificationIconListPreference.java
@@ -13,7 +13,6 @@ import android.graphics.Canvas;
 import android.graphics.Path;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
-import android.graphics.drawable.AdaptiveIconDrawable;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
@@ -35,8 +34,9 @@ import app.morphe.extension.shared.Utils;
  * with the corresponding {@code morphe_notification_icon_{value}} drawable tinted to the
  * contrasting foreground color - mirroring how Android displays notification icons in the shade.
  * <p>
- * FOLLOW and ORIGINAL have no dedicated notification icon resource and fall back to the
- * app's launcher icon instead.
+ * ORIGINAL uses the app's real notification icon resource (e.g. {@code ic_stat_yt_notification_logo}),
+ * injected at patch time via {@link IconListPreference#setOriginalNotificationIconName}.
+ * FOLLOW mirrors the currently selected app icon's notification counterpart.
  */
 @SuppressWarnings({"unused", "deprecation"})
 public class NotificationIconListPreference extends IconListPreference {
@@ -96,28 +96,30 @@ public class NotificationIconListPreference extends IconListPreference {
             Context context, String suffix, int sizePx, float cornerRadius,
             @ColorInt int fgColor, @ColorInt int bgColor) {
         try {
-            // ORIGINAL - extract the adaptive icon foreground, tint it, render on theme background.
+            // ORIGINAL - use the app's dedicated notification icon resource (injected at patch time).
             if ("original".equals(suffix)) {
-                Drawable appIcon = resolveOriginalIconDrawable(context);
-                if (appIcon instanceof AdaptiveIconDrawable) {
-                    Drawable fg = ((AdaptiveIconDrawable) appIcon).getForeground();
-                    if (fg != null) {
-                        Bitmap bmp = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888);
-                        Canvas canvas = new Canvas(bmp);
-                        Path clip = new Path();
-                        clip.addRoundRect(0, 0, sizePx, sizePx, cornerRadius, cornerRadius, Path.Direction.CW);
-                        canvas.clipPath(clip);
-                        canvas.drawColor(bgColor);
-                        fg.mutate().setColorFilter(new PorterDuffColorFilter(fgColor, PorterDuff.Mode.SRC_IN));
-                        int scaledSize = Math.round(sizePx * (108f / 72f));
-                        int offset = (scaledSize - sizePx) / 2;
-                        fg.setBounds(-offset, -offset, sizePx + offset, sizePx + offset);
-                        fg.draw(canvas);
-                        return new BitmapDrawable(context.getResources(), bmp);
+                String originalNotifName = IconListPreference.getOriginalNotificationIconName();
+                if (originalNotifName != null && !originalNotifName.isEmpty()) {
+                    int resId = resolveResId(originalNotifName);
+                    if (resId != 0) {
+                        Drawable notif = context.getDrawable(resId);
+                        if (notif != null) {
+                            Bitmap bmp = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888);
+                            Canvas canvas = new Canvas(bmp);
+                            Path clip = new Path();
+                            clip.addRoundRect(0, 0, sizePx, sizePx, cornerRadius, cornerRadius, Path.Direction.CW);
+                            canvas.clipPath(clip);
+                            canvas.drawColor(bgColor);
+                            int notifSize = Math.round(sizePx * NOTIF_ICON_SIZE_FRACTION);
+                            int notifOffset = (sizePx - notifSize) / 2;
+                            notif.mutate().setColorFilter(new PorterDuffColorFilter(fgColor, PorterDuff.Mode.SRC_IN));
+                            notif.setBounds(notifOffset, notifOffset, notifOffset + notifSize, notifOffset + notifSize);
+                            notif.draw(canvas);
+                            return new BitmapDrawable(context.getResources(), bmp);
+                        }
                     }
                 }
-                // Fallback for non-adaptive icons.
-                return renderToRounded(context.getResources(), appIcon, sizePx, cornerRadius, false);
+                return null;
             }
 
             int notifResId = resolveResId("morphe_notification_icon_" + suffix);

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/NotificationIconListPreference.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/NotificationIconListPreference.java
@@ -96,7 +96,7 @@ public class NotificationIconListPreference extends IconListPreference {
             Context context, String suffix, int sizePx, float cornerRadius,
             @ColorInt int fgColor, @ColorInt int bgColor) {
         try {
-            // ORIGINAL — extract the adaptive icon foreground, tint it, render on theme background.
+            // ORIGINAL - extract the adaptive icon foreground, tint it, render on theme background.
             if ("original".equals(suffix)) {
                 Drawable appIcon = resolveOriginalIconDrawable(context);
                 if (appIcon instanceof AdaptiveIconDrawable) {

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/NotificationIconListPreference.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/NotificationIconListPreference.java
@@ -13,6 +13,7 @@ import android.graphics.Canvas;
 import android.graphics.Path;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
+import android.graphics.drawable.AdaptiveIconDrawable;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
@@ -72,9 +73,19 @@ public class NotificationIconListPreference extends IconListPreference {
         int fgColor = Utils.getAppForegroundColor();
         int bgColor = isLightColor(fgColor) ? 0xFF000000 : 0xFFFFFFFF;
 
+        // Resolve the current app icon style so FOLLOW can mirror it.
+        String currentAppIconSuffix = null;
+        try {
+            String val = getSharedPreferences().getString("morphe_custom_branding_icon", null);
+            if (val != null) currentAppIconSuffix = val.toLowerCase(Locale.US);
+        } catch (Exception ignored) {}
+
         Drawable[] drawables = new Drawable[values.length];
         for (int i = 0; i < values.length; i++) {
             String suffix = values[i].toString().toLowerCase(Locale.US);
+            if ("follow".equals(suffix) && currentAppIconSuffix != null) {
+                suffix = currentAppIconSuffix;
+            }
             drawables[i] = buildNotificationIconDrawable(context, suffix, sizePx, cornerRadius, fgColor, bgColor);
         }
         return drawables;
@@ -85,9 +96,27 @@ public class NotificationIconListPreference extends IconListPreference {
             Context context, String suffix, int sizePx, float cornerRadius,
             @ColorInt int fgColor, @ColorInt int bgColor) {
         try {
-            // FOLLOW and ORIGINAL have no notification icon resource - show the original launcher icon.
-            if ("follow".equals(suffix) || "original".equals(suffix)) {
+            // ORIGINAL — extract the adaptive icon foreground, tint it, render on theme background.
+            if ("original".equals(suffix)) {
                 Drawable appIcon = resolveOriginalIconDrawable(context);
+                if (appIcon instanceof AdaptiveIconDrawable) {
+                    Drawable fg = ((AdaptiveIconDrawable) appIcon).getForeground();
+                    if (fg != null) {
+                        Bitmap bmp = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888);
+                        Canvas canvas = new Canvas(bmp);
+                        Path clip = new Path();
+                        clip.addRoundRect(0, 0, sizePx, sizePx, cornerRadius, cornerRadius, Path.Direction.CW);
+                        canvas.clipPath(clip);
+                        canvas.drawColor(bgColor);
+                        fg.mutate().setColorFilter(new PorterDuffColorFilter(fgColor, PorterDuff.Mode.SRC_IN));
+                        int scaledSize = Math.round(sizePx * (108f / 72f));
+                        int offset = (scaledSize - sizePx) / 2;
+                        fg.setBounds(-offset, -offset, sizePx + offset, sizePx + offset);
+                        fg.draw(canvas);
+                        return new BitmapDrawable(context.getResources(), bmp);
+                    }
+                }
+                // Fallback for non-adaptive icons.
                 return renderToRounded(context.getResources(), appIcon, sizePx, cornerRadius, false);
             }
 

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/NotificationIconListPreference.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/NotificationIconListPreference.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.settings.preference;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Path;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+import android.util.DisplayMetrics;
+import android.util.TypedValue;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Locale;
+
+import app.morphe.extension.shared.Utils;
+
+/**
+ * An {@link IconListPreference} for notification icon selection.
+ * <p>
+ * Each entry is rendered as a theme-colored rounded square (black in dark theme, white in light)
+ * with the corresponding {@code morphe_notification_icon_{value}} drawable tinted to the
+ * contrasting foreground color - mirroring how Android displays notification icons in the shade.
+ * <p>
+ * FOLLOW and ORIGINAL have no dedicated notification icon resource and fall back to the
+ * app's launcher icon instead.
+ */
+@SuppressWarnings({"unused", "deprecation"})
+public class NotificationIconListPreference extends IconListPreference {
+
+    private static final float NOTIF_ICON_SIZE_FRACTION = 0.6f;
+
+    public NotificationIconListPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    public NotificationIconListPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public NotificationIconListPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public NotificationIconListPreference(Context context) {
+        super(context);
+    }
+
+    @NonNull
+    @Override
+    protected Drawable[] resolveIconDrawables() {
+        CharSequence[] values = getEntryValues();
+        if (values == null) return new Drawable[0];
+
+        Context context = getContext();
+        DisplayMetrics dm = context.getResources().getDisplayMetrics();
+        int sizePx = Math.round(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, ICON_SIZE_DP, dm));
+        float cornerRadius = sizePx * ICON_CORNER_RADIUS_FRACTION;
+
+        int fgColor = Utils.getAppForegroundColor();
+        int bgColor = isLightColor(fgColor) ? 0xFF000000 : 0xFFFFFFFF;
+
+        Drawable[] drawables = new Drawable[values.length];
+        for (int i = 0; i < values.length; i++) {
+            String suffix = values[i].toString().toLowerCase(Locale.US);
+            drawables[i] = buildNotificationIconDrawable(context, suffix, sizePx, cornerRadius, fgColor, bgColor);
+        }
+        return drawables;
+    }
+
+    @Nullable
+    private static Drawable buildNotificationIconDrawable(
+            Context context, String suffix, int sizePx, float cornerRadius,
+            @ColorInt int fgColor, @ColorInt int bgColor) {
+        try {
+            // FOLLOW and ORIGINAL have no notification icon resource - show the app launcher icon.
+            if ("follow".equals(suffix) || "original".equals(suffix)) {
+                Drawable appIcon = context.getPackageManager().getApplicationIcon(context.getApplicationInfo());
+                return renderToRounded(context.getResources(), appIcon, sizePx, cornerRadius, false);
+            }
+
+            int notifResId = resolveResId("morphe_notification_icon_" + suffix);
+            if (notifResId == 0) return null;
+
+            Drawable notif = context.getDrawable(notifResId);
+            if (notif == null) return null;
+
+            Bitmap bmp = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888);
+            Canvas canvas = new Canvas(bmp);
+
+            Path clip = new Path();
+            clip.addRoundRect(0, 0, sizePx, sizePx, cornerRadius, cornerRadius, Path.Direction.CW);
+            canvas.clipPath(clip);
+            canvas.drawColor(bgColor);
+
+            int notifSize = Math.round(sizePx * NOTIF_ICON_SIZE_FRACTION);
+            int notifOffset = (sizePx - notifSize) / 2;
+            notif.mutate().setColorFilter(new PorterDuffColorFilter(fgColor, PorterDuff.Mode.SRC_IN));
+            notif.setBounds(notifOffset, notifOffset, notifOffset + notifSize, notifOffset + notifSize);
+            notif.draw(canvas);
+
+            return new BitmapDrawable(context.getResources(), bmp);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static boolean isLightColor(@ColorInt int color) {
+        int r = (color >> 16) & 0xFF;
+        int g = (color >> 8) & 0xFF;
+        int b = color & 0xFF;
+        return (0.299 * r + 0.587 * g + 0.114 * b) / 255.0 > 0.5;
+    }
+}

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/NotificationIconListPreference.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/NotificationIconListPreference.java
@@ -85,9 +85,9 @@ public class NotificationIconListPreference extends IconListPreference {
             Context context, String suffix, int sizePx, float cornerRadius,
             @ColorInt int fgColor, @ColorInt int bgColor) {
         try {
-            // FOLLOW and ORIGINAL have no notification icon resource - show the app launcher icon.
+            // FOLLOW and ORIGINAL have no notification icon resource - show the original launcher icon.
             if ("follow".equals(suffix) || "original".equals(suffix)) {
-                Drawable appIcon = context.getPackageManager().getApplicationIcon(context.getApplicationInfo());
+                Drawable appIcon = resolveOriginalIconDrawable(context);
                 return renderToRounded(context.getResources(), appIcon, sizePx, cornerRadius, false);
             }
 

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/branding/CustomBrandingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/branding/CustomBrandingPatch.kt
@@ -58,6 +58,7 @@ private val disableSplashAnimationPatch = bytecodePatch {
 @Suppress("unused")
 val customBrandingPatch = baseCustomBrandingPatch(
     originalLauncherIconName = "ic_launcher_release",
+    originalNotificationIconName = "music_push_notification_white",
     originalAppName = "@string/app_launcher_name",
     originalAppPackageName = MUSIC_PACKAGE_NAME,
     isYouTubeMusic = true,

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
@@ -95,6 +95,7 @@ internal const val EXTENSION_CLASS = "Lapp/morphe/extension/shared/patches/Custo
  */
 internal fun baseCustomBrandingPatch(
     originalLauncherIconName: String,
+    originalNotificationIconName: String,
     originalAppName: String,
     originalAppPackageName: String,
     isYouTubeMusic: Boolean,
@@ -158,6 +159,7 @@ internal fun baseCustomBrandingPatch(
                 UserProvidedCustomNameExtensionFingerprint.method.returnEarly(customName != null)
                 UserProvidedCustomIconExtensionFingerprint.method.returnEarly(customIcon != null)
                 OriginalLauncherIconNameExtensionFingerprint.method.returnEarly(originalLauncherIconName)
+                OriginalNotificationIconNameExtensionFingerprint.method.returnEarly(originalNotificationIconName)
 
                 NotificationBuilderFingerprint.let {
                     it.method.apply {

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
@@ -157,6 +157,7 @@ internal fun baseCustomBrandingPatch(
                 NumberOfPresetAppNamesExtensionFingerprint.method.returnEarly(numberOfPresetAppNames)
                 UserProvidedCustomNameExtensionFingerprint.method.returnEarly(customName != null)
                 UserProvidedCustomIconExtensionFingerprint.method.returnEarly(customIcon != null)
+                OriginalLauncherIconNameExtensionFingerprint.method.returnEarly(originalLauncherIconName)
 
                 NotificationBuilderFingerprint.let {
                     it.method.apply {

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
@@ -252,6 +252,7 @@ internal fun baseCustomBrandingPatch(
         if (useCustomIcon) {
             preferences += ListPreference(
                 key = "morphe_custom_branding_icon",
+                tag = "app.morphe.extension.shared.settings.preference.IconListPreference",
                 entriesKey = "morphe_custom_branding_icon_custom_entries",
                 entryValuesKey = "morphe_custom_branding_icon_custom_entry_values"
             )
@@ -261,7 +262,10 @@ internal fun baseCustomBrandingPatch(
                 entryValuesKey = "morphe_custom_branding_notification_icon_custom_entry_values"
             )
         } else {
-            preferences += ListPreference("morphe_custom_branding_icon")
+            preferences += ListPreference(
+                key = "morphe_custom_branding_icon",
+                tag = "app.morphe.extension.shared.settings.preference.IconListPreference"
+            )
             preferences += ListPreference("morphe_custom_branding_notification_icon")
         }
 

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
@@ -56,6 +56,7 @@ private val iconStyleNames = arrayOf(
     "dark",
     "light",
     "play",
+    "play_black",
 )
 
 private const val ORIGINAL_USER_ICON_STYLE_NAME = "original"

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
@@ -259,6 +259,7 @@ internal fun baseCustomBrandingPatch(
             )
             preferences += ListPreference(
                 key = "morphe_custom_branding_notification_icon",
+                tag = "app.morphe.extension.shared.settings.preference.NotificationIconListPreference",
                 entriesKey = "morphe_custom_branding_notification_icon_custom_entries",
                 entryValuesKey = "morphe_custom_branding_notification_icon_custom_entry_values"
             )
@@ -267,7 +268,10 @@ internal fun baseCustomBrandingPatch(
                 key = "morphe_custom_branding_icon",
                 tag = "app.morphe.extension.shared.settings.preference.IconListPreference"
             )
-            preferences += ListPreference("morphe_custom_branding_notification_icon")
+            preferences += ListPreference(
+                key = "morphe_custom_branding_notification_icon",
+                tag = "app.morphe.extension.shared.settings.preference.NotificationIconListPreference"
+            )
         }
 
         preferenceScreen.addPreferences(

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/Fingerprints.kt
@@ -40,6 +40,14 @@ internal object OriginalLauncherIconNameExtensionFingerprint : Fingerprint(
     parameters = listOf()
 )
 
+internal object OriginalNotificationIconNameExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS,
+    name = "originalNotificationIconName",
+    accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.STATIC),
+    returnType = "Ljava/lang/String;",
+    parameters = listOf()
+)
+
 // A much simpler fingerprint exists that can set the small icon (contains string "414843287017"),
 // but that has limited usage and this fingerprint allows changing any part of the notification.
 internal object NotificationBuilderFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/Fingerprints.kt
@@ -32,6 +32,14 @@ internal object UserProvidedCustomIconExtensionFingerprint : Fingerprint(
     parameters = listOf()
 )
 
+internal object OriginalLauncherIconNameExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS,
+    name = "originalLauncherIconName",
+    accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.STATIC),
+    returnType = "Ljava/lang/String;",
+    parameters = listOf()
+)
+
 // A much simpler fingerprint exists that can set the small icon (contains string "414843287017"),
 // but that has limited usage and this fingerprint allows changing any part of the notification.
 internal object NotificationBuilderFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/settings/SettingsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/settings/SettingsPatch.kt
@@ -89,6 +89,7 @@ fun settingsPatch (
             ),
             ResourceGroup("layout",
                 "morphe_custom_list_item_checked.xml",
+                "morphe_icon_list_item.xml",
                 // Color picker.
                 "morphe_color_dot_widget.xml",
                 "morphe_color_picker.xml",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/branding/CustomBrandingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/branding/CustomBrandingPatch.kt
@@ -11,6 +11,7 @@ import app.morphe.patches.youtube.shared.YouTubeActivityOnCreateFingerprint
 @Suppress("unused")
 val customBrandingPatch = baseCustomBrandingPatch(
     originalLauncherIconName = "ic_launcher",
+    originalNotificationIconName = "ic_stat_yt_notification_logo",
     originalAppName = "@string/application_name",
     originalAppPackageName = YOUTUBE_PACKAGE_NAME,
     isYouTubeMusic = false,

--- a/patches/src/main/resources/addresources/values/shared-youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/arrays.xml
@@ -7,6 +7,7 @@
         <item>@string/morphe_custom_branding_icon_entry_3</item>
         <item>@string/morphe_custom_branding_icon_entry_4</item>
         <item>@string/morphe_custom_branding_icon_entry_5</item>
+        <item>@string/morphe_custom_branding_icon_entry_6</item>
     </string-array>
     <string-array name="morphe_custom_branding_icon_entry_values">
         <item>ORIGINAL</item>
@@ -14,6 +15,7 @@
         <item>DARK</item>
         <item>LIGHT</item>
         <item>PLAY</item>
+        <item>PLAY_BLACK</item>
     </string-array>
     <string-array name="morphe_custom_branding_icon_custom_entries">
         <item>@string/morphe_custom_branding_icon_entry_1</item>
@@ -22,6 +24,7 @@
         <item>@string/morphe_custom_branding_icon_entry_4</item>
         <item>@string/morphe_custom_branding_icon_entry_5</item>
         <item>@string/morphe_custom_branding_icon_entry_6</item>
+        <item>@string/morphe_custom_branding_icon_entry_7</item>
     </string-array>
     <string-array name="morphe_custom_branding_icon_custom_entry_values">
         <item>ORIGINAL</item>
@@ -29,6 +32,7 @@
         <item>DARK</item>
         <item>LIGHT</item>
         <item>PLAY</item>
+        <item>PLAY_BLACK</item>
         <item>CUSTOM</item>
     </string-array>
     <string-array name="morphe_custom_branding_notification_icon_entries">
@@ -38,6 +42,7 @@
         <item>@string/morphe_custom_branding_icon_entry_3</item>
         <item>@string/morphe_custom_branding_icon_entry_4</item>
         <item>@string/morphe_custom_branding_icon_entry_5</item>
+        <item>@string/morphe_custom_branding_icon_entry_6</item>
     </string-array>
     <string-array name="morphe_custom_branding_notification_icon_entry_values">
         <item>FOLLOW</item>
@@ -46,6 +51,7 @@
         <item>DARK</item>
         <item>LIGHT</item>
         <item>PLAY</item>
+        <item>PLAY_BLACK</item>
     </string-array>
     <string-array name="morphe_custom_branding_notification_icon_custom_entries">
         <item>@string/morphe_custom_branding_notification_icon_entry_1</item>
@@ -55,6 +61,7 @@
         <item>@string/morphe_custom_branding_icon_entry_4</item>
         <item>@string/morphe_custom_branding_icon_entry_5</item>
         <item>@string/morphe_custom_branding_icon_entry_6</item>
+        <item>@string/morphe_custom_branding_icon_entry_7</item>
     </string-array>
     <string-array name="morphe_custom_branding_notification_icon_custom_entry_values">
         <item>FOLLOW</item>
@@ -63,6 +70,7 @@
         <item>DARK</item>
         <item>LIGHT</item>
         <item>PLAY</item>
+        <item>PLAY_BLACK</item>
         <item>CUSTOM</item>
     </string-array>
 </resources>

--- a/patches/src/main/resources/addresources/values/shared-youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/arrays.xml
@@ -38,39 +38,27 @@
     <string-array name="morphe_custom_branding_notification_icon_entries">
         <item>@string/morphe_custom_branding_notification_icon_entry_1</item>
         <item>@string/morphe_custom_branding_icon_entry_1</item>
-        <item>@string/morphe_custom_branding_icon_entry_2</item>
-        <item>@string/morphe_custom_branding_icon_entry_3</item>
-        <item>@string/morphe_custom_branding_icon_entry_4</item>
-        <item>@string/morphe_custom_branding_icon_entry_5</item>
-        <item>@string/morphe_custom_branding_icon_entry_6</item>
+        <item>@string/morphe_custom_branding_notification_icon_entry_2</item>
+        <item>@string/morphe_custom_branding_notification_icon_entry_3</item>
     </string-array>
     <string-array name="morphe_custom_branding_notification_icon_entry_values">
         <item>FOLLOW</item>
         <item>ORIGINAL</item>
         <item>BLACK</item>
-        <item>DARK</item>
-        <item>LIGHT</item>
         <item>PLAY</item>
-        <item>PLAY_BLACK</item>
     </string-array>
     <string-array name="morphe_custom_branding_notification_icon_custom_entries">
         <item>@string/morphe_custom_branding_notification_icon_entry_1</item>
         <item>@string/morphe_custom_branding_icon_entry_1</item>
-        <item>@string/morphe_custom_branding_icon_entry_2</item>
-        <item>@string/morphe_custom_branding_icon_entry_3</item>
-        <item>@string/morphe_custom_branding_icon_entry_4</item>
-        <item>@string/morphe_custom_branding_icon_entry_5</item>
-        <item>@string/morphe_custom_branding_icon_entry_6</item>
+        <item>@string/morphe_custom_branding_notification_icon_entry_2</item>
+        <item>@string/morphe_custom_branding_notification_icon_entry_3</item>
         <item>@string/morphe_custom_branding_icon_entry_7</item>
     </string-array>
     <string-array name="morphe_custom_branding_notification_icon_custom_entry_values">
         <item>FOLLOW</item>
         <item>ORIGINAL</item>
         <item>BLACK</item>
-        <item>DARK</item>
-        <item>LIGHT</item>
         <item>PLAY</item>
-        <item>PLAY_BLACK</item>
         <item>CUSTOM</item>
     </string-array>
 </resources>

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -21,7 +21,7 @@ Second \"item\" text"</string>
     <!-- layout.branding.baseCustomBrandingPatch -->
     <string name="morphe_custom_branding_name_title">App name</string>
 
-    <!-- Translations of this should be identical to morphe_custom_branding_icon_entry_6 -->
+    <!-- Translations of this should be identical to morphe_custom_branding_icon_entry_7 -->
     <string name="morphe_custom_branding_name_entry_5">Custom</string>
     <string name="morphe_custom_branding_icon_title">App icon</string>
     <string name="morphe_custom_branding_icon_entry_1">Original</string>

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -34,6 +34,8 @@ Second \"item\" text"</string>
     <string name="morphe_custom_branding_icon_entry_7">Custom</string>
     <string name="morphe_custom_branding_notification_icon_title">Notification icon</string>
     <string name="morphe_custom_branding_notification_icon_entry_1">Match app icon</string>
+    <string name="morphe_custom_branding_notification_icon_entry_2">Morphe</string>
+    <string name="morphe_custom_branding_notification_icon_entry_3">Morphe Play</string>
 
     <!-- misc.dns.checkWatchHistoryDomainNameResolutionPatch -->
     <string name="morphe_check_watch_history_domain_name_dialog_title">Morphe Notice</string>

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -28,9 +28,10 @@ Second \"item\" text"</string>
     <string name="morphe_custom_branding_icon_entry_2">Morphe black</string>
     <string name="morphe_custom_branding_icon_entry_3">Morphe dark</string>
     <string name="morphe_custom_branding_icon_entry_4">Morphe light</string>
-    <string name="morphe_custom_branding_icon_entry_5">Morphe play</string>
+    <string name="morphe_custom_branding_icon_entry_5">Morphe play light</string>
+    <string name="morphe_custom_branding_icon_entry_6">Morphe play black</string>
     <!-- Translations of this should be identical to morphe_custom_branding_name_entry_5 -->
-    <string name="morphe_custom_branding_icon_entry_6">Custom</string>
+    <string name="morphe_custom_branding_icon_entry_7">Custom</string>
     <string name="morphe_custom_branding_notification_icon_title">Notification icon</string>
     <string name="morphe_custom_branding_notification_icon_entry_1">Match app icon</string>
 

--- a/patches/src/main/resources/custom-branding/drawable/morphe_adaptive_background_play_black.xml
+++ b/patches/src/main/resources/custom-branding/drawable/morphe_adaptive_background_play_black.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<color xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="#000000" />

--- a/patches/src/main/resources/custom-branding/drawable/morphe_adaptive_foreground_play_black.xml
+++ b/patches/src/main/resources/custom-branding/drawable/morphe_adaptive_foreground_play_black.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Morphe. This is copyrighted content, and not licensed under open source terms.
+    See https://github.com/MorpheApp/morphe-branding
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+
+    <group
+        android:scaleX="0.6"
+        android:scaleY="0.6"
+        android:translateX="102.4"
+        android:translateY="102.4">
+
+        <path
+            android:fillColor="#00AFAE"
+            android:pathData="M338.522,191.141L130,389.345c0,20.488 23.813,33.294 42.863,23.05L254,368.764l84.523,-47.939 66.871,-39.951C414.496,275.434 420,266.055 420,255.983c0,-10.072 -5.504,-19.451 -14.606,-24.889z" />
+        <path
+            android:fillColor="#1E5AA8"
+            android:pathData="M211.339,120.261L172.863,99.57c-15.053,-8 -34.225,-1.777 -40.68,13.204c-0.311,0.965 -0.617,1.931 -0.873,2.925c-0.665,2.042 -1.064,4.15 -1.189,6.28c-0.039,0.304 -0.086,0.606 -0.121,0.91v266.186c1.194,15.262 10.893,26.566 27.932,26.886c26.079,0 54.147,-37.845 54.147,-53.491V129.049c0,-3.009 -0.271,-5.94 -0.74,-8.788z" />
+        <path
+            android:pathData="M420,255.982c0,-10.072 -5.504,-19.451 -14.606,-24.889l-66.872,-39.952C310.753,174.55 282.571,158.566 254,143.201L172.863,99.57C152.795,89.018 130.905,103.393 130,122.619l208.522,198.205 66.872,-39.952C414.496,275.434 420,266.054 420,255.982z">
+            <aapt:attr name="android:fillColor">
+                <gradient
+                    android:endX="418"
+                    android:endY="320"
+                    android:startX="129"
+                    android:startY="96"
+                    android:type="linear">
+                    <item
+                        android:color="#1E5AA8"
+                        android:offset="0" />
+                    <item
+                        android:color="#00AFAE"
+                        android:offset="1" />
+                </gradient>
+            </aapt:attr>
+        </path>
+    </group>
+</vector>

--- a/patches/src/main/resources/custom-branding/drawable/morphe_adaptive_monochrome_play_black.xml
+++ b/patches/src/main/resources/custom-branding/drawable/morphe_adaptive_monochrome_play_black.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Morphe. This is copyrighted content, and not licensed under open source terms.
+    See https://github.com/MorpheApp/morphe-branding
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+
+    <group
+        android:scaleX="0.6"
+        android:scaleY="0.6"
+        android:translateX="102.4"
+        android:translateY="102.4">
+
+        <path
+            android:fillColor="#000000"
+            android:pathData="M338.522,191.141L130,389.345c0,20.488 23.813,33.294 42.863,23.05L254,368.764l84.523,-47.939 66.871,-39.951C414.496,275.434 420,266.055 420,255.983c0,-10.072 -5.504,-19.451 -14.606,-24.889z" />
+        <path
+            android:fillColor="#000000"
+            android:pathData="M211.339,120.261L172.863,99.57c-15.053,-8 -34.225,-1.777 -40.68,13.204c-0.311,0.965 -0.617,1.931 -0.873,2.925c-0.665,2.042 -1.064,4.15 -1.189,6.28c-0.039,0.304 -0.086,0.606 -0.121,0.91v266.186c1.194,15.262 10.893,26.566 27.932,26.886c26.079,0 54.147,-37.845 54.147,-53.491V129.049c0,-3.009 -0.271,-5.94 -0.74,-8.788z" />
+        <path
+            android:fillColor="#000000"
+            android:pathData="M420,255.982c0,-10.072 -5.504,-19.451 -14.606,-24.889l-66.872,-39.952C310.753,174.55 282.571,158.566 254,143.201L172.863,99.57C152.795,89.018 130.905,103.393 130,122.619l208.522,198.205 66.872,-39.952C414.496,275.434 420,266.054 420,255.982z">
+        </path>
+    </group>
+</vector>

--- a/patches/src/main/resources/custom-branding/drawable/morphe_notification_icon_play_black.xml
+++ b/patches/src/main/resources/custom-branding/drawable/morphe_notification_icon_play_black.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Morphe. This is copyrighted content, and not licensed under open source terms.
+    See https://github.com/MorpheApp/morphe-branding
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+
+    <!-- Path must be white to ensure the icon appears white in the expanded status bar panel. -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M334.855,174.926L76,422.681c0,25.61 29.561,41.617 53.209,28.812l100.722,-54.539 104.925,-59.924 83.012,-49.939c11.3,-6.798 18.132,-18.522 18.132,-31.112c0,-12.59 -6.833,-24.314 -18.132,-31.111zM176.972,86.326L129.209,60.463C110.522,50.463 86.723,58.242 78.71,76.968c-0.386,1.206 -0.766,2.414 -1.084,3.656c-0.825,2.552 -1.321,5.187 -1.476,7.85C76.101,88.854 76.043,89.231 76,89.612V422.344c1.482,19.077 13.522,33.208 34.674,33.607c32.374,0 67.217,-47.306 67.217,-66.864V97.312c0,-3.761 -0.337,-7.425 -0.92,-10.986zM436,255.978c0,-12.59 -6.833,-24.314 -18.132,-31.111l-83.013,-49.94C300.383,154.188 265.399,134.208 229.931,115.002L129.209,60.463C104.297,47.273 77.123,65.241 76,89.274l258.855,247.756 83.013,-49.94c11.299,-6.798 18.132,-18.522 18.132,-31.112z"/>
+</vector>

--- a/patches/src/main/resources/custom-branding/mipmap-anydpi/morphe_launcher_play_black.xml
+++ b/patches/src/main/resources/custom-branding/mipmap-anydpi/morphe_launcher_play_black.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/morphe_adaptive_background_play_black" />
+    <foreground android:drawable="@drawable/morphe_adaptive_foreground_play_black" />
+    <monochrome android:drawable="@drawable/morphe_adaptive_monochrome_play_black" />
+</adaptive-icon>

--- a/patches/src/main/resources/settings/layout/morphe_icon_list_item.xml
+++ b/patches/src/main/resources/settings/layout/morphe_icon_list_item.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp"
+        android:gravity="center_vertical">
+
+    <ImageView
+            android:id="@+id/morphe_check_icon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginEnd="12dp"
+            android:src="@drawable/morphe_settings_custom_checkmark"
+            android:visibility="gone"
+            android:contentDescription="@null" />
+
+    <View
+            android:id="@+id/morphe_check_icon_placeholder"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginEnd="12dp"
+            android:visibility="invisible" />
+
+    <ImageView
+            android:id="@+id/morphe_item_icon"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginEnd="14dp"
+            android:scaleType="fitCenter"
+            android:visibility="invisible"
+            android:contentDescription="@null" />
+
+    <TextView
+            android:id="@+id/morphe_item_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceListItem"
+            android:textColor="?android:attr/textColorPrimary" />
+
+</LinearLayout>


### PR DESCRIPTION
## Description

The app icon and notification icon pickers in settings now display a preview of each style next to its name.

### App icon picker changes:
- Each entry shows a rounded preview of the actual icon
- New "Morphe play black" icon variant added
- "Morphe play" renamed to "Morphe play light" for clarity

### Notification icon picker changes:
- Each entry shows a monochrome preview on a theme-colored background, mirroring how Android renders notification icons in the shade
- "Match app icon" previews the notification icon that corresponds to the currently selected app icon
- "Original" previews the app's actual unpatched notification icon
___
![Screenshot_2026-05-21-13-33-30-395_app.morphe.android.youtube-edit.jpg](https://github.com/user-attachments/assets/8be4db7d-6436-4211-9fcd-1a8149bf2bd5)

![Screenshot_2026-05-21-13-33-42-313_app.morphe.android.youtube-edit.jpg](https://github.com/user-attachments/assets/81f21569-e18f-4fcb-ba49-21f85ac59c2b)




