### PR TITLE
feat(YouTube - Loop video): Add loop range via long-press on loop button

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LoopVideoPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LoopVideoPatch.java
@@ -37,9 +37,10 @@ public class LoopVideoPatch {
         return rangeStartMs >= 0 && rangeEndMs > rangeStartMs;
     }
 
-    public static void setRange(long startMs, long endMs) {
+    public static void setRange(long startMs, long endMs, boolean endIsVideoEnd) {
         rangeStartMs = startMs;
         rangeEndMs = endMs;
+        rangeEndIsVideoEnd = endIsVideoEnd;
         rangeVideoId = VideoInformation.getVideoId();
     }
 
@@ -60,6 +61,7 @@ public class LoopVideoPatch {
         final String currentVideoId = VideoInformation.getVideoId();
         if (!rangeVideoId.isEmpty() && !rangeVideoId.equals(currentVideoId)) {
             clearRange();
+            Settings.LOOP_VIDEO.save(false);
             LoopVideoButton.onRangeCleared();
             return;
         }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LoopVideoPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LoopVideoPatch.java
@@ -22,11 +22,16 @@ public class LoopVideoPatch {
     /** Range end in milliseconds. -1 means not set. */
     public static volatile long rangeEndMs = -1;
 
+    /** True when rangeEndMs was set to the video length (user left end field empty). */
+    public static volatile boolean rangeEndIsVideoEnd = false;
+
     /** Video ID at the time the range was set. Used to clear range when the video changes. */
     private static volatile String rangeVideoId = "";
 
     private static volatile long lastSeekTimeMs = 0;
     private static final long SEEK_COOLDOWN_MS = 2000;
+    /** How early to seek before rangeEndMs when rangeEndIsVideoEnd, to avoid the end screen. */
+    private static final long END_SCREEN_BUFFER_MS = 1500;
 
     public static boolean isRangeActive() {
         return rangeStartMs >= 0 && rangeEndMs > rangeStartMs;
@@ -41,6 +46,7 @@ public class LoopVideoPatch {
     public static void clearRange() {
         rangeStartMs = -1;
         rangeEndMs = -1;
+        rangeEndIsVideoEnd = false;
         rangeVideoId = "";
     }
 
@@ -58,7 +64,8 @@ public class LoopVideoPatch {
             return;
         }
 
-        if (time < rangeEndMs) return;
+        final long triggerMs = rangeEndIsVideoEnd ? rangeEndMs - END_SCREEN_BUFFER_MS : rangeEndMs;
+        if (time < triggerMs) return;
 
         final long now = System.currentTimeMillis();
         if (now - lastSeekTimeMs < SEEK_COOLDOWN_MS) return;

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LoopVideoPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LoopVideoPatch.java
@@ -1,16 +1,84 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.youtube.patches;
 
 import app.morphe.extension.youtube.settings.Settings;
+import app.morphe.extension.youtube.videoplayer.LoopVideoButton;
 
 @SuppressWarnings("unused")
 public class LoopVideoPatch {
+
+    /** Range start in milliseconds. -1 means not set (full video loop). */
+    public static volatile long rangeStartMs = -1;
+
+    /** Range end in milliseconds. -1 means not set. */
+    public static volatile long rangeEndMs = -1;
+
+    /** Video ID at the time the range was set. Used to clear range when the video changes. */
+    private static volatile String rangeVideoId = "";
+
+    private static volatile long lastSeekTimeMs = 0;
+    private static final long SEEK_COOLDOWN_MS = 2000;
+
+    public static boolean isRangeActive() {
+        return rangeStartMs >= 0 && rangeEndMs > rangeStartMs;
+    }
+
+    public static void setRange(long startMs, long endMs) {
+        rangeStartMs = startMs;
+        rangeEndMs = endMs;
+        rangeVideoId = VideoInformation.getVideoId();
+    }
+
+    public static void clearRange() {
+        rangeStartMs = -1;
+        rangeEndMs = -1;
+        rangeVideoId = "";
+    }
+
     /**
-     * Injection point
+     * Injection point. Called ~once per second with the current video time in milliseconds.
+     */
+    public static void videoTimeChanged(long time) {
+        if (!Settings.LOOP_VIDEO.get() || !isRangeActive()) return;
+
+        // Clear range if the video has changed since it was set.
+        final String currentVideoId = VideoInformation.getVideoId();
+        if (!rangeVideoId.isEmpty() && !rangeVideoId.equals(currentVideoId)) {
+            clearRange();
+            LoopVideoButton.onRangeCleared();
+            return;
+        }
+
+        if (time < rangeEndMs) return;
+
+        final long now = System.currentTimeMillis();
+        if (now - lastSeekTimeMs < SEEK_COOLDOWN_MS) return;
+        lastSeekTimeMs = now;
+
+        VideoInformation.seekTo(rangeStartMs);
+    }
+
+    /**
+     * Injection point.
      */
     public static boolean shouldLoopVideo(Enum<?> status) {
-        boolean shouldLoop = status != null && "ENDED".equals(status.name())
+        boolean isEnded = status != null && "ENDED".equals(status.name())
                 && Settings.LOOP_VIDEO.get();
-        // Instead of calling a method to loop the video, just seek to 00:00.
-        return shouldLoop && VideoInformation.seekTo(0);
+        if (!isEnded) return false;
+
+        // Fallback: if the video truly ended while range is active (videoTimeChanged was too slow),
+        // seek to range start so the end screen is dismissed.
+        if (isRangeActive()) return VideoInformation.seekTo(rangeStartMs);
+
+        return VideoInformation.seekTo(0);
     }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LoopVideoPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LoopVideoPatch.java
@@ -10,6 +10,7 @@
 
 package app.morphe.extension.youtube.patches;
 
+import app.morphe.extension.shared.Logger;
 import app.morphe.extension.youtube.settings.Settings;
 import app.morphe.extension.youtube.videoplayer.LoopVideoButton;
 
@@ -80,14 +81,19 @@ public class LoopVideoPatch {
      * Injection point.
      */
     public static boolean shouldLoopVideo(Enum<?> status) {
-        boolean isEnded = status != null && "ENDED".equals(status.name())
-                && Settings.LOOP_VIDEO.get();
-        if (!isEnded) return false;
-
-        // Fallback: if the video truly ended while range is active (videoTimeChanged was too slow),
-        // seek to range start so the end screen is dismissed.
-        if (isRangeActive()) return VideoInformation.seekTo(rangeStartMs);
-
-        return VideoInformation.seekTo(0);
+        try {
+            final boolean isEnded = Settings.LOOP_VIDEO.get()
+                    && status != null && "ENDED".equals(status.name());
+            if (isEnded) {
+                return VideoInformation.seekTo(isRangeActive()
+                        // Fallback: if the video truly ended while range is active (videoTimeChanged was too slow),
+                        // seek to range start so the end screen is dismissed.
+                        ? rangeStartMs
+                        : 0);
+            }
+        } catch (Exception ex) {
+            Logger.printException(() -> "shouldLoopVideo failure", ex);
+        }
+        return false;
     }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/PlayerFlyoutMenuComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/PlayerFlyoutMenuComponentsFilter.java
@@ -10,6 +10,19 @@
 
 package app.morphe.extension.youtube.patches.components;
 
+import static app.morphe.extension.youtube.settings.Settings.HIDE_PLAYER_FLYOUT_ADDITIONAL_SETTINGS;
+import static app.morphe.extension.youtube.settings.Settings.HIDE_PLAYER_FLYOUT_AMBIENT_MODE;
+import static app.morphe.extension.youtube.settings.Settings.HIDE_PLAYER_FLYOUT_AUDIO_TRACK;
+import static app.morphe.extension.youtube.settings.Settings.HIDE_PLAYER_FLYOUT_AUDIO_TRACK_FOOTER;
+import static app.morphe.extension.youtube.settings.Settings.HIDE_PLAYER_FLYOUT_CAPTIONS;
+import static app.morphe.extension.youtube.settings.Settings.HIDE_PLAYER_FLYOUT_HELP;
+import static app.morphe.extension.youtube.settings.Settings.HIDE_PLAYER_FLYOUT_LISTEN_WITH_YOUTUBE_MUSIC;
+import static app.morphe.extension.youtube.settings.Settings.HIDE_PLAYER_FLYOUT_LOCK_SCREEN;
+import static app.morphe.extension.youtube.settings.Settings.HIDE_PLAYER_FLYOUT_LOOP_VIDEO;
+import static app.morphe.extension.youtube.settings.Settings.HIDE_PLAYER_FLYOUT_QUALITY_FOOTER;
+import static app.morphe.extension.youtube.settings.Settings.HIDE_PLAYER_FLYOUT_SPEED;
+import static app.morphe.extension.youtube.settings.Settings.LOOP_VIDEO_BUTTON;
+
 import java.util.List;
 
 import app.morphe.extension.shared.settings.Setting;
@@ -35,6 +48,12 @@ public class PlayerFlyoutMenuComponentsFilter extends Filter {
         }
     }
 
+    private final ByteArrayFilterGroup flyoutLoopVideoButton = new ByteArrayFilterGroup(
+            null,
+            "yt_outline_arrow_repeat_1_",
+            "yt_outline_experimental_repeat1_",
+            "yt_outline_experimental_play_circle_black_"
+    );
     private final ByteArrayFilterGroupList flyoutFilterGroupList = new ByteArrayFilterGroupList();
     private final StringFilterGroup audioTrackMenuFooter;
     private final StringFilterGroup divider;
@@ -42,7 +61,7 @@ public class PlayerFlyoutMenuComponentsFilter extends Filter {
 
     public PlayerFlyoutMenuComponentsFilter() {
         audioTrackMenuFooter = new StringFilterGroup(
-                Settings.HIDE_PLAYER_FLYOUT_AUDIO_TRACK_FOOTER,
+                HIDE_PLAYER_FLYOUT_AUDIO_TRACK_FOOTER,
                 "audio_track_sheet_footer.e"
         );
 
@@ -52,7 +71,7 @@ public class PlayerFlyoutMenuComponentsFilter extends Filter {
         );
 
         qualityMenuFooter = new StringFilterGroup(
-                Settings.HIDE_PLAYER_FLYOUT_QUALITY_FOOTER,
+                HIDE_PLAYER_FLYOUT_QUALITY_FOOTER,
                 "quality_sheet_footer.e"
         );
 
@@ -65,50 +84,44 @@ public class PlayerFlyoutMenuComponentsFilter extends Filter {
 
         flyoutFilterGroupList.addAll(
                 new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_CAPTIONS,
+                        HIDE_PLAYER_FLYOUT_CAPTIONS,
                         "closed_caption_",
                         "yt_outline_experimental_closed_captions_"
                 ),
                 new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_LISTEN_WITH_YOUTUBE_MUSIC,
+                        HIDE_PLAYER_FLYOUT_LISTEN_WITH_YOUTUBE_MUSIC,
                         "yt_outline_youtube_music_",
                         "yt_outline_experimental_youtube_music_"
                 ),
                 new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_HELP,
+                        HIDE_PLAYER_FLYOUT_HELP,
                         "yt_outline_question_circle_",
                         "yt_outline_experimental_help_circle_"
                 ),
                 new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_LOCK_SCREEN,
+                        HIDE_PLAYER_FLYOUT_LOCK_SCREEN,
                         "yt_outline_lock_",
                         "yt_outline_experimental_lock_"
                 ),
                 new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_SPEED,
+                        HIDE_PLAYER_FLYOUT_SPEED,
                         "yt_outline_play_arrow_half_circle_",
                         "yt_outline_experimental_play_circle_half_dashed_"
                 ),
                 new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_AUDIO_TRACK,
+                        HIDE_PLAYER_FLYOUT_AUDIO_TRACK,
                         "yt_outline_person_",
                         "yt_outline_experimental_person_"
                 ),
                 new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_ADDITIONAL_SETTINGS,
+                        HIDE_PLAYER_FLYOUT_ADDITIONAL_SETTINGS,
                         "yt_outline_gear_",
                         "yt_outline_experimental_gear_"
                 ),
                 new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_AMBIENT_MODE,
+                        HIDE_PLAYER_FLYOUT_AMBIENT_MODE,
                         "yt_outline_screen_light_",
                         "yt_outline_experimental_ambient_mode_"
-                ),
-                new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_LOOP_VIDEO,
-                        "yt_outline_arrow_repeat_1_",
-                        "yt_outline_experimental_repeat1_",
-                        "yt_outline_experimental_play_circle_black_"
                 ),
                 new ByteArrayFilterGroup(
                         Settings.HIDE_PLAYER_FLYOUT_STABLE_VOLUME,
@@ -152,7 +165,7 @@ public class PlayerFlyoutMenuComponentsFilter extends Filter {
                 return Settings.HIDE_PLAYER_FLYOUT_CAPTIONS_FOOTER.get();
             }
             if (path.contains("quick_quality_sheet_content.e")) {
-                return Settings.HIDE_PLAYER_FLYOUT_QUALITY_FOOTER.get();
+                return HIDE_PLAYER_FLYOUT_QUALITY_FOOTER.get();
             }
             return false;
         }
@@ -169,6 +182,12 @@ public class PlayerFlyoutMenuComponentsFilter extends Filter {
         // 21.x+ fix.
         if (VersionCheckPatch.IS_20_31_OR_GREATER && path.contains("bottom_sheet_list_option.e")) {
             return false;
+        }
+
+        if (HIDE_PLAYER_FLYOUT_LOOP_VIDEO.get() || LOOP_VIDEO_BUTTON.get()) {
+            if (flyoutLoopVideoButton.check(buffer).isFiltered()) {
+                return true;
+            }
         }
 
         return flyoutFilterGroupList.check(buffer).isFiltered();

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -193,7 +193,6 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_TIMED_REACTIONS = new BooleanSetting("morphe_hide_timed_reactions", TRUE);
     public static final BooleanSetting HIDE_VIDEO_TITLE = new BooleanSetting("morphe_hide_video_title", FALSE);
     public static final BooleanSetting OPEN_VIDEOS_FULLSCREEN_PORTRAIT = new BooleanSetting("morphe_open_videos_fullscreen_portrait", FALSE);
-    public static final BooleanSetting LOOP_VIDEO = new BooleanSetting("morphe_loop_video", FALSE);
 
     // Overlay buttons
     public static final BooleanSetting COPY_VIDEO_URL_BUTTON = new BooleanSetting("morphe_copy_video_url_button", FALSE, true);
@@ -205,7 +204,11 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_FULLSCREEN_BUTTON = new BooleanSetting("morphe_hide_fullscreen_button", FALSE, true);
     public static final BooleanSetting HIDE_PLAYER_CONTROL_BUTTONS_BACKGROUND = new BooleanSetting("morphe_hide_player_control_buttons_background", FALSE, true);
     public static final BooleanSetting HIDE_PLAYER_PREVIOUS_NEXT_BUTTONS = new BooleanSetting("morphe_hide_player_previous_next_buttons", FALSE, true);
-    public static final BooleanSetting LOOP_VIDEO_BUTTON = new BooleanSetting("morphe_loop_video_button", FALSE);
+    // This following feature require the app reloading, to ensure
+    // stock repeat logic is disabled and hidden, once the
+    // LOOP_VIDEO_BUTTON will be visible.
+    public static final BooleanSetting LOOP_VIDEO_BUTTON = new BooleanSetting("morphe_loop_video_button", FALSE, true);
+    public static final BooleanSetting LOOP_VIDEO = new BooleanSetting("morphe_loop_video", FALSE, parent(LOOP_VIDEO_BUTTON));
     public static final BooleanSetting PLAY_ALL_BUTTON = new BooleanSetting("morphe_play_all_button", FALSE);
     public static final EnumSetting<PlaylistIDPrefix> PLAY_ALL_BUTTON_TYPE = new EnumSetting<>("morphe_play_all_button_type", PlaylistIDPrefix.ALL_CONTENTS_WITH_TIME_DESCENDING,  parent(PLAY_ALL_BUTTON));
     public static final BooleanSetting PLAYBACK_SPEED_DIALOG_BUTTON = new BooleanSetting("morphe_playback_speed_dialog_button", FALSE, true);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LoopVideoButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LoopVideoButton.java
@@ -125,7 +125,7 @@ public class LoopVideoButton {
             final String startPrefill = rangeActive
                     ? formatTime(LoopVideoPatch.rangeStartMs)
                     : (currentTime > 0 ? formatTime(currentTime) : "");
-            final String endPrefill = (rangeActive && !LoopVideoPatch.rangeEndIsVideoEnd)
+            final String endPrefill = rangeActive
                     ? formatTime(LoopVideoPatch.rangeEndMs)
                     : "";
 
@@ -175,7 +175,7 @@ public class LoopVideoButton {
         }
 
         final long endMs;
-        final boolean endIsVideoEnd = endInput.trim().isEmpty();
+        boolean endIsVideoEnd = endInput.trim().isEmpty();
         if (endIsVideoEnd) {
             if (videoLengthMs <= 0) {
                 Utils.showToastShort(str("morphe_loop_video_range_invalid_time"));
@@ -183,10 +183,16 @@ public class LoopVideoButton {
             }
             endMs = videoLengthMs;
         } else {
-            endMs = parseTime(endInput);
-            if (endMs < 0) {
+            final long parsed = parseTime(endInput);
+            if (parsed < 0) {
                 Utils.showToastShort(str("morphe_loop_video_range_invalid_time"));
                 return;
+            }
+            if (videoLengthMs > 0 && parsed >= videoLengthMs) {
+                endMs = videoLengthMs;
+                endIsVideoEnd = true;
+            } else {
+                endMs = parsed;
             }
         }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LoopVideoButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LoopVideoButton.java
@@ -13,15 +13,32 @@ package app.morphe.extension.youtube.videoplayer;
 import static app.morphe.extension.shared.StringRef.str;
 import static app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS;
 
+import android.app.Dialog;
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.drawable.ShapeDrawable;
+import android.graphics.drawable.shapes.RoundRectShape;
+import android.text.InputType;
+import android.util.Pair;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
 
 import androidx.annotation.Nullable;
+
+import java.util.Locale;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.ui.CustomDialog;
+import app.morphe.extension.shared.ui.Dim;
+import app.morphe.extension.youtube.patches.LoopVideoPatch;
+import app.morphe.extension.youtube.patches.VideoInformation;
 import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
@@ -46,6 +63,11 @@ public class LoopVideoButton {
             RESTORE_OLD_PLAYER_BUTTONS
                     ? "morphe_loop_video_button_off"
                     : "morphe_loop_video_button_off_bold");
+    private static final int LOOP_VIDEO_RANGE = ResourceUtils.getIdentifierOrThrow(
+            ResourceType.DRAWABLE,
+            RESTORE_OLD_PLAYER_BUTTONS
+                    ? "morphe_loop_video_button_range"
+                    : "morphe_loop_video_button_range_bold");
 
     /**
      * Injection point.
@@ -58,34 +80,154 @@ public class LoopVideoButton {
                     null,
                     null,
                     Settings.LOOP_VIDEO_BUTTON::get,
-                    v -> updateButtonAppearance(true, v),
-                    null
+                    LoopVideoButton::handleShortClick,
+                    v -> {
+                        showRangeDialog(v.getContext());
+                        return true;
+                    }
             );
-            // Set icon when initializing button based on current setting
-            updateButtonAppearance(false, null);
+            updateButtonIcon();
         } catch (Exception ex) {
             Logger.printException(() -> "initializeButton failure", ex);
         }
     }
 
     /**
-     * Animate button transition with fade and scale.
+     * Short click: toggle loop on/off. Turning off also clears any active range.
      */
-    private static void animateButtonTransition(View view, boolean newState) {
-        if (!(view instanceof ImageView imageView)) return;
+    private static void handleShortClick(View buttonView) {
+        if (legacy == null) return;
+        Utils.verifyOnMainThread();
 
-        // Fade out.
+        final boolean newState = !Settings.LOOP_VIDEO.get();
+        Settings.LOOP_VIDEO.save(newState);
+
+        if (!newState) {
+            LoopVideoPatch.clearRange();
+        }
+
+        Utils.showToastShort(str(newState
+                ? "morphe_loop_video_button_toast_on"
+                : "morphe_loop_video_button_toast_off"));
+
+        animateButtonTransition(buttonView, getTargetIcon());
+    }
+
+    /**
+     * Long click: open dialog to configure loop range.
+     */
+    private static void showRangeDialog(Context context) {
+        try {
+            final long currentTime = VideoInformation.getVideoTime();
+            final long videoLength = VideoInformation.getVideoLength();
+
+            final EditText startField = buildTimeEditText(context,
+                    str("morphe_loop_video_range_hint_start"),
+                    currentTime > 0 ? formatTime(currentTime) : "");
+
+            final EditText endField = buildTimeEditText(context,
+                    str("morphe_loop_video_range_hint_end"),
+                    LoopVideoPatch.rangeEndMs > 0 ? formatTime(LoopVideoPatch.rangeEndMs) : "");
+
+            Pair<Dialog, LinearLayout> result = CustomDialog.create(
+                    context,
+                    str("morphe_loop_video_range_dialog_title"),
+                    null,
+                    null,
+                    str("morphe_loop_video_range_set"),
+                    () -> applyRange(startField.getText().toString(),
+                            endField.getText().toString(), videoLength),
+                    () -> { /* dismiss only */ },
+                    str("morphe_loop_video_range_clear"),
+                    () -> {
+                        LoopVideoPatch.clearRange();
+                        Settings.LOOP_VIDEO.save(false);
+                        onRangeCleared();
+                    },
+                    true
+            );
+
+            Dialog dialog = result.first;
+            LinearLayout mainLayout = result.second;
+
+            // Insert the two time fields between title (index 0) and buttons (index 1).
+            mainLayout.addView(buildFieldsLayout(context, startField, endField), 1);
+
+            dialog.show();
+        } catch (Exception ex) {
+            Logger.printException(() -> "showRangeDialog failure", ex);
+        }
+    }
+
+    private static void applyRange(String startInput, String endInput, long videoLengthMs) {
+        final long startMs = parseTime(startInput);
+        if (startMs < 0) {
+            Utils.showToastShort(str("morphe_loop_video_range_invalid_time"));
+            return;
+        }
+
+        final long endMs;
+        if (endInput.trim().isEmpty()) {
+            if (videoLengthMs <= 0) {
+                Utils.showToastShort(str("morphe_loop_video_range_invalid_time"));
+                return;
+            }
+            endMs = videoLengthMs;
+        } else {
+            endMs = parseTime(endInput);
+            if (endMs < 0) {
+                Utils.showToastShort(str("morphe_loop_video_range_invalid_time"));
+                return;
+            }
+        }
+
+        if (endMs <= startMs) {
+            Utils.showToastShort(str("morphe_loop_video_range_invalid_time"));
+            return;
+        }
+
+        LoopVideoPatch.setRange(startMs, endMs);
+        Settings.LOOP_VIDEO.save(true);
+        Utils.showToastShort(str("morphe_loop_video_range_toast_on",
+                formatTime(startMs), formatTime(endMs)));
+        updateButtonIcon();
+    }
+
+    /**
+     * Called when the range is cleared externally (video change or "Clear" button).
+     */
+    public static void onRangeCleared() {
+        Utils.runOnMainThread(LoopVideoButton::updateButtonIcon);
+    }
+
+    private static int getTargetIcon() {
+        if (!Settings.LOOP_VIDEO.get()) return LOOP_VIDEO_OFF;
+        if (LoopVideoPatch.isRangeActive()) return LOOP_VIDEO_RANGE;
+        return LOOP_VIDEO_ON;
+    }
+
+    private static void updateButtonIcon() {
+        LegacyPlayerControlButton localInstance = legacy;
+        if (localInstance == null) return;
+        localInstance.setIcon(getTargetIcon());
+    }
+
+    private static void animateButtonTransition(View buttonView, int newIcon) {
+        LegacyPlayerControlButton localInstance = legacy;
+        if (localInstance == null) return;
+
+        if (!(buttonView instanceof ImageView imageView)) {
+            localInstance.setIcon(newIcon);
+            return;
+        }
+
         imageView.animate()
                 .alpha(0.3f)
                 .scaleX(1.15f)
                 .scaleY(1.15f)
                 .setDuration(100)
                 .withEndAction(() -> {
-                    if (legacy != null) {
-                        legacy.setIcon(newState ? LOOP_VIDEO_ON : LOOP_VIDEO_OFF);
-                    }
-
-                    // Fade in.
+                    localInstance.setIcon(newIcon);
                     imageView.animate()
                             .alpha(1.0f)
                             .scaleX(1.0f)
@@ -97,72 +239,173 @@ public class LoopVideoButton {
     }
 
     /**
-     * injection point.
+     * Injection point.
      */
     public static void setVisibilityNegatedImmediate() {
         if (legacy != null) legacy.setVisibilityNegatedImmediate();
     }
 
     /**
-     * injection point.
+     * Injection point.
      */
     public static void setVisibilityImmediate(boolean visible) {
         if (legacy != null) legacy.setVisibilityImmediate(visible);
-        if (visible) {
-            updateIconFromSettings();
-        }
+        if (visible) updateButtonIcon();
     }
 
     /**
-     * injection point.
+     * Injection point.
      */
     public static void setVisibility(boolean visible, boolean animated) {
         if (legacy != null) legacy.setVisibility(visible, animated);
-        if (visible) {
-            updateIconFromSettings();
+        if (visible) updateButtonIcon();
+    }
+
+    private static String formatTime(long ms) {
+        long totalSeconds = ms / 1000;
+        long hours = totalSeconds / 3600;
+        long minutes = (totalSeconds % 3600) / 60;
+        long seconds = totalSeconds % 60;
+        if (hours > 0) {
+            return String.format(Locale.ROOT, "%02d:%02d:%02d", hours, minutes, seconds);
         }
+        return String.format(Locale.ROOT, "%02d:%02d", minutes, seconds);
     }
 
     /**
-     * Update icon based on current setting value.
+     * @return milliseconds, or -1 if the input is not a valid time string.
      */
-    private static void updateIconFromSettings() {
-        LegacyPlayerControlButton localInstance = legacy;
-        if (localInstance == null) return;
-
-        final boolean currentState = Settings.LOOP_VIDEO.get();
-        localInstance.setIcon(currentState ? LOOP_VIDEO_ON : LOOP_VIDEO_OFF);
-    }
-
-    /**
-     * Updates the button's appearance.
-     */
-    private static void updateButtonAppearance(boolean userClickedButton, @Nullable View buttonView) {
-        if (legacy == null) return;
-
+    private static long parseTime(String input) {
+        String trimmed = input.trim();
+        if (trimmed.isEmpty()) return -1;
+        String[] parts = trimmed.split(":");
         try {
-            Utils.verifyOnMainThread();
-
-            final boolean currentState = Settings.LOOP_VIDEO.get();
-
-            if (userClickedButton) {
-                final boolean newState = !currentState;
-
-                Settings.LOOP_VIDEO.save(newState);
-                Utils.showToastShort(str(newState
-                        ? "morphe_loop_video_button_toast_on"
-                        : "morphe_loop_video_button_toast_off"));
-
-                // Animate with the new state.
-                if (buttonView != null) {
-                    animateButtonTransition(buttonView, newState);
-                }
+            long totalSeconds;
+            if (parts.length == 1) {
+                // Bare digits without colon — treat as seconds (e.g. "30" → 30s).
+                totalSeconds = Long.parseLong(parts[0]);
+            } else if (parts.length == 2) {
+                totalSeconds = Long.parseLong(parts[0]) * 60 + Long.parseLong(parts[1]);
+            } else if (parts.length == 3) {
+                totalSeconds = Long.parseLong(parts[0]) * 3600
+                        + Long.parseLong(parts[1]) * 60
+                        + Long.parseLong(parts[2]);
             } else {
-                // Initialization - just set icon based on current state.
-                legacy.setIcon(currentState ? LOOP_VIDEO_ON : LOOP_VIDEO_OFF);
+                return -1;
             }
-        } catch (Exception ex) {
-            Logger.printException(() -> "updateButtonAppearance failure", ex);
+            return totalSeconds * 1000;
+        } catch (NumberFormatException e) {
+            return -1;
         }
+    }
+
+    private static EditText buildTimeEditText(Context context, String hint, String prefilledText) {
+        EditText editText = new EditText(context);
+        editText.setHint(hint);
+        editText.setInputType(InputType.TYPE_CLASS_NUMBER);
+        // Override the DigitsKeyListener that TYPE_CLASS_NUMBER installs — it strips ':',
+        // which breaks the TextWatcher colon auto-insertion.
+        editText.setKeyListener(android.text.method.DigitsKeyListener.getInstance("0123456789:"));
+        editText.setTextColor(Utils.getAppForegroundColor());
+        editText.setHintTextColor(Color.GRAY);
+        editText.setBackgroundColor(Color.TRANSPARENT);
+        editText.setPadding(0, 0, 0, 0);
+        addAutoColonWatcher(editText);
+        if (!prefilledText.isEmpty()) {
+            editText.setText(prefilledText);
+            editText.setSelection(editText.getText().length());
+        }
+        return editText;
+    }
+
+    private static void addAutoColonWatcher(EditText editText) {
+        editText.addTextChangedListener(new android.text.TextWatcher() {
+            private boolean isFormatting = false;
+
+            @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            @Override public void onTextChanged(CharSequence s, int start, int before, int count) {}
+
+            @Override
+            public void afterTextChanged(android.text.Editable s) {
+                if (isFormatting) return;
+                isFormatting = true;
+                try {
+                    String digits = s.toString().replaceAll("[^0-9]", "");
+                    if (digits.length() > 6) digits = digits.substring(0, 6);
+                    String formatted = formatDigitsAsTime(digits);
+                    s.replace(0, s.length(), formatted);
+                    android.text.Selection.setSelection(s, formatted.length());
+                } finally {
+                    isFormatting = false;
+                }
+            }
+        });
+    }
+
+    private static String formatDigitsAsTime(String d) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < d.length(); i++) {
+            if (i == 2 || i == 4) sb.append(':');
+            sb.append(d.charAt(i));
+        }
+        return sb.toString();
+    }
+
+    private static LinearLayout buildFieldsLayout(Context context, EditText startField, EditText endField) {
+        LinearLayout container = new LinearLayout(context);
+        container.setOrientation(LinearLayout.VERTICAL);
+        container.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT));
+
+        container.addView(buildLabeledField(context,
+                str("morphe_loop_video_range_label_start"), startField, true));
+        container.addView(buildLabeledField(context,
+                str("morphe_loop_video_range_label_end"), endField, false));
+
+        return container;
+    }
+
+    private static LinearLayout buildLabeledField(Context context, String label, EditText field, boolean isFirst) {
+        LinearLayout column = new LinearLayout(context);
+        column.setOrientation(LinearLayout.VERTICAL);
+        LinearLayout.LayoutParams columnParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT);
+        columnParams.setMargins(0, isFirst ? Dim.dp8 : Dim.dp16, 0, 0);
+        column.setLayoutParams(columnParams);
+
+        TextView labelView = new TextView(context);
+        labelView.setText(label);
+        labelView.setTextSize(13);
+        labelView.setTextColor(Utils.getAppForegroundColor());
+        LinearLayout.LayoutParams labelParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT);
+        labelParams.setMargins(Dim.dp4, 0, 0, Dim.dp4);
+        labelView.setLayoutParams(labelParams);
+
+        ShapeDrawable fieldBackground = new ShapeDrawable(new RoundRectShape(
+                Dim.roundedCorners(10), null, null));
+        fieldBackground.getPaint().setColor(Utils.getEditTextBackground());
+
+        LinearLayout fieldBox = new LinearLayout(context);
+        fieldBox.setBackground(fieldBackground);
+        fieldBox.setClipToOutline(true);
+        fieldBox.setPadding(Dim.dp12, Dim.dp8, Dim.dp12, Dim.dp8);
+        fieldBox.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT));
+
+        ViewGroup parent = (ViewGroup) field.getParent();
+        if (parent != null) parent.removeView(field);
+        field.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT));
+        fieldBox.addView(field);
+
+        column.addView(labelView);
+        column.addView(fieldBox);
+        return column;
     }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LoopVideoButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LoopVideoButton.java
@@ -195,8 +195,7 @@ public class LoopVideoButton {
             return;
         }
 
-        LoopVideoPatch.setRange(startMs, endMs);
-        LoopVideoPatch.rangeEndIsVideoEnd = endIsVideoEnd;
+        LoopVideoPatch.setRange(startMs, endMs, endIsVideoEnd);
         Settings.LOOP_VIDEO.save(true);
         Utils.showToastShort(str("morphe_loop_video_range_toast_on",
                 formatTime(startMs), formatTime(endMs)));
@@ -407,8 +406,6 @@ public class LoopVideoButton {
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT));
 
-        ViewGroup parent = (ViewGroup) field.getParent();
-        if (parent != null) parent.removeView(field);
         field.setLayoutParams(new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT));

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LoopVideoButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LoopVideoButton.java
@@ -121,13 +121,21 @@ public class LoopVideoButton {
             final long currentTime = VideoInformation.getVideoTime();
             final long videoLength = VideoInformation.getVideoLength();
 
+            final boolean rangeActive = LoopVideoPatch.isRangeActive();
+            final String startPrefill = rangeActive
+                    ? formatTime(LoopVideoPatch.rangeStartMs)
+                    : (currentTime > 0 ? formatTime(currentTime) : "");
+            final String endPrefill = (rangeActive && !LoopVideoPatch.rangeEndIsVideoEnd)
+                    ? formatTime(LoopVideoPatch.rangeEndMs)
+                    : "";
+
             final EditText startField = buildTimeEditText(context,
                     str("morphe_loop_video_range_hint_start"),
-                    currentTime > 0 ? formatTime(currentTime) : "");
+                    startPrefill);
 
             final EditText endField = buildTimeEditText(context,
                     str("morphe_loop_video_range_hint_end"),
-                    LoopVideoPatch.rangeEndMs > 0 ? formatTime(LoopVideoPatch.rangeEndMs) : "");
+                    endPrefill);
 
             Pair<Dialog, LinearLayout> result = CustomDialog.create(
                     context,
@@ -167,7 +175,8 @@ public class LoopVideoButton {
         }
 
         final long endMs;
-        if (endInput.trim().isEmpty()) {
+        final boolean endIsVideoEnd = endInput.trim().isEmpty();
+        if (endIsVideoEnd) {
             if (videoLengthMs <= 0) {
                 Utils.showToastShort(str("morphe_loop_video_range_invalid_time"));
                 return;
@@ -187,6 +196,7 @@ public class LoopVideoButton {
         }
 
         LoopVideoPatch.setRange(startMs, endMs);
+        LoopVideoPatch.rangeEndIsVideoEnd = endIsVideoEnd;
         Settings.LOOP_VIDEO.save(true);
         Utils.showToastShort(str("morphe_loop_video_range_toast_on",
                 formatTime(startMs), formatTime(endMs)));

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/LoopVideoButtonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/LoopVideoButtonPatch.kt
@@ -28,6 +28,8 @@ private val loopVideoButtonResourcePatch = resourcePatch {
                 "morphe_loop_video_button_off.xml",
                 "morphe_loop_video_button_on_bold.xml",
                 "morphe_loop_video_button_off_bold.xml",
+                "morphe_loop_video_button_range.xml",
+                "morphe_loop_video_button_range_bold.xml"
             )
         )
     }
@@ -45,7 +47,7 @@ private const val EXTENSION_BUTTON =
     "Lapp/morphe/extension/youtube/videoplayer/LoopVideoButton;"
 
 internal val loopVideoButtonPatch = bytecodePatch(
-    description = "Adds an option to display loop video button in the video player.",
+    description = "Adds an option to display loop video button in the video player."
 ) {
     dependsOn(
         sharedExtensionPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/LoopVideoPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/LoopVideoPatch.kt
@@ -19,6 +19,7 @@ import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import app.morphe.patches.youtube.video.information.playerStatusMethodRef
 import app.morphe.patches.youtube.video.information.videoInformationPatch
+import app.morphe.patches.youtube.video.information.videoTimeHook
 import app.morphe.util.indexOfFirstInstructionOrThrow
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
@@ -41,6 +42,8 @@ val loopVideoPatch = bytecodePatch(
         PreferenceScreen.PLAYER.addPreferences(
             SwitchPreference("morphe_loop_video", summaryKey = null),
         )
+
+        videoTimeHook(EXTENSION_CLASS, "videoTimeChanged")
 
         playerStatusMethodRef.get()!!.apply {
             // Add call to start playback again, but must not allow exit fullscreen patch call

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -339,6 +339,15 @@ Verify the package name is correct and the app is installed"</string>
     <string name="morphe_loop_video_button_title">Show Loop video button</string>
     <string name="morphe_loop_video_button_toast_on">Loop video is on</string>
     <string name="morphe_loop_video_button_toast_off">Loop video is off</string>
+    <string name="morphe_loop_video_range_dialog_title">Loop range</string>
+    <string name="morphe_loop_video_range_label_start">Start</string>
+    <string name="morphe_loop_video_range_label_end">End</string>
+    <string name="morphe_loop_video_range_hint_start">mm:ss</string>
+    <string name="morphe_loop_video_range_hint_end">mm:ss (empty = video end)</string>
+    <string name="morphe_loop_video_range_set">Set</string>
+    <string name="morphe_loop_video_range_clear">Clear</string>
+    <string name="morphe_loop_video_range_toast_on">Looping %1$s - %2$s</string>
+    <string name="morphe_loop_video_range_invalid_time">Invalid time range</string>
 
     <!-- interaction.playall.playAllButtonPatch -->
     <string name="morphe_play_all_button_title">Show Play all button</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -342,8 +342,8 @@ Verify the package name is correct and the app is installed"</string>
     <string name="morphe_loop_video_range_dialog_title">Loop range</string>
     <string name="morphe_loop_video_range_label_start">Start</string>
     <string name="morphe_loop_video_range_label_end">End</string>
-    <string name="morphe_loop_video_range_hint_start">mm:ss</string>
-    <string name="morphe_loop_video_range_hint_end">mm:ss (empty = video end)</string>
+    <string name="morphe_loop_video_range_hint_start">[hh:]mm:ss</string>
+    <string name="morphe_loop_video_range_hint_end">[hh:]mm:ss (empty = video end)</string>
     <string name="morphe_loop_video_range_set">Set</string>
     <string name="morphe_loop_video_range_clear">Clear</string>
     <string name="morphe_loop_video_range_toast_on">Looping %1$s - %2$s</string>

--- a/patches/src/main/resources/loopvideobutton/drawable/morphe_loop_video_button_range.xml
+++ b/patches/src/main/resources/loopvideobutton/drawable/morphe_loop_video_button_range.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2022 Google
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M17.6914,2.19922 L16.9844,2.91797 L19.0625,5 L3.61719,5 C3.15625,5,2.76953,5.14844,2.46094,5.46094 C2.15234,5.76562,2,6.15234,2,6.61719 L2,10 L3,10 L3,6.61719 C3,6.43359,3.05859,6.28516,3.17188,6.17188 C3.28906,6.05859,3.4375,6,3.61719,6 L19.0703,6 L19.0703,6.00781 L16.9844,8.09375 L17.6914,8.8125 L21,5.50781 L17.6914,2.19922 Z M9.625,8.5h1.5v7h-1.5ZM12.875,8.5h1.5v7h-1.5Z M21,14 L21,17.3828 C21,17.5625,20.9414,17.7109,20.8281,17.8281 C20.7109,17.9414,20.5625,18,20.3828,18 L4.92969,18 L4.92969,17.9922 L7.01563,15.9023 L6.30859,15.1836 L3,18.4922 L6.30859,21.7969 L7.01563,21.0781 L4.9375,19 L20.3828,19 C20.8438,19,21.2305,18.8477,21.5391,18.5391 C21.8477,18.2305,22,17.8438,22,17.3828 L22,14 L21,14 Z" />
+</vector>

--- a/patches/src/main/resources/loopvideobutton/drawable/morphe_loop_video_button_range_bold.xml
+++ b/patches/src/main/resources/loopvideobutton/drawable/morphe_loop_video_button_range_bold.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2022 Google
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M17.293,1.293 C16.902,1.68361,16.902,2.31739,17.293,2.708 L18.586,4 L7,4 C4.23858,4,2,6.23858,2,9 L2,13 C2,14.3333,4,14.3333,4,13 L4,9 C4,7.34315,5.34315,6,7,6 L18.586,6 L17.293,7.293 C16.3497,8.23567,17.7637,9.65067,18.707,8.708 L22.414,5 L18.707,1.293 C18.3165,0.902618,17.6835,0.902618,17.293,1.293 Z M9.5,8.5 L11,8.5 L11,15.5 L9.5,15.5 Z M13,8.5 L14.5,8.5 L14.5,15.5 L13,15.5 Z M21,10 C20.4477,10,20,10.4477,20,11 L20,15 C20,16.6569,18.6569,18,17,18 L5.414,18 L6.707,16.708 C7.57723,15.766,6.23558,14.4234,5.293,15.293 L1.586,19 L5.293,22.707 C6.23449,23.711,7.71033,22.2362,6.707,21.294 L5.414,20 L17,20 C19.7614,20,22,17.7614,22,15 L22,11 C22,10.4477,21.5523,10,21,10 Z" />
+</vector>


### PR DESCRIPTION
### Description

Long-press the loop button to set a start and end time for looping.
A new icon indicates when a range is active. Short-press toggles loop on/off and clears any active range when turning off.

Closes https://github.com/MorpheApp/morphe-patches/issues/1281

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
___
![Screenshot_2026-05-25-19-42-35-085_app.morphe.android.youtube-edit.jpg](https://github.com/user-attachments/assets/e11198aa-a010-46e3-9bd3-94041be7011f)

