### PR TITLE
feat(YouTube - Hide video action buttons): Add quick actions top margin setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/QuickActionsMarginPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/QuickActionsMarginPatch.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to Morphe contributions.
+ */
+
+package app.morphe.extension.youtube.patches;
+
+import android.view.View;
+import android.view.ViewGroup;
+
+import app.morphe.extension.youtube.settings.Settings;
+
+@SuppressWarnings("unused")
+public class QuickActionsMarginPatch {
+
+    /**
+     * Injection point.
+     * Sets the top margin of the quick actions container view in dp units.
+     */
+    public static void setQuickActionsMargin(View view) {
+        final int marginDp = Settings.QUICK_ACTIONS_TOP_MARGIN.get();
+        if (marginDp == 0) {
+            return;
+        }
+        if (!(view.getLayoutParams() instanceof ViewGroup.MarginLayoutParams params)) {
+            return;
+        }
+        params.topMargin = Math.round(marginDp * view.getResources().getDisplayMetrics().density);
+        view.requestLayout();
+    }
+}

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/QuickActionsMarginPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/QuickActionsMarginPatch.java
@@ -24,10 +24,10 @@ public class QuickActionsMarginPatch {
         if (marginDp == 0) {
             return;
         }
-        if (!(view.getLayoutParams() instanceof ViewGroup.MarginLayoutParams params)) {
-            return;
+
+        if (view.getLayoutParams() instanceof ViewGroup.MarginLayoutParams params) {
+            params.topMargin = Math.round(marginDp * view.getResources().getDisplayMetrics().density);
+            view.requestLayout();
         }
-        params.topMargin = Math.round(marginDp * view.getResources().getDisplayMetrics().density);
-        view.requestLayout();
     }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -229,6 +229,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_QUICK_ACTIONS_PLAYLIST_BUTTON = new BooleanSetting("morphe_hide_quick_actions_playlist_button", FALSE, parentNot(HIDE_QUICK_ACTIONS));
     public static final BooleanSetting HIDE_QUICK_ACTIONS_SAVE_BUTTON = new BooleanSetting("morphe_hide_quick_actions_save_button", FALSE, parentNot(HIDE_QUICK_ACTIONS));
     public static final BooleanSetting HIDE_QUICK_ACTIONS_SHARE_BUTTON = new BooleanSetting("morphe_hide_quick_actions_share_button", FALSE, parentNot(HIDE_QUICK_ACTIONS));
+    public static final IntegerSetting QUICK_ACTIONS_TOP_MARGIN = new IntegerSetting("morphe_quick_actions_top_margin", 0, true);
 
     // Ambient mode
     public static final BooleanSetting DISABLE_AMBIENT_MODE = new BooleanSetting("morphe_disable_ambient_mode", FALSE, true);
@@ -639,5 +640,7 @@ public class Settings extends SharedYouTubeSettings {
                 1, 20, 1, ""));
         SeekBarPreference.register(new SeekBarConfig(SWIPE_SPEED_ZONE_HEIGHT,
                 5, 75, 1, "%"));
