### PR TITLE
feat: ifunny patches

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/ifunny/DEVELOPMENT.md
+++ b/patches/src/main/kotlin/app/morphe/patches/ifunny/DEVELOPMENT.md
@@ -1,97 +1,182 @@
 # iFunny Patches — Development Guide
 
+## Tested against
+
+**iFunny 10.39.11** (`mobi.ifunny`, minSdk 26). Fingerprints were authored and verified against
+this version. Use `--force` with morphe-cli to test on adjacent versions; re-verify fingerprints
+before bumping `Constants.kt`.
+
+---
+
 ## Patches
 
-| Patch | File | DEX class | Target method | Strategy |
-|-------|------|-----------|---------------|----------|
-| Hide ads | `ad/` | `Lmobi/ifunny/ads/criterions/AdsDisableManagerImpl;` | `g()` — public, no-arg boolean | `returnEarly(true)` |
-| Unlock premium | `premium/` | `Lmobi/ifunny/rest/content/User;` | `isUserPremium()` — named, stable | `returnEarly(true)` |
-| Save videos | `video/` | `Lmobi/ifunny/social/share/video/model/SaveContentCriterion;` | `a()` — contains string `"getUserInfo(...)"` | `returnEarly(true)` |
-
-All three class names are **stable** — verified via the `@Metadata` annotation in the decompiled source.
-`isUserPremium` is unobfuscated (Kotlin metadata preserves it). The other two are obfuscated
-single-letter names, so fingerprints use structural filters rather than method names.
+| Patch | Package | DEX class | Target method | Effect |
+|-------|---------|-----------|---------------|--------|
+| Hide ads | `ad/` | `Lmobi/ifunny/ads/criterions/AdsDisableManagerImpl;` | `g()` | Always return `true` |
+| Unlock premium | `premium/` | `Lmobi/ifunny/rest/content/User;` | `isUserPremium()` | Always return `true` |
+| Save videos | `video/` | `Lmobi/ifunny/social/share/video/model/SaveContentCriterion;` | `a()` | Always return `true` |
 
 ---
 
 ## Prerequisites
 
