### PR TITLE
feat(Settings): Add haptic feedback to settings toggles

### DIFF
--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/AbstractPreferenceFragment.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/AbstractPreferenceFragment.java
@@ -34,6 +34,7 @@ import android.preference.TwoStatePreference;
 import android.text.InputType;
 import android.util.Pair;
 import android.util.TypedValue;
+import android.os.Build;
 import android.view.HapticFeedbackConstants;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -93,8 +94,11 @@ public abstract class AbstractPreferenceFragment extends PreferenceFragment {
         public boolean performItemClick(View view, int position, long id) {
             Object item = getAdapter().getItem(position);
 
-            if (item instanceof TwoStatePreference) {
-                view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK);
+            if (item instanceof TwoStatePreference twoState) {
+                int feedbackConstant = Build.VERSION.SDK_INT >= 34
+                        ? (twoState.isChecked() ? HapticFeedbackConstants.TOGGLE_OFF : HapticFeedbackConstants.TOGGLE_ON)
+                        : HapticFeedbackConstants.CLOCK_TICK;
+                view.performHapticFeedback(feedbackConstant);
                 return super.performItemClick(view, position, id);
             }
 
@@ -112,8 +116,11 @@ public abstract class AbstractPreferenceFragment extends PreferenceFragment {
         public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
             Object item = parent.getAdapter().getItem(position);
 
-            if (item instanceof TwoStatePreference) {
-                view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK);
+            if (item instanceof TwoStatePreference twoState) {
+                int feedbackConstant = Build.VERSION.SDK_INT >= 34
+                        ? (twoState.isChecked() ? HapticFeedbackConstants.TOGGLE_OFF : HapticFeedbackConstants.TOGGLE_ON)
+                        : HapticFeedbackConstants.CLOCK_TICK;
+                view.performHapticFeedback(feedbackConstant);
                 originalListener.onItemClick(parent, view, position, id);
                 return;
             }

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/AbstractPreferenceFragment.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/AbstractPreferenceFragment.java
@@ -34,6 +34,7 @@ import android.preference.TwoStatePreference;
 import android.text.InputType;
 import android.util.Pair;
 import android.util.TypedValue;
+import android.view.HapticFeedbackConstants;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -93,6 +94,7 @@ public abstract class AbstractPreferenceFragment extends PreferenceFragment {
             Object item = getAdapter().getItem(position);
 
             if (item instanceof TwoStatePreference) {
+                view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK);
                 return super.performItemClick(view, position, id);
             }
 
@@ -111,6 +113,7 @@ public abstract class AbstractPreferenceFragment extends PreferenceFragment {
             Object item = parent.getAdapter().getItem(position);
 
             if (item instanceof TwoStatePreference) {
+                view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK);
                 originalListener.onItemClick(parent, view, position, id);
                 return;
             }


### PR DESCRIPTION
### Description

Adds haptic feedback when toggling switches in Morphe settings screens.

The feedback fires via `View.performHapticFeedback()`, which respects the system "Vibrate on touch" setting.

Closes https://github.com/MorpheApp/morphe-patches/issues/508

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
