### PR TITLE
feat(YouTube - SponsorBlock): Add draggable new segment panel with persistent position

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -525,6 +525,7 @@ public class Settings extends SharedYouTubeSettings {
     /** Do not use id setting directly. Instead, use {@link SponsorBlockSettings}. */
     public static final StringSetting SB_PRIVATE_USER_ID = new StringSetting("sb_private_user_id_Do_Not_Share", "", true, parent(SB_ENABLED));
     public static final IntegerSetting SB_CREATE_NEW_SEGMENT_STEP = new IntegerSetting("sb_create_new_segment_step", 150, parent(SB_ENABLED));
+    public static final LongSetting SB_NEW_SEGMENT_PANEL_POSITION = new LongSetting("sb_new_segment_panel_position", 0L);
     public static final BooleanSetting SB_VOTING_BUTTON = new BooleanSetting("sb_voting_button", FALSE, parent(SB_ENABLED));
     public static final BooleanSetting SB_CREATE_NEW_SEGMENT = new BooleanSetting("sb_create_new_segment", FALSE, parent(SB_ENABLED));
     public static final BooleanSetting SB_SQUARE_LAYOUT = new BooleanSetting("sb_square_layout", FALSE, parent(SB_ENABLED));

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/ui/NewSegmentLayout.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/ui/NewSegmentLayout.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.youtube.sponsorblock.ui;
 
 import static app.morphe.extension.shared.ResourceUtils.getColor;
@@ -11,6 +21,8 @@ import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.RippleDrawable;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
+import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
@@ -23,6 +35,12 @@ import app.morphe.extension.youtube.patches.VideoInformation;
 import app.morphe.extension.youtube.settings.Settings;
 import app.morphe.extension.youtube.sponsorblock.SponsorBlockUtils;
 
+/**
+ * Floating panel shown over the player when creating a new SponsorBlock segment.
+ * Supports drag-to-reposition; the position is persisted across sessions via
+ * {@link Settings#SB_NEW_SEGMENT_PANEL_POSITION} as relative fractions of the parent's
+ * dimensions, so it scales correctly across screen rotations and different screen sizes.
+ */
 public final class NewSegmentLayout extends FrameLayout {
     private static final ColorStateList rippleColorStateList = new ColorStateList(
             new int[][]{new int[]{android.R.attr.state_enabled}},
@@ -31,6 +49,12 @@ public final class NewSegmentLayout extends FrameLayout {
 
     final int defaultBottomMargin;
     final int ctaBottomMargin;
+
+    private float dragStartX, dragStartY;
+    private float initialTransX, initialTransY;
+    private boolean isDragging;
+    // Stored squared to compare against squared distance, avoiding sqrt() in the hot path.
+    private final int touchSlopSquare;
 
     public NewSegmentLayout(final Context context) {
         this(context, null);
@@ -47,6 +71,9 @@ public final class NewSegmentLayout extends FrameLayout {
     public NewSegmentLayout(final Context context, final AttributeSet attributeSet,
                             final int defStyleAttr, final int defStyleRes) {
         super(context, attributeSet, defStyleAttr, defStyleRes);
+
+        final int touchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
+        touchSlopSquare = touchSlop * touchSlop;
 
         LayoutInflater.from(context).inflate(ResourceUtils.getIdentifierOrThrow(context,
                 ResourceType.LAYOUT,  "morphe_sb_new_segment"), this, true
@@ -129,11 +156,8 @@ public final class NewSegmentLayout extends FrameLayout {
         button.setImageResource(background);
 
         // Add ripple effect
-        RippleDrawable rippleDrawable = new RippleDrawable(
-                rippleColorStateList, null, null
-        );
-        button.setBackground(rippleDrawable);
-        button.setOnClickListener((v) -> {
+        button.setBackground(new RippleDrawable(rippleColorStateList, null, null));
+        button.setOnClickListener(v -> {
             handler.apply();
             Logger.printDebug(() -> debugMessage);
         });
@@ -157,6 +181,117 @@ public final class NewSegmentLayout extends FrameLayout {
         final float cornerRadius = squareLayout ? 0f : Dim.dp16;
         backgroundDrawable.setCornerRadius(cornerRadius);
         setBackground(backgroundDrawable);
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+        // Reapply the saved position on every layout change (first load, rotation, resize).
+        // Stored as relative fractions, so scaling to the new parent size preserves the
+        // panel's proportional location across orientations (e.g. right edge stays right edge).
+        // Skip during an active drag to avoid snapping the panel mid-gesture.
+        if (changed && !isDragging && getWidth() > 0 && getHeight() > 0) {
+            ViewGroup parent = (ViewGroup) getParent();
+            if (parent != null && parent.getWidth() > 0 && parent.getHeight() > 0) {
+                final long saved = Settings.SB_NEW_SEGMENT_PANEL_POSITION.get();
+                // Position is packed as two 32-bit float bit patterns: X fraction in the upper
+                // 32 bits, Y fraction in the lower 32 bits. Default 0L → (0f, 0f) → no translation.
+                setTranslationX(Float.intBitsToFloat((int) (saved >> 32)) * parent.getWidth());
+                setTranslationY(Float.intBitsToFloat((int) saved) * parent.getHeight());
+                clampTranslationToBounds();
+            }
+        }
+    }
+
+    /**
+     * Required when overriding {@link #onTouchEvent} - ensures accessibility services receive click events.
+     */
+    @Override
+    public boolean performClick() {
+        return super.performClick();
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent ev) {
+        switch (ev.getActionMasked()) {
+            case MotionEvent.ACTION_DOWN:
+                dragStartX = ev.getRawX();
+                dragStartY = ev.getRawY();
+                initialTransX = getTranslationX();
+                initialTransY = getTranslationY();
+                isDragging = false;
+                return false;
+            case MotionEvent.ACTION_MOVE:
+                if (!isDragging) {
+                    float dx = ev.getRawX() - dragStartX;
+                    float dy = ev.getRawY() - dragStartY;
+                    if (dx * dx + dy * dy > touchSlopSquare) {
+                        isDragging = true;
+                        // Prevent ancestor scrollable views from stealing subsequent events.
+                        if (getParent() != null) {
+                            getParent().requestDisallowInterceptTouchEvent(true);
+                        }
+                        return true;
+                    }
+                }
+                return isDragging;
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_CANCEL:
+                isDragging = false;
+                return false;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent ev) {
+        switch (ev.getActionMasked()) {
+            case MotionEvent.ACTION_MOVE:
+                setTranslationX(initialTransX + (ev.getRawX() - dragStartX));
+                setTranslationY(initialTransY + (ev.getRawY() - dragStartY));
+                return true;
+            case MotionEvent.ACTION_UP:
+                isDragging = false;
+                clampTranslationToBounds();
+                saveRelativePosition();
+                performClick();
+                return true;
+            case MotionEvent.ACTION_CANCEL:
+                isDragging = false;
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Clamps the panel's translation so all four edges stay within the parent's bounds,
+     * preventing the panel from becoming unreachable after a screen rotation or resize.
+     * No-op if the parent is unavailable or the view has not completed its first layout pass.
+     */
+    private void clampTranslationToBounds() {
+        ViewGroup parent = (ViewGroup) getParent();
+        if (parent == null) return;
+
+        final int height = getHeight();
+        final int width = getWidth();
+        if (width == 0 || height == 0) return;
+
+        final int top = getTop();
+        final int left = getLeft();
+        final float transX = Math.max(-left, Math.min(getTranslationX(), parent.getWidth() - left - width));
+        final float transY = Math.max(-top, Math.min(getTranslationY(), parent.getHeight() - top - height));
+        setTranslationX(transX);
+        setTranslationY(transY);
+    }
+
+    private void saveRelativePosition() {
+        ViewGroup parent = (ViewGroup) getParent();
+        if (parent == null || parent.getWidth() == 0 || parent.getHeight() == 0) return;
+        // Save as fractions of parent dimensions so the position scales correctly on rotation.
+        // & 0xFFFFFFFFL prevents sign extension when widening the Y int bits to long.
+        Settings.SB_NEW_SEGMENT_PANEL_POSITION.save(
+                (long) Float.floatToIntBits(getTranslationX() / parent.getWidth()) << 32
+                        | (Float.floatToIntBits(getTranslationY() / parent.getHeight()) & 0xFFFFFFFFL));
     }
 
     @FunctionalInterface


### PR DESCRIPTION
### Description

The SponsorBlock new segment panel can now be repositioned by dragging it anywhere on the screen. Its position is saved between sessions and automatically corrected after screen rotation.

Closes https://github.com/MorpheApp/morphe-patches/issues/657

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
___
![Screenshot_2026-05-25-23-04-45-087_app.morphe.android.youtube-edit.jpg](https://github.com/user-attachments/assets/79894d2d-4227-4547-ad58-b05ad0de3706)