-- **Java 11+** on PATH
-- **Android SDK** — set `%ANDROID_HOME%` or `%LOCALAPPDATA%\Android\Sdk`
-- **ADB** on PATH
-- **morphe-cli JAR** — download from [morphe-cli releases](https://github.com/MorpheApp/morphe-cli/releases)
-- **GitHub PAT** with `read:packages` scope to pull the Morphe Gradle plugin:
+| Tool | Notes |
+|------|-------|
+| Java 11+ | On PATH |
+| Android SDK | `ANDROID_HOME` set, `build-tools` installed |
+| ADB | On PATH |
+| morphe-cli JAR | [Latest release](https://github.com/MorpheApp/morphe-cli/releases) |
+| APKEditor JAR | [Latest release](https://github.com/REAndroid/APKEditor/releases) — needed for single-APK distribution only |
+| jadx | For re-decompiling on version bumps |
 
-  `~/.gradle/gradle.properties`:
-  ```properties
-  gpr.user=<github-username>
-  gpr.key=<github-pat>
-  ```
+**`~/.gradle/gradle.properties`** — GitHub PAT with `read:packages` to resolve the Morphe plugin:
+```properties
+gpr.user=<github-username>
+gpr.key=<github-pat>
+```
 
-- **`local.properties`** at the repo root pointing to your Android SDK:
-  ```properties
-  sdk.dir=C\:\\Users\\YourName\\AppData\\Local\\Android\\Sdk
-  ```
+**`local.properties`** at repo root:
+```properties
+sdk.dir=/path/to/Android/Sdk
+```
 
 ---
 
-## Build the patches bundle
+## Build
 
-```bat
+```
 gradlew :patches:build
 ```
-
 Output: `patches/build/libs/patches-<version>.mpp`
 
 ---
 
-## Signing note — IMPORTANT
+## Signing keystore
 
-morphe-cli's built-in signing uses BouncyCastle, which rejects keystores created by JDK 9+.
-Always patch with `--unsigned` and sign separately with `apksigner` from Android build-tools.
+morphe-cli's built-in signing uses BouncyCastle, which is **incompatible with keystores generated
+by JDK 9+**. Always patch with `--unsigned` and sign with `apksigner` instead.
+
+Create a PKCS12 keystore once:
+```
+keytool -genkeypair -keystore morphe.p12 -storetype PKCS12 \
+  -alias morphe -keyalg RSA -keysize 2048 -validity 10000 \
+  -storepass morphe123 -keypass morphe123 \
+  -dname "CN=Morphe, O=Morphe, C=US"
+```
+
+The certificate contains no PII — only the anonymous DN above and a creation timestamp.
 
 ---
 
-## Install flow for split APKs (Play Store installs)
+## APK prep — pulling from a device (recommended)
 
-iFunny ships as split APKs. `adb install` alone fails with `INSTALL_FAILED_MISSING_SPLIT`.
-All splits must be signed with the same certificate.
+iFunny from the Play Store installs as split APKs. Pulling from a connected device guarantees
+the correct ABI.
 
 ```
-scripts\create-keystore.bat          # one-time setup
-scripts\pull-apks-from-device.bat    # pull base + splits from connected device
-scripts\patch-and-install.bat        # patch, sign all, adb install-multiple
+adb shell pm path mobi.ifunny          # lists all split paths on device
+adb pull <path>/base.apk
+adb pull <path>/split_config.arm64_v8a.apk
+adb pull <path>/split_config.xxxhdpi.apk
 ```
 
-Edit the variables at the top of `patch-and-install.bat` before running.
+## APK prep — extracting from XAPK
+
+An XAPK is a ZIP file. Rename `.xapk` → `.zip` and extract. You'll find `mobi.ifunny.apk`
+(base) plus ABI and density splits inside. **Check the ABI split matches your test device**
+before continuing — a mismatch causes `INSTALL_FAILED_NO_MATCHING_ABIS`.
 
 ---
 
-## Fingerprint design notes
+## Development testing (split install)
 
-### `IsAdsDisabledFingerprint`
-`AdsDisableManagerImpl` has several public no-arg boolean methods. The target `g()` is the only
-one that **writes** (IPUT_OBJECT) a `Ljava/lang/Boolean;` field, so the fingerprint uses:
-- `accessFlags = PUBLIC` (class is final but method is not marked final in DEX)
-- `methodCall(INVOKE_STATIC, Boolean.valueOf)`
-- `fieldAccess(IPUT_OBJECT, type = "Ljava/lang/Boolean;")`
+```
+# 1. Patch unsigned — morphe-cli aligns automatically
+java -jar morphe-cli.jar patch -p patches.mpp \
+  --exclusive --force --unsigned \
+  -e "Hide ads" -e "Unlock premium" -e "Save videos" \
+  -o base-patched.apk base.apk
+
+# 2. Sign base
+apksigner sign --ks morphe.p12 --ks-pass pass:morphe123 \
+  --ks-key-alias morphe --key-pass pass:morphe123 \
+  --out base-signed.apk base-patched.apk
+
+# 3. Re-sign splits with the same certificate (all splits must share one cert)
+cp split_config.arm64_v8a.apk  split_arm64_signed.apk
+cp split_config.xxxhdpi.apk    split_xxxhdpi_signed.apk
+apksigner sign --ks morphe.p12 --ks-pass pass:morphe123 \
+  --ks-key-alias morphe --key-pass pass:morphe123 split_arm64_signed.apk
+apksigner sign --ks morphe.p12 --ks-pass pass:morphe123 \
+  --ks-key-alias morphe --key-pass pass:morphe123 split_xxxhdpi_signed.apk
+
+# 4. Install (uninstall original iFunny first if signature changes)
+adb install-multiple base-signed.apk split_arm64_signed.apk split_xxxhdpi_signed.apk
+```
+
+---
+
+## Distribution — single merged APK
+
+```
+# 1. Merge signed splits into one APK
+java -jar APKEditor.jar m -i <dir-containing-all-signed-apks> -o universal.apk -f
+
+# 2. Re-sign — APKEditor invalidates the existing signature
+apksigner sign --ks morphe.p12 --ks-pass pass:morphe123 \
+  --ks-key-alias morphe --key-pass pass:morphe123 \
+  --out universal-signed.apk universal.apk
+
+# 3. Install
+adb install -r universal-signed.apk
+```
+
+Recipients must **uninstall the Play Store version of iFunny first** (signature mismatch).
+
+---
+
+## Fingerprint design
+
+All DEX class names are taken from the `d2` array of the `@Metadata` Kotlin annotation embedded
+in each class — **not** from jadx's decompiled package names, which differ (`mobi.content.*` vs
+the real `mobi.ifunny.*`). This makes them stable across jadx versions and deobfuscation settings.
 
 ### `IsUserPremiumFingerprint`
-Fully stable — method name `isUserPremium` is preserved by Kotlin metadata and unobfuscated
-in the DEX. No structural filters needed.
+`isUserPremium` is an unobfuscated method name preserved by the Kotlin compiler in the DEX.
+Fingerprint matches by name alone — no structural filters needed. Most stable of the three.
+
+### `IsAdsDisabledFingerprint`
+`AdsDisableManagerImpl` has several public no-arg boolean methods. The target `g()` is uniquely
+identified by two filters:
+- `methodCall(INVOKE_STATIC, Ljava/lang/Boolean;, valueOf)` — calls `Boolean.valueOf()`
+- `fieldAccess(IPUT_OBJECT, type = Ljava/lang/Boolean;)` — *writes* the cached field
+
+Method `a()` in the same class also calls `Boolean.valueOf` but only *reads* (IGET) the field,
+so the IPUT filter excludes it. `accessFlags = PUBLIC` only — the class is `final` but individual
+methods do not carry `ACC_FINAL` in the DEX.
 
 ### `CanSaveVideoFingerprint`
-`SaveContentCriterion.a()` is identified by the hard-coded string `"getUserInfo(...)"` passed to
-`Intrinsics.checkNotNullExpressionValue`. This string is unique to this method in the class.
+`SaveContentCriterion.a()` is identified by the hard-coded string `"getUserInfo(...)"` passed
+to `Intrinsics.checkNotNullExpressionValue`. This string literal is unique within the class and
+unlikely to change as it reflects a Kotlin compiler convention.
 
 ---
 
-## Re-decompiling for a new version
+## Future-proofing
 
-```bat
+- **Class names**: sourced from `@Metadata` — stable as long as the class exists and isn't
+  renamed in source. Verify the `d2` array after each version bump.
+- **Method names**: only `isUserPremium` relies on a name; the others use structural filters
+  that survive method renaming across R8/ProGuard runs.
+- **Structural filters**: `Boolean.valueOf` + `IPUT_OBJECT` and `"getUserInfo(...)"` are
+  tied to Kotlin compiler output patterns, not obfuscation — highly stable.
+
+To verify after a version bump, re-decompile and check each class:
+```
 jadx --deobf --deobf-min 3 -d ifunny_decompiled base.apk
 ```
-
-Check the `@Metadata` `d2` array in each target class to verify the DEX class descriptors
-have not changed between versions. Update `Constants.kt` with the new version and SHA-256
-certificate fingerprint (`apksigner verify --print-certs base.apk`).
+Check `@Metadata` `d2` arrays match the class descriptors in `Fingerprints.kt`.
+Update `Constants.kt` with the new version string and app cert SHA-256:
+```
+apksigner verify --print-certs base.apk
+```

--- a/patches/src/main/kotlin/app/morphe/patches/ifunny/DEVELOPMENT.md
+++ b/patches/src/main/kotlin/app/morphe/patches/ifunny/DEVELOPMENT.md
@@ -1,0 +1,97 @@
+# iFunny Patches — Development Guide
+
+## Patches
+
+| Patch | File | DEX class | Target method | Strategy |
+|-------|------|-----------|---------------|----------|
+| Hide ads | `ad/` | `Lmobi/ifunny/ads/criterions/AdsDisableManagerImpl;` | `g()` — public, no-arg boolean | `returnEarly(true)` |
+| Unlock premium | `premium/` | `Lmobi/ifunny/rest/content/User;` | `isUserPremium()` — named, stable | `returnEarly(true)` |
+| Save videos | `video/` | `Lmobi/ifunny/social/share/video/model/SaveContentCriterion;` | `a()` — contains string `"getUserInfo(...)"` | `returnEarly(true)` |
+
+All three class names are **stable** — verified via the `@Metadata` annotation in the decompiled source.
+`isUserPremium` is unobfuscated (Kotlin metadata preserves it). The other two are obfuscated
+single-letter names, so fingerprints use structural filters rather than method names.
+
+---
+
+## Prerequisites
+
+- **Java 11+** on PATH
+- **Android SDK** — set `%ANDROID_HOME%` or `%LOCALAPPDATA%\Android\Sdk`
+- **ADB** on PATH
+- **morphe-cli JAR** — download from [morphe-cli releases](https://github.com/MorpheApp/morphe-cli/releases)
+- **GitHub PAT** with `read:packages` scope to pull the Morphe Gradle plugin:
+
+  `~/.gradle/gradle.properties`:
+  ```properties
+  gpr.user=<github-username>
+  gpr.key=<github-pat>
+  ```
+
+- **`local.properties`** at the repo root pointing to your Android SDK:
+  ```properties
+  sdk.dir=C\:\\Users\\YourName\\AppData\\Local\\Android\\Sdk
+  ```
+
+---
+
+## Build the patches bundle
+
+```bat
+gradlew :patches:build
+```
+
+Output: `patches/build/libs/patches-<version>.mpp`
+
+---
+
+## Signing note — IMPORTANT
+
+morphe-cli's built-in signing uses BouncyCastle, which rejects keystores created by JDK 9+.
+Always patch with `--unsigned` and sign separately with `apksigner` from Android build-tools.
+
+---
+
+## Install flow for split APKs (Play Store installs)
+
+iFunny ships as split APKs. `adb install` alone fails with `INSTALL_FAILED_MISSING_SPLIT`.
+All splits must be signed with the same certificate.
+
+```
+scripts\create-keystore.bat          # one-time setup
+scripts\pull-apks-from-device.bat    # pull base + splits from connected device
+scripts\patch-and-install.bat        # patch, sign all, adb install-multiple
+```
+
+Edit the variables at the top of `patch-and-install.bat` before running.
+
+---
+
+## Fingerprint design notes
+
+### `IsAdsDisabledFingerprint`
+`AdsDisableManagerImpl` has several public no-arg boolean methods. The target `g()` is the only
+one that **writes** (IPUT_OBJECT) a `Ljava/lang/Boolean;` field, so the fingerprint uses:
+- `accessFlags = PUBLIC` (class is final but method is not marked final in DEX)
+- `methodCall(INVOKE_STATIC, Boolean.valueOf)`
+- `fieldAccess(IPUT_OBJECT, type = "Ljava/lang/Boolean;")`
+
+### `IsUserPremiumFingerprint`
+Fully stable — method name `isUserPremium` is preserved by Kotlin metadata and unobfuscated
+in the DEX. No structural filters needed.
+
+### `CanSaveVideoFingerprint`
+`SaveContentCriterion.a()` is identified by the hard-coded string `"getUserInfo(...)"` passed to
+`Intrinsics.checkNotNullExpressionValue`. This string is unique to this method in the class.
+
+---
+
+## Re-decompiling for a new version
+
+```bat
+jadx --deobf --deobf-min 3 -d ifunny_decompiled base.apk
+```
+
+Check the `@Metadata` `d2` array in each target class to verify the DEX class descriptors
+have not changed between versions. Update `Constants.kt` with the new version and SHA-256
+certificate fingerprint (`apksigner verify --print-certs base.apk`).

--- a/patches/src/main/kotlin/app/morphe/patches/ifunny/ad/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/ifunny/ad/Fingerprints.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.patches.ifunny.ad
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.fieldAccess
+import app.morphe.patcher.methodCall
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+internal object IsAdsDisabledFingerprint : Fingerprint(
+    definingClass = "Lmobi/ifunny/ads/criterions/AdsDisableManagerImpl;",
+    returnType = "Z",
+    parameters = listOf(),
+    accessFlags = listOf(AccessFlags.PUBLIC),
+    filters = listOf(
+        methodCall(
+            opcode = Opcode.INVOKE_STATIC,
+            definingClass = "Ljava/lang/Boolean;",
+            name = "valueOf"
+        ),
+        fieldAccess(
+            opcode = Opcode.IPUT_OBJECT,
+            type = "Ljava/lang/Boolean;"
+        )
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/ifunny/ad/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/ifunny/ad/HideAdsPatch.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.patches.ifunny.ad
+
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.ifunny.shared.Constants.COMPATIBILITY_IFUNNY
+import app.morphe.util.returnEarly
+
+@Suppress("unused")
+val hideAdsPatch = bytecodePatch(
+    name = "Hide ads",
+    description = "Hides ads."
+) {
+    compatibleWith(COMPATIBILITY_IFUNNY)
+
+    execute {
+        IsAdsDisabledFingerprint.method.returnEarly(true)
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/ifunny/premium/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/ifunny/premium/Fingerprints.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.patches.ifunny.premium
+
+import app.morphe.patcher.Fingerprint
+
+internal object IsUserPremiumFingerprint : Fingerprint(
+    definingClass = "Lmobi/ifunny/rest/content/User;",
+    name = "isUserPremium",
+    returnType = "Z",
+    parameters = listOf()
+)

--- a/patches/src/main/kotlin/app/morphe/patches/ifunny/premium/UnlockPremiumPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/ifunny/premium/UnlockPremiumPatch.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.patches.ifunny.premium
+
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.ifunny.shared.Constants.COMPATIBILITY_IFUNNY
+import app.morphe.util.returnEarly
+
+@Suppress("unused")
+val unlockPremiumPatch = bytecodePatch(
+    name = "Unlock premium",
+    description = "Unlocks premium features and the ability to save videos without watermarks."
+) {
+    compatibleWith(COMPATIBILITY_IFUNNY)
+
+    execute {
+        IsUserPremiumFingerprint.method.returnEarly(true)
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/ifunny/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/ifunny/shared/Constants.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.patches.ifunny.shared
+
+import app.morphe.patcher.patch.ApkFileType
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+
+internal object Constants {
+    val COMPATIBILITY_IFUNNY = Compatibility(
+        name = "iFunny",
+        packageName = "mobi.ifunny",
+        apkFileType = ApkFileType.APK,
+        appIconColor = 0x000000,
+        signatures = setOf(
+            "8e16f4751388194da1f7f5feafea5e86ad0424cc394e61f78b87dd328fdebebd"
+        ),
+        targets = listOf(
+            AppTarget(
+                version = "10.39.11",
+                minSdk = 26,
+            )
+        )
+    )
+}

--- a/patches/src/main/kotlin/app/morphe/patches/ifunny/video/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/ifunny/video/Fingerprints.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.patches.ifunny.video
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.string
+
+internal object CanSaveVideoFingerprint : Fingerprint(
+    definingClass = "Lmobi/ifunny/social/share/video/model/SaveContentCriterion;",
+    returnType = "Z",
+    parameters = listOf(),
+    filters = listOf(
+        string("getUserInfo(...)")
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/ifunny/video/SaveVideosPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/ifunny/video/SaveVideosPatch.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.patches.ifunny.video
+
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.ifunny.shared.Constants.COMPATIBILITY_IFUNNY
+import app.morphe.util.returnEarly
+
+@Suppress("unused")
+val saveVideosPatch = bytecodePatch(
+    name = "Save videos",
+    description = "Unlocks the ability to save videos."
+) {
+    compatibleWith(COMPATIBILITY_IFUNNY)
+
+    execute {
+        CanSaveVideoFingerprint.method.returnEarly(true)
+    }
+}


### PR DESCRIPTION
### Description

Adds three bytecode patches for iFunny (mobi.ifunny):

  - Hide ads — patches AdsDisableManagerImpl to always return true, suppressing all ad display checks
  - Unlock premium — patches User.isUserPremium() to always return true, enabling premium features
  - Save videos — patches SaveContentCriterion to always return true, unlocking video saving

All fingerprints target stable DEX class names sourced from Kotlin @Metadata annotations rather than jadx-renamed package names. Obfuscated methods are identified using structural filters (field access patterns and string literals) rather than method names, making them resilient to R8/ProGuard reruns across versions.


### Additional context

iFunny uses partial obfuscation — package/class names under mobi.ifunny.* are stable, but method names inside classes are minified to single letters. The fingerprint for each patch accounts for this: isUserPremium is unobfuscated and matched by name; the other two use structural bytecode filters unique to their target methods. See DEVELOPMENT.md in the patch directory for full rationale.

_(Tested on iFunny 10.38.11 and authored against 10.39.11)_