### PR TITLE
fix(YouTube - Hide player flyout menu components): Hide the divider for overflow menu

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/PlayerFlyoutMenuComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/PlayerFlyoutMenuComponentsFilter.java
@@ -154,7 +154,7 @@ public class PlayerFlyoutMenuComponentsFilter extends Filter {
             if (path.contains("quick_quality_sheet_content.e")) {
                 return Settings.HIDE_PLAYER_FLYOUT_QUALITY_FOOTER.get();
             }
-            return false;
+            return path.contains("overflow_menu_item.e");
         }
 
         if (contentIndex != 0) {


### PR DESCRIPTION
To filter the unique (and useless) divider shown in other settings, in the flyout video player (the one placed before stats for nerds, to be more clear).