### PR TITLE
feat(YouTube - SponsorBlock): Add fade animation to the new segment panel

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/ui/NewSegmentLayout.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/ui/NewSegmentLayout.java
@@ -31,6 +31,7 @@ import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.ui.Dim;
+import app.morphe.extension.shared.ui.ViewAnimations;
 import app.morphe.extension.youtube.patches.VideoInformation;
 import app.morphe.extension.youtube.settings.Settings;
 import app.morphe.extension.youtube.sponsorblock.SponsorBlockUtils;
@@ -292,6 +293,14 @@ public final class NewSegmentLayout extends FrameLayout {
         Settings.SB_NEW_SEGMENT_PANEL_POSITION.save(
                 (long) Float.floatToIntBits(getTranslationX() / parent.getWidth()) << 32
                         | (Float.floatToIntBits(getTranslationY() / parent.getHeight()) & 0xFFFFFFFFL));
+    }
+
+    void showWithAnimation() {
+        ViewAnimations.fadeIn(this, 100);
+    }
+
+    void hideWithAnimation() {
+        ViewAnimations.fadeOut(this, 100);
     }
 
     @FunctionalInterface

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/ui/SponsorBlockViewController.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/ui/SponsorBlockViewController.java
@@ -218,12 +218,19 @@ public class SponsorBlockViewController {
         if (skipHighlight != null) {
             setGenericViewVisibility(skipHighlightButtonRef.get(), !newSegmentLayoutVisible);
         }
-        setGenericViewVisibility(newSegmentLayout, newSegmentLayoutVisible);
+        if (newSegmentLayoutVisible && canShowViewElements) {
+            newSegmentLayout.showWithAnimation();
+        } else {
+            newSegmentLayout.hideWithAnimation();
+        }
     }
 
     public static void hideNewSegmentLayout() {
         newSegmentLayoutVisible = false;
-        setGenericViewVisibility(newSegmentLayoutRef.get(), false);
+        NewSegmentLayout layout = newSegmentLayoutRef.get();
+        if (layout != null && layout.getVisibility() == View.VISIBLE) {
+            layout.hideWithAnimation();
+        }
     }
 
     private static void setGenericViewVisibility(@Nullable View view, boolean visible) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/views/SwipeControlsOverlayLayout.kt
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/views/SwipeControlsOverlayLayout.kt
@@ -2,8 +2,6 @@
 
 package app.morphe.extension.youtube.swipecontrols.views
 
-import android.animation.Animator
-import android.animation.AnimatorListenerAdapter
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.Resources
@@ -19,6 +17,7 @@ import android.view.HapticFeedbackConstants
 import android.view.View
 import android.widget.RelativeLayout
 import app.morphe.extension.shared.ResourceType
+import app.morphe.extension.shared.ui.ViewAnimations
 import app.morphe.extension.shared.ResourceUtils.getIdentifierOrThrow
 import app.morphe.extension.shared.StringRef.str
 import app.morphe.extension.youtube.swipecontrols.SwipeControlsConfigurationProvider
@@ -163,31 +162,8 @@ class SwipeControlsOverlayLayout(
         addView(verticalVolumeProgressView)
     }
 
-    private fun View.fadeIn() {
-        animate().cancel()
-        if (visibility == VISIBLE && alpha == 1f) return
-        if (visibility != VISIBLE) {
-            alpha = 0f
-            visibility = VISIBLE
-        }
-        animate().alpha(1f).setDuration(100).setListener(null).start()
-    }
-
-    private fun View.fadeOut() {
-        animate().cancel()
-        animate().alpha(0f).setDuration(100)
-            .setListener(object : AnimatorListenerAdapter() {
-                override fun onAnimationEnd(animation: Animator) {
-                    visibility = GONE
-                    alpha = 1f
-                    animate().setListener(null)
-                }
-                override fun onAnimationCancel(animation: Animator) {
-                    animate().setListener(null)
-                }
-            })
-            .start()
-    }
+    private fun View.fadeIn() = ViewAnimations.fadeIn(this, 100)
+    private fun View.fadeOut() = ViewAnimations.fadeOut(this, 100)
 
     // Handler and callback for hiding progress bars.
     private val feedbackHideHandler = Handler(Looper.getMainLooper())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 [versions]
 morphe-patcher = "1.5.1"
-morphe-patches-library = "1.4.0-dev.5"
+morphe-patches-library = "1.4.0-dev.6"
 # Tracking https://github.com/google/smali/issues/100.
 smali = "d92701d947"
 agp = "9.1.0"


### PR DESCRIPTION
Add fade in/out animation to the SponsorBlock new segment panel, and migrate `SwipeControlsOverlayLayout`'s local `fadeIn/fadeOut` helpers to the new shared `ViewAnimations` utility.