+        SeekBarPreference.register(new SeekBarConfig(QUICK_ACTIONS_TOP_MARGIN,
+                0, 32, 1, "dp"));
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/Fingerprints.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to Morphe contributions.
+ */
+
+package app.morphe.patches.youtube.layout.buttons.action
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.opcode
+import app.morphe.patches.all.misc.resources.ResourceType
+import app.morphe.patches.all.misc.resources.resourceLiteral
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+/**
+ * Matches the method that processes the quick actions container view.
+ * Used to inject a top margin adjustment into the quick actions bar.
+ */
+internal object QuickActionsElementSyntheticFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf("Landroid/view/View;"),
+    filters = listOf(
+        resourceLiteral(ResourceType.ID, "quick_actions_element_container"),
+        opcode(Opcode.CHECK_CAST)
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/Fingerprints.kt
@@ -8,11 +8,11 @@
 package app.morphe.patches.youtube.layout.buttons.action
 
 import app.morphe.patcher.Fingerprint
-import app.morphe.patcher.opcode
+import app.morphe.patcher.InstructionLocation.MatchAfterWithin
+import app.morphe.patcher.checkCast
 import app.morphe.patches.all.misc.resources.ResourceType
 import app.morphe.patches.all.misc.resources.resourceLiteral
 import com.android.tools.smali.dexlib2.AccessFlags
-import com.android.tools.smali.dexlib2.Opcode
 
 /**
  * Matches the method that processes the quick actions container view.
@@ -24,6 +24,6 @@ internal object QuickActionsElementSyntheticFingerprint : Fingerprint(
     parameters = listOf("Landroid/view/View;"),
     filters = listOf(
         resourceLiteral(ResourceType.ID, "quick_actions_element_container"),
-        opcode(Opcode.CHECK_CAST)
+        checkCast("Landroid/view/ViewGroup;", location = MatchAfterWithin(10))
     )
 )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/HideVideoActionButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/HideVideoActionButtonsPatch.kt
@@ -14,6 +14,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.shared.misc.fix.proto.fixProtoLibraryPatch
+import app.morphe.patches.shared.misc.settings.preference.NonInteractivePreference
 import app.morphe.patches.shared.misc.settings.preference.PreferenceCategory
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
@@ -46,6 +47,7 @@ val hideVideoActionButtonsPatch = bytecodePatch(
         treeNodeElementHookPatch,
         fixProtoLibraryPatch,
         videoInformationPatch,
+        quickActionsMarginPatch
     )
 
     compatibleWith(COMPATIBILITY_YOUTUBE)
@@ -73,12 +75,16 @@ val hideVideoActionButtonsPatch = bytecodePatch(
                             SwitchPreference("morphe_hide_share_button", summaryKey = null),
                             SwitchPreference("morphe_hide_shop_button", summaryKey = null),
                             SwitchPreference("morphe_hide_stop_ads_button", summaryKey = null),
-                            SwitchPreference("morphe_hide_thanks_button", summaryKey = null),
+                            SwitchPreference("morphe_hide_thanks_button", summaryKey = null)
                         )
                     ),
                     PreferenceCategory(
                         titleKey = "morphe_fullscreen_buttons",
                         preferences = setOf(
+                            NonInteractivePreference(
+                                key = "morphe_quick_actions_top_margin",
+                                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference"
+                            ),
                             SwitchPreference("morphe_hide_quick_actions", summaryKey = null),
                             SwitchPreference("morphe_hide_quick_actions_ask_button", summaryKey = null),
                             SwitchPreference("morphe_hide_quick_actions_comments_button", summaryKey = null),
@@ -90,7 +96,7 @@ val hideVideoActionButtonsPatch = bytecodePatch(
                             SwitchPreference("morphe_hide_quick_actions_more_videos_button", summaryKey = null),
                             SwitchPreference("morphe_hide_quick_actions_playlist_button", summaryKey = null),
                             SwitchPreference("morphe_hide_quick_actions_save_button", summaryKey = null),
-                            SwitchPreference("morphe_hide_quick_actions_share_button", summaryKey = null),
+                            SwitchPreference("morphe_hide_quick_actions_share_button", summaryKey = null)
                         )
                     )
                 )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/QuickActionsMarginPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/QuickActionsMarginPatch.kt
@@ -28,7 +28,7 @@ internal val quickActionsMarginPatch = bytecodePatch(
     execute {
         QuickActionsElementSyntheticFingerprint.let {
             it.method.apply {
-                val checkCastIndex = it.instructionMatches[1].index
+                val checkCastIndex = it.instructionMatches.last().index
                 val insertRegister = getInstruction<OneRegisterInstruction>(checkCastIndex).registerA
 
                 addInstruction(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/QuickActionsMarginPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/QuickActionsMarginPatch.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to Morphe contributions.
+ */
+
+package app.morphe.patches.youtube.layout.buttons.action
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.all.misc.resources.resourceMappingPatch
+import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+
+private const val EXTENSION_CLASS =
+    "Lapp/morphe/extension/youtube/patches/QuickActionsMarginPatch;"
+
+internal val quickActionsMarginPatch = bytecodePatch(
+    description = "Injects a configurable top margin into the quick actions container view."
+) {
+    dependsOn(
+        sharedExtensionPatch,
+        resourceMappingPatch
+    )
+
+    execute {
+        QuickActionsElementSyntheticFingerprint.let {
+            it.method.apply {
+                val checkCastIndex = it.instructionMatches[1].index
+                val insertRegister = getInstruction<OneRegisterInstruction>(checkCastIndex).registerA
+
+                addInstruction(
+                    checkCastIndex + 1,
+                    "invoke-static { v$insertRegister }, $EXTENSION_CLASS->setQuickActionsMargin(Landroid/view/View;)V"
+                )
+            }
+        }
+    }
+}

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -502,6 +502,8 @@ Info: May not work on live streams"</string>
     <string name="morphe_hide_quick_actions_playlist_button_title">Hide Playlist button</string>
     <string name="morphe_hide_quick_actions_save_button_title">Hide Save button</string>
     <string name="morphe_hide_quick_actions_share_button_title">Hide Share button</string>
+    <string name="morphe_quick_actions_top_margin_title">Quick actions top margin</string>
+    <string name="morphe_quick_actions_top_margin_summary">Set the top margin of the quick actions bar (0-32 dp)</string>
 
     <!-- layout.captions.captionsPatch -->
     <string name="morphe_captions_screen_title">Captions</string>


### PR DESCRIPTION
### Description

Add a SeekBar preference to the Action  buttons section that lets users set a custom top margin (0–32 dp) for the quick actions bar, raising the seekbar above the gesture navigation area.

Closes https://github.com/MorpheApp/morphe-patches/issues/636

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
