### PR TITLE
fix(YouTube - SponsorBlock): Prevent undo skip toast from stealing window focus

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/SegmentPlaybackController.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/SegmentPlaybackController.java
@@ -915,6 +915,7 @@ public class SegmentPlaybackController {
             window.setWindowAnimations(0); // Remove window animations and use custom fade animation.
             window.addFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL);
             window.addFlags(WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH);
+            window.addFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
 
             Utils.setDialogWindowParameters(window, Gravity.BOTTOM, 72, 60, true);
         }


### PR DESCRIPTION
Closes https://github.com/MorpheApp/morphe-patches/issues/1555

### Test results

- [ ] Tested on both the **minimum** and **maximum** supported versions
- [ ] Tested on **experimental** supported versions (Optional)
