### PR TITLE
feat(YouTube - Hide layout components): Add "Hide Featured channels section" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/DescriptionComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/DescriptionComponentsFilter.java
@@ -43,6 +43,10 @@ final class DescriptionComponentsFilter extends Filter {
 
         featuredSectionGroupList.addAll(
                 new ByteArrayFilterGroup(
+                        Settings.HIDE_FEATURED_CHANNELS_SECTION,
+                        "structured_description_channel_lockup"
+                ),
+                new ByteArrayFilterGroup(
                         Settings.HIDE_FEATURED_LINKS_SECTION,
                         "media_lockup"
                 ),

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -291,6 +291,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_HOW_THIS_WAS_MADE_SECTION = new BooleanSetting("morphe_hide_how_this_was_made_section", FALSE);
     public static final BooleanSetting HIDE_HYPE_POINTS = new BooleanSetting("morphe_hide_hype_points", FALSE);
     public static final BooleanSetting HIDE_INFO_CARDS_SECTION = new BooleanSetting("morphe_hide_info_cards_section", FALSE);
+    public static final BooleanSetting HIDE_FEATURED_CHANNELS_SECTION = new BooleanSetting("morphe_hide_featured_channels_section", FALSE, parentNot(HIDE_INFO_CARDS_SECTION));
     public static final BooleanSetting HIDE_FEATURED_LINKS_SECTION = new BooleanSetting("morphe_hide_featured_links_section", FALSE, parentNot(HIDE_INFO_CARDS_SECTION));
     public static final BooleanSetting HIDE_FEATURED_VIDEOS_SECTION = new BooleanSetting("morphe_hide_featured_videos_section", FALSE, parentNot(HIDE_INFO_CARDS_SECTION));
     public static final BooleanSetting HIDE_SUBSCRIBE_BUTTON = new BooleanSetting("morphe_hide_subscribe_button", FALSE, parentNot(HIDE_INFO_CARDS_SECTION));

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -113,6 +113,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
                     SwitchPreference("morphe_hide_explore_section"),
                     SwitchPreference("morphe_hide_explore_course_section", summaryKey = null),
                     SwitchPreference("morphe_hide_explore_podcast_section", summaryKey = null),
+                    SwitchPreference("morphe_hide_featured_channels_section", summaryKey = null),
                     SwitchPreference("morphe_hide_featured_links_section", summaryKey = null),
                     SwitchPreference("morphe_hide_featured_places_section", summaryKey = null),
                     SwitchPreference("morphe_hide_featured_videos_section", summaryKey = null),

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -154,6 +154,7 @@ Showing YouTube Doodles may prevent custom headers from displaying."</string>
     <string name="morphe_hide_explore_section_summary">Hides the Explore this course and Explore the podcast sections</string>
     <string name="morphe_hide_explore_course_section_title">Hide \'Explore this course\' section</string>
     <string name="morphe_hide_explore_podcast_section_title">Hide \'Explore the podcast\' section</string>
+    <string name="morphe_hide_featured_channels_section_title">Hide Featured channels section</string>
     <string name="morphe_hide_featured_links_section_title">Hide Featured links section</string>
     <string name="morphe_hide_featured_places_section_title">Hide \'Featured places\' section</string>
     <string name="morphe_hide_featured_videos_section_title">Hide Featured videos section</string>


### PR DESCRIPTION
### Description

<img width="1080" height="993" alt="Screenshot_20260526_162735_YouTube" src="https://github.com/user-attachments/assets/4baba5f8-571d-4f36-b192-7289203bac59" />

### Additional context

```
05-26 16:14:20.701 22115 22395 D morphe: LithoFilterPatch: Searching ID: infocards_section.eml-fe|dba3a2ab444fa9e0 Path: infocards_section.eml-fe|dba3a2ab444fa9e0|CellType|ContainerType|ContainerType| BufferStrings: (compact_infocard.eml-fe|a9d35622ea0df598*❙zhttps://yt3.ggpht.com/hHexFKdfZ0oz0b6ImjkfZaoylbl8zJzcX52hN80iKjRnljRadVNcXyeyoLVvQgN8wVkaV0fCIQ=s64-c-k-c0x00ffffff-no-rj @(@❙{https://yt3.ggpht.com/hHexFKdfZ0oz0b6ImjkfZaoylbl8zJzcX52hN80iKjRnljRadVNcXyeyoLVvQgN8wVkaV0fCIQ=s128-c-k-c0x00ffffff-no-rj ❙Extra high❙443K subscribers"C❙UCO4YwjfJvxyg0J1runJeTEw2❙for chill gaym times*❙infocard-section-item-2"❙theme|1a8f1f8b14a595ef❙333?❙dismiss❙$KEN_BURNS_ANIMATION_TYPE_UNSPECIFIED❙capabilities|f277662b511b70d6❙content❙<structured_description_channel_lockup.eml-fe|3c1b1cf51d1d9dd*❙zhttps://yt3.ggpht.com/hHexFKdfZ0oz0b6ImjkfZaoylbl8zJzcX52hN80iKjRnljRadVNcXyeyoLVvQgN8wVkaV0fCIQ=s64-c-k-c0x00ffffff-no-rj @(@❙{https://yt3.ggpht.com/hHexFKdfZ0oz0b6ImjkfZaoylbl8zJzcX52hN80iKjRnljRadVNcXyeyoLVvQgN8wVkaV0fCIQ=s128-c-k-c0x00ffffff-no-rj ❙Extra high❙443K subscribers"C❙UCO4YwjfJvxyg0J1runJeTEw2❙theme|1a8f1f8b14a595ef❙333?❙dismiss❙$KEN_BURNS_ANIMATION_TYPE_UNSPECIFIED❙capabilities|f277662b511b70d6❙theme|1a8f1f8b14a595ef❙capabilities|f277662b511b70d6❙theme|1a8f1f8b14a595ef❙capabilities|f277662b511b70d6❙theme|1a8f1f8b14a595ef❙capabilities|f277662b511b70d6❙theme|1a8f1f8b14a595ef❙capabilities|f277662b511b70d6❙UCO4YwjfJvxyg0J1runJeTEw❙infocard-2❙
``` 

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
