### PR TITLE
chore(YouTube Music - Track crossfade): Localize crossfade curve preview labels

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/preference/CrossfadeCurvePreference.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/preference/CrossfadeCurvePreference.java
@@ -1,5 +1,7 @@
 package app.morphe.extension.music.settings.preference;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -230,19 +232,19 @@ public final class CrossfadeCurvePreference extends Preference
             canvas.drawCircle(legendX, legendY, dp(4), outPaint);
             outPaint.setStyle(Paint.Style.STROKE);
             textPaint.setTextAlign(Paint.Align.LEFT);
-            canvas.drawText("Outgoing", legendX + dp(8), legendY + dp(3.5f), textPaint);
+            canvas.drawText(str("morphe_music_crossfade_curve_preview_outgoing"), legendX + dp(8), legendY + dp(3.5f), textPaint);
 
             float inLegendX = legendX + dp(80);
             inPaint.setStyle(Paint.Style.FILL);
             canvas.drawCircle(inLegendX, legendY, dp(4), inPaint);
             inPaint.setStyle(Paint.Style.STROKE);
-            canvas.drawText("Incoming", inLegendX + dp(8), legendY + dp(3.5f), textPaint);
+            canvas.drawText(str("morphe_music_crossfade_curve_preview_incoming"), inLegendX + dp(8), legendY + dp(3.5f), textPaint);
 
             String curveName = switch (curve) {
-                case EASE_OUT_CUBIC -> "Subtle hold";
-                case EASE_OUT_QUAD -> "Gentle ease";
-                case SMOOTHSTEP -> "Smooth S-curve";
-                default -> "Equal power";
+                case EASE_OUT_CUBIC -> str("morphe_music_crossfade_curve_entry_ease_out_cubic");
+                case EASE_OUT_QUAD -> str("morphe_music_crossfade_curve_entry_ease_out_quad");
+                case SMOOTHSTEP -> str("morphe_music_crossfade_curve_entry_smoothstep");
+                default -> str("morphe_music_crossfade_curve_entry_equal_power");
             };
             textPaint.setTextAlign(Paint.Align.RIGHT);
             canvas.drawText(curveName, w - padR, legendY + dp(3.5f), textPaint);

--- a/patches/src/main/resources/addresources/values/music/strings.xml
+++ b/patches/src/main/resources/addresources/values/music/strings.xml
@@ -52,6 +52,8 @@ Second \"item\" text"</string>
     <string name="morphe_music_crossfade_curve_entry_smoothstep">Smooth S-curve</string>
     <!-- Empty string because custom preference handles the title itself -->
     <string name="morphe_music_crossfade_curve_preview_title" translatable="false"> </string>
+    <string name="morphe_music_crossfade_curve_preview_outgoing">Outgoing</string>
+    <string name="morphe_music_crossfade_curve_preview_incoming">Incoming</string>
     <string name="morphe_music_crossfade_duration_title">Crossfade duration</string>
     <string name="morphe_crossfade_duration_250ms">250 milliseconds</string>
     <string name="morphe_crossfade_duration_500ms">500 milliseconds</string>


### PR DESCRIPTION
### Description

Replaces hardcoded crossfade curve preview labels ("Outgoing", "Incoming", and curve names) with localized string references via `str()`.

Closes #

### Additional context

<details><summary>Screenshot</summary>
<p>

<img width="1080" height="657" alt="Screenshot_20260528-073930" src="https://github.com/user-attachments/assets/86ddec85-1961-4aab-9a0c-834b7ed7f01d" />

</p>
</details> 

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
