### PR TITLE
feat(YouTube Music): Add support for Track Crossfade in 9.x

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
@@ -2232,10 +2232,13 @@ public class CrossfadeManager {
         activityRunning = false;
         // Do not stop the auto-advance monitor here — crossfade should continue
         // even when the screen locks or the app is minimised (#1311).
-        if (crossfadeInProgress) {
-            logInfo("onActivityStop: aborting crossfade");
-            abortCrossfadeNow();
-        }
+        //
+        // Do not abort an in-progress crossfade either — YTM is a music app with
+        // a foreground service, so playback continues after onStop. The fade
+        // animations keep ticking on mainHandler and complete naturally in the
+        // background. Aborting here caused the outgoing track to be released
+        // mid-fade when the user pressed the power button during a crossfade
+        // (#1442).
     }
 
     public static void onActivityStart() {

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
@@ -360,6 +360,15 @@ public class CrossfadeManager {
     private static volatile boolean autoAdvanceCrossfadeActive = false;
     /** Retained for cleanup symmetry only. */
     private static volatile boolean monitorCrossfadeActive = false;
+    /**
+     * 9.x auto-advance: true after onBeforeStopVideo has pre-started the outgoing
+     * player's fade-out at coordinator swap time.  Tells onPendingPlayerReady not
+     * to re-add the outgoing to the fade list (it's already in flight).  Decouples
+     * fade-out integrity from new-player load latency, which can exceed the
+     * remaining audio on the outgoing track and otherwise causes the fade-out to
+     * be shortened or skipped entirely.
+     */
+    private static volatile boolean outgoingFadePreStarted = false;
 
     /**
      * Set at patch time via sput-boolean — true when running on YTM 9.x.
@@ -648,10 +657,13 @@ public class CrossfadeManager {
                 return false;
             }
             // If a manual skip fires while a 9.x volume-fade is running, abort the fade
-            // and fall through to the normal crossfade path.
+            // and fall through to the normal crossfade path. The pre-started outgoing
+            // fade-out (if any) keeps running independently on the original outgoing
+            // player; the new manual skip creates a different outgoing.
             if (is9x && !isAutoAdvance && autoAdvanceCrossfadeActive) {
                 autoAdvanceCrossfadeActive = false;
                 queueAdvancedByMonitor = false;
+                outgoingFadePreStarted = false;
                 logInfo("9.x: manual skip aborted volume-fade — proceeding with normal crossfade");
             }
 
@@ -745,13 +757,14 @@ public class CrossfadeManager {
                 // of this stopVideo, it was YTM-internal (skip setup), not a genuine user pause.
                 // A genuine user pause precedes the next song selection by seconds, so the gap
                 // will be >> 500ms and playerIsPlaying=false will correctly keep the player silent.
+                boolean outgoingWasPlaying = false;
                 try {
                     long msSincePause = System.currentTimeMillis() - lastPauseVideoMs;
-                    boolean wasPlaying = playerIsPlaying
+                    outgoingWasPlaying = playerIsPlaying
                             || msSincePause < PAUSE_TO_STOP_INTERNAL_WINDOW_MS;
                     logInfo("9.x: outgoing player re-enable check: playerIsPlaying=" + playerIsPlaying
-                            + " msSincePause=" + msSincePause + "ms → wasPlaying=" + wasPlaying);
-                    if (wasPlaying) {
+                            + " msSincePause=" + msSincePause + "ms → wasPlaying=" + outgoingWasPlaying);
+                    if (outgoingWasPlaying) {
                         currentExo.patch_setPlayWhenReady(true);
                         currentExo.patch_setVolume(1.0f);
                         logInfo("9.x: re-enabled outgoing player @" + System.identityHashCode(currentExo));
@@ -762,6 +775,26 @@ public class CrossfadeManager {
                     }
                 } catch (Exception e) {
                     logWarn("9.x: could not configure outgoing player: " + e.getMessage());
+                }
+
+                // 9.x auto-advance: start the outgoing fade-out NOW (at swap time)
+                // rather than waiting for the new player to reach READY. On 9.x the
+                // MEDIA_NEXT skip path triggers a cold load, not a pre-warmed gapless
+                // buffer, so new-player READY latency can exceed the remaining audio
+                // on the outgoing track. If we waited for READY, onPendingPlayerReady
+                // would shorten the fade-out to actualRemaining (min 150ms) or skip
+                // it entirely via the trackAlreadyEnded path. Pre-starting decouples
+                // fade-out integrity from load latency: the outgoing always gets the
+                // full configured fade duration and reaches silence gracefully.
+                if (isAutoAdvance && outgoingWasPlaying) {
+                    FadeCurve outCurve = Settings.CROSSFADE_CURVE.get();
+                    long outFadeDuration = getCrossfadeDurationMs();
+                    fadingOutPlayers.add(new FadingPlayer(currentExo, outFadeDuration, outCurve));
+                    outgoingFadePreStarted = true;
+                    ensureFadingLoopRunning();
+                    logInfo("9.x auto-advance: pre-started outgoing fade-out @"
+                            + System.identityHashCode(currentExo)
+                            + " over " + outFadeDuration + "ms");
                 }
 
                 pollForNewTrackReady(newExo);
@@ -1310,45 +1343,54 @@ public class CrossfadeManager {
                 logInfo("onPendingPlayerReady (9.x): coordinator listener already migrated at start");
             }
 
-            // Match fade-out duration to actual remaining audio on the outgoing track.
-            // This is critical for auto-advance: the trigger fires 300ms+ before the
-            // configured fade duration, but READY latency is variable (100-500ms+).
-            // Without this adjustment, the fade-out may start too late, causing the
-            // outgoing track to end at non-zero volume (perceptible cutoff).
-            long fadeOutDuration = fadeDuration;
-            try {
-                long pos = outgoing.patch_getCurrentPosition();
-                long dur = outgoing.patch_getDuration();
-                if (dur > 0 && pos >= 0) {
-                    long actualRemaining = dur - pos;
-                    logInfo("onPendingPlayerReady: outgoing remaining=" + actualRemaining
-                            + "ms fadeDuration=" + fadeDuration + "ms");
-                    if (actualRemaining <= 0) {
-                        // Auto-advance: content only loads after natural track end, so READY
-                        // always arrives after the old track has finished. Release the old player
-                        // immediately — there is no audio to fade out. The new track will fade in
-                        // from silence (true overlap requires intercepting YTM's gapless preload).
-                        trackAlreadyEnded = true;
-                        logInfo("Auto-advance: outgoing track ended before READY — "
-                                + "releasing silently, fade-in only (no overlap possible)");
-                    } else if (actualRemaining < fadeDuration) {
-                        fadeOutDuration = Math.max(150, actualRemaining);
-                        logInfo("Fade-out shortened to " + fadeOutDuration
-                                + "ms to match remaining audio (was " + fadeDuration + "ms)");
-                    }
-                }
-            } catch (Exception e) {
-                logDebug("Could not read outgoing remaining time: " + e.getMessage());
-            }
-            pendingOutPlayer = null;
-            if (trackAlreadyEnded) {
-                releasePlayer(outgoing);
-                logInfo("Original outgoing player @" + System.identityHashCode(outgoing)
-                        + " → released (track ended before READY)");
+            if (outgoingFadePreStarted) {
+                // 9.x auto-advance: fade-out was pre-started at coordinator swap time
+                // in onBeforeStopVideo. The outgoing is already in fadingOutPlayers
+                // running the full configured fade duration. Skip the re-add and the
+                // actualRemaining adjustment — those exist for the legacy path where
+                // fade-out only began once the new player reached READY.
+                logInfo("onPendingPlayerReady: outgoing @" + System.identityHashCode(outgoing)
+                        + " fade-out already in flight (pre-started at swap time)");
+                pendingOutPlayer = null;
+                outgoingFadePreStarted = false;
             } else {
-                fadingOutPlayers.add(new FadingPlayer(outgoing, fadeOutDuration, curve));
-                logInfo("Original outgoing player @" + System.identityHashCode(outgoing)
-                        + " → fade-out list (" + fadeOutDuration + "ms)");
+                // Match fade-out duration to actual remaining audio on the outgoing track.
+                // Used for the legacy path (manual skip, 8.x auto-advance) where the
+                // fade-out only begins here. Without this adjustment, the fade-out may
+                // start too late, causing the outgoing track to end at non-zero volume.
+                long fadeOutDuration = fadeDuration;
+                try {
+                    long pos = outgoing.patch_getCurrentPosition();
+                    long dur = outgoing.patch_getDuration();
+                    if (dur > 0 && pos >= 0) {
+                        long actualRemaining = dur - pos;
+                        logInfo("onPendingPlayerReady: outgoing remaining=" + actualRemaining
+                                + "ms fadeDuration=" + fadeDuration + "ms");
+                        if (actualRemaining <= 0) {
+                            // Content only loads after natural track end, so READY always
+                            // arrives after the old track has finished. Release silently.
+                            trackAlreadyEnded = true;
+                            logInfo("Outgoing track ended before READY — "
+                                    + "releasing silently, fade-in only (no overlap possible)");
+                        } else if (actualRemaining < fadeDuration) {
+                            fadeOutDuration = Math.max(150, actualRemaining);
+                            logInfo("Fade-out shortened to " + fadeOutDuration
+                                    + "ms to match remaining audio (was " + fadeDuration + "ms)");
+                        }
+                    }
+                } catch (Exception e) {
+                    logDebug("Could not read outgoing remaining time: " + e.getMessage());
+                }
+                pendingOutPlayer = null;
+                if (trackAlreadyEnded) {
+                    releasePlayer(outgoing);
+                    logInfo("Original outgoing player @" + System.identityHashCode(outgoing)
+                            + " → released (track ended before READY)");
+                } else {
+                    fadingOutPlayers.add(new FadingPlayer(outgoing, fadeOutDuration, curve));
+                    logInfo("Original outgoing player @" + System.identityHashCode(outgoing)
+                            + " → fade-out list (" + fadeOutDuration + "ms)");
+                }
             }
         }
 
@@ -1585,6 +1627,7 @@ public class CrossfadeManager {
         autoAdvanceCrossfadeActive = false;
         queueAdvancedByMonitor = false;
         monitorCrossfadeActive = false;
+        outgoingFadePreStarted = false;
         deferredSwapPending = false;
         currentFadeInVolume = 0.0f;
 
@@ -2121,6 +2164,7 @@ public class CrossfadeManager {
         autoAdvanceCrossfadeActive = false;
         queueAdvancedByMonitor = false;
         monitorCrossfadeActive = false;
+        outgoingFadePreStarted = false;
         deferredSwapPending = false;
         currentFadeInVolume = 0.0f;
         coordinatorListenerBxi = null;

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
@@ -8,12 +8,14 @@ package app.morphe.extension.music.patches;
 
 import static app.morphe.extension.shared.StringRef.str;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
 import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
 import android.media.AudioPlaybackConfiguration;
+import android.media.MediaRouter;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
@@ -22,13 +24,24 @@ import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.os.VibratorManager;
 import android.view.KeyEvent;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
-import android.annotation.SuppressLint;
 
 import java.lang.ref.WeakReference;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import app.morphe.extension.music.settings.Settings;
 import app.morphe.extension.shared.Logger;
@@ -251,28 +264,28 @@ public class CrossfadeManager {
     //  Constants and fields                                                //
     // ------------------------------------------------------------------ //
 
-    private static void logDebug(String msg) {
-        Logger.printInfo(() -> msg);
+    private static void logDebug(Logger.LogMessage msg) {
+        Logger.printDebug(msg);
     }
 
-    private static void logInfo(String msg) {
-        Logger.printInfo(() -> msg);
+    private static void logInfo(Logger.LogMessage msg) {
+        Logger.printInfo(msg);
     }
 
-    private static void logError(String msg) {
-        Logger.printException(() -> msg);
+    private static void logWarn(Logger.LogMessage msg) {
+        Logger.printInfo(msg);
     }
 
-    private static void logError(String msg, Exception e) {
-        Logger.printException(() -> msg, e);
+    private static void logWarn(Logger.LogMessage msg, Exception e) {
+        Logger.printInfo(msg, e);
     }
 
-    private static void logWarn(String msg) {
-        Logger.printInfo(() -> msg);
+    private static void logError(Logger.LogMessage msg) {
+        Logger.printException(msg);
     }
 
-    private static void logWarn(String msg, Exception e) {
-        Logger.printInfo(() -> msg, e);
+    private static void logError(Logger.LogMessage msg, Exception e) {
+        Logger.printException(msg, e);
     }
 
     private static String stopReasonName(int reason) {
@@ -302,7 +315,7 @@ public class CrossfadeManager {
                 + " pendIn=@" + System.identityHashCode(pendingInPlayer)
                 + " pendOut=@" + System.identityHashCode(pendingOutPlayer)
                 + " fadingOut=" + fadingOutPlayers.size()
-                + " inVol=" + String.format("%.2f", currentFadeInVolume)
+                + " inVol=" + String.format(Locale.US, "%.2f", currentFadeInVolume)
                 + " inVideo=" + inVideoMode
                 + " nbaAlive=" + (lastNbaRef != null && lastNbaRef.get() != null)
                 + " atadAlive=" + (lastAtadRef != null && lastAtadRef.get() != null)
@@ -326,12 +339,12 @@ public class CrossfadeManager {
         SMOOTHSTEP;
 
         public float out(float t) {
-            switch (this) {
-                case EASE_OUT_CUBIC: return 1.0f - t * t * t;
-                case EASE_OUT_QUAD:  return (1.0f - t) * (1.0f - t);
-                case SMOOTHSTEP:    return 1.0f - (3.0f * t * t - 2.0f * t * t * t);
-                default:            return (float) Math.cos(t * Math.PI / 2.0);
-            }
+            return switch (this) {
+                case EASE_OUT_CUBIC -> 1.0f - t * t * t;
+                case EASE_OUT_QUAD -> (1.0f - t) * (1.0f - t);
+                case SMOOTHSTEP -> 1.0f - (3.0f * t * t - 2.0f * t * t * t);
+                default -> (float) Math.cos(t * Math.PI / 2.0);
+            };
         }
 
         public float in(float t) {
@@ -385,7 +398,8 @@ public class CrossfadeManager {
      * On 9.x, blocking stopVideo also blocks playVideo (same call chain),
      * so we use a deferred coordinator swap instead of blocking native.
      */
-    public static volatile boolean is9x = false;
+    public static final boolean is9x = VersionCheckPatch.IS_9_00_OR_GREATER;
+    
     /**
      * 9.x: When true, the injected early-return in cwh.U()V prevents the Lcvu Runnable from
      * being posted to the handler. This blocks cvu.run() → cwh.b.d() → CopyOnWriteArraySet.clear()
@@ -478,8 +492,8 @@ public class CrossfadeManager {
      */
     private static volatile Object coordinatorListenerBxi = null;
 
-    private static final java.util.List<FadingPlayer> fadingOutPlayers =
-            java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+    private static final List<FadingPlayer> fadingOutPlayers =
+            Collections.synchronizedList(new ArrayList<>());
     private static volatile boolean fadingLoopRunning = false;
 
     private static WeakReference<Object> lastAtadRef = new WeakReference<>(null);
@@ -498,8 +512,8 @@ public class CrossfadeManager {
 
     private static int playersCreated = 0;
     private static int playersReleased = 0;
-    private static final java.util.List<WeakReference<View>> longPressRefs =
-            new java.util.ArrayList<>();
+    private static final List<WeakReference<View>> longPressRefs =
+            new ArrayList<>();
 
     /**
      * Tracks a single player's fade-out animation.
@@ -562,13 +576,13 @@ public class CrossfadeManager {
         // Only gate when no crossfade is already in flight — if one is in
         // progress (cast started mid-fade), let it complete normally.
         if (!crossfadeInProgress && isAudioRoutedToCast()) {
-            logInfo("stopVideo(" + reason + "): skip — audio routed to cast/mirror (#1549)");
+            logDebug(() -> "stopVideo(" + reason + "): skip — audio routed to cast/mirror (#1549)");
             return false;
         }
 
         int atadId = System.identityHashCode(atadInstance);
         if (atadId != lastAtadIdentity && lastAtadIdentity != 0) {
-            logInfo("QUEUE-CHANGE DETECTED: atad identity changed @"
+            logDebug(() -> "QUEUE-CHANGE DETECTED: atad identity changed @"
                     + lastAtadIdentity + " → @" + atadId
                     + " (new session/queue) " + dumpState());
         }
@@ -582,7 +596,7 @@ public class CrossfadeManager {
                     if (queueAdvancedByMonitor) {
                         // Block: queue already advanced via MEDIA_NEXT; letting native run
                         // would double-advance to song N+2.
-                        logInfo("stopVideo(5): auto-advance + queue already advanced — BLOCKING natural-end");
+                        logDebug(() -> "stopVideo(5): auto-advance + queue already advanced — BLOCKING natural-end");
                         return true;
                     }
                     return false;
@@ -592,10 +606,10 @@ public class CrossfadeManager {
             if (is9x) {
                 // 9.x: native stopVideo(5) body calls stopVideo(1)/loadVideo/playVideo to
                 // load the next track on the new coordinator player; must pass through.
-                logDebug("stopVideo/" + stopReasonName(reason) + ": ALLOW — 9.x native cycle (crossfade in progress)");
+                logDebug(() -> "stopVideo/" + stopReasonName(reason) + ": ALLOW — 9.x native cycle (crossfade in progress)");
                 return false;
             }
-            logDebug("stopVideo/" + stopReasonName(reason) + ": BLOCKED — crossfade in progress");
+            logDebug(() -> "stopVideo/" + stopReasonName(reason) + ": BLOCKED — crossfade in progress");
             return true;
         }
 
@@ -604,10 +618,10 @@ public class CrossfadeManager {
                 suppressedReasonCount++;
             } else {
                 if (suppressedReasonCount > 0) {
-                    logDebug("  (suppressed " + suppressedReasonCount
-                            + " duplicate reason=" + lastLoggedReason + " entries)");
+                    logDebug(() -> "  (suppressed " + suppressedReasonCount
+                                        + " duplicate reason=" + lastLoggedReason + " entries)");
                 }
-                logDebug("stopVideo reason=" + reason + " — not a skip, ignoring");
+                logDebug(() -> "stopVideo reason=" + reason + " — not a skip, ignoring");
                 lastLoggedReason = reason;
                 suppressedReasonCount = 0;
             }
@@ -617,18 +631,18 @@ public class CrossfadeManager {
         suppressedReasonCount = 0;
 
         if (System.currentTimeMillis() < manualToggleSuppressionUntil) {
-            logInfo("stopVideo(5): skip — within manual toggle suppression window");
+            logDebug(() -> "stopVideo(5): skip — within manual toggle suppression window");
             return false;
         }
 
         if (isCrossfadePaused || getCrossfadeDurationMs() <= 0) {
-            logDebug("stopVideo(5): skip [paused=" + isCrossfadePaused
+            logDebug(() -> "stopVideo(5): skip [paused=" + isCrossfadePaused
                     + " inVideo=" + isCurrentlyInVideoMode() + "]");
             return false;
         }
 
         if (isFromTaskRemoval()) {
-            logDebug("stopVideo(5): skip — triggered by onTaskRemoved (activity killed)");
+            logDebug(() -> "stopVideo(5): skip — triggered by onTaskRemoved (activity killed)");
             if (crossfadeInProgress) cleanupAllPlayers();
             return false;
         }
@@ -636,13 +650,13 @@ public class CrossfadeManager {
         try {
             PlayerCoordinatorAccess coordinator = getCoordinatorFromAtad(atadInstance);
             if (coordinator == null) {
-                logError("Could not find coordinator from atad");
+                logError(() -> "Could not find coordinator from atad");
                 return false;
             }
 
             ExoPlayerAccess currentExo = (ExoPlayerAccess) coordinator.patch_getExoPlayer();
             if (currentExo == null) {
-                logError("Coordinator ExoPlayer is null");
+                logError(() -> "Coordinator ExoPlayer is null");
                 return false;
             }
 
@@ -653,19 +667,20 @@ public class CrossfadeManager {
                 long remaining = (duration > 0) ? duration - pos : Long.MAX_VALUE;
                 isAutoAdvance = duration > 0 && remaining >= 0
                         && remaining < AUTO_ADVANCE_THRESHOLD_MS;
-                logDebug("stopVideo(5): pos=" + pos + "ms dur=" + duration
+                final boolean isAutoAdvanceFinal = isAutoAdvance;
+                logDebug(() -> "stopVideo(5): pos=" + pos + "ms dur=" + duration
                         + "ms remaining=" + remaining
-                        + "ms → " + (isAutoAdvance ? "AUTO-ADVANCE" : "MANUAL SKIP"));
+                        + "ms → " + (isAutoAdvanceFinal ? "AUTO-ADVANCE" : "MANUAL SKIP"));
             } catch (Exception e) {
-                logWarn("Could not read position/duration, assuming manual skip", e);
+                logWarn(()-> "Could not read position/duration, assuming manual skip", e);
             }
 
             if (isAutoAdvance && !Settings.CROSSFADE_ON_AUTO_ADVANCE.get()) {
-                logDebug("stopVideo(5): skip — auto-advance crossfade disabled");
+                logDebug(() -> "stopVideo(5): skip — auto-advance crossfade disabled");
                 return false;
             }
             if (!isAutoAdvance && !Settings.CROSSFADE_ON_SKIP.get()) {
-                logDebug("stopVideo(5): skip — manual skip crossfade disabled");
+                logDebug(() -> "stopVideo(5): skip — manual skip crossfade disabled");
                 return false;
             }
 
@@ -673,7 +688,7 @@ public class CrossfadeManager {
             // player's volume. Allow the natural transition through — bacw.I() will create
             // the incoming player and onBeforeLoadVideo will start the fade-in.
             if (is9x && isAutoAdvance && autoAdvanceCrossfadeActive) {
-                logInfo("9.x: volume-fade auto-advance — allowing stopVideo(5) (outgoing fade running)");
+                logDebug(() -> "9.x: volume-fade auto-advance — allowing stopVideo(5) (outgoing fade running)");
                 return false;
             }
             // If a manual skip fires while a 9.x volume-fade is running, abort the fade
@@ -684,22 +699,22 @@ public class CrossfadeManager {
                 autoAdvanceCrossfadeActive = false;
                 queueAdvancedByMonitor = false;
                 outgoingFadePreStarted = false;
-                logInfo("9.x: manual skip aborted volume-fade — proceeding with normal crossfade");
+                logDebug(() -> "9.x: manual skip aborted volume-fade — proceeding with normal crossfade");
             }
 
             boolean wasInVideoMode = isCurrentlyInVideoMode();
 
-            logInfo("stopVideo(5): STARTING crossfade [paused=" + isCrossfadePaused
-                    + " wasInVideo=" + wasInVideoMode
-                    + " is9x=" + is9x + "]");
+            logDebug(() -> "stopVideo(5): STARTING crossfade [paused=" + isCrossfadePaused
+                        + " wasInVideo=" + wasInVideoMode
+                        + " is9x=" + is9x + "]");
 
             int currentState = currentExo.patch_getPlaybackState();
-            logDebug("Current player state=" + currentState
+            logDebug(() -> "Current player state=" + currentState
                     + " class=" + currentExo.getClass().getName());
 
             if (wasInVideoMode) {
                 forceAudioModeIfNeeded();
-                logInfo("Silent audio mode set BEFORE factory (video→audio, no nmi broadcast)");
+                logDebug(() -> "Silent audio mode set BEFORE factory (video→audio, no nmi broadcast)");
             }
 
             ExoPlayerAccess newExo = createNewPlayer(coordinator);
@@ -717,7 +732,7 @@ public class CrossfadeManager {
                     // Prevents the natural track-end auih.y() from calling handleChainedSkip
                     // via onBeforePlayNext, which would corrupt the already-in-flight crossfade.
                     autoAdvanceCrossfadeActive = true;
-                    logDebug("9.x: auto-advance crossfade → autoAdvanceCrossfadeActive=true");
+                    logDebug(() -> "9.x: auto-advance crossfade → autoAdvanceCrossfadeActive=true");
 
                     // Detach cwh at swap time (auto-advance only): outgoing reaches natural-
                     // end during the fade and would fire onEnded through the shared
@@ -726,10 +741,10 @@ public class CrossfadeManager {
                     // far-from-end outgoing keeps reporting pause/seek/position events.
                     try {
                         currentExo.patch_detachCwhFromEventDispatch();
-                        logInfo("9.x auto-advance: detached cwh from OUTGOING @"
+                        logDebug(() -> "9.x auto-advance: detached cwh from OUTGOING @"
                                 + System.identityHashCode(currentExo) + " at swap time");
                     } catch (Exception e) {
-                        logWarn("9.x auto-advance: cwh detach on outgoing failed: " + e.getMessage());
+                        logWarn(()-> "9.x auto-advance: cwh detach on outgoing failed: " + e.getMessage());
                     }
                 }
                 deferredSwapStartTime = System.currentTimeMillis(); // gates internal stopVideo(5) detection
@@ -745,15 +760,15 @@ public class CrossfadeManager {
                     coordListener = coordinator.patch_getCoordinatorListener();
                     if (coordListener != null) {
                         currentExo.patch_removeDirectListener(coordListener);
-                        logInfo("9.x: pre-removed coord listener from outgoing @"
+                        logDebug(() -> "9.x: pre-removed coord listener from outgoing @"
                                 + System.identityHashCode(currentExo));
                     }
                 } catch (Exception e) {
-                    logWarn("9.x: pre-remove coord listener failed: " + e.getMessage());
+                    logWarn(()-> "9.x: pre-remove coord listener failed: " + e.getMessage());
                 }
 
                 coordinator.patch_setPlayerWithBindings(newExo);
-                logInfo("9.x: swapped coordinator → new player @" + System.identityHashCode(newExo)
+                logDebug(() -> "9.x: swapped coordinator → new player @" + System.identityHashCode(newExo)
                         + " via patch_setPlayerWithBindings (Lcou backref updated)");
 
                 // Re-register Lcou into the new player's Lcrh.N.
@@ -764,7 +779,7 @@ public class CrossfadeManager {
                     try {
                         newExo.patch_addDirectListener(coordListener);
                     } catch (Exception e) {
-                        logWarn("9.x: re-register coord listener failed: " + e.getMessage());
+                        logWarn(()-> "9.x: re-register coord listener failed: " + e.getMessage());
                     }
                 }
                 VideoSurfaceAccess surface = (VideoSurfaceAccess) coordinator.patch_getVideoSurface();
@@ -782,19 +797,20 @@ public class CrossfadeManager {
                     long msSincePause = System.currentTimeMillis() - lastPauseVideoMs;
                     outgoingWasPlaying = playerIsPlaying
                             || msSincePause < PAUSE_TO_STOP_INTERNAL_WINDOW_MS;
-                    logInfo("9.x: outgoing player re-enable check: playerIsPlaying=" + playerIsPlaying
-                            + " msSincePause=" + msSincePause + "ms → wasPlaying=" + outgoingWasPlaying);
+                    final boolean outgoingWasPlayingFinal = outgoingWasPlaying;
+                    logDebug(() -> "9.x: outgoing player re-enable check: playerIsPlaying=" + playerIsPlaying
+                                        + " msSincePause=" + msSincePause + "ms → wasPlaying=" + outgoingWasPlayingFinal);
                     if (outgoingWasPlaying) {
                         currentExo.patch_setPlayWhenReady(true);
                         currentExo.patch_setVolume(1.0f);
-                        logInfo("9.x: re-enabled outgoing player @" + System.identityHashCode(currentExo));
+                        logDebug(() -> "9.x: re-enabled outgoing player @" + System.identityHashCode(currentExo));
                     } else {
                         currentExo.patch_setVolume(0.0f);
-                        logInfo("9.x: outgoing player was paused (genuine) — keeping silent @"
+                        logDebug(() -> "9.x: outgoing player was paused (genuine) — keeping silent @"
                                 + System.identityHashCode(currentExo));
                     }
                 } catch (Exception e) {
-                    logWarn("9.x: could not configure outgoing player: " + e.getMessage());
+                    logWarn(()-> "9.x: could not configure outgoing player: " + e.getMessage());
                 }
 
                 // 9.x auto-advance: start the outgoing fade-out NOW (at swap time)
@@ -812,7 +828,7 @@ public class CrossfadeManager {
                     fadingOutPlayers.add(new FadingPlayer(currentExo, outFadeDuration, outCurve));
                     outgoingFadePreStarted = true;
                     ensureFadingLoopRunning();
-                    logInfo("9.x auto-advance: pre-started outgoing fade-out @"
+                    logDebug(() -> "9.x auto-advance: pre-started outgoing fade-out @"
                             + System.identityHashCode(currentExo)
                             + " over " + outFadeDuration + "ms");
                 }
@@ -828,27 +844,27 @@ public class CrossfadeManager {
                 crossfadeInProgress = true;
                 if (isAutoAdvance) {
                     autoAdvanceCrossfadeActive = true;
-                    logDebug("8.x: auto-advance crossfade → autoAdvanceCrossfadeActive=true");
+                    logDebug(() -> "8.x: auto-advance crossfade → autoAdvanceCrossfadeActive=true");
                 }
 
                 coordinator.patch_setExoPlayer(newExo);
-                logInfo("Swapped coordinator ExoPlayer → new player");
+                logDebug(() -> "Swapped coordinator ExoPlayer → new player");
 
                 VideoSurfaceAccess surface = (VideoSurfaceAccess) coordinator.patch_getVideoSurface();
                 if (surface != null) {
                     surface.patch_setPlayerReference(newExo);
-                    logDebug("Updated video surface → new player");
+                    logDebug(() -> "Updated video surface → new player");
                 }
 
-                logInfo("Old player preserved (keeps playing), polling for new track ready"
-                        + " — BLOCKING native stopVideo");
+                logDebug(() -> "Old player preserved (keeps playing), polling for new track ready"
+                                + " — BLOCKING native stopVideo");
                 pollForNewTrackReady(newExo);
 
                 return true;
             }
 
         } catch (Exception e) {
-            logError("onBeforeStopVideo error", e);
+            logError(()-> "onBeforeStopVideo error", e);
             cleanupAllPlayers();
             if (audioModeWasForced) {
                 audioModeWasForced = false;
@@ -865,7 +881,7 @@ public class CrossfadeManager {
      * naturally loads the next track onto it.
      */
     private static boolean handleChainedSkip(Object atadInstance) {
-        logInfo("stopVideo(5): CHAINED SKIP — creating new player, deferring demotion until READY");
+        logDebug(() -> "stopVideo(5): CHAINED SKIP — creating new player, deferring demotion until READY");
 
         if (is9x) {
             long elapsed = System.currentTimeMillis() - deferredSwapStartTime;
@@ -873,14 +889,14 @@ public class CrossfadeManager {
                 // This is the 9.x-internal second stopVideo(5) that always fires ~1ms
                 // after the first as part of the native track-transition sequence.
                 // It is NOT a user double-skip — pass it through untouched.
-                logDebug("9.x: internal second stopVideo(5) after " + elapsed
-                        + "ms — allowing through");
+                logDebug(() -> "9.x: internal second stopVideo(5) after " + elapsed
+                                + "ms — allowing through");
                 return false;
             }
         }
 
         if (isCrossfadePaused || getCrossfadeDurationMs() <= 0) {
-            logDebug("Chained skip: crossfade now paused — aborting crossfade");
+            logDebug(() -> "Chained skip: crossfade now paused — aborting crossfade");
             abortCrossfadeNow();
             return false;
         }
@@ -890,7 +906,7 @@ public class CrossfadeManager {
             if (coordinator == null) {
                 coordinator = getCoordinatorFromAtad(atadInstance);
                 if (coordinator == null) {
-                    logError("Chained skip: coordinator null — aborting");
+                    logError(() -> "Chained skip: coordinator null — aborting");
                     abortCrossfadeNow();
                     return false;
                 }
@@ -902,7 +918,7 @@ public class CrossfadeManager {
 
             ExoPlayerAccess newExo = createNewPlayer(coordinator);
             if (newExo == null) {
-                logError("Chained skip: factory failed — aborting crossfade");
+                logError(() -> "Chained skip: factory failed — aborting crossfade");
                 // Clean up old pending before aborting.
                 if (oldPending != null) {
                     if (is9x) detachPlayerListeners(oldPending);
@@ -926,16 +942,16 @@ public class CrossfadeManager {
                     chainedCoordListener = coordinator.patch_getCoordinatorListener();
                     if (chainedCoordListener != null && oldPending != null) {
                         oldPending.patch_removeDirectListener(chainedCoordListener);
-                        logInfo("9.x chained: pre-removed coord listener from @"
+                        logDebug(() -> "9.x chained: pre-removed coord listener from @"
                                 + System.identityHashCode(oldPending));
                     }
                 } catch (Exception e) {
-                    logWarn("9.x chained: pre-remove coord listener failed: " + e.getMessage());
+                    logWarn(()-> "9.x chained: pre-remove coord listener failed: " + e.getMessage());
                 }
             }
 
             coordinator.patch_setPlayerWithBindings(newExo);
-            logInfo("Chained skip: swapped coordinator → new player @"
+            logDebug(() -> "Chained skip: swapped coordinator → new player @"
                     + System.identityHashCode(newExo));
 
             // Re-register Lcou into new player's Lcrh.N (9.x only).
@@ -943,11 +959,11 @@ public class CrossfadeManager {
                 try {
                     newExo.patch_addDirectListener(chainedCoordListener);
                 } catch (Exception e) {
-                    logWarn("9.x chained: re-register coord listener failed: " + e.getMessage());
+                    logWarn(()-> "9.x chained: re-register coord listener failed: " + e.getMessage());
                 }
             }
             if (oldPending != null) {
-                logInfo("Chained skip: releasing old pending @"
+                logDebug(() -> "Chained skip: releasing old pending @"
                         + System.identityHashCode(oldPending)
                         + " (never reached READY)");
                 if (is9x) detachPlayerListeners(oldPending);
@@ -963,7 +979,7 @@ public class CrossfadeManager {
 
             return !is9x; // 8.x: block native stopVideo; 9.x: allow native chain to load track onto newExo
         } catch (Exception e) {
-            logError("handleChainedSkip error", e);
+            logError(()-> "handleChainedSkip error", e);
             abortCrossfadeNow();
             return false;
         }
@@ -977,31 +993,41 @@ public class CrossfadeManager {
     private static ExoPlayerAccess createNewPlayer(PlayerCoordinatorAccess coordinator) {
         try {
             SessionAccess session = (SessionAccess) coordinator.patch_getSession();
-            if (session == null) { logError("createNewPlayer: session null"); return null; }
+            if (session == null) {
+                logError(() -> "createNewPlayer: session null");
+                return null; }
 
             PlayerFactoryAccess factory = (PlayerFactoryAccess) session.patch_getFactory();
-            if (factory == null) { logError("createNewPlayer: factory null"); return null; }
+            if (factory == null) {
+                logError(() -> "createNewPlayer: factory null");
+                return null; }
 
             Object loadControl = coordinator.patch_getLoadControl();
-            if (loadControl == null) { logError("createNewPlayer: loadControl null"); return null; }
+            if (loadControl == null) {
+                logError(() -> "createNewPlayer: loadControl null");
+                return null; }
 
             SharedStateAccess sharedState = (SharedStateAccess) coordinator.patch_getSharedState();
-            if (sharedState == null) { logError("createNewPlayer: sharedState null"); return null; }
+            if (sharedState == null) {
+                logError(() -> "createNewPlayer: sharedState null");
+                return null; }
 
             SharedCallbackAccess sharedCallback =
                     (SharedCallbackAccess) coordinator.patch_getSharedCallback();
-            if (sharedCallback == null) { logError("createNewPlayer: sharedCallback null"); return null; }
+            if (sharedCallback == null) {
+                logError(() -> "createNewPlayer: sharedCallback null");
+                return null; }
             activeSharedCallback = sharedCallback;
 
             Object oldTimeline = sharedState.patch_getTimeline();
             Object oldCqb = sharedCallback.patch_getCqb();
-            logDebug("Pre-factory shared state: cqb=" + (oldCqb != null));
+            logDebug(() -> "Pre-factory shared state: cqb=" + (oldCqb != null));
             sharedState.patch_setTimeline(null);
             sharedCallback.patch_setCqb(null);
 
             ExoPlayerAccess newExo = createPlayerViaFactory(factory, coordinator, loadControl);
             if (newExo == null) {
-                logError("Factory returned null — restoring");
+                logError(() -> "Factory returned null — restoring");
                 sharedState.patch_setTimeline(oldTimeline);
                 sharedCallback.patch_setCqb(oldCqb);
                 return null;
@@ -1009,22 +1035,22 @@ public class CrossfadeManager {
 
             Object postTimeline = sharedState.patch_getTimeline();
             Object postCqb = sharedCallback.patch_getCqb();
-            logDebug("Post-factory shared state: cqb=" + (postCqb != null)
+            logDebug(() -> "Post-factory shared state: cqb=" + (postCqb != null)
                     + " newExo=" + System.identityHashCode(newExo));
             if (postTimeline == null) {
                 if (!is9x) {
-                    logError("Factory failed to set timeline — aborting");
+                    logError(() -> "Factory failed to set timeline — aborting");
                     sharedState.patch_setTimeline(oldTimeline);
                     sharedCallback.patch_setCqb(oldCqb);
                     return null;
                 }
                 // On 9.x the timeline field is final; the factory cannot re-set it.
                 // Restore the old value so the shared state remains coherent.
-                logWarn("Factory did not re-set timeline (expected on 9.x — field is final, restoring)");
+                logWarn(()-> "Factory did not re-set timeline (expected on 9.x — field is final, restoring)");
                 sharedState.patch_setTimeline(oldTimeline);
             }
             if (postCqb == null) {
-                logError("Factory failed to set cqb — aborting");
+                logError(() -> "Factory failed to set cqb — aborting");
                 sharedState.patch_setTimeline(oldTimeline);
                 sharedCallback.patch_setCqb(oldCqb);
                 return null;
@@ -1032,7 +1058,7 @@ public class CrossfadeManager {
 
             return newExo;
         } catch (Exception e) {
-            logError("createNewPlayer error", e);
+            logError(()-> "createNewPlayer error", e);
             return null;
         }
     }
@@ -1052,7 +1078,7 @@ public class CrossfadeManager {
         // #1549: skip crossfade when audio is routed to a cast/mirror receiver.
         // Native gapless transition runs unchanged.
         if (!crossfadeInProgress && isAudioRoutedToCast()) {
-            logInfo("playNext: skip — audio routed to cast/mirror (#1549)");
+            logDebug(() -> "playNext: skip — audio routed to cast/mirror (#1549)");
             return false;
         }
 
@@ -1060,7 +1086,7 @@ public class CrossfadeManager {
         // which onBeforeStopVideo will intercept for a true overlap crossfade.
         if (monitorTriggeredSkip) {
             monitorTriggeredSkip = false;
-            logDebug("PlayNext: monitor-triggered — allowing native auih.y()V (stopVideo intercepted by onBeforeStopVideo)");
+            logDebug(() -> "PlayNext: monitor-triggered — allowing native auih.y()V (stopVideo intercepted by onBeforeStopVideo)");
             return false;
         }
 
@@ -1070,7 +1096,7 @@ public class CrossfadeManager {
             return false;
         }
 
-        logInfo("onBeforePlayNext called [crossfading=" + crossfadeInProgress
+        logDebug(() -> "onBeforePlayNext called [crossfading=" + crossfadeInProgress
                 + " autoAdvance=" + autoAdvanceCrossfadeActive + "]");
         tryAttachLongPressHandler();
 
@@ -1082,14 +1108,14 @@ public class CrossfadeManager {
                 // YTM's native gapless mechanism fired playNextInQueue after our auto-advance
                 // monitor already triggered it. Block this duplicate call to prevent loading
                 // the next-next track onto the incoming player mid-crossfade.
-                logDebug("PlayNext: auto-advance crossfade in progress — blocking duplicate native call");
+                logDebug(() -> "PlayNext: auto-advance crossfade in progress — blocking duplicate native call");
                 return true;
             }
             return false;
         }
 
         if (!Settings.CROSSFADE_ON_AUTO_ADVANCE.get()) {
-            logDebug("PlayNext: skip — auto-advance crossfade disabled");
+            logDebug(() -> "PlayNext: skip — auto-advance crossfade disabled");
             return false;
         }
 
@@ -1103,8 +1129,8 @@ public class CrossfadeManager {
             if (currentExo == null) return false;
 
             int currentState = currentExo.patch_getPlaybackState();
-            logDebug("PlayNext: current player state=" + currentState
-                    + " wasInVideo=" + wasInVideoMode);
+            logDebug(() -> "PlayNext: current player state=" + currentState
+                        + " wasInVideo=" + wasInVideoMode);
 
             ExoPlayerAccess newExo = createNewPlayer(coordinator);
             if (newExo == null) return false;
@@ -1125,15 +1151,15 @@ public class CrossfadeManager {
                     playNextCoordListener = coordinator.patch_getCoordinatorListener();
                     if (playNextCoordListener != null) {
                         currentExo.patch_removeDirectListener(playNextCoordListener);
-                        logInfo("9.x PlayNext: pre-removed coord listener from @"
+                        logDebug(() -> "9.x PlayNext: pre-removed coord listener from @"
                                 + System.identityHashCode(currentExo));
                     }
                 } catch (Exception e) {
-                    logWarn("9.x PlayNext: pre-remove coord listener failed: " + e.getMessage());
+                    logWarn(()-> "9.x PlayNext: pre-remove coord listener failed: " + e.getMessage());
                 }
             }
             coordinator.patch_setPlayerWithBindings(newExo);
-            logInfo("PlayNext: swapped coordinator → new player @"
+            logDebug(() -> "PlayNext: swapped coordinator → new player @"
                     + System.identityHashCode(newExo));
 
             // Re-register Lcou into new player's Lcrh.N (9.x only).
@@ -1141,19 +1167,19 @@ public class CrossfadeManager {
                 try {
                     newExo.patch_addDirectListener(playNextCoordListener);
                 } catch (Exception e) {
-                    logWarn("9.x PlayNext: re-register coord listener failed: " + e.getMessage());
+                    logWarn(()-> "9.x PlayNext: re-register coord listener failed: " + e.getMessage());
                 }
             }
             VideoSurfaceAccess surface =
                     (VideoSurfaceAccess) coordinator.patch_getVideoSurface();
             if (surface != null) {
                 surface.patch_setPlayerReference(newExo);
-                logDebug("PlayNext: updated video surface → new player");
+                logDebug(() -> "PlayNext: updated video surface → new player");
             }
 
             if (wasInVideoMode) {
                 forceAudioModeIfNeeded();
-                logInfo("PlayNext: forced audio mode for incoming track (was in video mode)");
+                logDebug(() -> "PlayNext: forced audio mode for incoming track (was in video mode)");
             }
 
             // Re-invoke via atzq.p()→Lausd→y()V to advance the queue and trigger the
@@ -1165,25 +1191,25 @@ public class CrossfadeManager {
                 try {
                     ((MedialibPlayerAccess) atad).patch_playNextInQueue();
                 } catch (Exception e) {
-                    logWarn("PlayNext: re-invoke threw: " + e.getMessage());
+                    logWarn(()-> "PlayNext: re-invoke threw: " + e.getMessage());
                 } finally {
                     internalPlayNext = false;
                 }
                 try {
                     newExo.patch_setVolume(0.0f);
-                    logInfo("PlayNext: volume re-enforced to 0 after native");
+                    logDebug(() -> "PlayNext: volume re-enforced to 0 after native");
                 } catch (Exception ignored) {}
             } else {
                 internalPlayNext = false;
-                logWarn("PlayNext: atad ref lost — cannot re-invoke native");
+                logWarn(()-> "PlayNext: atad ref lost — cannot re-invoke native");
             }
 
-            logInfo("PlayNext: old player preserved, polling for new track ready");
+            logDebug(() -> "PlayNext: old player preserved, polling for new track ready");
             pollForNewTrackReady(newExo);
             return true; // block original call
 
         } catch (Exception e) {
-            logError("onBeforePlayNext error", e);
+            logError(()-> "onBeforePlayNext error", e);
             cleanupAllPlayers();
             if (audioModeWasForced) {
                 audioModeWasForced = false;
@@ -1196,7 +1222,7 @@ public class CrossfadeManager {
     /** 9.x atzq.o (loadVideo) entry hook — diagnostic only; fade-in is driven by onPendingPlayerReady. */
     public static void onBeforeLoadVideo(Object newAtzqInstance) {
         if (!is9x) return;
-        logDebug("9.x: onBeforeLoadVideo atzq=@" + System.identityHashCode(newAtzqInstance)
+        logDebug(() -> "9.x: onBeforeLoadVideo atzq=@" + System.identityHashCode(newAtzqInstance)
                 + " crossfadeInProgress=" + crossfadeInProgress
                 + " autoAdvActive=" + autoAdvanceCrossfadeActive);
     }
@@ -1237,13 +1263,13 @@ public class CrossfadeManager {
         lastPauseEventMs = now;
 
         lastPauseVideoMs = now;
-        logInfo("onPauseVideo [crossfading=" + crossfadeInProgress + " autoAdv=" + autoAdvanceCrossfadeActive + "]");
+        logDebug(() -> "onPauseVideo [crossfading=" + crossfadeInProgress + " autoAdv=" + autoAdvanceCrossfadeActive + "]");
 
         if (!crossfadeInProgress) {
             return false;
         }
 
-        logInfo("onPauseVideo: aborting crossfade " + dumpState());
+        logDebug(() -> "onPauseVideo: aborting crossfade " + dumpState());
         abortCrossfadeNow();
         return false;
     }
@@ -1263,7 +1289,7 @@ public class CrossfadeManager {
             lastAtadRef = new WeakReference<>(atadInstance);
         }
 
-        logInfo("onPlayVideo [crossfading=" + crossfadeInProgress
+        logDebug(() -> "onPlayVideo [crossfading=" + crossfadeInProgress
                 + " deferred=" + deferredSwapPending
                 + " atad=" + (atadInstance != null)
                 + " nbaAlive=" + (lastNbaRef != null && lastNbaRef.get() != null) + "]");
@@ -1271,15 +1297,15 @@ public class CrossfadeManager {
         // Coerce video → audio at song-start (shouldBlockVideoToggle catches manual
         // toggles but not auto-loaded video-mode songs like music videos).
         if (!isCrossfadePaused && isCurrentlyInVideoMode()) {
-            logInfo("onPlayVideo: coercing video → audio (crossfade active)");
+            logDebug(() -> "onPlayVideo: coercing video → audio (crossfade active)");
             forceAudioModeIfNeeded();
         }
 
         if (!crossfadeInProgress) {
-            logInfo("onPlayVideo: starting auto-advance monitor");
+            logDebug(() -> "onPlayVideo: starting auto-advance monitor");
             startAutoAdvanceMonitor();
         } else {
-            logDebug("onPlayVideo: crossfade in progress — skipping auto-advance monitor start");
+            logDebug(() -> "onPlayVideo: crossfade in progress — skipping auto-advance monitor start");
         }
     }
 
@@ -1307,13 +1333,13 @@ public class CrossfadeManager {
                 try {
                     int state = newPlayer.patch_getPlaybackState();
                     if (state == STATE_READY) {
-                        logInfo("Pending track READY — promoting to crossfade");
+                        logDebug(() -> "Pending track READY — promoting to crossfade");
                         onPendingPlayerReady(newPlayer);
                         return;
                     }
 
                     if (state == 4) {
-                        logError("Pending player ENDED unexpectedly — aborting");
+                        logError(() -> "Pending player ENDED unexpectedly — aborting");
                         cleanupAllPlayers();
                         if (audioModeWasForced) {
                             audioModeWasForced = false;
@@ -1323,12 +1349,12 @@ public class CrossfadeManager {
                     }
 
                     if (state != lastPollState) {
-                        logDebug("Poll: state → " + state);
+                        logDebug(() -> "Poll: state → " + state);
                         lastPollState = state;
                     }
 
                     if (System.currentTimeMillis() > deadline) {
-                        logError("Timeout waiting for new track");
+                        logError(() -> "Timeout waiting for new track");
                         cleanupAllPlayers();
                         if (audioModeWasForced) {
                             audioModeWasForced = false;
@@ -1339,7 +1365,7 @@ public class CrossfadeManager {
 
                     mainHandler.postDelayed(this, READY_POLL_MS);
                 } catch (Exception e) {
-                    logError("Poll error", e);
+                    logError(()-> "Poll error", e);
                     cleanupAllPlayers();
                     if (audioModeWasForced) {
                         audioModeWasForced = false;
@@ -1367,7 +1393,7 @@ public class CrossfadeManager {
                 // moved from the outgoing player to the incoming player at crossfade start time
                 // (in onBeforeStopVideo). No listener migration needed here.
                 // The old player's N set is now empty; it is safe to release after fade-out.
-                logInfo("onPendingPlayerReady (9.x): coordinator listener already migrated at start");
+                logDebug(() -> "onPendingPlayerReady (9.x): coordinator listener already migrated at start");
             }
 
             if (outgoingFadePreStarted) {
@@ -1376,7 +1402,7 @@ public class CrossfadeManager {
                 // running the full configured fade duration. Skip the re-add and the
                 // actualRemaining adjustment — those exist for the legacy path where
                 // fade-out only began once the new player reached READY.
-                logInfo("onPendingPlayerReady: outgoing @" + System.identityHashCode(outgoing)
+                logDebug(() -> "onPendingPlayerReady: outgoing @" + System.identityHashCode(outgoing)
                         + " fade-out already in flight (pre-started at swap time)");
                 pendingOutPlayer = null;
                 outgoingFadePreStarted = false;
@@ -1391,32 +1417,34 @@ public class CrossfadeManager {
                     long dur = outgoing.patch_getDuration();
                     if (dur > 0 && pos >= 0) {
                         long actualRemaining = dur - pos;
-                        logInfo("onPendingPlayerReady: outgoing remaining=" + actualRemaining
-                                + "ms fadeDuration=" + fadeDuration + "ms");
+                        logDebug(() -> "onPendingPlayerReady: outgoing remaining=" + actualRemaining
+                                                + "ms fadeDuration=" + fadeDuration + "ms");
                         if (actualRemaining <= 0) {
                             // Content only loads after natural track end, so READY always
                             // arrives after the old track has finished. Release silently.
                             trackAlreadyEnded = true;
-                            logInfo("Outgoing track ended before READY — "
-                                    + "releasing silently, fade-in only (no overlap possible)");
+                            logDebug(() -> "Outgoing track ended before READY — "
+                                                        + "releasing silently, fade-in only (no overlap possible)");
                         } else if (actualRemaining < fadeDuration) {
                             fadeOutDuration = Math.max(150, actualRemaining);
-                            logInfo("Fade-out shortened to " + fadeOutDuration
+                            final long fadeOutDurationFinal = fadeOutDuration;
+                            logDebug(() -> "Fade-out shortened to " + fadeOutDurationFinal
                                     + "ms to match remaining audio (was " + fadeDuration + "ms)");
                         }
                     }
                 } catch (Exception e) {
-                    logDebug("Could not read outgoing remaining time: " + e.getMessage());
+                    logDebug(() -> "Could not read outgoing remaining time: " + e.getMessage());
                 }
                 pendingOutPlayer = null;
                 if (trackAlreadyEnded) {
                     releasePlayer(outgoing);
-                    logInfo("Original outgoing player @" + System.identityHashCode(outgoing)
+                    logDebug(() -> "Original outgoing player @" + System.identityHashCode(outgoing)
                             + " → released (track ended before READY)");
                 } else {
                     fadingOutPlayers.add(new FadingPlayer(outgoing, fadeOutDuration, curve));
-                    logInfo("Original outgoing player @" + System.identityHashCode(outgoing)
-                            + " → fade-out list (" + fadeOutDuration + "ms)");
+                    final long fadeOutDurationFinal = fadeOutDuration;
+                    logDebug(() -> "Original outgoing player @" + System.identityHashCode(outgoing)
+                            + " → fade-out list (" + fadeOutDurationFinal + "ms)");
                 }
             }
         }
@@ -1427,13 +1455,13 @@ public class CrossfadeManager {
             long quickDuration = Math.max(200, (long) (QUICK_FADE_MS * vol));
             if (vol > 0.01f) {
                 fadingOutPlayers.add(new FadingPlayer(prevIncoming, vol, quickDuration));
-                logInfo("Previous incoming player @"
+                logDebug(() -> "Previous incoming player @"
                         + System.identityHashCode(prevIncoming)
-                        + " → quick fade-out from " + String.format("%.2f", vol)
+                        + " → quick fade-out from " + String.format(Locale.US, "%.2f", vol)
                         + " over " + quickDuration + "ms");
             } else {
                 releasePlayer(prevIncoming);
-                logInfo("Previous incoming player @"
+                logDebug(() -> "Previous incoming player @"
                         + System.identityHashCode(prevIncoming)
                         + " → released (vol ≈ 0)");
             }
@@ -1456,12 +1484,12 @@ public class CrossfadeManager {
     private static void startAutoAdvanceMonitor() {
         stopAutoAdvanceMonitor();
         if (!isEnabled() || !Settings.CROSSFADE_ON_AUTO_ADVANCE.get()) {
-            logDebug("startAutoAdvanceMonitor: skipped [enabled=" + isEnabled()
+            logDebug(() -> "startAutoAdvanceMonitor: skipped [enabled=" + isEnabled()
                     + " onAutoAdvance=" + Settings.CROSSFADE_ON_AUTO_ADVANCE.get() + "]");
             return;
         }
         if (autoAdvanceCrossfadeActive) {
-            logDebug("startAutoAdvanceMonitor: skipped — 9.x volume-fade in progress");
+            logDebug(() -> "startAutoAdvanceMonitor: skipped — 9.x volume-fade in progress");
             return;
         }
 
@@ -1520,9 +1548,9 @@ public class CrossfadeManager {
                     long fadeDuration = getCrossfadeDurationMs();
 
                     if (remaining % 5000 < MONITOR_POLL_MS) {
-                        logDebug("Auto-advance monitor: pos=" + pos
-                                + "ms dur=" + dur + "ms remaining=" + remaining
-                                + "ms trigger@" + (fadeDuration + AUTO_ADVANCE_TRIGGER_BUFFER_MS) + "ms");
+                        logDebug(() -> "Auto-advance monitor: pos=" + pos
+                                                + "ms dur=" + dur + "ms remaining=" + remaining
+                                                + "ms trigger@" + (fadeDuration + AUTO_ADVANCE_TRIGGER_BUFFER_MS) + "ms");
                     }
 
                     if (dur <= fadeDuration + AUTO_ADVANCE_TRIGGER_BUFFER_MS) {
@@ -1531,8 +1559,8 @@ public class CrossfadeManager {
                     }
 
                     if (remaining <= fadeDuration + AUTO_ADVANCE_TRIGGER_BUFFER_MS && remaining > 0) {
-                        logInfo("Auto-advance: monitor trigger at remaining=" + remaining
-                                + "ms (fadeDuration=" + fadeDuration + "ms)");
+                        logDebug(() -> "Auto-advance: monitor trigger at remaining=" + remaining
+                                                + "ms (fadeDuration=" + fadeDuration + "ms)");
                         stopAutoAdvanceMonitor();
 
                         // Auto-advance trigger: simulated MEDIA_NEXT key event.  Other paths
@@ -1541,7 +1569,7 @@ public class CrossfadeManager {
                         // through YTM's mediasession skip handler which runs the full
                         // queue-advance + clearQueue + loadOnesieVideo chain.  onBeforeStopVideo
                         // intercepts the resulting stopVideo(5) for crossfade setup.
-                        logInfo("Auto-advance: TRIGGER FIRED is9x=" + is9x
+                        logDebug(() -> "Auto-advance: TRIGGER FIRED is9x=" + is9x
                                 + " outgoing=@" + System.identityHashCode(exo)
                                 + " coordExo=@" + System.identityHashCode(coordinator.patch_getExoPlayer())
                                 + " fadeDur=" + fadeDuration + "ms state=" + state
@@ -1552,14 +1580,14 @@ public class CrossfadeManager {
                         if (ctx == null) {
                             monitorTriggeredSkip = false;
                             queueAdvancedByMonitor = false;
-                            logWarn("Auto-advance: no Context — cannot dispatch MEDIA_NEXT");
+                            logWarn(()-> "Auto-advance: no Context — cannot dispatch MEDIA_NEXT");
                             return;
                         }
                         AudioManager am = (AudioManager) ctx.getSystemService(Context.AUDIO_SERVICE);
                         if (am == null) {
                             monitorTriggeredSkip = false;
                             queueAdvancedByMonitor = false;
-                            logWarn("Auto-advance: no AudioManager — cannot dispatch MEDIA_NEXT");
+                            logWarn(()-> "Auto-advance: no AudioManager — cannot dispatch MEDIA_NEXT");
                             return;
                         }
                         try {
@@ -1570,24 +1598,24 @@ public class CrossfadeManager {
                                     KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MEDIA_NEXT, 0);
                             am.dispatchMediaKeyEvent(down);
                             am.dispatchMediaKeyEvent(up);
-                            logInfo("Auto-advance: dispatched MEDIA_NEXT key event");
+                            logDebug(() -> "Auto-advance: dispatched MEDIA_NEXT key event");
                         } catch (Exception e) {
                             monitorTriggeredSkip = false;
                             queueAdvancedByMonitor = false;
-                            logWarn("Auto-advance: dispatchMediaKeyEvent failed: " + e.getMessage());
+                            logWarn(()-> "Auto-advance: dispatchMediaKeyEvent failed: " + e.getMessage());
                         }
                         return;
                     }
 
                     mainHandler.postDelayed(this, MONITOR_POLL_MS);
                 } catch (Exception e) {
-                    logWarn("Auto-advance monitor error", e);
+                    logWarn(()-> "Auto-advance monitor error", e);
                     mainHandler.postDelayed(this, MONITOR_POLL_MS * 2);
                 }
             }
         };
         mainHandler.postDelayed(autoAdvanceMonitorRunnable, MONITOR_POLL_MS);
-        logInfo("Auto-advance monitor started");
+        logDebug(() -> "Auto-advance monitor started");
     }
 
     private static void stopAutoAdvanceMonitor() {
@@ -1603,14 +1631,14 @@ public class CrossfadeManager {
 
     private static void abortCrossfadeNow() {
         if (!crossfadeInProgress) return;
-        logInfo("ABORT: " + dumpState());
+        logDebug(() -> "ABORT: " + dumpState());
 
         ExoPlayerAccess inp = crossfadeInPlayer;
         ExoPlayerAccess pending = pendingInPlayer;
         ExoPlayerAccess pendOut = pendingOutPlayer;
         PlayerCoordinatorAccess coord = activeCoordinator;
 
-        ExoPlayerAccess bestPlayer = null;
+        ExoPlayerAccess bestPlayer;
         boolean inpReady = false;
         if (inp != null) {
             try { inpReady = inp.patch_getPlaybackState() == STATE_READY; }
@@ -1628,10 +1656,12 @@ public class CrossfadeManager {
             bestPlayer = inp;
         } else if (pendOut != null) {
             bestPlayer = pendOut;
+        } else {
+            bestPlayer = null;
         }
 
         if (bestPlayer != null && coord != null) {
-            logInfo("abortCrossfadeNow: snapping to player @"
+            logDebug(() -> "abortCrossfadeNow: snapping to player @"
                     + System.identityHashCode(bestPlayer));
             try {
                 bestPlayer.patch_setVolume(1.0f);
@@ -1641,7 +1671,7 @@ public class CrossfadeManager {
                         (VideoSurfaceAccess) coord.patch_getVideoSurface();
                 if (surface != null) surface.patch_setPlayerReference(bestPlayer);
             } catch (Exception e) {
-                logWarn("abortCrossfadeNow: snap failed: " + e.getMessage());
+                logWarn(()-> "abortCrossfadeNow: snap failed: " + e.getMessage());
             }
         }
 
@@ -1684,7 +1714,7 @@ public class CrossfadeManager {
         try {
             inPlayer.patch_setVolume(0.0f);
         } catch (Exception e) {
-            logWarn("fade-in pre-start: failed to zero volume: " + e.getMessage());
+            logWarn(()-> "fade-in pre-start: failed to zero volume: " + e.getMessage());
         }
 
         try { inPlayer.patch_setPlayWhenReady(true); } catch (Exception ignored) {}
@@ -1692,7 +1722,7 @@ public class CrossfadeManager {
         final long startTime = System.currentTimeMillis();
         final long duration = (durationOverrideMs > 0) ? durationOverrideMs : getCrossfadeDurationMs();
 
-        logInfo("Crossfade fade-in started for @" + System.identityHashCode(inPlayer)
+        logDebug(() -> "Crossfade fade-in started for @" + System.identityHashCode(inPlayer)
                 + ", duration=" + duration + "ms"
                 + ", fading-out players=" + fadingOutPlayers.size());
 
@@ -1713,18 +1743,18 @@ public class CrossfadeManager {
                     inPlayer.patch_setVolume(inVol);
                     if (elapsed % 500 < TICK_MS) {
                         int inState = inPlayer.patch_getPlaybackState();
-                        logDebug(String.format(
+                        logDebug(() -> String.format(Locale.US,
                                 "fade-in: t=%.2f inVol=%.2f(st=%d) fadingOut=%d",
                                 t, inVol, inState, fadingOutPlayers.size()));
                     }
                 } catch (Exception e) {
-                    logError("Fade-in tick error", e);
+                    logError(()-> "Fade-in tick error", e);
                 }
 
                 if (t < 1.0f) {
                     mainHandler.postDelayed(this, TICK_MS);
                 } else {
-                    logInfo("Fade-in complete for @" + System.identityHashCode(inPlayer));
+                    logDebug(() -> "Fade-in complete for @" + System.identityHashCode(inPlayer));
                     inVideoMode = false;
                     currentFadeInVolume = 1.0f;
                     try { inPlayer.patch_setVolume(1.0f); } catch (Exception ignored) {}
@@ -1747,8 +1777,8 @@ public class CrossfadeManager {
 
                         startAutoAdvanceMonitor();
                     } else {
-                        logDebug("Fade-in complete but pending player exists — "
-                                + "waiting for it to reach READY");
+                        logDebug(() -> "Fade-in complete but pending player exists — "
+                                                + "waiting for it to reach READY");
                     }
                 }
             }
@@ -1767,7 +1797,7 @@ public class CrossfadeManager {
             Object player = factory.patch_createPlayer(coordinator, loadControl, 0);
             if (player != null) {
                 playersCreated++;
-                logInfo("Factory created player @"
+                logDebug(() -> "Factory created player @"
                         + System.identityHashCode(player)
                         + " [created=" + playersCreated
                         + " released=" + playersReleased
@@ -1776,7 +1806,7 @@ public class CrossfadeManager {
             }
             return (ExoPlayerAccess) player;
         } catch (Exception e) {
-            logError("createPlayerViaFactory failed", e);
+            logError(()-> "createPlayerViaFactory failed", e);
             return null;
         }
     }
@@ -1830,7 +1860,7 @@ public class CrossfadeManager {
             MedialibPlayerAccess atad = (MedialibPlayerAccess) atadInstance;
             Object chain = atad.patch_getPlayerChain();
             if (chain == null) {
-                logError("atad player chain is null");
+                logError(() -> "atad player chain is null");
                 return null;
             }
 
@@ -1842,18 +1872,20 @@ public class CrossfadeManager {
                 depth++;
             }
 
-            logDebug("Traversed " + depth + " delegates → "
-                    + chain.getClass().getName());
+            final int depthFinal = depth;
+            Object chainFinal = chain;
+            logDebug(() -> "Traversed " + depthFinal + " delegates → "
+                    + chainFinal.getClass().getName());
 
             if (chain instanceof PlayerCoordinatorAccess) {
                 return (PlayerCoordinatorAccess) chain;
             }
 
-            logError("Innermost class is not a PlayerCoordinatorAccess: "
-                    + chain.getClass().getName());
+            logError(() -> "Innermost class is not a PlayerCoordinatorAccess: "
+                    + chainFinal.getClass().getName());
             return null;
         } catch (Exception e) {
-            logError("getCoordinatorFromAtad error", e);
+            logError(()-> "getCoordinatorFromAtad error", e);
             return null;
         }
     }
@@ -1870,7 +1902,7 @@ public class CrossfadeManager {
      * {@link #unwrapForwardingTarget} recover the original listener and avoid
      * proxy-of-proxy accumulation on consecutive skips.</p>
      */
-    private static final class ForwardingHandler implements java.lang.reflect.InvocationHandler {
+    private static final class ForwardingHandler implements InvocationHandler {
         final Object target;
 
         ForwardingHandler(Object target) {
@@ -1878,11 +1910,11 @@ public class CrossfadeManager {
         }
 
         @Override
-        public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args)
+        public Object invoke(Object proxy, Method method, Object[] args)
                 throws Throwable {
             try {
                 return method.invoke(target, args);
-            } catch (java.lang.reflect.InvocationTargetException e) {
+            } catch (InvocationTargetException e) {
                 Throwable cause = e.getCause();
                 throw (cause != null) ? cause : e;
             }
@@ -1896,9 +1928,8 @@ public class CrossfadeManager {
      * Returns {@code listener} unchanged if it is not a forwarding proxy.
      */
     private static Object unwrapForwardingTarget(Object listener) {
-        while (java.lang.reflect.Proxy.isProxyClass(listener.getClass())) {
-            java.lang.reflect.InvocationHandler h =
-                    java.lang.reflect.Proxy.getInvocationHandler(listener);
+        while (Proxy.isProxyClass(listener.getClass())) {
+            InvocationHandler h = Proxy.getInvocationHandler(listener);
             if (h instanceof ForwardingHandler) {
                 listener = ((ForwardingHandler) h).target;
             } else {
@@ -1913,7 +1944,7 @@ public class CrossfadeManager {
      * found in {@code realListener}'s class hierarchy and forwards all calls to it.
      *
      * <p>The proxy has a different object identity from {@code realListener}, so
-     * {@link java.util.concurrent.CopyOnWriteArraySet#add} always succeeds even when
+     * {@link CopyOnWriteArraySet#add} always succeeds even when
      * {@code realListener} is already in the set.  ExoPlayer's listener dispatch
      * uses {@code invoke-interface} against the stored Object, so a Proxy that
      * implements the same interfaces receives the call correctly.</p>
@@ -1921,22 +1952,20 @@ public class CrossfadeManager {
      * @return the proxy, or {@code null} if no interfaces are discoverable (should never happen).
      */
     private static Object createForwardingProxy(Object realListener) {
-        java.util.Set<Class<?>> ifaceSet = new java.util.LinkedHashSet<>();
+        Set<Class<?>> ifaceSet = new LinkedHashSet<>();
         for (Class<?> cls = realListener.getClass(); cls != null && cls != Object.class;
                 cls = cls.getSuperclass()) {
-            for (Class<?> iface : cls.getInterfaces()) {
-                ifaceSet.add(iface);
-            }
+            ifaceSet.addAll(Arrays.asList(cls.getInterfaces()));
         }
         if (ifaceSet.isEmpty()) return null;
         Class<?>[] ifaces = ifaceSet.toArray(new Class<?>[0]);
         try {
-            return java.lang.reflect.Proxy.newProxyInstance(
+            return Proxy.newProxyInstance(
                     realListener.getClass().getClassLoader(),
                     ifaces,
                     new ForwardingHandler(realListener));
         } catch (Exception e) {
-            logWarn("createForwardingProxy failed: " + e.getMessage());
+            logWarn(()-> "createForwardingProxy failed: " + e.getMessage());
             return null;
         }
     }
@@ -1955,7 +1984,7 @@ public class CrossfadeManager {
      * is not found at patch time, the bridge falls back to a raw {@code iput-object} that
      * performs NO listener migration.  The coordinator's MedialibPlayerEvents listener
      * (which drives the seekbar and play/pause state) therefore remains on the OLD player's
-     * {@link java.util.concurrent.CopyOnWriteArraySet}, causing UI disconnection.
+     * {@link CopyOnWriteArraySet}, causing UI disconnection.
      *
      * <h3>Strategy (B2 proxy approach)</h3>
      * <ol>
@@ -1968,7 +1997,7 @@ public class CrossfadeManager {
      *   <li>For each bxi NOT already in the new player: wrap it in a
      *       {@link ForwardingHandler} {@link java.lang.reflect.Proxy} and register via
      *       {@code cau.add}.  The proxy has a fresh object identity, bypassing
-     *       {@link java.util.concurrent.CopyOnWriteArraySet}'s equality check, while
+     *       {@link CopyOnWriteArraySet}'s equality check, while
      *       ExoPlayer's {@code invoke-interface} dispatch still reaches the real listener.</li>
      *   <li>Fallback: if proxy creation or {@code cau.add} fails for every listener,
      *       copy the original cat objects directly.</li>
@@ -1978,19 +2007,18 @@ public class CrossfadeManager {
     private static void migrateListeners(ExoPlayerAccess fromPlayer, ExoPlayerAccess toPlayer) {
         try {
             Object fromSetObj = fromPlayer.patch_getListenerSet();
-            if (!(fromSetObj instanceof java.util.concurrent.CopyOnWriteArraySet)) {
-                logWarn("migrateListeners: unexpected set type — clearing only");
+            if (!(fromSetObj instanceof CopyOnWriteArraySet)) {
+                logWarn(()-> "migrateListeners: unexpected set type — clearing only");
                 detachPlayerListeners(fromPlayer);
                 return;
             }
-            java.util.concurrent.CopyOnWriteArraySet<Object> from =
-                    (java.util.concurrent.CopyOnWriteArraySet<Object>) fromSetObj;
+            CopyOnWriteArraySet<Object> from = (CopyOnWriteArraySet<Object>) fromSetObj;
 
             // Snapshot before clearing so we have the original cat objects for the fallback.
-            java.util.List<Object> catSnapshot = new java.util.ArrayList<>(from);
+            List<Object> catSnapshot = new ArrayList<>(from);
 
             // Extract real listeners (unwrap any proxy layers from prior skips).
-            java.util.List<Object> realListeners = new java.util.ArrayList<>(catSnapshot.size());
+            List<Object> realListeners = new ArrayList<>(catSnapshot.size());
             for (Object cat : catSnapshot) {
                 if (cat instanceof ListenerWrapperAccess) {
                     Object raw = ((ListenerWrapperAccess) cat).patch_getWrappedListener();
@@ -2003,16 +2031,16 @@ public class CrossfadeManager {
 
             // Inspect new player's existing listener set.
             Object toSetObj = toPlayer.patch_getListenerSet();
-            java.util.concurrent.CopyOnWriteArraySet<Object> toSet =
-                    (toSetObj instanceof java.util.concurrent.CopyOnWriteArraySet)
-                    ? (java.util.concurrent.CopyOnWriteArraySet<Object>) toSetObj : null;
+            CopyOnWriteArraySet<Object> toSet =
+                    (toSetObj instanceof CopyOnWriteArraySet)
+                    ? (CopyOnWriteArraySet<Object>) toSetObj : null;
             int toSizeBefore = toSet != null ? toSet.size() : -1;
 
             // Build the set of real listeners already in the new player so we can skip
             // factory duplicates (they are already registered at construction time).
-            java.util.Set<Object> alreadyPresent = new java.util.HashSet<>();
+            Set<Object> alreadyPresent = new HashSet<>();
             if (toSet != null) {
-                for (Object cat : new java.util.ArrayList<>(toSet)) {
+                for (Object cat : new ArrayList<>(toSet)) {
                     if (cat instanceof ListenerWrapperAccess) {
                         Object raw = ((ListenerWrapperAccess) cat).patch_getWrappedListener();
                         if (raw != null) alreadyPresent.add(unwrapForwardingTarget(raw));
@@ -2047,7 +2075,7 @@ public class CrossfadeManager {
                 // Either coordinatorListenerBxi is null (first crossfade) or real IS it.
                 Object proxy = createForwardingProxy(real);
                 if (proxy == null) {
-                    logWarn("migrateListeners: proxy creation returned null for "
+                    logWarn(()-> "migrateListeners: proxy creation returned null for "
                             + real.getClass().getName());
                     continue;
                 }
@@ -2057,18 +2085,20 @@ public class CrossfadeManager {
                     if (coordinatorListenerBxi == null) {
                         // Record the coordinator bxi on first successful migration.
                         coordinatorListenerBxi = real;
-                        logInfo("migrateListeners: identified coordinator bxi: "
+                        logDebug(() -> "migrateListeners: identified coordinator bxi: "
                                 + real.getClass().getName()
                                 + "@" + System.identityHashCode(real));
                     }
                 } catch (Exception e) {
-                    logWarn("migrateListeners: cau.add threw: " + e.getMessage());
+                    logWarn(()-> "migrateListeners: cau.add threw: " + e.getMessage());
                 }
             }
 
             if (registered > 0 || skipped > 0) {
-                logInfo("migrateListeners: registered=" + registered
-                        + " skipped=" + skipped
+                final int registeredFinal = registered;
+                final int skippedFinal = skipped;
+                logDebug(() -> "migrateListeners: registered=" + registeredFinal
+                        + " skipped=" + skippedFinal
                         + " total=" + realListeners.size()
                         + " toPlayer had=" + toSizeBefore
                         + " @" + System.identityHashCode(fromPlayer)
@@ -2076,12 +2106,12 @@ public class CrossfadeManager {
             } else {
                 // All proxy creations or cau.add calls failed — fall back:
                 // copy the original cat objects directly into the new player's set.
-                logWarn("migrateListeners: proxy path failed — copying " + catSnapshot.size()
+                logWarn(()-> "migrateListeners: proxy path failed — copying " + catSnapshot.size()
                         + " original cats to toPlayer (had " + toSizeBefore + ")");
                 if (toSet != null) toSet.addAll(catSnapshot);
             }
         } catch (Exception e) {
-            logWarn("migrateListeners failed", e);
+            logWarn(()-> "migrateListeners failed", e);
             detachPlayerListeners(fromPlayer);
         }
     }
@@ -2093,13 +2123,13 @@ public class CrossfadeManager {
     private static void detachPlayerListeners(ExoPlayerAccess player) {
         try {
             Object listenerSet = player.patch_getListenerSet();
-            if (listenerSet instanceof java.util.concurrent.CopyOnWriteArraySet) {
-                ((java.util.concurrent.CopyOnWriteArraySet<?>) listenerSet).clear();
-                logInfo("Detached @" + System.identityHashCode(player)
+            if (listenerSet instanceof CopyOnWriteArraySet) {
+                ((CopyOnWriteArraySet<?>) listenerSet).clear();
+                logDebug(() -> "Detached @" + System.identityHashCode(player)
                         + " from UI listeners (cleared listener set)");
             }
         } catch (Exception e) {
-            logWarn("Could not detach player from UI listeners", e);
+            logWarn(()-> "Could not detach player from UI listeners", e);
         }
     }
 
@@ -2107,7 +2137,7 @@ public class CrossfadeManager {
         if (p == null) return;
 
         playersReleased++;
-        logInfo("releasePlayer: @" + System.identityHashCode(p)
+        logDebug(() -> "releasePlayer: @" + System.identityHashCode(p)
                 + " [created=" + playersCreated + " released=" + playersReleased
                 + " outstanding=" + (playersCreated - playersReleased) + "]");
 
@@ -2128,10 +2158,10 @@ public class CrossfadeManager {
         if (is9x) {
             try {
                 p.patch_detachCwhFromEventDispatch();
-                logInfo("releasePlayer: 9.x detached cwh from event dispatch on @"
+                logDebug(() -> "releasePlayer: 9.x detached cwh from event dispatch on @"
                         + System.identityHashCode(p));
             } catch (Exception e) {
-                logDebug("releasePlayer: 9.x cwh event dispatch detach failed: " + e.getMessage());
+                logDebug(() -> "releasePlayer: 9.x cwh event dispatch detach failed: " + e.getMessage());
             }
         }
 
@@ -2146,7 +2176,7 @@ public class CrossfadeManager {
         try {
             p.patch_release();
         } catch (Exception e) {
-            logDebug("releasePlayer: release() threw: " + e.getMessage());
+            logDebug(() -> "releasePlayer: release() threw: " + e.getMessage());
         } finally {
             if (is9x) suppressCwhU = false;
         }
@@ -2156,11 +2186,11 @@ public class CrossfadeManager {
             Object postDlt = callback.patch_getDlt();
             if (savedCqb != null && postCqb == null) {
                 callback.patch_setCqb(savedCqb);
-                logDebug("releasePlayer: restored shared cqb");
+                logDebug(() -> "releasePlayer: restored shared cqb");
             }
             if (savedDlt != null && postDlt == null) {
                 callback.patch_setDlt(savedDlt);
-                logDebug("releasePlayer: restored shared dlt");
+                logDebug(() -> "releasePlayer: restored shared dlt");
             }
         }
     }
@@ -2181,7 +2211,7 @@ public class CrossfadeManager {
      * Used on errors and when crossfade is disabled/paused.
      */
     private static void cleanupAllPlayers() {
-        logError("CLEANUP (emergency): " + dumpState());
+        logError(() -> "CLEANUP (emergency): " + dumpState());
         if (deferredSwapRunnable != null) {
             mainHandler.removeCallbacks(deferredSwapRunnable);
             deferredSwapRunnable = null;
@@ -2195,7 +2225,7 @@ public class CrossfadeManager {
         activeCoordinator = null;
         crossfadeInProgress = false;
         if (autoAdvanceCrossfadeActive) {
-            logWarn("cleanupAllPlayers: clearing autoAdvanceCrossfadeActive mid-fade " + dumpState());
+            logWarn(()-> "cleanupAllPlayers: clearing autoAdvanceCrossfadeActive mid-fade " + dumpState());
         }
         autoAdvanceCrossfadeActive = false;
         queueAdvancedByMonitor = false;
@@ -2230,14 +2260,16 @@ public class CrossfadeManager {
                     fp.player.patch_setVolume(Math.max(0.0f, vol));
                     long elapsed = System.currentTimeMillis() - fp.startTimeMs;
                     if (elapsed % 500 < TICK_MS) {
-                        logDebug(String.format(
+                        final int playerStateFinal = playerState;
+                        logDebug(() -> String.format(Locale.US,
                                 "fade-out: @%d vol=%.2f state=%d elapsed=%dms",
-                                System.identityHashCode(fp.player), vol, playerState, elapsed));
+                                System.identityHashCode(fp.player), vol, playerStateFinal, elapsed));
                     }
                 } catch (Exception e) {
-                    logWarn("fade-out setVolume threw: " + e.getMessage()
+                    final int playerStateFinal = playerState;
+                    logWarn(()-> "fade-out setVolume threw: " + e.getMessage()
                             + " player=@" + System.identityHashCode(fp.player)
-                            + " state=" + playerState);
+                            + " state=" + playerStateFinal);
                 }
 
                 if (fp.isComplete()) {
@@ -2256,7 +2288,7 @@ public class CrossfadeManager {
             mainHandler.postDelayed(CrossfadeManager::tickFadingLoop, TICK_MS);
         } else {
             fadingLoopRunning = false;
-            logDebug("Fading loop stopped — all fade-outs complete");
+            logDebug(() -> "Fading loop stopped — all fade-outs complete");
         }
     }
 
@@ -2283,7 +2315,7 @@ public class CrossfadeManager {
         // Pause is per-session: reset on every activity start so a stale paused state
         // can't survive a process that wasn't actually killed on swipe.
         if (isCrossfadePaused) {
-            logInfo("onActivityStart: auto-resetting isCrossfadePaused to false");
+            logDebug(() -> "onActivityStart: auto-resetting isCrossfadePaused to false");
             isCrossfadePaused = false;
         }
 
@@ -2355,20 +2387,18 @@ public class CrossfadeManager {
                 // decoding happens locally (built-in speaker, BT A2DP, wired, USB),
                 // crossfade works fine — so we LEAVE those alone.
                 //
-                // android.media.MediaRouter is deprecated since API 30 but still
+                // MediaRouter is deprecated since API 30 but still
                 // works through API 36+.  The newer MediaRouter2 lives in a separate
                 // module we'd have to bring in via the patcher classpath; deprecated
                 // is the simpler choice here.
-                android.media.MediaRouter mr =
-                        (android.media.MediaRouter) ctx.getSystemService(Context.MEDIA_ROUTER_SERVICE);
+                MediaRouter mr = (MediaRouter) ctx.getSystemService(Context.MEDIA_ROUTER_SERVICE);
                 if (mr != null) {
-                    android.media.MediaRouter.RouteInfo selected = mr.getSelectedRoute(
-                            android.media.MediaRouter.ROUTE_TYPE_LIVE_AUDIO);
+                    MediaRouter.RouteInfo selected = mr.getSelectedRoute(MediaRouter.ROUTE_TYPE_LIVE_AUDIO);
                     if (selected != null) {
                         int pt = selected.getPlaybackType();
                         probe.append("route{name=").append(selected.getName(ctx))
                                 .append(",pbType=").append(pt).append("} ");
-                        if (pt == android.media.MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE) {
+                        if (pt == MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE) {
                             casting = true;
                         }
                     } else {
@@ -2381,6 +2411,7 @@ public class CrossfadeManager {
                 if (!casting) {
                     AudioManager am = (AudioManager) ctx.getSystemService(Context.AUDIO_SERVICE);
                     if (am != null) {
+                        // noinspection WrongConstant
                         for (AudioDeviceInfo info : am.getDevices(AudioManager.GET_DEVICES_OUTPUTS)) {
                             int type = info.getType();
                             probe.append("dev{type=").append(type)
@@ -2399,12 +2430,13 @@ public class CrossfadeManager {
                 }
             }
         } catch (Exception e) {
-            logDebug("isAudioRoutedToCast check failed: " + e.getMessage());
+            logDebug(() -> "isAudioRoutedToCast check failed: " + e.getMessage());
         }
 
         if (casting != lastCastResult) {
-            logInfo("Cast routing " + (casting ? "ENGAGED" : "RELEASED")
-                    + " — crossfade " + (casting ? "disabled" : "re-enabled")
+            final boolean castingFinal = casting;
+            logDebug(() -> "Cast routing " + (castingFinal ? "ENGAGED" : "RELEASED")
+                    + " — crossfade " + (castingFinal ? "disabled" : "re-enabled")
                     + " [" + probe.toString().trim() + "]");
         }
 
@@ -2416,7 +2448,7 @@ public class CrossfadeManager {
     @SuppressLint("MissingPermission")
     public static void toggleSessionPause() {
         isCrossfadePaused = !isCrossfadePaused;
-        logInfo("Session " + (isCrossfadePaused ? "PAUSED" : "RESUMED")
+        logDebug(() -> "Session " + (isCrossfadePaused ? "PAUSED" : "RESUMED")
                 + " [inVideo=" + isCurrentlyInVideoMode()
                 + " inProgress=" + crossfadeInProgress + "]");
 
@@ -2469,7 +2501,7 @@ public class CrossfadeManager {
      */
     public static void onNbaCreated(Object nba) {
         lastNbaRef = new WeakReference<>(nba);
-        logInfo("onNbaCreated: nba captured @" + System.identityHashCode(nba)
+        logDebug(() -> "onNbaCreated: nba captured @" + System.identityHashCode(nba)
                 + " class=" + nba.getClass().getSimpleName());
     }
 
@@ -2486,12 +2518,12 @@ public class CrossfadeManager {
             VideoToggleAccess toggle = (VideoToggleAccess) nba;
             boolean isAudioMode = toggle.patch_isAudioMode();
 
-            logInfo("videoToggle: isAudioMode=" + isAudioMode
+            logDebug(() -> "videoToggle: isAudioMode=" + isAudioMode
                     + " enabled=" + isEnabled() + " paused=" + isCrossfadePaused
                     + " inVideoMode(before)=" + inVideoMode);
 
             if (!isEnabled()) {
-                logInfo("videoToggle → ALLOW (crossfade disabled)");
+                logDebug(() -> "videoToggle → ALLOW (crossfade disabled)");
                 return false;
             }
 
@@ -2506,31 +2538,31 @@ public class CrossfadeManager {
                         inVideoMode = true;
                         audioModeWasForced = false;
                         manualToggleSuppressionUntil = System.currentTimeMillis() + 500;
-                        logInfo("videoToggle → INTERCEPTED (audio→video while paused) — applied broadcast restoreVideoMode");
+                        logDebug(() -> "videoToggle → INTERCEPTED (audio→video while paused) — applied broadcast restoreVideoMode");
                         return true;
                     } catch (Exception e) {
-                        logWarn("videoToggle intercept failed, allowing natural toggle: " + e.getMessage());
+                        logWarn(()-> "videoToggle intercept failed, allowing natural toggle: " + e.getMessage());
                         return false;
                     }
                 }
                 manualToggleSuppressionUntil = System.currentTimeMillis() + 500;
-                logInfo("videoToggle → ALLOW (video→audio while paused)");
+                logDebug(() -> "videoToggle → ALLOW (video→audio while paused)");
                 return false;
             }
 
             // Active crossfade: block audio→video, allow video→audio.
             if (isAudioMode) {
-                logInfo("videoToggle → BLOCK (audio→video while crossfade active)");
+                logDebug(() -> "videoToggle → BLOCK (audio→video while crossfade active)");
                 Utils.showToastShort(str("morphe_music_crossfade_video_mode_disabled_toast"));
                 return true;
             }
 
             inVideoMode = false;
             manualToggleSuppressionUntil = System.currentTimeMillis() + 500;
-            logInfo("videoToggle → ALLOW (video→audio, suppressing crossfade for 500ms)");
+            logDebug(() -> "videoToggle → ALLOW (video→audio, suppressing crossfade for 500ms)");
             return false;
         } catch (Exception e) {
-            logWarn("Could not check video toggle state", e);
+            logWarn(()-> "Could not check video toggle state", e);
             return false;
         }
     }
@@ -2553,9 +2585,11 @@ public class CrossfadeManager {
             int depth = 0;
             while (chain != null) {
                 if (chain instanceof VideoToggleAccess) {
-                    logInfo("findNbaInChain: found nba @" + System.identityHashCode(chain)
-                            + " class=" + chain.getClass().getSimpleName()
-                            + " at depth=" + depth);
+                    final int depthFinal = depth;
+                    final Object chainFinal = chain;
+                    logDebug(() -> "findNbaInChain: found nba @" + System.identityHashCode(chainFinal)
+                            + " class=" + chainFinal.getClass().getSimpleName()
+                            + " at depth=" + depthFinal);
                     lastNbaRef = new WeakReference<>(chain);
                     return chain;
                 }
@@ -2566,9 +2600,9 @@ public class CrossfadeManager {
                 depth++;
             }
         } catch (Exception e) {
-            logDebug("findNbaInChain error: " + e.getMessage());
+            logDebug(() -> "findNbaInChain error: " + e.getMessage());
         }
-        logWarn("findNbaInChain: nba not found in delegate chain — audio/video mode unknown");
+        logWarn(()-> "findNbaInChain: nba not found in delegate chain — audio/video mode unknown");
         return null;
     }
 
@@ -2579,7 +2613,7 @@ public class CrossfadeManager {
             nba = findNbaInChain();
         }
         if (nba == null) {
-            logWarn("forceAudioModeIfNeeded: nba not found — cannot force audio mode. "
+            logWarn(()-> "forceAudioModeIfNeeded: nba not found — cannot force audio mode. "
                     + "Video mode may be active. " + dumpState());
             return;
         }
@@ -2589,10 +2623,10 @@ public class CrossfadeManager {
                 toggle.patch_forceAudioModeSilent();
                 inVideoMode = false;
                 audioModeWasForced = true;
-                logInfo("Silently forced audio mode (no reactive broadcast to nmi)");
+                logDebug(() -> "Silently forced audio mode (no reactive broadcast to nmi)");
             }
         } catch (Exception e) {
-            logWarn("Could not force audio mode: " + e.getMessage());
+            logWarn(()-> "Could not force audio mode: " + e.getMessage());
         }
     }
 
@@ -2612,7 +2646,7 @@ public class CrossfadeManager {
             nba = findNbaInChain();
         }
         if (nba == null) {
-            logWarn("forceAudioModeBroadcastIfNeeded: nba not found — cannot force audio mode");
+            logWarn(()-> "forceAudioModeBroadcastIfNeeded: nba not found — cannot force audio mode");
             return;
         }
         try {
@@ -2621,10 +2655,10 @@ public class CrossfadeManager {
                 toggle.patch_forceAudioMode();
                 inVideoMode = false;
                 audioModeWasForced = true;
-                logInfo("Broadcast forced audio mode — nmi subscribers will reconcile, song will reload as audio-only");
+                logDebug(() -> "Broadcast forced audio mode — nmi subscribers will reconcile, song will reload as audio-only");
             }
         } catch (Exception e) {
-            logWarn("Could not broadcast force audio mode: " + e.getMessage());
+            logWarn(()-> "Could not broadcast force audio mode: " + e.getMessage());
         }
     }
 
@@ -2634,9 +2668,9 @@ public class CrossfadeManager {
         try {
             ((VideoToggleAccess) nba).patch_restoreVideoModeSilent();
             inVideoMode = true;
-            logInfo("Silently restored video mode preference (ready for next crossfade)");
+            logDebug(() -> "Silently restored video mode preference (ready for next crossfade)");
         } catch (Exception e) {
-            logWarn("Could not restore video mode: " + e.getMessage());
+            logWarn(()-> "Could not restore video mode: " + e.getMessage());
         }
     }
 
@@ -2652,10 +2686,10 @@ public class CrossfadeManager {
                 inVideoMode = !isAudio;
                 return !isAudio;
             } catch (Exception e) {
-                logDebug("Could not query live video mode: " + e.getMessage());
+                logDebug(() -> "Could not query live video mode: " + e.getMessage());
             }
         }
-        logWarn("isCurrentlyInVideoMode: nba not in chain — returning cached inVideoMode=" + inVideoMode
+        logWarn(()-> "isCurrentlyInVideoMode: nba not in chain — returning cached inVideoMode=" + inVideoMode
                 + " (may be stale)");
         return inVideoMode;
     }
@@ -2722,12 +2756,12 @@ public class CrossfadeManager {
             Resources res = activity.getResources();
             String pkg = activity.getPackageName();
 
-            java.util.List<View> allButtons = new java.util.ArrayList<>();
-            java.util.List<String> matchedIds = new java.util.ArrayList<>();
+            List<View> allButtons = new ArrayList<>();
+            List<String> matchedIds = new ArrayList<>();
             for (String idName : SHUFFLE_IDS) {
                 int id = res.getIdentifier(idName, "id", pkg);
                 if (id == 0) continue;
-                java.util.List<View> matched = new java.util.ArrayList<>();
+                List<View> matched = new ArrayList<>();
                 findAllViewsById(decorView, id, matched);
                 if (!matched.isEmpty()) {
                     matchedIds.add(idName + "(" + matched.size() + ")");
@@ -2756,10 +2790,10 @@ public class CrossfadeManager {
                             .append("(").append(parent.getClass().getSimpleName()).append(")");
                 }
             }
-            logInfo(attachLog.toString());
+            logDebug(() -> attachLog.toString());
             return true;
         } catch (Exception e) {
-            logDebug("tryAttachLongPressNow exception: " + e.getMessage());
+            logDebug(() -> "tryAttachLongPressNow exception: " + e.getMessage());
             return false;
         }
     }
@@ -2792,14 +2826,14 @@ public class CrossfadeManager {
             };
             longPressLayoutListenerHost = new WeakReference<>(decorView);
             decorView.getViewTreeObserver().addOnGlobalLayoutListener(longPressLayoutListener);
-            logDebug("Long-press attach: registered GlobalLayoutListener");
+            logDebug(() -> "Long-press attach: registered GlobalLayoutListener");
         } catch (Exception e) {
-            logDebug("registerLongPressLayoutListener exception: " + e.getMessage());
+            logDebug(() -> "registerLongPressLayoutListener exception: " + e.getMessage());
         }
     }
 
     private static void findAllViewsById(View root, int id,
-                                          java.util.List<View> out) {
+                                          List<View> out) {
         if (root.getId() == id) out.add(root);
         if (root instanceof ViewGroup) {
             ViewGroup vg = (ViewGroup) root;
@@ -2817,7 +2851,7 @@ public class CrossfadeManager {
         // touch-handler rebinds.
         btn.setOnLongClickListener(v -> {
             toggleSessionPause();
-            logInfo("Shuffle long-press fired on " + tag + "@" + viewId);
+            logDebug(() -> "Shuffle long-press fired on " + tag + "@" + viewId);
             return true;
         });
         btn.setLongClickable(true);

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
 package app.morphe.extension.music.patches;
 
 import static app.morphe.extension.shared.StringRef.str;
@@ -5,12 +11,15 @@ import static app.morphe.extension.shared.StringRef.str;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
+import android.media.AudioManager;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.SystemClock;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.os.VibratorManager;
+import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -66,7 +75,8 @@ public class CrossfadeManager {
         MILLISECONDS_7000(7_000),
         MILLISECONDS_8000(8_000),
         MILLISECONDS_9000(9_000),
-        MILLISECONDS_10000(10_000);
+        MILLISECONDS_10000(10_000),
+        MILLISECONDS_12000(12_000);
 
         public final int milliseconds;
 
@@ -101,6 +111,14 @@ public class CrossfadeManager {
          * 9.x only — 8.x bridge is not injected.
          */
         Object patch_getCoordinatorListener();
+        /**
+         * Calls the coordinator's own playNextInQueue method (auih.y()V) directly.
+         * The auto-advance monitor and onBeforePlayNext re-invoke must use this
+         * instead of atad.patch_playNextInQueue() (which calls atzq.p() → Lausd→y()V).
+         * auih does NOT implement Lausd, so the Lausd dispatch path never reaches
+         * the hooked auih.y()V — meaning onBeforePlayNext would never fire.
+         */
+        void patch_playNextInQueueDirect();
     }
 
     /**
@@ -190,19 +208,25 @@ public class CrossfadeManager {
     public interface MedialibPlayerAccess {
         Object patch_getPlayerChain();
         void patch_playNextInQueue();
+        /** Calls atad.stopVideo(REASON_DIRECTOR_RESET=5) through the hooked method. Used by 8.x and 9.x auto-advance monitor. */
+        void patch_forceStopVideo();
+        /** Calls atad.stopVideo(REASON_STOP=1).  Currently unused — kept for future flows. */
+        void patch_forceLoadVideo();
     }
 
-    /**
-     * Audio / video toggle (nba).
-     * Bridge method queries the internal state provider and returns
-     * whether the player is currently in audio mode.
-     */
+    /** Audio / video toggle (nba). */
     public interface VideoToggleAccess {
         boolean patch_isAudioMode();
         void patch_forceAudioMode();
         void patch_triggerToggle();
         void patch_forceAudioModeSilent();
         void patch_restoreVideoModeSilent();
+        /**
+         * Broadcast variant: calls nlw.setState → chxp.mo6606iF, notifying all
+         * subscribers (including nmi).  Use to resync subscribers whose cached state
+         * is out of sync with chxp after a silent toggle.
+         */
+        void patch_restoreVideoMode();
     }
 
     /**
@@ -249,6 +273,44 @@ public class CrossfadeManager {
         Logger.printInfo(() -> msg, e);
     }
 
+    private static String stopReasonName(int reason) {
+        switch (reason) {
+            case 1:  return "STOP(1)";
+            case 2:  return "PAUSE(2)";
+            case 3:  return "END_OF_CONTENT(3)";
+            case 4:  return "ERROR(4)";
+            case 5:  return "DIRECTOR_RESET/SKIP(5)";
+            case 6:  return "SEEK(6)";
+            case 7:  return "QUEUE_CHANGED(7)";
+            case 8:  return "PLAYLIST_CHANGED(8)";
+            case 9:  return "UNKNOWN_9(9)";
+            case 10: return "UNKNOWN_10(10)";
+            case 11: return "UNKNOWN_11(11)";
+            case 12: return "RESET_INTERNALLY(12)";
+            default: return "UNKNOWN(" + reason + ")";
+        }
+    }
+
+    private static String dumpState() {
+        return "STATE["
+                + "inProgress=" + crossfadeInProgress
+                + " autoAdv=" + autoAdvanceCrossfadeActive
+                + " deferred=" + deferredSwapPending
+                + " inPlayer=@" + System.identityHashCode(crossfadeInPlayer)
+                + " pendIn=@" + System.identityHashCode(pendingInPlayer)
+                + " pendOut=@" + System.identityHashCode(pendingOutPlayer)
+                + " fadingOut=" + fadingOutPlayers.size()
+                + " inVol=" + String.format("%.2f", currentFadeInVolume)
+                + " inVideo=" + inVideoMode
+                + " nbaAlive=" + (lastNbaRef != null && lastNbaRef.get() != null)
+                + " atadAlive=" + (lastAtadRef != null && lastAtadRef.get() != null)
+                + " playing=" + playerIsPlaying
+                + " created=" + playersCreated
+                + " released=" + playersReleased
+                + " outstanding=" + (playersCreated - playersReleased)
+                + "]";
+    }
+
     /**
      * Fade curve profiles available for crossfade.
      * Uses switch instead of abstract methods to avoid anonymous inner classes,
@@ -276,12 +338,28 @@ public class CrossfadeManager {
         }
     }
 
-    private static volatile boolean sessionPaused = false;
+    private static volatile boolean isCrossfadePaused = false;
     private static volatile boolean inVideoMode = false;
     private static volatile long manualToggleSuppressionUntil = 0;
     private static volatile boolean crossfadeInProgress = false;
     private static volatile boolean audioModeWasForced = false;
     private static volatile boolean activityRunning = false;
+    /**
+     * Tracks whether the outer MedialibPlayer is currently in a playing state.
+     * Set to true by onPlayVideo, false by onPauseVideo. Prevents the 9.x crossfade
+     * from resuming a paused outgoing player when the user selects a new song while paused.
+     */
+    private static volatile boolean playerIsPlaying = true;
+    /**
+     * True when a crossfade was initiated by the auto-advance monitor (via onBeforePlayNext).
+     * Used to distinguish the natural track-end stopVideo(5) (which fires ~fadeDuration ms
+     * after the crossfade started) from a genuine user double-skip, avoiding a false
+     * handleChainedSkip call that would corrupt the auto-advance crossfade state.
+     * Cleared whenever crossfadeInProgress is cleared.
+     */
+    private static volatile boolean autoAdvanceCrossfadeActive = false;
+    /** Retained for cleanup symmetry only. */
+    private static volatile boolean monitorCrossfadeActive = false;
 
     /**
      * Set at patch time via sput-boolean — true when running on YTM 9.x.
@@ -289,6 +367,22 @@ public class CrossfadeManager {
      * so we use a deferred coordinator swap instead of blocking native.
      */
     public static volatile boolean is9x = false;
+    /**
+     * 9.x: When true, the injected early-return in cwh.U()V prevents the Lcvu Runnable from
+     * being posted to the handler. This blocks cvu.run() → cwh.b.d() → CopyOnWriteArraySet.clear()
+     * which would otherwise destroy auih.k (MediaSession listener) in the shared cwh.b Lcgd.
+     * Set to true synchronously before patch_release() on an outgoing crossfade player, cleared
+     * in the finally block. Only needed on 9.x (crh.P() calls cwh.U() on the shared singleton).
+     */
+    public static volatile boolean suppressCwhU = false;
+
+    /**
+     * Read once at class init.  Pairs with {@code rebootApp=true} on
+     * {@link Settings#CROSSFADE_ENABLED}: toggling the setting requires
+     * an app restart, so the value is frozen for the process lifetime.
+     * When false, the JIT can dead-code-eliminate every hook body.
+     */
+    private static final boolean CROSSFADE_ENABLED = Settings.CROSSFADE_ENABLED.get();
 
     /**
      * True when we have set up crossfade state but deliberately NOT swapped
@@ -328,6 +422,10 @@ public class CrossfadeManager {
     private static final Handler mainHandler = new Handler(Looper.getMainLooper());
 
     private static final int TICK_MS = 50;
+    /** Delay between setting fade-out volume to 0 and releasing the player.
+     *  Lets ExoPlayer's AudioTrack drain its buffered frames (typically ~250ms deep)
+     *  so the abrupt teardown doesn't cut off any still-queued audio. */
+    private static final long RELEASE_DRAIN_DELAY_MS = 150;
     private static final int READY_POLL_MS = 100;
     private static final int READY_TIMEOUT_MS = 10000;
     private static final int STATE_READY = 3;
@@ -369,6 +467,14 @@ public class CrossfadeManager {
     private static WeakReference<Object> lastNbaRef = new WeakReference<>(null);
     private static volatile boolean internalToggle = false;
     private static volatile boolean internalPlayNext = false;
+    /** Marks the auih.y() hook to pass through when the monitor invoked it. */
+    private static volatile boolean monitorTriggeredSkip = false;
+    /**
+     * True when the monitor advanced the queue (MEDIA_NEXT dispatch).  Causes the
+     * OUTGOING's natural-end stopVideo(5) to be BLOCKED instead of allowed — without
+     * this, YTM's gapless code would advance the queue a second time (double-skip).
+     */
+    private static volatile boolean queueAdvancedByMonitor = false;
     private static Runnable autoAdvanceMonitorRunnable = null;
 
     private static int playersCreated = 0;
@@ -426,25 +532,41 @@ public class CrossfadeManager {
 
     private static int lastLoggedReason = -1;
     private static int suppressedReasonCount = 0;
+    private static int lastAtadIdentity = 0;
 
     public static boolean onBeforeStopVideo(Object atadInstance, int reason) {
+        if (!CROSSFADE_ENABLED) return false;
+
+        int atadId = System.identityHashCode(atadInstance);
+        if (atadId != lastAtadIdentity && lastAtadIdentity != 0) {
+            logInfo("QUEUE-CHANGE DETECTED: atad identity changed @"
+                    + lastAtadIdentity + " → @" + atadId
+                    + " (new session/queue) " + dumpState());
+        }
+        lastAtadIdentity = atadId;
         lastAtadRef = new WeakReference<>(atadInstance);
         tryAttachLongPressHandler();
 
         if (crossfadeInProgress) {
             if (reason == REASON_DIRECTOR_RESET) {
+                if (autoAdvanceCrossfadeActive) {
+                    if (queueAdvancedByMonitor) {
+                        // Block: queue already advanced via MEDIA_NEXT; letting native run
+                        // would double-advance to song N+2.
+                        logInfo("stopVideo(5): auto-advance + queue already advanced — BLOCKING natural-end");
+                        return true;
+                    }
+                    return false;
+                }
                 return handleChainedSkip(atadInstance);
             }
             if (is9x) {
-                // On 9.x the native stopVideo(5) body calls stopVideo(1) (and possibly
-                // other reasons) as part of the stopVideo→loadVideo→playVideo chain that
-                // loads the next track and connects the UI. We MUST allow these through
-                // so loadVideo and playVideo complete on the new player in the coordinator.
-                // The old player is kept separately as pendingOutPlayer and is unaffected.
-                logDebug("stopVideo(" + reason + "): ALLOW — 9.x native cycle (crossfade in progress)");
+                // 9.x: native stopVideo(5) body calls stopVideo(1)/loadVideo/playVideo to
+                // load the next track on the new coordinator player; must pass through.
+                logDebug("stopVideo/" + stopReasonName(reason) + ": ALLOW — 9.x native cycle (crossfade in progress)");
                 return false;
             }
-            logDebug("stopVideo(" + reason + "): BLOCKED — crossfade in progress");
+            logDebug("stopVideo/" + stopReasonName(reason) + ": BLOCKED — crossfade in progress");
             return true;
         }
 
@@ -470,9 +592,9 @@ public class CrossfadeManager {
             return false;
         }
 
-        if (!isEnabled() || sessionPaused || getCrossfadeDurationMs() <= 0) {
-            logDebug("stopVideo(5): skip [enabled=" + isEnabled()
-                    + " paused=" + sessionPaused + " inVideo=" + isCurrentlyInVideoMode() + "]");
+        if (isCrossfadePaused || getCrossfadeDurationMs() <= 0) {
+            logDebug("stopVideo(5): skip [paused=" + isCrossfadePaused
+                    + " inVideo=" + isCurrentlyInVideoMode() + "]");
             return false;
         }
 
@@ -518,10 +640,24 @@ public class CrossfadeManager {
                 return false;
             }
 
+            // 9.x volume-fade auto-advance: the monitor started fading out the outgoing
+            // player's volume. Allow the natural transition through — bacw.I() will create
+            // the incoming player and onBeforeLoadVideo will start the fade-in.
+            if (is9x && isAutoAdvance && autoAdvanceCrossfadeActive) {
+                logInfo("9.x: volume-fade auto-advance — allowing stopVideo(5) (outgoing fade running)");
+                return false;
+            }
+            // If a manual skip fires while a 9.x volume-fade is running, abort the fade
+            // and fall through to the normal crossfade path.
+            if (is9x && !isAutoAdvance && autoAdvanceCrossfadeActive) {
+                autoAdvanceCrossfadeActive = false;
+                queueAdvancedByMonitor = false;
+                logInfo("9.x: manual skip aborted volume-fade — proceeding with normal crossfade");
+            }
+
             boolean wasInVideoMode = isCurrentlyInVideoMode();
 
-            logInfo("stopVideo(5): STARTING crossfade [enabled=" + isEnabled()
-                    + " paused=" + sessionPaused
+            logInfo("stopVideo(5): STARTING crossfade [paused=" + isCrossfadePaused
                     + " wasInVideo=" + wasInVideoMode
                     + " is9x=" + is9x + "]");
 
@@ -544,6 +680,26 @@ public class CrossfadeManager {
                 pendingInPlayer = newExo;
                 activeCoordinator = coordinator;
                 crossfadeInProgress = true;
+                if (isAutoAdvance) {
+                    // Set when the monitor triggers via patch_playNextInQueueDirect → auih.y()V.
+                    // Prevents the natural track-end auih.y() from calling handleChainedSkip
+                    // via onBeforePlayNext, which would corrupt the already-in-flight crossfade.
+                    autoAdvanceCrossfadeActive = true;
+                    logDebug("9.x: auto-advance crossfade → autoAdvanceCrossfadeActive=true");
+
+                    // Detach cwh at swap time (auto-advance only): outgoing reaches natural-
+                    // end during the fade and would fire onEnded through the shared
+                    // MedialibPlayerEvents bus, which YTM mis-routes to the INCOMING and
+                    // double-advances the queue.  Manual-skip keeps cwh attached so the
+                    // far-from-end outgoing keeps reporting pause/seek/position events.
+                    try {
+                        currentExo.patch_detachCwhFromEventDispatch();
+                        logInfo("9.x auto-advance: detached cwh from OUTGOING @"
+                                + System.identityHashCode(currentExo) + " at swap time");
+                    } catch (Exception e) {
+                        logWarn("9.x auto-advance: cwh detach on outgoing failed: " + e.getMessage());
+                    }
+                }
                 deferredSwapStartTime = System.currentTimeMillis(); // gates internal stopVideo(5) detection
 
                 // Pre-remove the coordinator's listener (Lcou) from the outgoing player's direct
@@ -564,19 +720,6 @@ public class CrossfadeManager {
                     logWarn("9.x: pre-remove coord listener failed: " + e.getMessage());
                 }
 
-                // Detach coordinator_cwh from outgoing player's crh.h:Lcgd BEFORE the swap.
-                // When released later, the outgoing player fires isPlayingChanged(false) through
-                // crh.h → cwh.b → MediaSession. The boolean is captured at source and not
-                // re-queried, so even though cwh.g = new player (playing), MediaSession shows
-                // PAUSED. Removing cwh from crh.h silences all future events from this player.
-                try {
-                    currentExo.patch_detachCwhFromEventDispatch();
-                    logInfo("9.x: detached cwh from event dispatch on outgoing @"
-                            + System.identityHashCode(currentExo));
-                } catch (Exception e) {
-                    logWarn("9.x: cwh event dispatch detach failed: " + e.getMessage());
-                }
-
                 coordinator.patch_setPlayerWithBindings(newExo);
                 logInfo("9.x: swapped coordinator → new player @" + System.identityHashCode(newExo)
                         + " via patch_setPlayerWithBindings (Lcou backref updated)");
@@ -587,43 +730,39 @@ public class CrossfadeManager {
                 // player's Lcrh.N and MediaSession never receives onIsPlayingChanged(true).
                 if (coordListener != null) {
                     try {
-                        int lnBefore = newExo.patch_getDirectListenerCount();
                         newExo.patch_addDirectListener(coordListener);
-                        int lnAfter = newExo.patch_getDirectListenerCount();
-                        logInfo("9.x: Lcrh.N on newExo @" + System.identityHashCode(newExo)
-                                + ": before=" + lnBefore + " after=" + lnAfter
-                                + (lnAfter > lnBefore ? " ✓ Lcou registered" : " ✗ count unchanged — add may have failed"));
                     } catch (Exception e) {
                         logWarn("9.x: re-register coord listener failed: " + e.getMessage());
                     }
                 }
-                // Diagnostic: confirm coordinator is pointing to newExo after swap.
-                try {
-                    Object coordNow = coordinator.patch_getExoPlayer();
-                    logInfo("9.x: coordinator.exoPlayer=@" + System.identityHashCode(coordNow)
-                            + " newExo=@" + System.identityHashCode(newExo)
-                            + (coordNow == newExo ? " ✓ match" : " ✗ MISMATCH"));
-                } catch (Exception e) {
-                    logWarn("9.x: coord identity check failed: " + e.getMessage());
-                }
-
                 VideoSurfaceAccess surface = (VideoSurfaceAccess) coordinator.patch_getVideoSurface();
                 if (surface != null) {
                     surface.patch_setPlayerReference(newExo);
                 }
 
                 // Re-enable the outgoing player for audible fade-out.
+                // Use a timestamp check: if pauseVideo fired within PAUSE_TO_STOP_INTERNAL_WINDOW_MS
+                // of this stopVideo, it was YTM-internal (skip setup), not a genuine user pause.
+                // A genuine user pause precedes the next song selection by seconds, so the gap
+                // will be >> 500ms and playerIsPlaying=false will correctly keep the player silent.
                 try {
-                    currentExo.patch_setPlayWhenReady(true);
-                    currentExo.patch_setVolume(1.0f);
-                    logInfo("9.x: re-enabled outgoing player @" + System.identityHashCode(currentExo));
+                    long msSincePause = System.currentTimeMillis() - lastPauseVideoMs;
+                    boolean wasPlaying = playerIsPlaying
+                            || msSincePause < PAUSE_TO_STOP_INTERNAL_WINDOW_MS;
+                    logInfo("9.x: outgoing player re-enable check: playerIsPlaying=" + playerIsPlaying
+                            + " msSincePause=" + msSincePause + "ms → wasPlaying=" + wasPlaying);
+                    if (wasPlaying) {
+                        currentExo.patch_setPlayWhenReady(true);
+                        currentExo.patch_setVolume(1.0f);
+                        logInfo("9.x: re-enabled outgoing player @" + System.identityHashCode(currentExo));
+                    } else {
+                        currentExo.patch_setVolume(0.0f);
+                        logInfo("9.x: outgoing player was paused (genuine) — keeping silent @"
+                                + System.identityHashCode(currentExo));
+                    }
                 } catch (Exception e) {
-                    logWarn("9.x: could not re-enable outgoing player: " + e.getMessage());
+                    logWarn("9.x: could not configure outgoing player: " + e.getMessage());
                 }
-
-                // Clear the outgoing player's cau ListenerHolderSet so STATE_IDLE/ENDED at
-                // release time does not overwrite MediaSession state.
-                detachPlayerListeners(currentExo);
 
                 pollForNewTrackReady(newExo);
                 return false; // Allow native stopVideo chain → loads track onto newExo
@@ -634,6 +773,10 @@ public class CrossfadeManager {
                 pendingInPlayer = newExo;
                 activeCoordinator = coordinator;
                 crossfadeInProgress = true;
+                if (isAutoAdvance) {
+                    autoAdvanceCrossfadeActive = true;
+                    logDebug("8.x: auto-advance crossfade → autoAdvanceCrossfadeActive=true");
+                }
 
                 coordinator.patch_setExoPlayer(newExo);
                 logInfo("Swapped coordinator ExoPlayer → new player");
@@ -683,8 +826,8 @@ public class CrossfadeManager {
             }
         }
 
-        if (!isEnabled() || sessionPaused || getCrossfadeDurationMs() <= 0) {
-            logDebug("Chained skip: crossfade now disabled/paused — aborting crossfade");
+        if (isCrossfadePaused || getCrossfadeDurationMs() <= 0) {
+            logDebug("Chained skip: crossfade now paused — aborting crossfade");
             abortCrossfadeNow();
             return false;
         }
@@ -737,15 +880,7 @@ public class CrossfadeManager {
                     logWarn("9.x chained: pre-remove coord listener failed: " + e.getMessage());
                 }
             }
-            if (is9x && oldPending != null) {
-                try {
-                    oldPending.patch_detachCwhFromEventDispatch();
-                    logInfo("9.x chained: detached cwh from event dispatch on outgoing @"
-                            + System.identityHashCode(oldPending));
-                } catch (Exception e) {
-                    logWarn("9.x chained: cwh event dispatch detach failed: " + e.getMessage());
-                }
-            }
+
             coordinator.patch_setPlayerWithBindings(newExo);
             logInfo("Chained skip: swapped coordinator → new player @"
                     + System.identityHashCode(newExo));
@@ -753,33 +888,16 @@ public class CrossfadeManager {
             // Re-register Lcou into new player's Lcrh.N (9.x only).
             if (is9x && chainedCoordListener != null) {
                 try {
-                    int lnBefore = newExo.patch_getDirectListenerCount();
                     newExo.patch_addDirectListener(chainedCoordListener);
-                    int lnAfter = newExo.patch_getDirectListenerCount();
-                    logInfo("9.x chained: Lcrh.N on newExo @" + System.identityHashCode(newExo)
-                            + ": before=" + lnBefore + " after=" + lnAfter
-                            + (lnAfter > lnBefore ? " ✓ Lcou registered" : " ✗ count unchanged"));
                 } catch (Exception e) {
                     logWarn("9.x chained: re-register coord listener failed: " + e.getMessage());
                 }
             }
-            if (is9x) {
-                try {
-                    Object coordNow = coordinator.patch_getExoPlayer();
-                    logInfo("9.x chained: coordinator.exoPlayer=@" + System.identityHashCode(coordNow)
-                            + " newExo=@" + System.identityHashCode(newExo)
-                            + (coordNow == newExo ? " ✓ match" : " ✗ MISMATCH"));
-                } catch (Exception e) {
-                    logWarn("9.x chained: coord identity check failed: " + e.getMessage());
-                }
-            }
-
-            // Now release old pending.
             if (oldPending != null) {
                 logInfo("Chained skip: releasing old pending @"
                         + System.identityHashCode(oldPending)
                         + " (never reached READY)");
-                if (is9x) detachPlayerListeners(oldPending); // clear cau listeners
+                if (is9x) detachPlayerListeners(oldPending);
                 releasePlayer(oldPending);
             }
 
@@ -871,27 +989,42 @@ public class CrossfadeManager {
     // ------------------------------------------------------------------ //
 
     /**
-     * Returns true to BLOCK the native playNextInQueue, false to allow it.
-     *
-     * Strategy: we block the original call, set up our crossfade state, then
-     * invoke playNextInQueue again via patch_playNextInQueue with internalPlayNext=true.
-     * That second call passes through immediately (returns false), allowing the native
-     * to load the next track onto our new player. We then synchronously re-enforce
-     * volume=0 right after the native returns — eliminating the blip that occurred
-     * in the void-hook design where the native ran in the 100ms poll window.
+     * Returns true to block the native playNextInQueue.  Sets up crossfade state and
+     * re-invokes via internalPlayNext=true so native loads the next track on our new
+     * player, then re-enforces volume=0 to prevent a blip.
      */
     public static boolean onBeforePlayNext(Object coordinatorInstance) {
+        if (!CROSSFADE_ENABLED) return false;
+
+        // Monitor-triggered native skip: let auih.y()V run so it calls stopVideo(5),
+        // which onBeforeStopVideo will intercept for a true overlap crossfade.
+        if (monitorTriggeredSkip) {
+            monitorTriggeredSkip = false;
+            logDebug("PlayNext: monitor-triggered — allowing native auih.y()V (stopVideo intercepted by onBeforeStopVideo)");
+            return false;
+        }
+
         // Internal re-invoke: let native through immediately.
         if (internalPlayNext) {
             internalPlayNext = false;
             return false;
         }
 
-        logInfo("onBeforePlayNext called");
+        logInfo("onBeforePlayNext called [crossfading=" + crossfadeInProgress
+                + " autoAdvance=" + autoAdvanceCrossfadeActive + "]");
         tryAttachLongPressHandler();
 
-        if (!isEnabled() || sessionPaused || getCrossfadeDurationMs() <= 0
-                || crossfadeInProgress) {
+        if (isCrossfadePaused || getCrossfadeDurationMs() <= 0) {
+            return false;
+        }
+        if (crossfadeInProgress) {
+            if (autoAdvanceCrossfadeActive) {
+                // YTM's native gapless mechanism fired playNextInQueue after our auto-advance
+                // monitor already triggered it. Block this duplicate call to prevent loading
+                // the next-next track onto the incoming player mid-crossfade.
+                logDebug("PlayNext: auto-advance crossfade in progress — blocking duplicate native call");
+                return true;
+            }
             return false;
         }
 
@@ -922,6 +1055,7 @@ public class CrossfadeManager {
             pendingInPlayer = newExo;
             activeCoordinator = coordinator;
             crossfadeInProgress = true;
+            autoAdvanceCrossfadeActive = true;
             deferredSwapStartTime = System.currentTimeMillis(); // gate 9.x internal stopVideo(5)
 
             Object playNextCoordListener = null;
@@ -938,15 +1072,6 @@ public class CrossfadeManager {
                     logWarn("9.x PlayNext: pre-remove coord listener failed: " + e.getMessage());
                 }
             }
-            if (is9x) {
-                try {
-                    currentExo.patch_detachCwhFromEventDispatch();
-                    logInfo("9.x PlayNext: detached cwh from event dispatch on outgoing @"
-                            + System.identityHashCode(currentExo));
-                } catch (Exception e) {
-                    logWarn("9.x PlayNext: cwh event dispatch detach failed: " + e.getMessage());
-                }
-            }
             coordinator.patch_setPlayerWithBindings(newExo);
             logInfo("PlayNext: swapped coordinator → new player @"
                     + System.identityHashCode(newExo));
@@ -954,27 +1079,11 @@ public class CrossfadeManager {
             // Re-register Lcou into new player's Lcrh.N (9.x only).
             if (is9x && playNextCoordListener != null) {
                 try {
-                    int lnBefore = newExo.patch_getDirectListenerCount();
                     newExo.patch_addDirectListener(playNextCoordListener);
-                    int lnAfter = newExo.patch_getDirectListenerCount();
-                    logInfo("9.x PlayNext: Lcrh.N on newExo @" + System.identityHashCode(newExo)
-                            + ": before=" + lnBefore + " after=" + lnAfter
-                            + (lnAfter > lnBefore ? " ✓ Lcou registered" : " ✗ count unchanged"));
                 } catch (Exception e) {
                     logWarn("9.x PlayNext: re-register coord listener failed: " + e.getMessage());
                 }
             }
-            if (is9x) {
-                try {
-                    Object coordNow = coordinator.patch_getExoPlayer();
-                    logInfo("9.x PlayNext: coordinator.exoPlayer=@" + System.identityHashCode(coordNow)
-                            + " newExo=@" + System.identityHashCode(newExo)
-                            + (coordNow == newExo ? " ✓ match" : " ✗ MISMATCH"));
-                } catch (Exception e) {
-                    logWarn("9.x PlayNext: coord identity check failed: " + e.getMessage());
-                }
-            }
-
             VideoSurfaceAccess surface =
                     (VideoSurfaceAccess) coordinator.patch_getVideoSurface();
             if (surface != null) {
@@ -987,23 +1096,25 @@ public class CrossfadeManager {
                 logInfo("PlayNext: forced audio mode for incoming track (was in video mode)");
             }
 
-            // Re-invoke natively so the next track actually loads onto the new player.
-            // internalPlayNext=true causes the hook to pass through immediately.
-            // We then re-enforce volume=0 synchronously, before any poll tick.
+            // Re-invoke via atzq.p()→Lausd→y()V to advance the queue and trigger the
+            // native loadVideo onto the new coordinator player.  internalPlayNext guards
+            // against re-entry if our hook ever fires during the re-invoke.
+            internalPlayNext = true;
             Object atad = lastAtadRef.get();
             if (atad instanceof MedialibPlayerAccess) {
-                internalPlayNext = true;
                 try {
                     ((MedialibPlayerAccess) atad).patch_playNextInQueue();
                 } catch (Exception e) {
-                    internalPlayNext = false;
                     logWarn("PlayNext: re-invoke threw: " + e.getMessage());
+                } finally {
+                    internalPlayNext = false;
                 }
                 try {
                     newExo.patch_setVolume(0.0f);
                     logInfo("PlayNext: volume re-enforced to 0 after native");
                 } catch (Exception ignored) {}
             } else {
+                internalPlayNext = false;
                 logWarn("PlayNext: atad ref lost — cannot re-invoke native");
             }
 
@@ -1022,6 +1133,14 @@ public class CrossfadeManager {
         }
     }
 
+    /** 9.x atzq.o (loadVideo) entry hook — diagnostic only; fade-in is driven by onPendingPlayerReady. */
+    public static void onBeforeLoadVideo(Object newAtzqInstance) {
+        if (!is9x) return;
+        logDebug("9.x: onBeforeLoadVideo atzq=@" + System.identityHashCode(newAtzqInstance)
+                + " crossfadeInProgress=" + crossfadeInProgress
+                + " autoAdvActive=" + autoAdvanceCrossfadeActive);
+    }
+
     // ------------------------------------------------------------------ //
     //  Public hooks: pauseVideo / playVideo (MedialibPlayer layer)        //
     // ------------------------------------------------------------------ //
@@ -1029,21 +1148,42 @@ public class CrossfadeManager {
     private static long lastPauseEventMs = 0;
     private static long lastPlayEventMs = 0;
     private static final long EVENT_DEDUP_WINDOW_MS = 100;
+    /**
+     * Wall-clock time of the last onPauseVideo call.
+     * Used to distinguish YTM-internal pauseVideo calls (which arrive ~1–50ms before
+     * a skip-triggered stopVideo) from genuine user pauses (seconds earlier).
+     * If pauseVideo and stopVideo(5) arrive within PAUSE_TO_STOP_INTERNAL_WINDOW_MS,
+     * the pause was internal and we still re-enable the outgoing player for fade-out.
+     */
+    private static volatile long lastPauseVideoMs = System.currentTimeMillis();
+    /**
+     * If pauseVideo fired within this many ms before a crossfade-triggering stopVideo(5),
+     * the pause is treated as YTM-internal (skip setup) not a genuine user pause.
+     * YTM typically calls pauseVideo → stopVideo within ~10–50ms during a skip;
+     * a genuine user pause precedes the next song selection by seconds.
+     */
+    private static final long PAUSE_TO_STOP_INTERNAL_WINDOW_MS = 500;
 
     /**
      * Hooked at the top of MedialibPlayer.pauseVideo.
      * Returns true to BLOCK the pause, false to allow.
      */
     public static boolean onPauseVideo() {
+        if (!CROSSFADE_ENABLED) return false;
+
+        playerIsPlaying = false;
         long now = System.currentTimeMillis();
         if (now - lastPauseEventMs < EVENT_DEDUP_WINDOW_MS) return false;
         lastPauseEventMs = now;
+
+        lastPauseVideoMs = now;
+        logInfo("onPauseVideo [crossfading=" + crossfadeInProgress + " autoAdv=" + autoAdvanceCrossfadeActive + "]");
 
         if (!crossfadeInProgress) {
             return false;
         }
 
-        logInfo("onPauseVideo during crossfade — aborting crossfade, allowing pause");
+        logInfo("onPauseVideo: aborting crossfade " + dumpState());
         abortCrossfadeNow();
         return false;
     }
@@ -1052,6 +1192,9 @@ public class CrossfadeManager {
      * Hooked at the top of MedialibPlayer.playVideo.
      */
     public static void onPlayVideo(Object atadInstance) {
+        if (!CROSSFADE_ENABLED) return;
+
+        playerIsPlaying = true;
         long now = System.currentTimeMillis();
         if (now - lastPlayEventMs < EVENT_DEDUP_WINDOW_MS) return;
         lastPlayEventMs = now;
@@ -1060,12 +1203,23 @@ public class CrossfadeManager {
             lastAtadRef = new WeakReference<>(atadInstance);
         }
 
-        logDebug("onPlayVideo [crossfading=" + crossfadeInProgress
+        logInfo("onPlayVideo [crossfading=" + crossfadeInProgress
                 + " deferred=" + deferredSwapPending
-                + " atad=" + (atadInstance != null) + "]");
+                + " atad=" + (atadInstance != null)
+                + " nbaAlive=" + (lastNbaRef != null && lastNbaRef.get() != null) + "]");
+
+        // Coerce video → audio at song-start (shouldBlockVideoToggle catches manual
+        // toggles but not auto-loaded video-mode songs like music videos).
+        if (!isCrossfadePaused && isCurrentlyInVideoMode()) {
+            logInfo("onPlayVideo: coercing video → audio (crossfade active)");
+            forceAudioModeIfNeeded();
+        }
 
         if (!crossfadeInProgress) {
+            logInfo("onPlayVideo: starting auto-advance monitor");
             startAutoAdvanceMonitor();
+        } else {
+            logDebug("onPlayVideo: crossfade in progress — skipping auto-advance monitor start");
         }
     }
 
@@ -1093,21 +1247,6 @@ public class CrossfadeManager {
                 try {
                     int state = newPlayer.patch_getPlaybackState();
                     if (state == STATE_READY) {
-                        // Diagnostic: verify coordinator is still pointing to this player
-                        // and that Lcrh.N has a listener registered (9.x only).
-                        if (is9x && activeCoordinator != null) {
-                            try {
-                                Object coordNow = activeCoordinator.patch_getExoPlayer();
-                                int lnCount = newPlayer.patch_getDirectListenerCount();
-                                logInfo("READY: newPlayer=@" + System.identityHashCode(newPlayer)
-                                        + " coordinator.exoPlayer=@" + System.identityHashCode(coordNow)
-                                        + (coordNow == newPlayer ? " ✓ coord match" : " ✗ COORD MISMATCH")
-                                        + " Lcrh.N.size=" + lnCount
-                                        + (lnCount > 0 ? " ✓" : " ✗ NO DIRECT LISTENERS — MediaSession will stay PAUSED"));
-                            } catch (Exception e) {
-                                logWarn("READY: diagnostic check failed: " + e.getMessage());
-                            }
-                        }
                         logInfo("Pending track READY — promoting to crossfade");
                         onPendingPlayerReady(newPlayer);
                         return;
@@ -1160,6 +1299,7 @@ public class CrossfadeManager {
         FadeCurve curve = Settings.CROSSFADE_CURVE.get();
         long fadeDuration = getCrossfadeDurationMs();
 
+        boolean trackAlreadyEnded = false;
         ExoPlayerAccess outgoing = pendingOutPlayer;
         if (outgoing != null) {
             if (is9x) {
@@ -1183,7 +1323,15 @@ public class CrossfadeManager {
                     long actualRemaining = dur - pos;
                     logInfo("onPendingPlayerReady: outgoing remaining=" + actualRemaining
                             + "ms fadeDuration=" + fadeDuration + "ms");
-                    if (actualRemaining < fadeDuration) {
+                    if (actualRemaining <= 0) {
+                        // Auto-advance: content only loads after natural track end, so READY
+                        // always arrives after the old track has finished. Release the old player
+                        // immediately — there is no audio to fade out. The new track will fade in
+                        // from silence (true overlap requires intercepting YTM's gapless preload).
+                        trackAlreadyEnded = true;
+                        logInfo("Auto-advance: outgoing track ended before READY — "
+                                + "releasing silently, fade-in only (no overlap possible)");
+                    } else if (actualRemaining < fadeDuration) {
                         fadeOutDuration = Math.max(150, actualRemaining);
                         logInfo("Fade-out shortened to " + fadeOutDuration
                                 + "ms to match remaining audio (was " + fadeDuration + "ms)");
@@ -1192,10 +1340,16 @@ public class CrossfadeManager {
             } catch (Exception e) {
                 logDebug("Could not read outgoing remaining time: " + e.getMessage());
             }
-            fadingOutPlayers.add(new FadingPlayer(outgoing, fadeOutDuration, curve));
             pendingOutPlayer = null;
-            logInfo("Original outgoing player @" + System.identityHashCode(outgoing)
-                    + " → fade-out list (" + fadeOutDuration + "ms)");
+            if (trackAlreadyEnded) {
+                releasePlayer(outgoing);
+                logInfo("Original outgoing player @" + System.identityHashCode(outgoing)
+                        + " → released (track ended before READY)");
+            } else {
+                fadingOutPlayers.add(new FadingPlayer(outgoing, fadeOutDuration, curve));
+                logInfo("Original outgoing player @" + System.identityHashCode(outgoing)
+                        + " → fade-out list (" + fadeOutDuration + "ms)");
+            }
         }
 
         ExoPlayerAccess prevIncoming = crossfadeInPlayer;
@@ -1221,7 +1375,9 @@ public class CrossfadeManager {
         currentFadeInVolume = 0.0f;
 
         ensureFadingLoopRunning();
-        animateCrossfade(newPlayer);
+        // When the old track already ended before READY (auto-advance gap), snap in
+        // quickly rather than doing a slow 3s fade from silence.
+        animateCrossfade(newPlayer, trackAlreadyEnded ? QUICK_FADE_MS : 0);
     }
 
     // ------------------------------------------------------------------ //
@@ -1230,14 +1386,23 @@ public class CrossfadeManager {
 
     private static void startAutoAdvanceMonitor() {
         stopAutoAdvanceMonitor();
-        if (!isEnabled() || !Settings.CROSSFADE_ON_AUTO_ADVANCE.get()) return;
+        if (!isEnabled() || !Settings.CROSSFADE_ON_AUTO_ADVANCE.get()) {
+            logDebug("startAutoAdvanceMonitor: skipped [enabled=" + isEnabled()
+                    + " onAutoAdvance=" + Settings.CROSSFADE_ON_AUTO_ADVANCE.get() + "]");
+            return;
+        }
+        if (autoAdvanceCrossfadeActive) {
+            logDebug("startAutoAdvanceMonitor: skipped — 9.x volume-fade in progress");
+            return;
+        }
 
         autoAdvanceMonitorRunnable = new Runnable() {
             @Override
             public void run() {
-                if (!isEnabled() || sessionPaused
+                if (!isEnabled() || isCrossfadePaused
                         || !Settings.CROSSFADE_ON_AUTO_ADVANCE.get()
-                        || crossfadeInProgress) {
+                        || crossfadeInProgress
+                        || autoAdvanceCrossfadeActive) {
                     return;
                 }
 
@@ -1288,14 +1453,50 @@ public class CrossfadeManager {
                     }
 
                     if (remaining <= fadeDuration + AUTO_ADVANCE_TRIGGER_BUFFER_MS && remaining > 0) {
-                        logInfo("Auto-advance: triggering playNextInQueue"
-                                + " at remaining=" + remaining
+                        logInfo("Auto-advance: monitor trigger at remaining=" + remaining
                                 + "ms (fadeDuration=" + fadeDuration + "ms)");
                         stopAutoAdvanceMonitor();
+
+                        // Auto-advance trigger: simulated MEDIA_NEXT key event.  Other paths
+                        // tested (auih.y direct, atzq.p, atad.stopVideo(5) direct) either no-op
+                        // on 9.x or fail to advance the queue.  The MEDIA_NEXT dispatch goes
+                        // through YTM's mediasession skip handler which runs the full
+                        // queue-advance + clearQueue + loadOnesieVideo chain.  onBeforeStopVideo
+                        // intercepts the resulting stopVideo(5) for crossfade setup.
+                        logInfo("Auto-advance: TRIGGER FIRED is9x=" + is9x
+                                + " outgoing=@" + System.identityHashCode(exo)
+                                + " coordExo=@" + System.identityHashCode(coordinator.patch_getExoPlayer())
+                                + " fadeDur=" + fadeDuration + "ms state=" + state
+                                + " pos=" + pos + " dur=" + dur);
+                        monitorTriggeredSkip = true;
+                        queueAdvancedByMonitor = true;
+                        Context ctx = Utils.getContext();
+                        if (ctx == null) {
+                            monitorTriggeredSkip = false;
+                            queueAdvancedByMonitor = false;
+                            logWarn("Auto-advance: no Context — cannot dispatch MEDIA_NEXT");
+                            return;
+                        }
+                        AudioManager am = (AudioManager) ctx.getSystemService(Context.AUDIO_SERVICE);
+                        if (am == null) {
+                            monitorTriggeredSkip = false;
+                            queueAdvancedByMonitor = false;
+                            logWarn("Auto-advance: no AudioManager — cannot dispatch MEDIA_NEXT");
+                            return;
+                        }
                         try {
-                            ((MedialibPlayerAccess) atad).patch_playNextInQueue();
+                            long evTime = SystemClock.uptimeMillis();
+                            KeyEvent down = new KeyEvent(evTime, evTime,
+                                    KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MEDIA_NEXT, 0);
+                            KeyEvent up = new KeyEvent(evTime, evTime,
+                                    KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MEDIA_NEXT, 0);
+                            am.dispatchMediaKeyEvent(down);
+                            am.dispatchMediaKeyEvent(up);
+                            logInfo("Auto-advance: dispatched MEDIA_NEXT key event");
                         } catch (Exception e) {
-                            logWarn("playNextInQueue threw: " + e.getMessage());
+                            monitorTriggeredSkip = false;
+                            queueAdvancedByMonitor = false;
+                            logWarn("Auto-advance: dispatchMediaKeyEvent failed: " + e.getMessage());
                         }
                         return;
                     }
@@ -1324,6 +1525,7 @@ public class CrossfadeManager {
 
     private static void abortCrossfadeNow() {
         if (!crossfadeInProgress) return;
+        logInfo("ABORT: " + dumpState());
 
         ExoPlayerAccess inp = crossfadeInPlayer;
         ExoPlayerAccess pending = pendingInPlayer;
@@ -1380,6 +1582,9 @@ public class CrossfadeManager {
         pendingOutPlayer = null;
         activeCoordinator = null;
         crossfadeInProgress = false;
+        autoAdvanceCrossfadeActive = false;
+        queueAdvancedByMonitor = false;
+        monitorCrossfadeActive = false;
         deferredSwapPending = false;
         currentFadeInVolume = 0.0f;
 
@@ -1394,15 +1599,11 @@ public class CrossfadeManager {
      * Fade-outs are managed independently by the fading loop.
      * Self-terminates if this player is superseded by a chained skip.
      */
-    private static void animateCrossfade(final ExoPlayerAccess inPlayer) {
-        // Re-enforce volume=0 before unmuting the player. For auto-advance,
-        // the native playNextInQueue runs after our hook and may reset the
-        // volume to 1.0. For manual-skip the native is blocked, so the
-        // initial patch_setVolume(0) holds — but we re-enforce here for both.
+    private static void animateCrossfade(final ExoPlayerAccess inPlayer, final long durationOverrideMs) {
+        // Re-enforce volume=0 before unmuting: for auto-advance, the native
+        // playNextInQueue runs after our hook and may reset volume to 1.0.
         try {
             inPlayer.patch_setVolume(0.0f);
-            logInfo("fade-in pre-start: @" + System.identityHashCode(inPlayer)
-                    + " volume enforced to 0 before setPlayWhenReady");
         } catch (Exception e) {
             logWarn("fade-in pre-start: failed to zero volume: " + e.getMessage());
         }
@@ -1410,7 +1611,7 @@ public class CrossfadeManager {
         try { inPlayer.patch_setPlayWhenReady(true); } catch (Exception ignored) {}
 
         final long startTime = System.currentTimeMillis();
-        final long duration = getCrossfadeDurationMs();
+        final long duration = (durationOverrideMs > 0) ? durationOverrideMs : getCrossfadeDurationMs();
 
         logInfo("Crossfade fade-in started for @" + System.identityHashCode(inPlayer)
                 + ", duration=" + duration + "ms"
@@ -1451,16 +1652,19 @@ public class CrossfadeManager {
 
                     if (pendingInPlayer == null) {
                         crossfadeInProgress = false;
+                        autoAdvanceCrossfadeActive = false;
+                        queueAdvancedByMonitor = false;
+                        monitorCrossfadeActive = false;
                         crossfadeInPlayer = null;
                         activeCoordinator = null;
 
-                        if (audioModeWasForced) {
-                            audioModeWasForced = false;
-                            mainHandler.post(() -> {
-                                if (crossfadeInProgress) return;
-                                restoreVideoModeSilently();
-                            });
-                        }
+                        // Do NOT silently restore video mode here.  Stream loaded by the
+                        // crossfade is audio-only, so chxp must stay at audio-preferred to
+                        // keep the album-art UI subscriber in sync.  Restoring video would
+                        // make YTM's UI swap to the video-player fragment, which has no
+                        // stream to render → black box.  User can restore video by long-
+                        // pressing to pause crossfade (handled in shouldBlockVideoToggle).
+                        audioModeWasForced = false;
 
                         startAutoAdvanceMonitor();
                     } else {
@@ -1688,7 +1892,7 @@ public class CrossfadeManager {
      *       {@link java.util.concurrent.CopyOnWriteArraySet}'s equality check, while
      *       ExoPlayer's {@code invoke-interface} dispatch still reaches the real listener.</li>
      *   <li>Fallback: if proxy creation or {@code cau.add} fails for every listener,
-     *       copy the original cat objects directly (v151 behaviour).</li>
+     *       copy the original cat objects directly.</li>
      * </ol>
      */
     @SuppressWarnings("unchecked")
@@ -1791,7 +1995,7 @@ public class CrossfadeManager {
                         + " @" + System.identityHashCode(fromPlayer)
                         + " → @" + System.identityHashCode(toPlayer));
             } else {
-                // All proxy creations or cau.add calls failed — fall back to v151 behaviour:
+                // All proxy creations or cau.add calls failed — fall back:
                 // copy the original cat objects directly into the new player's set.
                 logWarn("migrateListeners: proxy path failed — copying " + catSnapshot.size()
                         + " original cats to toPlayer (had " + toSizeBefore + ")");
@@ -1837,10 +2041,35 @@ public class CrossfadeManager {
 
         try { p.patch_setDltCallback(null); } catch (Exception ignored) {}
 
+        // 9.x: detach coordinator_cwh from the player's crh.h event dispatch set at the last
+        // possible moment — just before release(). This prevents the release from firing
+        // isPlayingChanged(false) through crh.h → cwh.b → MediaSession (which would show PAUSED
+        // even though the new player is already playing). Doing this at release time (not at swap
+        // time) preserves normal pause/seek/position events on the active player during crossfade.
+        if (is9x) {
+            try {
+                p.patch_detachCwhFromEventDispatch();
+                logInfo("releasePlayer: 9.x detached cwh from event dispatch on @"
+                        + System.identityHashCode(p));
+            } catch (Exception e) {
+                logDebug("releasePlayer: 9.x cwh event dispatch detach failed: " + e.getMessage());
+            }
+        }
+
+        // 9.x: suppress cwh.U() for the duration of this release.
+        // crh.P() calls cwh.U() on the SHARED singleton cwh, which asynchronously calls
+        // cwh.b.d() via a posted Runnable (cvu.run()). cwh.b.d() clears the CopyOnWriteArraySet
+        // that holds auih.k (MediaSession listener) and sets cgd.i=true, preventing future adds.
+        // After this, NO player can send events to MediaSession (pause/seek/position all frozen).
+        // The injected early-return in cwh.U()V checks suppressCwhU and skips posting the
+        // Runnable — preserving cwh.b and all its listeners for the new (incoming) player.
+        if (is9x) suppressCwhU = true;
         try {
             p.patch_release();
         } catch (Exception e) {
             logDebug("releasePlayer: release() threw: " + e.getMessage());
+        } finally {
+            if (is9x) suppressCwhU = false;
         }
 
         if (callback != null) {
@@ -1873,6 +2102,7 @@ public class CrossfadeManager {
      * Used on errors and when crossfade is disabled/paused.
      */
     private static void cleanupAllPlayers() {
+        logError("CLEANUP (emergency): " + dumpState());
         if (deferredSwapRunnable != null) {
             mainHandler.removeCallbacks(deferredSwapRunnable);
             deferredSwapRunnable = null;
@@ -1885,6 +2115,12 @@ public class CrossfadeManager {
         crossfadeInPlayer = null;
         activeCoordinator = null;
         crossfadeInProgress = false;
+        if (autoAdvanceCrossfadeActive) {
+            logWarn("cleanupAllPlayers: clearing autoAdvanceCrossfadeActive mid-fade " + dumpState());
+        }
+        autoAdvanceCrossfadeActive = false;
+        queueAdvancedByMonitor = false;
+        monitorCrossfadeActive = false;
         deferredSwapPending = false;
         currentFadeInVolume = 0.0f;
         coordinatorListenerBxi = null;
@@ -1926,7 +2162,11 @@ public class CrossfadeManager {
 
                 if (fp.isComplete()) {
                     try { fp.player.patch_setVolume(0.0f); } catch (Exception ignored) {}
-                    releasePlayer(fp.player);
+                    // Defer the release so ExoPlayer's AudioTrack buffer can drain the
+                    // now-silent frames before the player is torn down — prevents an
+                    // abrupt cut/click when buffered non-zero-volume audio gets discarded.
+                    final ExoPlayerAccess toRelease = fp.player;
+                    mainHandler.postDelayed(() -> releasePlayer(toRelease), RELEASE_DRAIN_DELAY_MS);
                     it.remove();
                 }
             }
@@ -1939,10 +2179,6 @@ public class CrossfadeManager {
             logDebug("Fading loop stopped — all fade-outs complete");
         }
     }
-
-    // ------------------------------------------------------------------ //
-    //  Settings                                                           //
-    // ------------------------------------------------------------------ //
 
     // ------------------------------------------------------------------ //
     //  Activity lifecycle                                                 //
@@ -1960,24 +2196,39 @@ public class CrossfadeManager {
 
     public static void onActivityStart() {
         activityRunning = true;
-        if (isEnabled() && !sessionPaused) {
+
+        // Pause is per-session: reset on every activity start so a stale paused state
+        // can't survive a process that wasn't actually killed on swipe.
+        if (isCrossfadePaused) {
+            logInfo("onActivityStart: auto-resetting isCrossfadePaused to false");
+            isCrossfadePaused = false;
+        }
+
+        // Proactive attach: hot-path hooks alone leave the handler unattached on a
+        // freshly-recreated activity until the user does something else first.
+        tryAttachLongPressHandler();
+
+        if (isEnabled() && !isCrossfadePaused) {
             startAutoAdvanceMonitor();
         }
     }
 
     public static boolean isSessionPaused() {
-        return sessionPaused;
+        return isCrossfadePaused;
     }
 
     @SuppressWarnings("deprecation")
     @SuppressLint("MissingPermission")
     public static void toggleSessionPause() {
-        sessionPaused = !sessionPaused;
-        logInfo("Session " + (sessionPaused ? "PAUSED" : "RESUMED")
+        isCrossfadePaused = !isCrossfadePaused;
+        logInfo("Session " + (isCrossfadePaused ? "PAUSED" : "RESUMED")
                 + " [inVideo=" + isCurrentlyInVideoMode()
                 + " inProgress=" + crossfadeInProgress + "]");
 
-        if (sessionPaused) {
+        if (isCrossfadePaused) {
+            // Suppress abortCrossfadeNow's silent restore; video resync is the user's
+            // responsibility via the audio/video toggle (handled in shouldBlockVideoToggle).
+            audioModeWasForced = false;
             abortCrossfadeNow();
             stopAutoAdvanceMonitor();
         } else {
@@ -2005,14 +2256,26 @@ public class CrossfadeManager {
                 }
             } catch (Exception ignored) {}
 
-            Utils.showToastShort(str(sessionPaused
+            Utils.showToastShort(str(isCrossfadePaused
                     ? "morphe_music_crossfade_paused_toast"
                     : "morphe_music_crossfade_resumed_toast"));
         }
     }
 
     public static boolean isCrossfadeActive() {
-        return isEnabled() && !sessionPaused;
+        return isEnabled() && !isCrossfadePaused;
+    }
+
+    /**
+     * Called from the nba constructor hook so we always have a valid reference
+     * to the audio/video toggle object even before any toggle interaction fires.
+     * This ensures forceAudioModeIfNeeded() can act on songs loaded from the main
+     * feed without requiring the user to trigger an explicit audio/video toggle.
+     */
+    public static void onNbaCreated(Object nba) {
+        lastNbaRef = new WeakReference<>(nba);
+        logInfo("onNbaCreated: nba captured @" + System.identityHashCode(nba)
+                + " class=" + nba.getClass().getSimpleName());
     }
 
     /**
@@ -2029,17 +2292,38 @@ public class CrossfadeManager {
             boolean isAudioMode = toggle.patch_isAudioMode();
 
             logInfo("videoToggle: isAudioMode=" + isAudioMode
-                    + " enabled=" + isEnabled() + " paused=" + sessionPaused
+                    + " enabled=" + isEnabled() + " paused=" + isCrossfadePaused
                     + " inVideoMode(before)=" + inVideoMode);
 
-            if (!isEnabled() || sessionPaused) {
-                if (!isAudioMode) {
-                    manualToggleSuppressionUntil = System.currentTimeMillis() + 500;
-                }
-                logInfo("videoToggle → ALLOW (crossfade inactive)");
+            if (!isEnabled()) {
+                logInfo("videoToggle → ALLOW (crossfade disabled)");
                 return false;
             }
 
+            // Paused: audio→video must go through patch_restoreVideoMode (broadcast).  The
+            // natural toggle's broadcast can no-op at subscriber level because prior silent
+            // forceAudioModeSilent left subscribers' cached state out of sync with chxp.
+            // Video→audio direction works via the natural toggle.
+            if (isCrossfadePaused) {
+                if (isAudioMode) {
+                    try {
+                        ((VideoToggleAccess) nba).patch_restoreVideoMode();
+                        inVideoMode = true;
+                        audioModeWasForced = false;
+                        manualToggleSuppressionUntil = System.currentTimeMillis() + 500;
+                        logInfo("videoToggle → INTERCEPTED (audio→video while paused) — applied broadcast restoreVideoMode");
+                        return true;
+                    } catch (Exception e) {
+                        logWarn("videoToggle intercept failed, allowing natural toggle: " + e.getMessage());
+                        return false;
+                    }
+                }
+                manualToggleSuppressionUntil = System.currentTimeMillis() + 500;
+                logInfo("videoToggle → ALLOW (video→audio while paused)");
+                return false;
+            }
+
+            // Active crossfade: block audio→video, allow video→audio.
             if (isAudioMode) {
                 logInfo("videoToggle → BLOCK (audio→video while crossfade active)");
                 Utils.showToastShort(str("morphe_music_crossfade_video_mode_disabled_toast"));
@@ -2056,9 +2340,54 @@ public class CrossfadeManager {
         }
     }
 
+
+    /**
+     * Walks the delegate chain from the last known atad instance looking for a
+     * {@link VideoToggleAccess} node (the nba class). Updates {@link #lastNbaRef} on success.
+     *
+     * <p>This is a fallback for sessions where {@link #shouldBlockVideoToggle} was never called
+     * (e.g., songs loaded from the main feed without any audio/video toggle interaction).
+     * Returns the nba object, or null if not found in the chain.</p>
+     */
+    private static Object findNbaInChain() {
+        Object atad = lastAtadRef != null ? lastAtadRef.get() : null;
+        if (atad == null) return null;
+        try {
+            MedialibPlayerAccess player = (MedialibPlayerAccess) atad;
+            Object chain = player.patch_getPlayerChain();
+            int depth = 0;
+            while (chain != null) {
+                if (chain instanceof VideoToggleAccess) {
+                    logInfo("findNbaInChain: found nba @" + System.identityHashCode(chain)
+                            + " class=" + chain.getClass().getSimpleName()
+                            + " at depth=" + depth);
+                    lastNbaRef = new WeakReference<>(chain);
+                    return chain;
+                }
+                if (!(chain instanceof DelegateAccess)) break;
+                Object next = ((DelegateAccess) chain).patch_getDelegate();
+                if (next == null || next == chain) break;
+                chain = next;
+                depth++;
+            }
+        } catch (Exception e) {
+            logDebug("findNbaInChain error: " + e.getMessage());
+        }
+        logWarn("findNbaInChain: nba not found in delegate chain — audio/video mode unknown");
+        return null;
+    }
+
+
     private static void forceAudioModeIfNeeded() {
         Object nba = lastNbaRef.get();
-        if (nba == null) return;
+        if (nba == null) {
+            nba = findNbaInChain();
+        }
+        if (nba == null) {
+            logWarn("forceAudioModeIfNeeded: nba not found — cannot force audio mode. "
+                    + "Video mode may be active. " + dumpState());
+            return;
+        }
         try {
             VideoToggleAccess toggle = (VideoToggleAccess) nba;
             if (!toggle.patch_isAudioMode()) {
@@ -2069,6 +2398,38 @@ public class CrossfadeManager {
             }
         } catch (Exception e) {
             logWarn("Could not force audio mode: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Broadcast variant of forceAudioModeIfNeeded — fires the full nmi reactive
+     * broadcast so all YTM subscribers (MediaView, album-art ImageView, content-mode
+     * UI) reconcile their cached state.  Use this when crossfade is becoming active
+     * for the user's session (onPlayVideo) so the UI properly switches to album-art
+     * display.  Cost: brief stream reload to the audio-only stream.  Cannot be used
+     * during the crossfade SWAP itself (onBeforeStopVideo / onBeforePlayNext) because
+     * the broadcast triggers an nmi-driven stopVideo(5) jump that would re-enter our
+     * own hook and corrupt the swap-in-progress.
+     */
+    private static void forceAudioModeBroadcastIfNeeded() {
+        Object nba = lastNbaRef.get();
+        if (nba == null) {
+            nba = findNbaInChain();
+        }
+        if (nba == null) {
+            logWarn("forceAudioModeBroadcastIfNeeded: nba not found — cannot force audio mode");
+            return;
+        }
+        try {
+            VideoToggleAccess toggle = (VideoToggleAccess) nba;
+            if (!toggle.patch_isAudioMode()) {
+                toggle.patch_forceAudioMode();
+                inVideoMode = false;
+                audioModeWasForced = true;
+                logInfo("Broadcast forced audio mode — nmi subscribers will reconcile, song will reload as audio-only");
+            }
+        } catch (Exception e) {
+            logWarn("Could not broadcast force audio mode: " + e.getMessage());
         }
     }
 
@@ -2086,6 +2447,9 @@ public class CrossfadeManager {
 
     private static boolean isCurrentlyInVideoMode() {
         Object nba = lastNbaRef != null ? lastNbaRef.get() : null;
+        if (nba == null) {
+            nba = findNbaInChain();
+        }
         if (nba != null) {
             try {
                 VideoToggleAccess toggle = (VideoToggleAccess) nba;
@@ -2096,6 +2460,8 @@ public class CrossfadeManager {
                 logDebug("Could not query live video mode: " + e.getMessage());
             }
         }
+        logWarn("isCurrentlyInVideoMode: nba not in chain — returning cached inVideoMode=" + inVideoMode
+                + " (may be stale)");
         return inVideoMode;
     }
 
@@ -2129,67 +2495,112 @@ public class CrossfadeManager {
     private static Runnable pendingLongPress;
     private static volatile boolean longPressHandled = false;
 
+    /** Tracks the currently-registered global layout listener so we can remove it. */
+    private static android.view.ViewTreeObserver.OnGlobalLayoutListener longPressLayoutListener;
+    private static WeakReference<View> longPressLayoutListenerHost = new WeakReference<>(null);
+
+    /** Debounce: skip duplicate posts when hot-path hooks fire in rapid succession. */
+    private static volatile boolean pendingLongPressAttach = false;
+
     private static void tryAttachLongPressHandler() {
         if (!isSessionControlEnabled() || !isEnabled()) return;
-
-        boolean allAlive = !longPressRefs.isEmpty();
-        for (WeakReference<View> ref : longPressRefs) {
-            View v = ref.get();
-            if (v == null || !v.isAttachedToWindow()) {
-                allAlive = false;
-                break;
-            }
-        }
-        if (allAlive && !longPressRefs.isEmpty()) return;
+        if (pendingLongPressAttach) return;
+        pendingLongPressAttach = true;
 
         mainHandler.post(() -> {
-            try {
-                Activity activity = Utils.getActivity();
-                if (activity == null || activity.getWindow() == null) return;
-
-                View decorView = activity.getWindow().getDecorView();
-                Resources res = activity.getResources();
-                String pkg = activity.getPackageName();
-
-                java.util.List<View> allButtons = new java.util.ArrayList<>();
-                for (String idName : SHUFFLE_IDS) {
-                    int id = res.getIdentifier(idName, "id", pkg);
-                    if (id == 0) {
-                        logDebug("  shuffle id '" + idName + "' → not found in resources");
-                        continue;
-                    }
-                    java.util.List<View> matched = new java.util.ArrayList<>();
-                    findAllViewsById(decorView, id, matched);
-                    for (View v : matched) {
-                        logDebug("  shuffle id '" + idName + "' → "
-                                + v.getClass().getSimpleName()
-                                + " vis=" + v.getVisibility()
-                                + " attached=" + v.isAttachedToWindow()
-                                + " parent=" + (v.getParent() != null
-                                    ? v.getParent().getClass().getSimpleName() : "null"));
-                    }
-                    allButtons.addAll(matched);
-                }
-
-                logDebug("Found " + allButtons.size()
-                        + " shuffle button instances");
-
-                longPressRefs.clear();
-
-                for (View shuffleBtn : allButtons) {
-                    attachTouchLongPress(shuffleBtn);
-                    longPressRefs.add(new WeakReference<>(shuffleBtn));
-
-                    View parent = (View) shuffleBtn.getParent();
-                    if (parent != null && parent != decorView) {
-                        attachTouchLongPress(parent);
-                        longPressRefs.add(new WeakReference<>(parent));
-                    }
-                }
-            } catch (Exception e) {
-                logDebug("Long-press attach skipped: " + e.getMessage());
-            }
+            pendingLongPressAttach = false;
+            tryAttachLongPressNow();
+            registerLongPressLayoutListener();
         });
+    }
+
+    /**
+     * Walks the current activity's decor view for the shuffle button and attaches the
+     * long-press handler. Returns true if any attachments were made.
+     */
+    private static boolean tryAttachLongPressNow() {
+        try {
+            Activity activity = Utils.getActivity();
+            if (activity == null || activity.getWindow() == null) return false;
+
+            View decorView = activity.getWindow().getDecorView();
+            Resources res = activity.getResources();
+            String pkg = activity.getPackageName();
+
+            java.util.List<View> allButtons = new java.util.ArrayList<>();
+            java.util.List<String> matchedIds = new java.util.ArrayList<>();
+            for (String idName : SHUFFLE_IDS) {
+                int id = res.getIdentifier(idName, "id", pkg);
+                if (id == 0) continue;
+                java.util.List<View> matched = new java.util.ArrayList<>();
+                findAllViewsById(decorView, id, matched);
+                if (!matched.isEmpty()) {
+                    matchedIds.add(idName + "(" + matched.size() + ")");
+                }
+                allButtons.addAll(matched);
+            }
+
+            if (allButtons.isEmpty()) return false;
+
+            longPressRefs.clear();
+            StringBuilder attachLog = new StringBuilder("Long-press attach: matched=" + matchedIds + " — attaching to:");
+            for (View shuffleBtn : allButtons) {
+                attachTouchLongPress(shuffleBtn, "btn");
+                longPressRefs.add(new WeakReference<>(shuffleBtn));
+                attachLog.append(" btn@").append(System.identityHashCode(shuffleBtn))
+                        .append("(").append(shuffleBtn.getClass().getSimpleName())
+                        .append(" vis=").append(shuffleBtn.getVisibility())
+                        .append(" clickable=").append(shuffleBtn.isClickable())
+                        .append(")");
+
+                View parent = (View) shuffleBtn.getParent();
+                if (parent != null && parent != decorView) {
+                    attachTouchLongPress(parent, "parent");
+                    longPressRefs.add(new WeakReference<>(parent));
+                    attachLog.append(" parent@").append(System.identityHashCode(parent))
+                            .append("(").append(parent.getClass().getSimpleName()).append(")");
+                }
+            }
+            logInfo(attachLog.toString());
+            return true;
+        } catch (Exception e) {
+            logDebug("tryAttachLongPressNow exception: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Registers a global layout listener on the activity's decor view that re-attaches
+     * the long-press handler on every layout pass (does not self-remove — YTM's reactive
+     * UI may rebind handlers at any time).
+     */
+    private static void registerLongPressLayoutListener() {
+        try {
+            Activity activity = Utils.getActivity();
+            if (activity == null || activity.getWindow() == null) return;
+
+            View decorView = activity.getWindow().getDecorView();
+            View prevHost = longPressLayoutListenerHost.get();
+            if (longPressLayoutListener != null && prevHost == decorView) return;
+            if (longPressLayoutListener != null && prevHost != null
+                    && prevHost.getViewTreeObserver() != null
+                    && prevHost.getViewTreeObserver().isAlive()) {
+                try {
+                    prevHost.getViewTreeObserver().removeOnGlobalLayoutListener(longPressLayoutListener);
+                } catch (Exception ignored) {}
+            }
+            longPressLayoutListener = new android.view.ViewTreeObserver.OnGlobalLayoutListener() {
+                @Override
+                public void onGlobalLayout() {
+                    tryAttachLongPressNow();
+                }
+            };
+            longPressLayoutListenerHost = new WeakReference<>(decorView);
+            decorView.getViewTreeObserver().addOnGlobalLayoutListener(longPressLayoutListener);
+            logDebug("Long-press attach: registered GlobalLayoutListener");
+        } catch (Exception e) {
+            logDebug("registerLongPressLayoutListener exception: " + e.getMessage());
+        }
     }
 
     private static void findAllViewsById(View root, int id,
@@ -2203,63 +2614,18 @@ public class CrossfadeManager {
         }
     }
 
-    private static void attachTouchLongPress(View btn) {
-        final float[] downXY = new float[2];
-        final boolean[] longPressTriggered = {false};
+    private static void attachTouchLongPress(View btn, String tag) {
+        final int viewId = System.identityHashCode(btn);
 
-        btn.setOnTouchListener((v, event) -> {
-            switch (event.getActionMasked()) {
-                case MotionEvent.ACTION_DOWN:
-                    downXY[0] = event.getRawX();
-                    downXY[1] = event.getRawY();
-                    longPressTriggered[0] = false;
-                    longPressHandled = false;
-                    if (pendingLongPress != null) {
-                        mainHandler.removeCallbacks(pendingLongPress);
-                    }
-                    pendingLongPress = () -> {
-                        if (longPressHandled) return;
-                        longPressHandled = true;
-                        longPressTriggered[0] = true;
-                        toggleSessionPause();
-                        logInfo("Shuffle long-press fired ("
-                                + getLongPressThresholdMs() + "ms)");
-                    };
-                    mainHandler.postDelayed(pendingLongPress,
-                            getLongPressThresholdMs());
-                    return true;
-
-                case MotionEvent.ACTION_MOVE:
-                    float dx = event.getRawX() - downXY[0];
-                    float dy = event.getRawY() - downXY[1];
-                    if (Math.sqrt(dx * dx + dy * dy) > 30) {
-                        if (pendingLongPress != null) {
-                            mainHandler.removeCallbacks(pendingLongPress);
-                            pendingLongPress = null;
-                        }
-                    }
-                    return true;
-
-                case MotionEvent.ACTION_UP:
-                    if (pendingLongPress != null) {
-                        mainHandler.removeCallbacks(pendingLongPress);
-                        pendingLongPress = null;
-                    }
-                    if (longPressTriggered[0]) {
-                        return true;
-                    }
-                    v.performClick();
-                    return true;
-
-                case MotionEvent.ACTION_CANCEL:
-                    if (pendingLongPress != null) {
-                        mainHandler.removeCallbacks(pendingLongPress);
-                        pendingLongPress = null;
-                    }
-                    return true;
-            }
-            return false;
+        // setOnLongClickListener coexists with setOnTouchListener / setOnClickListener,
+        // so YTM's normal shuffle-tap keeps working and our handler isn't wiped by YTM's
+        // touch-handler rebinds.
+        btn.setOnLongClickListener(v -> {
+            toggleSessionPause();
+            logInfo("Shuffle long-press fired on " + tag + "@" + viewId);
+            return true;
         });
+        btn.setLongClickable(true);
     }
 
 }

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
@@ -2,7 +2,6 @@ package app.morphe.extension.music.patches;
 
 import static app.morphe.extension.shared.StringRef.str;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
@@ -15,14 +14,10 @@ import android.os.VibratorManager;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.annotation.SuppressLint;
 
 import java.lang.ref.WeakReference;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import app.morphe.extension.music.settings.Settings;
 import app.morphe.extension.shared.Logger;
@@ -30,7 +25,7 @@ import app.morphe.extension.shared.Utils;
 
 /**
  * Player-swap crossfade manager for YouTube Music.
- * <p>
+ *
  * Strategy: when a skip-next is detected (stopVideo reason=5), we
  * preserve the OLD ExoPlayer (which keeps playing the outgoing track)
  * and create a NEW ExoPlayer via YT Music's own factory method so it
@@ -38,14 +33,14 @@ import app.morphe.extension.shared.Utils;
  * player to the new one so the subsequent loadVideo flow uses it.
  * Once the new track reaches STATE_READY we run a configurable
  * crossfade, then release the old player.
- * <p>
+ *
  * Multi-player fade system: when a skip arrives during an active
  * crossfade, the current incoming player is "demoted" to a quick
  * fade-out, a fresh player is created for the next track, and the
  * native loadVideo naturally loads onto it.  Multiple fade-out
  * animations run concurrently via a dedicated fading loop, each
  * player releasing when its volume reaches zero.
- * <p>
+ *
  * Each obfuscated YTM class is accessed through a dedicated interface
  * whose bridge methods are injected at patch time (same pattern as YT
  * VideoInformation).  Each interface maps 1-to-1 with an obfuscated
@@ -54,7 +49,7 @@ import app.morphe.extension.shared.Utils;
  * updating.
  * @noinspection unused
  */
-
+@SuppressLint({"MissingPermission", "PrivateApi", "DiscouragedApi"})
 @SuppressWarnings("unused")
 public class CrossfadeManager {
 
@@ -80,6 +75,10 @@ public class CrossfadeManager {
         }
     }
 
+    // ------------------------------------------------------------------ //
+    //  Interfaces — one per obfuscated class, bound at patch time         //
+    // ------------------------------------------------------------------ //
+
     /**
      * Inner player coordinator (athu).
      * Holds the ExoPlayer, session, load control, shared state,
@@ -88,11 +87,20 @@ public class CrossfadeManager {
     public interface PlayerCoordinatorAccess {
         Object patch_getExoPlayer();
         void patch_setExoPlayer(Object player);
+        /** Calls the coordinator's internal player-transition method (listener migration + field write). */
+        void patch_setPlayerWithBindings(Object player);
         Object patch_getSession();
         Object patch_getLoadControl();
         Object patch_getSharedState();
         Object patch_getSharedCallback();
         Object patch_getVideoSurface();
+        /**
+         * Returns the coordinator's Player.Listener (b field, type Lcou).
+         * This listener is registered into ExoPlayer's direct N set (Lcrh.N)
+         * via O(Lcou;)V, NOT via the cau ListenerHolderSet.
+         * 9.x only — 8.x bridge is not injected.
+         */
+        Object patch_getCoordinatorListener();
     }
 
     /**
@@ -109,6 +117,32 @@ public class CrossfadeManager {
         Object patch_getListenerSet();
         Object patch_getInternalListener();
         void patch_setDltCallback(Object dlt);
+        /** Registers a raw Player.Listener on this player via ExoPlayer's addListener. */
+        void patch_addListener(Object listener);
+        /**
+         * Adds a listener directly to this player's N set (Lcrh.N —
+         * the direct CopyOnWriteArraySet, NOT the cau ListenerHolderSet).
+         * 9.x only — 8.x bridge is not injected.
+         */
+        void patch_addDirectListener(Object listener);
+        /**
+         * Removes a listener from this player's N set (Lcrh.N).
+         * 9.x only — 8.x bridge is not injected.
+         */
+        void patch_removeDirectListener(Object listener);
+        /**
+         * Removes coordinator_cwh from this player's crh.h:Lcgd event dispatch set.
+         * Must be called on the OUTGOING player before release so its release-time
+         * isPlayingChanged(false) does not propagate through cwh.b to MediaSession.
+         * 9.x only — 8.x bridge is not injected.
+         */
+        void patch_detachCwhFromEventDispatch();
+        /**
+         * Returns the size of this player's direct N set (Lcrh.N).
+         * Diagnostic only — lets us verify patch_addDirectListener actually registered the listener.
+         * 9.x only — 8.x bridge is not injected.
+         */
+        int patch_getDirectListenerCount();
     }
 
     /**
@@ -187,6 +221,34 @@ public class CrossfadeManager {
         Object patch_getWrappedListener();
     }
 
+    // ------------------------------------------------------------------ //
+    //  Constants and fields                                                //
+    // ------------------------------------------------------------------ //
+
+    private static void logDebug(String msg) {
+        Logger.printInfo(() -> msg);
+    }
+
+    private static void logInfo(String msg) {
+        Logger.printInfo(() -> msg);
+    }
+
+    private static void logError(String msg) {
+        Logger.printException(() -> msg);
+    }
+
+    private static void logError(String msg, Exception e) {
+        Logger.printException(() -> msg, e);
+    }
+
+    private static void logWarn(String msg) {
+        Logger.printInfo(() -> msg);
+    }
+
+    private static void logWarn(String msg, Exception e) {
+        Logger.printInfo(() -> msg, e);
+    }
+
     /**
      * Fade curve profiles available for crossfade.
      * Uses switch instead of abstract methods to avoid anonymous inner classes,
@@ -200,12 +262,12 @@ public class CrossfadeManager {
         SMOOTHSTEP;
 
         public float out(float t) {
-            return switch (this) {
-                case EASE_OUT_CUBIC -> 1.0f - t * t * t;
-                case EASE_OUT_QUAD -> (1.0f - t) * (1.0f - t);
-                case SMOOTHSTEP -> 1.0f - (3.0f * t * t - 2.0f * t * t * t);
-                default -> (float) Math.cos(t * Math.PI / 2.0);
-            };
+            switch (this) {
+                case EASE_OUT_CUBIC: return 1.0f - t * t * t;
+                case EASE_OUT_QUAD:  return (1.0f - t) * (1.0f - t);
+                case SMOOTHSTEP:    return 1.0f - (3.0f * t * t - 2.0f * t * t * t);
+                default:            return (float) Math.cos(t * Math.PI / 2.0);
+            }
         }
 
         public float in(float t) {
@@ -214,14 +276,54 @@ public class CrossfadeManager {
         }
     }
 
-    private static final boolean CROSSFADE_ENABLED = Settings.CROSSFADE_ENABLED.get();
-
-    private static final AtomicBoolean sessionPaused = new AtomicBoolean(false);
+    private static volatile boolean sessionPaused = false;
     private static volatile boolean inVideoMode = false;
     private static volatile long manualToggleSuppressionUntil = 0;
     private static volatile boolean crossfadeInProgress = false;
     private static volatile boolean audioModeWasForced = false;
     private static volatile boolean activityRunning = false;
+
+    /**
+     * Set at patch time via sput-boolean — true when running on YTM 9.x.
+     * On 9.x, blocking stopVideo also blocks playVideo (same call chain),
+     * so we use a deferred coordinator swap instead of blocking native.
+     */
+    public static volatile boolean is9x = false;
+
+    /**
+     * True when we have set up crossfade state but deliberately NOT swapped
+     * the coordinator yet (9.x path). The swap is deferred until onPlayVideo
+     * fires (or the postDelayed fallback runs after the native cycle completes).
+     */
+    private static volatile boolean deferredSwapPending = false;
+
+    /**
+     * Fallback Runnable for the 9.x deferred swap.
+     * Scheduled at DEFERRED_SWAP_DELAY_MS after allowing native stopVideo to proceed.
+     * Cancelled if onPlayVideo fires first, or if the crossfade is aborted.
+     */
+    private static Runnable deferredSwapRunnable = null;
+
+    /**
+     * How long to wait after allowing native stopVideo before executing the deferred
+     * coordinator swap (9.x path). The native stopVideo→loadVideo→playVideo cycle
+     * typically completes in ~250ms. 500ms is conservative.
+     */
+    private static final long DEFERRED_SWAP_DELAY_MS = 500;
+
+    /**
+     * Wall-clock time when deferredSwapPending was set to true.
+     * Used to distinguish the 9.x-internal second stopVideo(5) call (arrives ~1ms
+     * after the first) from a genuine user double-skip (arrives 200ms+).
+     */
+    private static volatile long deferredSwapStartTime = 0L;
+
+    /**
+     * Any second REASON_DIRECTOR_RESET that arrives within this window of
+     * deferredSwapStartTime is treated as the 9.x-internal double-call and
+     * allowed through without cancelling the deferred swap.
+     */
+    private static final long INTERNAL_CALL_WINDOW_MS = 100L;
 
     private static final Handler mainHandler = new Handler(Looper.getMainLooper());
 
@@ -230,6 +332,7 @@ public class CrossfadeManager {
     private static final int READY_TIMEOUT_MS = 10000;
     private static final int STATE_READY = 3;
     private static final int REASON_DIRECTOR_RESET = 5;
+    private static final long AUTO_ADVANCE_THRESHOLD_MS = 5000;
     private static final long MONITOR_POLL_MS = 100;
     // Extra lead time to absorb poll granularity + new-player READY latency (~120-200ms typical).
     // Ensures the fade-out completes before the old track's audio content runs out.
@@ -243,18 +346,35 @@ public class CrossfadeManager {
     private static volatile PlayerCoordinatorAccess activeCoordinator = null;
     private static volatile float currentFadeInVolume = 0.0f;
 
-    private static final List<FadingPlayer> fadingOutPlayers = Collections.synchronizedList(new ArrayList<>());
+    /**
+     * The coordinator's UI listener (bxi) identified on the first successful
+     * {@link #migrateListeners} call by eliminating factory-registered listeners.
+     *
+     * <p>Factory listeners whose bxi is shared (static) across ExoPlayer instances are
+     * filtered via {@code alreadyPresent} identity check.  However, some factory
+     * listeners have a fresh bxi instance per ExoPlayer — these are NOT identity-equal
+     * to the new player's factory cats and would incorrectly pass the filter.
+     *
+     * <p>Once we've identified the real coordinator listener on skip 1, we record it here
+     * and on all subsequent skips only migrate that exact object, ignoring per-player
+     * factory variants regardless of whether they pass the identity check.</p>
+     */
+    private static volatile Object coordinatorListenerBxi = null;
+
+    private static final java.util.List<FadingPlayer> fadingOutPlayers =
+            java.util.Collections.synchronizedList(new java.util.ArrayList<>());
     private static volatile boolean fadingLoopRunning = false;
 
     private static WeakReference<Object> lastAtadRef = new WeakReference<>(null);
     private static WeakReference<Object> lastNbaRef = new WeakReference<>(null);
-    private static final boolean internalToggle = false;
+    private static volatile boolean internalToggle = false;
     private static volatile boolean internalPlayNext = false;
     private static Runnable autoAdvanceMonitorRunnable = null;
 
     private static int playersCreated = 0;
     private static int playersReleased = 0;
-    private static final List<WeakReference<View>> longPressRefs = new ArrayList<>();
+    private static final java.util.List<WeakReference<View>> longPressRefs =
+            new java.util.ArrayList<>();
 
     /**
      * Tracks a single player's fade-out animation.
@@ -300,15 +420,14 @@ public class CrossfadeManager {
         }
     }
 
+    // ------------------------------------------------------------------ //
+    //  Public hook: stopVideo (manual skip-next)                          //
+    // ------------------------------------------------------------------ //
+
     private static int lastLoggedReason = -1;
     private static int suppressedReasonCount = 0;
 
-    /**
-     * Injection point.
-     */
     public static boolean onBeforeStopVideo(Object atadInstance, int reason) {
-        if (!CROSSFADE_ENABLED) return false;
-
         lastAtadRef = new WeakReference<>(atadInstance);
         tryAttachLongPressHandler();
 
@@ -316,7 +435,16 @@ public class CrossfadeManager {
             if (reason == REASON_DIRECTOR_RESET) {
                 return handleChainedSkip(atadInstance);
             }
-            Logger.printDebug(() -> "stopVideo(" + reason + "): BLOCKED — crossfade in progress");
+            if (is9x) {
+                // On 9.x the native stopVideo(5) body calls stopVideo(1) (and possibly
+                // other reasons) as part of the stopVideo→loadVideo→playVideo chain that
+                // loads the next track and connects the UI. We MUST allow these through
+                // so loadVideo and playVideo complete on the new player in the coordinator.
+                // The old player is kept separately as pendingOutPlayer and is unaffected.
+                logDebug("stopVideo(" + reason + "): ALLOW — 9.x native cycle (crossfade in progress)");
+                return false;
+            }
+            logDebug("stopVideo(" + reason + "): BLOCKED — crossfade in progress");
             return true;
         }
 
@@ -325,10 +453,10 @@ public class CrossfadeManager {
                 suppressedReasonCount++;
             } else {
                 if (suppressedReasonCount > 0) {
-                    Logger.printDebug(() -> "  (suppressed " + suppressedReasonCount
-                                        + " duplicate reason=" + lastLoggedReason + " entries)");
+                    logDebug("  (suppressed " + suppressedReasonCount
+                            + " duplicate reason=" + lastLoggedReason + " entries)");
                 }
-                Logger.printDebug(() -> "stopVideo reason=" + reason + " — not a skip, ignoring");
+                logDebug("stopVideo reason=" + reason + " — not a skip, ignoring");
                 lastLoggedReason = reason;
                 suppressedReasonCount = 0;
             }
@@ -338,18 +466,18 @@ public class CrossfadeManager {
         suppressedReasonCount = 0;
 
         if (System.currentTimeMillis() < manualToggleSuppressionUntil) {
-            Logger.printDebug(() -> "stopVideo(5): skip — within manual toggle suppression window");
+            logInfo("stopVideo(5): skip — within manual toggle suppression window");
             return false;
         }
 
-        if (sessionPaused.get() || getCrossfadeDurationMs() <= 0) {
-            Logger.printDebug(() -> "stopVideo(5): skip [paused=" + sessionPaused.get()
-                    + " inVideo=" + isCurrentlyInVideoMode() + "]");
+        if (!isEnabled() || sessionPaused || getCrossfadeDurationMs() <= 0) {
+            logDebug("stopVideo(5): skip [enabled=" + isEnabled()
+                    + " paused=" + sessionPaused + " inVideo=" + isCurrentlyInVideoMode() + "]");
             return false;
         }
 
         if (isFromTaskRemoval()) {
-            Logger.printDebug(() -> "stopVideo(5): skip — triggered by onTaskRemoved (activity killed)");
+            logDebug("stopVideo(5): skip — triggered by onTaskRemoved (activity killed)");
             if (crossfadeInProgress) cleanupAllPlayers();
             return false;
         }
@@ -357,35 +485,53 @@ public class CrossfadeManager {
         try {
             PlayerCoordinatorAccess coordinator = getCoordinatorFromAtad(atadInstance);
             if (coordinator == null) {
-                Logger.printException(() -> "Could not find coordinator from atad");
+                logError("Could not find coordinator from atad");
                 return false;
             }
 
             ExoPlayerAccess currentExo = (ExoPlayerAccess) coordinator.patch_getExoPlayer();
             if (currentExo == null) {
-                Logger.printException(() -> "Coordinator ExoPlayer is null");
+                logError("Coordinator ExoPlayer is null");
                 return false;
             }
 
-            // onBeforeStopVideo is always a manual skip — true auto-advance is handled
-            // exclusively by onBeforePlayNext. The position-based isAutoAdvance heuristic
-            // caused CROSSFADE_ON_SKIP to be bypassed for skips near the end of a track.
-            if (!Settings.CROSSFADE_ON_SKIP.get()) {
-                Logger.printDebug(() -> "stopVideo(5): skip — manual skip crossfade disabled");
+            boolean isAutoAdvance = false;
+            try {
+                long pos = currentExo.patch_getCurrentPosition();
+                long duration = currentExo.patch_getDuration();
+                long remaining = (duration > 0) ? duration - pos : Long.MAX_VALUE;
+                isAutoAdvance = duration > 0 && remaining >= 0
+                        && remaining < AUTO_ADVANCE_THRESHOLD_MS;
+                logDebug("stopVideo(5): pos=" + pos + "ms dur=" + duration
+                        + "ms remaining=" + remaining
+                        + "ms → " + (isAutoAdvance ? "AUTO-ADVANCE" : "MANUAL SKIP"));
+            } catch (Exception e) {
+                logWarn("Could not read position/duration, assuming manual skip", e);
+            }
+
+            if (isAutoAdvance && !Settings.CROSSFADE_ON_AUTO_ADVANCE.get()) {
+                logDebug("stopVideo(5): skip — auto-advance crossfade disabled");
+                return false;
+            }
+            if (!isAutoAdvance && !Settings.CROSSFADE_ON_SKIP.get()) {
+                logDebug("stopVideo(5): skip — manual skip crossfade disabled");
                 return false;
             }
 
             boolean wasInVideoMode = isCurrentlyInVideoMode();
 
-            Logger.printDebug(() -> "stopVideo(5): STARTING crossfade [paused=" + sessionPaused.get()
-                    + " wasInVideo=" + wasInVideoMode + "]");
+            logInfo("stopVideo(5): STARTING crossfade [enabled=" + isEnabled()
+                    + " paused=" + sessionPaused
+                    + " wasInVideo=" + wasInVideoMode
+                    + " is9x=" + is9x + "]");
 
-            Logger.printDebug(() -> "Current player state=" + currentExo.patch_getPlaybackState()
+            int currentState = currentExo.patch_getPlaybackState();
+            logDebug("Current player state=" + currentState
                     + " class=" + currentExo.getClass().getName());
 
             if (wasInVideoMode) {
                 forceAudioModeIfNeeded();
-                Logger.printDebug(() -> "Silent audio mode set BEFORE factory (video→audio, no nmi broadcast)");
+                logInfo("Silent audio mode set BEFORE factory (video→audio, no nmi broadcast)");
             }
 
             ExoPlayerAccess newExo = createNewPlayer(coordinator);
@@ -393,28 +539,120 @@ public class CrossfadeManager {
 
             newExo.patch_setVolume(0.0f);
 
-            pendingOutPlayer = currentExo;
-            pendingInPlayer = newExo;
-            activeCoordinator = coordinator;
-            crossfadeInProgress = true;
+            if (is9x) {
+                pendingOutPlayer = currentExo;
+                pendingInPlayer = newExo;
+                activeCoordinator = coordinator;
+                crossfadeInProgress = true;
+                deferredSwapStartTime = System.currentTimeMillis(); // gates internal stopVideo(5) detection
 
-            coordinator.patch_setExoPlayer(newExo);
-            Logger.printDebug(() -> "Swapped coordinator ExoPlayer → new player");
+                // Pre-remove the coordinator's listener (Lcou) from the outgoing player's direct
+                // listener set (Lcrh.N) BEFORE calling patch_setPlayerWithBindings.
+                // On skip 2+, the outgoing player is a factory player. Without this, the transition
+                // method's internal stop of the factory player fires STOPPAGE_REASON_UNKNOWN via
+                // Lcou (still registered in the factory player's Lcrh.N), triggering a premature
+                // clearQueue → state machine corruption → onPlaying() never fires.
+                Object coordListener = null;
+                try {
+                    coordListener = coordinator.patch_getCoordinatorListener();
+                    if (coordListener != null) {
+                        currentExo.patch_removeDirectListener(coordListener);
+                        logInfo("9.x: pre-removed coord listener from outgoing @"
+                                + System.identityHashCode(currentExo));
+                    }
+                } catch (Exception e) {
+                    logWarn("9.x: pre-remove coord listener failed: " + e.getMessage());
+                }
 
-            VideoSurfaceAccess surface = (VideoSurfaceAccess) coordinator.patch_getVideoSurface();
-            if (surface != null) {
-                surface.patch_setPlayerReference(newExo);
-                Logger.printDebug(() -> "Updated video surface → new player");
+                // Detach coordinator_cwh from outgoing player's crh.h:Lcgd BEFORE the swap.
+                // When released later, the outgoing player fires isPlayingChanged(false) through
+                // crh.h → cwh.b → MediaSession. The boolean is captured at source and not
+                // re-queried, so even though cwh.g = new player (playing), MediaSession shows
+                // PAUSED. Removing cwh from crh.h silences all future events from this player.
+                try {
+                    currentExo.patch_detachCwhFromEventDispatch();
+                    logInfo("9.x: detached cwh from event dispatch on outgoing @"
+                            + System.identityHashCode(currentExo));
+                } catch (Exception e) {
+                    logWarn("9.x: cwh event dispatch detach failed: " + e.getMessage());
+                }
+
+                coordinator.patch_setPlayerWithBindings(newExo);
+                logInfo("9.x: swapped coordinator → new player @" + System.identityHashCode(newExo)
+                        + " via patch_setPlayerWithBindings (Lcou backref updated)");
+
+                // Re-register Lcou into the new player's Lcrh.N.
+                // patch_setPlayerWithBindings (the coordinator's transition method) only migrates
+                // cau-level listeners — it never touches Lcrh.N. Without this, Lcou is in neither
+                // player's Lcrh.N and MediaSession never receives onIsPlayingChanged(true).
+                if (coordListener != null) {
+                    try {
+                        int lnBefore = newExo.patch_getDirectListenerCount();
+                        newExo.patch_addDirectListener(coordListener);
+                        int lnAfter = newExo.patch_getDirectListenerCount();
+                        logInfo("9.x: Lcrh.N on newExo @" + System.identityHashCode(newExo)
+                                + ": before=" + lnBefore + " after=" + lnAfter
+                                + (lnAfter > lnBefore ? " ✓ Lcou registered" : " ✗ count unchanged — add may have failed"));
+                    } catch (Exception e) {
+                        logWarn("9.x: re-register coord listener failed: " + e.getMessage());
+                    }
+                }
+                // Diagnostic: confirm coordinator is pointing to newExo after swap.
+                try {
+                    Object coordNow = coordinator.patch_getExoPlayer();
+                    logInfo("9.x: coordinator.exoPlayer=@" + System.identityHashCode(coordNow)
+                            + " newExo=@" + System.identityHashCode(newExo)
+                            + (coordNow == newExo ? " ✓ match" : " ✗ MISMATCH"));
+                } catch (Exception e) {
+                    logWarn("9.x: coord identity check failed: " + e.getMessage());
+                }
+
+                VideoSurfaceAccess surface = (VideoSurfaceAccess) coordinator.patch_getVideoSurface();
+                if (surface != null) {
+                    surface.patch_setPlayerReference(newExo);
+                }
+
+                // Re-enable the outgoing player for audible fade-out.
+                try {
+                    currentExo.patch_setPlayWhenReady(true);
+                    currentExo.patch_setVolume(1.0f);
+                    logInfo("9.x: re-enabled outgoing player @" + System.identityHashCode(currentExo));
+                } catch (Exception e) {
+                    logWarn("9.x: could not re-enable outgoing player: " + e.getMessage());
+                }
+
+                // Clear the outgoing player's cau ListenerHolderSet so STATE_IDLE/ENDED at
+                // release time does not overwrite MediaSession state.
+                detachPlayerListeners(currentExo);
+
+                pollForNewTrackReady(newExo);
+                return false; // Allow native stopVideo chain → loads track onto newExo
+            } else {
+                // 8.x path: block native, swap coordinator immediately so loadVideo
+                // routes content onto the new player.
+                pendingOutPlayer = currentExo;
+                pendingInPlayer = newExo;
+                activeCoordinator = coordinator;
+                crossfadeInProgress = true;
+
+                coordinator.patch_setExoPlayer(newExo);
+                logInfo("Swapped coordinator ExoPlayer → new player");
+
+                VideoSurfaceAccess surface = (VideoSurfaceAccess) coordinator.patch_getVideoSurface();
+                if (surface != null) {
+                    surface.patch_setPlayerReference(newExo);
+                    logDebug("Updated video surface → new player");
+                }
+
+                logInfo("Old player preserved (keeps playing), polling for new track ready"
+                        + " — BLOCKING native stopVideo");
+                pollForNewTrackReady(newExo);
+
+                return true;
             }
 
-            Logger.printDebug(() -> "Old player preserved (keeps playing), polling for new track ready"
-                        + " - BLOCKING native stopVideo");
-            pollForNewTrackReady(newExo);
-
-            return true;
-
-        } catch (Exception ex) {
-            Logger.printException(() -> "onBeforeStopVideo error", ex);
+        } catch (Exception e) {
+            logError("onBeforeStopVideo error", e);
             cleanupAllPlayers();
             if (audioModeWasForced) {
                 audioModeWasForced = false;
@@ -431,10 +669,22 @@ public class CrossfadeManager {
      * naturally loads the next track onto it.
      */
     private static boolean handleChainedSkip(Object atadInstance) {
-        Logger.printDebug(() -> "stopVideo(5): CHAINED SKIP — creating new player, deferring demotion until READY");
+        logInfo("stopVideo(5): CHAINED SKIP — creating new player, deferring demotion until READY");
 
-        if (sessionPaused.get() || getCrossfadeDurationMs() <= 0) {
-            Logger.printDebug(() -> "Chained skip: crossfade now disabled/paused — aborting crossfade");
+        if (is9x) {
+            long elapsed = System.currentTimeMillis() - deferredSwapStartTime;
+            if (elapsed < INTERNAL_CALL_WINDOW_MS) {
+                // This is the 9.x-internal second stopVideo(5) that always fires ~1ms
+                // after the first as part of the native track-transition sequence.
+                // It is NOT a user double-skip — pass it through untouched.
+                logDebug("9.x: internal second stopVideo(5) after " + elapsed
+                        + "ms — allowing through");
+                return false;
+            }
+        }
+
+        if (!isEnabled() || sessionPaused || getCrossfadeDurationMs() <= 0) {
+            logDebug("Chained skip: crossfade now disabled/paused — aborting crossfade");
             abortCrossfadeNow();
             return false;
         }
@@ -444,23 +694,24 @@ public class CrossfadeManager {
             if (coordinator == null) {
                 coordinator = getCoordinatorFromAtad(atadInstance);
                 if (coordinator == null) {
-                    Logger.printException(() -> "Chained skip: coordinator null — aborting");
+                    logError("Chained skip: coordinator null — aborting");
                     abortCrossfadeNow();
                     return false;
                 }
             }
 
+            // Save and clear pendingInPlayer before factory call.
             ExoPlayerAccess oldPending = pendingInPlayer;
-            if (oldPending != null) {
-                Logger.printDebug(() -> "Chained skip: releasing previous pending player @"
-                        + System.identityHashCode(oldPending)
-                        + " (never reached READY)");
-                releasePlayer(oldPending);
-            }
+            pendingInPlayer = null;
 
             ExoPlayerAccess newExo = createNewPlayer(coordinator);
             if (newExo == null) {
-                Logger.printException(() -> "Chained skip: factory failed — aborting crossfade");
+                logError("Chained skip: factory failed — aborting crossfade");
+                // Clean up old pending before aborting.
+                if (oldPending != null) {
+                    if (is9x) detachPlayerListeners(oldPending);
+                    releasePlayer(oldPending);
+                }
                 abortCrossfadeNow();
                 return false;
             }
@@ -469,10 +720,68 @@ public class CrossfadeManager {
             pendingInPlayer = newExo;
             activeCoordinator = coordinator;
 
-            coordinator.patch_setExoPlayer(newExo);
-            Logger.printDebug(() -> "Chained skip: swapped coordinator → new player @"
-                    + System.identityHashCode(newExo)
-                    + " (current animation continues uninterrupted)");
+            // Transition coordinator BEFORE releasing oldPending.
+            // coordinator.exoPlayer currently points to oldPending (set during first skip).
+            Object chainedCoordListener = null;
+            if (is9x) {
+                // Pre-remove coord listener from the outgoing player (coordinator's current player
+                // = oldPending = the first skip's factory player) to prevent premature clearQueue.
+                try {
+                    chainedCoordListener = coordinator.patch_getCoordinatorListener();
+                    if (chainedCoordListener != null && oldPending != null) {
+                        oldPending.patch_removeDirectListener(chainedCoordListener);
+                        logInfo("9.x chained: pre-removed coord listener from @"
+                                + System.identityHashCode(oldPending));
+                    }
+                } catch (Exception e) {
+                    logWarn("9.x chained: pre-remove coord listener failed: " + e.getMessage());
+                }
+            }
+            if (is9x && oldPending != null) {
+                try {
+                    oldPending.patch_detachCwhFromEventDispatch();
+                    logInfo("9.x chained: detached cwh from event dispatch on outgoing @"
+                            + System.identityHashCode(oldPending));
+                } catch (Exception e) {
+                    logWarn("9.x chained: cwh event dispatch detach failed: " + e.getMessage());
+                }
+            }
+            coordinator.patch_setPlayerWithBindings(newExo);
+            logInfo("Chained skip: swapped coordinator → new player @"
+                    + System.identityHashCode(newExo));
+
+            // Re-register Lcou into new player's Lcrh.N (9.x only).
+            if (is9x && chainedCoordListener != null) {
+                try {
+                    int lnBefore = newExo.patch_getDirectListenerCount();
+                    newExo.patch_addDirectListener(chainedCoordListener);
+                    int lnAfter = newExo.patch_getDirectListenerCount();
+                    logInfo("9.x chained: Lcrh.N on newExo @" + System.identityHashCode(newExo)
+                            + ": before=" + lnBefore + " after=" + lnAfter
+                            + (lnAfter > lnBefore ? " ✓ Lcou registered" : " ✗ count unchanged"));
+                } catch (Exception e) {
+                    logWarn("9.x chained: re-register coord listener failed: " + e.getMessage());
+                }
+            }
+            if (is9x) {
+                try {
+                    Object coordNow = coordinator.patch_getExoPlayer();
+                    logInfo("9.x chained: coordinator.exoPlayer=@" + System.identityHashCode(coordNow)
+                            + " newExo=@" + System.identityHashCode(newExo)
+                            + (coordNow == newExo ? " ✓ match" : " ✗ MISMATCH"));
+                } catch (Exception e) {
+                    logWarn("9.x chained: coord identity check failed: " + e.getMessage());
+                }
+            }
+
+            // Now release old pending.
+            if (oldPending != null) {
+                logInfo("Chained skip: releasing old pending @"
+                        + System.identityHashCode(oldPending)
+                        + " (never reached READY)");
+                if (is9x) detachPlayerListeners(oldPending); // clear cau listeners
+                releasePlayer(oldPending);
+            }
 
             VideoSurfaceAccess surface = (VideoSurfaceAccess) coordinator.patch_getVideoSurface();
             if (surface != null) {
@@ -481,9 +790,9 @@ public class CrossfadeManager {
 
             pollForNewTrackReady(newExo);
 
-            return true;
-        } catch (Exception ex) {
-            Logger.printException(() -> "handleChainedSkip error", ex);
+            return !is9x; // 8.x: block native stopVideo; 9.x: allow native chain to load track onto newExo
+        } catch (Exception e) {
+            logError("handleChainedSkip error", e);
             abortCrossfadeNow();
             return false;
         }
@@ -497,41 +806,31 @@ public class CrossfadeManager {
     private static ExoPlayerAccess createNewPlayer(PlayerCoordinatorAccess coordinator) {
         try {
             SessionAccess session = (SessionAccess) coordinator.patch_getSession();
-            if (session == null) {
-                Logger.printException(() -> "createNewPlayer: session null");
-                return null; }
+            if (session == null) { logError("createNewPlayer: session null"); return null; }
 
             PlayerFactoryAccess factory = (PlayerFactoryAccess) session.patch_getFactory();
-            if (factory == null) {
-                Logger.printException(() -> "createNewPlayer: factory null");
-                return null; }
+            if (factory == null) { logError("createNewPlayer: factory null"); return null; }
 
             Object loadControl = coordinator.patch_getLoadControl();
-            if (loadControl == null) {
-                Logger.printException(() -> "createNewPlayer: loadControl null");
-                return null; }
+            if (loadControl == null) { logError("createNewPlayer: loadControl null"); return null; }
 
             SharedStateAccess sharedState = (SharedStateAccess) coordinator.patch_getSharedState();
-            if (sharedState == null) {
-                Logger.printException(() -> "createNewPlayer: sharedState null");
-                return null; }
+            if (sharedState == null) { logError("createNewPlayer: sharedState null"); return null; }
 
             SharedCallbackAccess sharedCallback =
                     (SharedCallbackAccess) coordinator.patch_getSharedCallback();
-            if (sharedCallback == null) {
-                Logger.printException(() -> "createNewPlayer: sharedCallback null");
-                return null; }
+            if (sharedCallback == null) { logError("createNewPlayer: sharedCallback null"); return null; }
             activeSharedCallback = sharedCallback;
 
             Object oldTimeline = sharedState.patch_getTimeline();
             Object oldCqb = sharedCallback.patch_getCqb();
-            Logger.printDebug(() -> "Pre-factory shared state: cqb=" + (oldCqb != null));
+            logDebug("Pre-factory shared state: cqb=" + (oldCqb != null));
             sharedState.patch_setTimeline(null);
             sharedCallback.patch_setCqb(null);
 
             ExoPlayerAccess newExo = createPlayerViaFactory(factory, coordinator, loadControl);
             if (newExo == null) {
-                Logger.printException(() -> "Factory returned null — restoring");
+                logError("Factory returned null — restoring");
                 sharedState.patch_setTimeline(oldTimeline);
                 sharedCallback.patch_setCqb(oldCqb);
                 return null;
@@ -539,33 +838,41 @@ public class CrossfadeManager {
 
             Object postTimeline = sharedState.patch_getTimeline();
             Object postCqb = sharedCallback.patch_getCqb();
-            Logger.printDebug(() -> "Post-factory shared state: cqb=" + (postCqb != null)
+            logDebug("Post-factory shared state: cqb=" + (postCqb != null)
                     + " newExo=" + System.identityHashCode(newExo));
             if (postTimeline == null) {
-                Logger.printException(() -> "Factory failed to set timeline — aborting");
+                if (!is9x) {
+                    logError("Factory failed to set timeline — aborting");
+                    sharedState.patch_setTimeline(oldTimeline);
+                    sharedCallback.patch_setCqb(oldCqb);
+                    return null;
+                }
+                // On 9.x the timeline field is final; the factory cannot re-set it.
+                // Restore the old value so the shared state remains coherent.
+                logWarn("Factory did not re-set timeline (expected on 9.x — field is final, restoring)");
                 sharedState.patch_setTimeline(oldTimeline);
-                sharedCallback.patch_setCqb(oldCqb);
-                return null;
             }
             if (postCqb == null) {
-                Logger.printException(() -> "Factory failed to set cqb — aborting");
+                logError("Factory failed to set cqb — aborting");
                 sharedState.patch_setTimeline(oldTimeline);
                 sharedCallback.patch_setCqb(oldCqb);
                 return null;
             }
 
             return newExo;
-        } catch (Exception ex) {
-            Logger.printException(() -> "createNewPlayer error", ex);
+        } catch (Exception e) {
+            logError("createNewPlayer error", e);
             return null;
         }
     }
 
+    // ------------------------------------------------------------------ //
+    //  Public hook: playNextInQueue (gapless auto-advance)                //
+    // ------------------------------------------------------------------ //
+
     /**
-     * Injection point.
-     * <p>
      * Returns true to BLOCK the native playNextInQueue, false to allow it.
-     * <p>
+     *
      * Strategy: we block the original call, set up our crossfade state, then
      * invoke playNextInQueue again via patch_playNextInQueue with internalPlayNext=true.
      * That second call passes through immediately (returns false), allowing the native
@@ -574,24 +881,22 @@ public class CrossfadeManager {
      * in the void-hook design where the native ran in the 100ms poll window.
      */
     public static boolean onBeforePlayNext(Object coordinatorInstance) {
-        if (!CROSSFADE_ENABLED) return false;
-
         // Internal re-invoke: let native through immediately.
         if (internalPlayNext) {
             internalPlayNext = false;
             return false;
         }
 
-        Logger.printDebug(() -> "onBeforePlayNext called");
+        logInfo("onBeforePlayNext called");
         tryAttachLongPressHandler();
 
-        if (sessionPaused.get() || getCrossfadeDurationMs() <= 0
+        if (!isEnabled() || sessionPaused || getCrossfadeDurationMs() <= 0
                 || crossfadeInProgress) {
             return false;
         }
 
         if (!Settings.CROSSFADE_ON_AUTO_ADVANCE.get()) {
-            Logger.printDebug(() -> "PlayNext: skip — auto-advance crossfade disabled");
+            logDebug("PlayNext: skip — auto-advance crossfade disabled");
             return false;
         }
 
@@ -605,8 +910,8 @@ public class CrossfadeManager {
             if (currentExo == null) return false;
 
             int currentState = currentExo.patch_getPlaybackState();
-            Logger.printDebug(() -> "PlayNext: current player state=" + currentState
-                        + " wasInVideo=" + wasInVideoMode);
+            logDebug("PlayNext: current player state=" + currentState
+                    + " wasInVideo=" + wasInVideoMode);
 
             ExoPlayerAccess newExo = createNewPlayer(coordinator);
             if (newExo == null) return false;
@@ -617,50 +922,97 @@ public class CrossfadeManager {
             pendingInPlayer = newExo;
             activeCoordinator = coordinator;
             crossfadeInProgress = true;
+            deferredSwapStartTime = System.currentTimeMillis(); // gate 9.x internal stopVideo(5)
 
-            coordinator.patch_setExoPlayer(newExo);
-            Logger.printDebug(() -> "PlayNext: swapped coordinator ExoPlayer → new player");
+            Object playNextCoordListener = null;
+            if (is9x) {
+                // Pre-remove coord listener from outgoing player before transition.
+                try {
+                    playNextCoordListener = coordinator.patch_getCoordinatorListener();
+                    if (playNextCoordListener != null) {
+                        currentExo.patch_removeDirectListener(playNextCoordListener);
+                        logInfo("9.x PlayNext: pre-removed coord listener from @"
+                                + System.identityHashCode(currentExo));
+                    }
+                } catch (Exception e) {
+                    logWarn("9.x PlayNext: pre-remove coord listener failed: " + e.getMessage());
+                }
+            }
+            if (is9x) {
+                try {
+                    currentExo.patch_detachCwhFromEventDispatch();
+                    logInfo("9.x PlayNext: detached cwh from event dispatch on outgoing @"
+                            + System.identityHashCode(currentExo));
+                } catch (Exception e) {
+                    logWarn("9.x PlayNext: cwh event dispatch detach failed: " + e.getMessage());
+                }
+            }
+            coordinator.patch_setPlayerWithBindings(newExo);
+            logInfo("PlayNext: swapped coordinator → new player @"
+                    + System.identityHashCode(newExo));
+
+            // Re-register Lcou into new player's Lcrh.N (9.x only).
+            if (is9x && playNextCoordListener != null) {
+                try {
+                    int lnBefore = newExo.patch_getDirectListenerCount();
+                    newExo.patch_addDirectListener(playNextCoordListener);
+                    int lnAfter = newExo.patch_getDirectListenerCount();
+                    logInfo("9.x PlayNext: Lcrh.N on newExo @" + System.identityHashCode(newExo)
+                            + ": before=" + lnBefore + " after=" + lnAfter
+                            + (lnAfter > lnBefore ? " ✓ Lcou registered" : " ✗ count unchanged"));
+                } catch (Exception e) {
+                    logWarn("9.x PlayNext: re-register coord listener failed: " + e.getMessage());
+                }
+            }
+            if (is9x) {
+                try {
+                    Object coordNow = coordinator.patch_getExoPlayer();
+                    logInfo("9.x PlayNext: coordinator.exoPlayer=@" + System.identityHashCode(coordNow)
+                            + " newExo=@" + System.identityHashCode(newExo)
+                            + (coordNow == newExo ? " ✓ match" : " ✗ MISMATCH"));
+                } catch (Exception e) {
+                    logWarn("9.x PlayNext: coord identity check failed: " + e.getMessage());
+                }
+            }
 
             VideoSurfaceAccess surface =
                     (VideoSurfaceAccess) coordinator.patch_getVideoSurface();
             if (surface != null) {
                 surface.patch_setPlayerReference(newExo);
-                Logger.printDebug(() -> "PlayNext: updated video surface → new player");
+                logDebug("PlayNext: updated video surface → new player");
             }
 
             if (wasInVideoMode) {
                 forceAudioModeIfNeeded();
-                Logger.printDebug(() -> "PlayNext: forced audio mode for incoming track (was in video mode)");
+                logInfo("PlayNext: forced audio mode for incoming track (was in video mode)");
             }
 
             // Re-invoke natively so the next track actually loads onto the new player.
             // internalPlayNext=true causes the hook to pass through immediately.
             // We then re-enforce volume=0 synchronously, before any poll tick.
             Object atad = lastAtadRef.get();
-            if (atad instanceof MedialibPlayerAccess medialibPlayerAccessObj) {
+            if (atad instanceof MedialibPlayerAccess) {
                 internalPlayNext = true;
                 try {
-                    medialibPlayerAccessObj.patch_playNextInQueue();
-                } catch (Exception ex) {
+                    ((MedialibPlayerAccess) atad).patch_playNextInQueue();
+                } catch (Exception e) {
                     internalPlayNext = false;
-                    Logger.printDebug(() -> "PlayNext: re-invoke threw exception", ex);
+                    logWarn("PlayNext: re-invoke threw: " + e.getMessage());
                 }
                 try {
                     newExo.patch_setVolume(0.0f);
-                    Logger.printDebug(() -> "PlayNext: volume re-enforced to 0 after native");
-                } catch (Exception ex) {
-                    Logger.printDebug(() -> "Ignoring patch_setVolume exception", ex);
-                }
+                    logInfo("PlayNext: volume re-enforced to 0 after native");
+                } catch (Exception ignored) {}
             } else {
-                Logger.printDebug(() -> "PlayNext: atad ref lost — cannot re-invoke native");
+                logWarn("PlayNext: atad ref lost — cannot re-invoke native");
             }
 
-            Logger.printDebug(() -> "PlayNext: old player preserved, polling for new track ready");
+            logInfo("PlayNext: old player preserved, polling for new track ready");
             pollForNewTrackReady(newExo);
             return true; // block original call
 
-        } catch (Exception ex) {
-            Logger.printException(() -> "onBeforePlayNext error", ex);
+        } catch (Exception e) {
+            logError("onBeforePlayNext error", e);
             cleanupAllPlayers();
             if (audioModeWasForced) {
                 audioModeWasForced = false;
@@ -670,20 +1022,19 @@ public class CrossfadeManager {
         }
     }
 
+    // ------------------------------------------------------------------ //
+    //  Public hooks: pauseVideo / playVideo (MedialibPlayer layer)        //
+    // ------------------------------------------------------------------ //
+
     private static long lastPauseEventMs = 0;
     private static long lastPlayEventMs = 0;
     private static final long EVENT_DEDUP_WINDOW_MS = 100;
 
-     /**
-     * Injection point.
-     * <p>
+    /**
      * Hooked at the top of MedialibPlayer.pauseVideo.
      * Returns true to BLOCK the pause, false to allow.
      */
-    @SuppressWarnings("SameReturnValue")
     public static boolean onPauseVideo() {
-        if (!CROSSFADE_ENABLED) return false;
-
         long now = System.currentTimeMillis();
         if (now - lastPauseEventMs < EVENT_DEDUP_WINDOW_MS) return false;
         lastPauseEventMs = now;
@@ -692,19 +1043,15 @@ public class CrossfadeManager {
             return false;
         }
 
-        Logger.printDebug(() -> "onPauseVideo during crossfade — aborting crossfade, allowing pause");
+        logInfo("onPauseVideo during crossfade — aborting crossfade, allowing pause");
         abortCrossfadeNow();
         return false;
     }
 
     /**
-     * Injection point.
-     * <p>
      * Hooked at the top of MedialibPlayer.playVideo.
      */
     public static void onPlayVideo(Object atadInstance) {
-        if (!CROSSFADE_ENABLED) return;
-
         long now = System.currentTimeMillis();
         if (now - lastPlayEventMs < EVENT_DEDUP_WINDOW_MS) return;
         lastPlayEventMs = now;
@@ -713,12 +1060,18 @@ public class CrossfadeManager {
             lastAtadRef = new WeakReference<>(atadInstance);
         }
 
-        Logger.printDebug(() -> "onPlayVideo [crossfading=" + crossfadeInProgress
-                + ", atad=" + (atadInstance != null) + "]");
+        logDebug("onPlayVideo [crossfading=" + crossfadeInProgress
+                + " deferred=" + deferredSwapPending
+                + " atad=" + (atadInstance != null) + "]");
+
         if (!crossfadeInProgress) {
             startAutoAdvanceMonitor();
         }
     }
+
+    // ------------------------------------------------------------------ //
+    //  Poller: waits for new track to reach STATE_READY                   //
+    // ------------------------------------------------------------------ //
 
     private static int lastPollState = -1;
 
@@ -735,22 +1088,33 @@ public class CrossfadeManager {
                 // Keep new player silent while waiting for READY. The native
                 // playNextInQueue (auto-advance) runs after our void hook and
                 // resets the player to volume 1.0 — re-enforce on every tick.
-                try {
-                    newPlayer.patch_setVolume(0.0f);
-                } catch (Exception ex) {
-                    Logger.printDebug(() -> "Ignoring pollForNewTrackReady exception", ex);
-                }
+                try { newPlayer.patch_setVolume(0.0f); } catch (Exception ignored) {}
 
                 try {
                     int state = newPlayer.patch_getPlaybackState();
                     if (state == STATE_READY) {
-                        Logger.printDebug(() -> "Pending track READY — promoting to crossfade");
+                        // Diagnostic: verify coordinator is still pointing to this player
+                        // and that Lcrh.N has a listener registered (9.x only).
+                        if (is9x && activeCoordinator != null) {
+                            try {
+                                Object coordNow = activeCoordinator.patch_getExoPlayer();
+                                int lnCount = newPlayer.patch_getDirectListenerCount();
+                                logInfo("READY: newPlayer=@" + System.identityHashCode(newPlayer)
+                                        + " coordinator.exoPlayer=@" + System.identityHashCode(coordNow)
+                                        + (coordNow == newPlayer ? " ✓ coord match" : " ✗ COORD MISMATCH")
+                                        + " Lcrh.N.size=" + lnCount
+                                        + (lnCount > 0 ? " ✓" : " ✗ NO DIRECT LISTENERS — MediaSession will stay PAUSED"));
+                            } catch (Exception e) {
+                                logWarn("READY: diagnostic check failed: " + e.getMessage());
+                            }
+                        }
+                        logInfo("Pending track READY — promoting to crossfade");
                         onPendingPlayerReady(newPlayer);
                         return;
                     }
 
                     if (state == 4) {
-                        Logger.printException(() -> "Pending player ENDED unexpectedly — aborting");
+                        logError("Pending player ENDED unexpectedly — aborting");
                         cleanupAllPlayers();
                         if (audioModeWasForced) {
                             audioModeWasForced = false;
@@ -760,12 +1124,12 @@ public class CrossfadeManager {
                     }
 
                     if (state != lastPollState) {
-                        Logger.printDebug(() -> "Poll: state → " + state);
+                        logDebug("Poll: state → " + state);
                         lastPollState = state;
                     }
 
                     if (System.currentTimeMillis() > deadline) {
-                        Logger.printException(() -> "Timeout waiting for new track");
+                        logError("Timeout waiting for new track");
                         cleanupAllPlayers();
                         if (audioModeWasForced) {
                             audioModeWasForced = false;
@@ -775,8 +1139,8 @@ public class CrossfadeManager {
                     }
 
                     mainHandler.postDelayed(this, READY_POLL_MS);
-                } catch (Exception ex) {
-                    Logger.printException(() -> "Poll error", ex);
+                } catch (Exception e) {
+                    logError("Poll error", e);
                     cleanupAllPlayers();
                     if (audioModeWasForced) {
                         audioModeWasForced = false;
@@ -798,6 +1162,14 @@ public class CrossfadeManager {
 
         ExoPlayerAccess outgoing = pendingOutPlayer;
         if (outgoing != null) {
+            if (is9x) {
+                // On 9.x the coordinator's UI listener (auge.b:Lcou, in Lcrh.N) was already
+                // moved from the outgoing player to the incoming player at crossfade start time
+                // (in onBeforeStopVideo). No listener migration needed here.
+                // The old player's N set is now empty; it is safe to release after fade-out.
+                logInfo("onPendingPlayerReady (9.x): coordinator listener already migrated at start");
+            }
+
             // Match fade-out duration to actual remaining audio on the outgoing track.
             // This is critical for auto-advance: the trigger fires 300ms+ before the
             // configured fade duration, but READY latency is variable (100-500ms+).
@@ -809,24 +1181,21 @@ public class CrossfadeManager {
                 long dur = outgoing.patch_getDuration();
                 if (dur > 0 && pos >= 0) {
                     long actualRemaining = dur - pos;
-                    Logger.printDebug(() -> "onPendingPlayerReady: outgoing remaining=" + actualRemaining
-                                        + "ms fadeDuration=" + fadeDuration + "ms");
+                    logInfo("onPendingPlayerReady: outgoing remaining=" + actualRemaining
+                            + "ms fadeDuration=" + fadeDuration + "ms");
                     if (actualRemaining < fadeDuration) {
                         fadeOutDuration = Math.max(150, actualRemaining);
-                        final long fadeOutDurationFinal = fadeOutDuration;
-                        Logger.printDebug(() -> "Fade-out shortened to " + fadeOutDurationFinal
-                                                + "ms to match remaining audio (was " + fadeOutDurationFinal + "ms)");
+                        logInfo("Fade-out shortened to " + fadeOutDuration
+                                + "ms to match remaining audio (was " + fadeDuration + "ms)");
                     }
                 }
-            } catch (Exception ex) {
-                Logger.printDebug(() -> "Could not read outgoing remaining time", ex);
+            } catch (Exception e) {
+                logDebug("Could not read outgoing remaining time: " + e.getMessage());
             }
             fadingOutPlayers.add(new FadingPlayer(outgoing, fadeOutDuration, curve));
             pendingOutPlayer = null;
-
-            final long fadeOutDurationFinal = fadeOutDuration;
-            Logger.printDebug(() -> "Original outgoing player @" + System.identityHashCode(outgoing)
-                    + " → fade-out list (" + fadeOutDurationFinal + "ms)");
+            logInfo("Original outgoing player @" + System.identityHashCode(outgoing)
+                    + " → fade-out list (" + fadeOutDuration + "ms)");
         }
 
         ExoPlayerAccess prevIncoming = crossfadeInPlayer;
@@ -835,13 +1204,13 @@ public class CrossfadeManager {
             long quickDuration = Math.max(200, (long) (QUICK_FADE_MS * vol));
             if (vol > 0.01f) {
                 fadingOutPlayers.add(new FadingPlayer(prevIncoming, vol, quickDuration));
-                Logger.printDebug(() -> "Previous incoming player @"
+                logInfo("Previous incoming player @"
                         + System.identityHashCode(prevIncoming)
-                        + " → quick fade-out from " + String.format(Locale.US, "%.2f", vol)
+                        + " → quick fade-out from " + String.format("%.2f", vol)
                         + " over " + quickDuration + "ms");
             } else {
                 releasePlayer(prevIncoming);
-                Logger.printDebug(() -> "Previous incoming player @"
+                logInfo("Previous incoming player @"
                         + System.identityHashCode(prevIncoming)
                         + " → released (vol ≈ 0)");
             }
@@ -855,14 +1224,18 @@ public class CrossfadeManager {
         animateCrossfade(newPlayer);
     }
 
+    // ------------------------------------------------------------------ //
+    //  Auto-advance: position monitor & timed crossfade                   //
+    // ------------------------------------------------------------------ //
+
     private static void startAutoAdvanceMonitor() {
         stopAutoAdvanceMonitor();
-        if (!Settings.CROSSFADE_ON_AUTO_ADVANCE.get()) return;
+        if (!isEnabled() || !Settings.CROSSFADE_ON_AUTO_ADVANCE.get()) return;
 
         autoAdvanceMonitorRunnable = new Runnable() {
             @Override
             public void run() {
-                if (sessionPaused.get()
+                if (!isEnabled() || sessionPaused
                         || !Settings.CROSSFADE_ON_AUTO_ADVANCE.get()
                         || crossfadeInProgress) {
                     return;
@@ -904,9 +1277,9 @@ public class CrossfadeManager {
                     long fadeDuration = getCrossfadeDurationMs();
 
                     if (remaining % 5000 < MONITOR_POLL_MS) {
-                        Logger.printDebug(() -> "Auto-advance monitor: pos=" + pos
-                                                + "ms dur=" + dur + "ms remaining=" + remaining
-                                                + "ms trigger@" + (fadeDuration + AUTO_ADVANCE_TRIGGER_BUFFER_MS) + "ms");
+                        logDebug("Auto-advance monitor: pos=" + pos
+                                + "ms dur=" + dur + "ms remaining=" + remaining
+                                + "ms trigger@" + (fadeDuration + AUTO_ADVANCE_TRIGGER_BUFFER_MS) + "ms");
                     }
 
                     if (dur <= fadeDuration + AUTO_ADVANCE_TRIGGER_BUFFER_MS) {
@@ -915,27 +1288,27 @@ public class CrossfadeManager {
                     }
 
                     if (remaining <= fadeDuration + AUTO_ADVANCE_TRIGGER_BUFFER_MS && remaining > 0) {
-                        Logger.printDebug(() -> "Auto-advance: triggering playNextInQueue"
-                                                + " at remaining=" + remaining
-                                                + "ms (fadeDuration=" + fadeDuration + "ms)");
+                        logInfo("Auto-advance: triggering playNextInQueue"
+                                + " at remaining=" + remaining
+                                + "ms (fadeDuration=" + fadeDuration + "ms)");
                         stopAutoAdvanceMonitor();
                         try {
                             ((MedialibPlayerAccess) atad).patch_playNextInQueue();
-                        } catch (Exception ex) {
-                            Logger.printDebug(() -> "Ignoring playNextInQueue exceptoin", ex);
+                        } catch (Exception e) {
+                            logWarn("playNextInQueue threw: " + e.getMessage());
                         }
                         return;
                     }
 
                     mainHandler.postDelayed(this, MONITOR_POLL_MS);
-                } catch (Exception ex) {
-                    Logger.printDebug(() -> "Auto-advance monitor error", ex);
+                } catch (Exception e) {
+                    logWarn("Auto-advance monitor error", e);
                     mainHandler.postDelayed(this, MONITOR_POLL_MS * 2);
                 }
             }
         };
         mainHandler.postDelayed(autoAdvanceMonitorRunnable, MONITOR_POLL_MS);
-        Logger.printDebug(() -> "Auto-advance monitor started");
+        logInfo("Auto-advance monitor started");
     }
 
     private static void stopAutoAdvanceMonitor() {
@@ -944,6 +1317,10 @@ public class CrossfadeManager {
             autoAdvanceMonitorRunnable = null;
         }
     }
+
+    // ------------------------------------------------------------------ //
+    //  Volume animation (configurable curve)                              //
+    // ------------------------------------------------------------------ //
 
     private static void abortCrossfadeNow() {
         if (!crossfadeInProgress) return;
@@ -956,19 +1333,13 @@ public class CrossfadeManager {
         ExoPlayerAccess bestPlayer = null;
         boolean inpReady = false;
         if (inp != null) {
-            try {
-                inpReady = inp.patch_getPlaybackState() == STATE_READY;
-            } catch (Exception ex) {
-                Logger.printDebug(() -> "Ignoring in.patch_getPlaybackState exception", ex);
-            }
+            try { inpReady = inp.patch_getPlaybackState() == STATE_READY; }
+            catch (Exception ignored) {}
         }
         boolean pendingReady = false;
         if (pending != null) {
-            try {
-                pendingReady = pending.patch_getPlaybackState() == STATE_READY;
-            } catch (Exception ex) {
-                Logger.printDebug(() -> "Ignoring pending.patch_getPlaybackState exception", ex);
-            }
+            try { pendingReady = pending.patch_getPlaybackState() == STATE_READY; }
+            catch (Exception ignored) {}
         }
 
         if (pendingReady) {
@@ -980,9 +1351,8 @@ public class CrossfadeManager {
         }
 
         if (bestPlayer != null && coord != null) {
-            final ExoPlayerAccess bestPlayerFinal = bestPlayer;
-            Logger.printDebug(() -> "abortCrossfadeNow: snapping to player @"
-                    + System.identityHashCode(bestPlayerFinal));
+            logInfo("abortCrossfadeNow: snapping to player @"
+                    + System.identityHashCode(bestPlayer));
             try {
                 bestPlayer.patch_setVolume(1.0f);
                 bestPlayer.patch_setPlayWhenReady(true);
@@ -990,8 +1360,8 @@ public class CrossfadeManager {
                 VideoSurfaceAccess surface =
                         (VideoSurfaceAccess) coord.patch_getVideoSurface();
                 if (surface != null) surface.patch_setPlayerReference(bestPlayer);
-            } catch (Exception ex) {
-                Logger.printDebug(() -> "abortCrossfadeNow: snap failed", ex);
+            } catch (Exception e) {
+                logWarn("abortCrossfadeNow: snap failed: " + e.getMessage());
             }
         }
 
@@ -1001,11 +1371,16 @@ public class CrossfadeManager {
 
         releaseAllFadingPlayers();
 
+        if (deferredSwapRunnable != null) {
+            mainHandler.removeCallbacks(deferredSwapRunnable);
+            deferredSwapRunnable = null;
+        }
         crossfadeInPlayer = null;
         pendingInPlayer = null;
         pendingOutPlayer = null;
         activeCoordinator = null;
         crossfadeInProgress = false;
+        deferredSwapPending = false;
         currentFadeInVolume = 0.0f;
 
         if (audioModeWasForced) {
@@ -1026,22 +1401,18 @@ public class CrossfadeManager {
         // initial patch_setVolume(0) holds — but we re-enforce here for both.
         try {
             inPlayer.patch_setVolume(0.0f);
-            Logger.printDebug(() -> "fade-in pre-start: @" + System.identityHashCode(inPlayer)
+            logInfo("fade-in pre-start: @" + System.identityHashCode(inPlayer)
                     + " volume enforced to 0 before setPlayWhenReady");
-        } catch (Exception ex) {
-            Logger.printDebug(() -> "fade-in pre-start: failed to zero volume", ex);
+        } catch (Exception e) {
+            logWarn("fade-in pre-start: failed to zero volume: " + e.getMessage());
         }
 
-        try {
-            inPlayer.patch_setPlayWhenReady(true);
-        } catch (Exception ex) {
-            Logger.printDebug(() -> "Ignoring inPlayer.patch_setPlayWhenReady exception", ex);
-        }
+        try { inPlayer.patch_setPlayWhenReady(true); } catch (Exception ignored) {}
 
         final long startTime = System.currentTimeMillis();
         final long duration = getCrossfadeDurationMs();
 
-        Logger.printDebug(() -> "Crossfade fade-in started for @" + System.identityHashCode(inPlayer)
+        logInfo("Crossfade fade-in started for @" + System.identityHashCode(inPlayer)
                 + ", duration=" + duration + "ms"
                 + ", fading-out players=" + fadingOutPlayers.size());
 
@@ -1062,25 +1433,21 @@ public class CrossfadeManager {
                     inPlayer.patch_setVolume(inVol);
                     if (elapsed % 500 < TICK_MS) {
                         int inState = inPlayer.patch_getPlaybackState();
-                        Logger.printDebug(() -> String.format(Locale.US,
+                        logDebug(String.format(
                                 "fade-in: t=%.2f inVol=%.2f(st=%d) fadingOut=%d",
                                 t, inVol, inState, fadingOutPlayers.size()));
                     }
-                } catch (Exception ex) {
-                    Logger.printException(() -> "Fade-in tick error", ex);
+                } catch (Exception e) {
+                    logError("Fade-in tick error", e);
                 }
 
                 if (t < 1.0f) {
                     mainHandler.postDelayed(this, TICK_MS);
                 } else {
-                    Logger.printDebug(() -> "Fade-in complete for @" + System.identityHashCode(inPlayer));
+                    logInfo("Fade-in complete for @" + System.identityHashCode(inPlayer));
                     inVideoMode = false;
                     currentFadeInVolume = 1.0f;
-                    try {
-                        inPlayer.patch_setVolume(1.0f);
-                    } catch (Exception ex) {
-                        Logger.printDebug(() -> "Ignoring inPlayer.patch_setVolume exception", ex);
-                    }
+                    try { inPlayer.patch_setVolume(1.0f); } catch (Exception ignored) {}
 
                     if (pendingInPlayer == null) {
                         crossfadeInProgress = false;
@@ -1097,13 +1464,17 @@ public class CrossfadeManager {
 
                         startAutoAdvanceMonitor();
                     } else {
-                        Logger.printDebug(() -> "Fade-in complete but pending player exists - "
+                        logDebug("Fade-in complete but pending player exists — "
                                 + "waiting for it to reach READY");
                     }
                 }
             }
         });
     }
+
+    // ------------------------------------------------------------------ //
+    //  Player creation via YTM factory                                    //
+    // ------------------------------------------------------------------ //
 
     private static ExoPlayerAccess createPlayerViaFactory(
             PlayerFactoryAccess factory,
@@ -1113,7 +1484,7 @@ public class CrossfadeManager {
             Object player = factory.patch_createPlayer(coordinator, loadControl, 0);
             if (player != null) {
                 playersCreated++;
-                Logger.printDebug(() -> "Factory created player @"
+                logInfo("Factory created player @"
                         + System.identityHashCode(player)
                         + " [created=" + playersCreated
                         + " released=" + playersReleased
@@ -1121,11 +1492,15 @@ public class CrossfadeManager {
                         + (playersCreated - playersReleased) + "]");
             }
             return (ExoPlayerAccess) player;
-        } catch (Exception ex) {
-            Logger.printException(() -> "createPlayerViaFactory failed", ex);
+        } catch (Exception e) {
+            logError("createPlayerViaFactory failed", e);
             return null;
         }
     }
+
+    // ------------------------------------------------------------------ //
+    //  Stack trace utilities                                               //
+    // ------------------------------------------------------------------ //
 
     private static boolean isFromTaskRemoval() {
         for (StackTraceElement frame : Thread.currentThread().getStackTrace()) {
@@ -1133,6 +1508,10 @@ public class CrossfadeManager {
         }
         return false;
     }
+
+    // ------------------------------------------------------------------ //
+    //  Coordinator traversal from atad                                    //
+    // ------------------------------------------------------------------ //
 
     /**
      * Quiet variant — no traversal logging.
@@ -1153,8 +1532,7 @@ public class CrossfadeManager {
                 return (PlayerCoordinatorAccess) chain;
             }
             return null;
-        } catch (Exception ex) {
-            Logger.printDebug(() -> "getCoordinatorQuiet failure", ex);
+        } catch (Exception e) {
             return null;
         }
     }
@@ -1169,7 +1547,7 @@ public class CrossfadeManager {
             MedialibPlayerAccess atad = (MedialibPlayerAccess) atadInstance;
             Object chain = atad.patch_getPlayerChain();
             if (chain == null) {
-                Logger.printException(() -> "atad player chain is null");
+                logError("atad player chain is null");
                 return null;
             }
 
@@ -1181,23 +1559,264 @@ public class CrossfadeManager {
                 depth++;
             }
 
-
-            final int depthFinal = depth;
-            final Object chainFinal = chain;
-            Logger.printDebug(() -> "Traversed " + depthFinal + " delegates → "
-                    + chainFinal.getClass().getName());
+            logDebug("Traversed " + depth + " delegates → "
+                    + chain.getClass().getName());
 
             if (chain instanceof PlayerCoordinatorAccess) {
                 return (PlayerCoordinatorAccess) chain;
             }
 
-            final Object chainFinal2 = chain;
-            Logger.printException(() -> "Innermost class is not a PlayerCoordinatorAccess: "
-                    + chainFinal2.getClass().getName());
+            logError("Innermost class is not a PlayerCoordinatorAccess: "
+                    + chain.getClass().getName());
             return null;
-        } catch (Exception ex) {
-            Logger.printException(() -> "getCoordinatorFromAtad error", ex);
+        } catch (Exception e) {
+            logError("getCoordinatorFromAtad error", e);
             return null;
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Player lifecycle — release and fading loop                         //
+    // ------------------------------------------------------------------ //
+
+    /**
+     * InvocationHandler that forwards every method call to a captured real listener.
+     * Used by {@link #migrateListeners} to create proxy wrappers around migrated bxi objects.
+     *
+     * <p>Storing the target in a named field (rather than a lambda capture) lets
+     * {@link #unwrapForwardingTarget} recover the original listener and avoid
+     * proxy-of-proxy accumulation on consecutive skips.</p>
+     */
+    private static final class ForwardingHandler implements java.lang.reflect.InvocationHandler {
+        final Object target;
+
+        ForwardingHandler(Object target) {
+            this.target = target;
+        }
+
+        @Override
+        public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args)
+                throws Throwable {
+            try {
+                return method.invoke(target, args);
+            } catch (java.lang.reflect.InvocationTargetException e) {
+                Throwable cause = e.getCause();
+                throw (cause != null) ? cause : e;
+            }
+        }
+    }
+
+    /**
+     * If {@code listener} is a {@link java.lang.reflect.Proxy} backed by a
+     * {@link ForwardingHandler}, returns the handler's {@code target} (unwrapping one
+     * layer). Recurses until the deepest non-proxy target is reached.
+     * Returns {@code listener} unchanged if it is not a forwarding proxy.
+     */
+    private static Object unwrapForwardingTarget(Object listener) {
+        while (java.lang.reflect.Proxy.isProxyClass(listener.getClass())) {
+            java.lang.reflect.InvocationHandler h =
+                    java.lang.reflect.Proxy.getInvocationHandler(listener);
+            if (h instanceof ForwardingHandler) {
+                listener = ((ForwardingHandler) h).target;
+            } else {
+                break; // Foreign proxy — leave it alone.
+            }
+        }
+        return listener;
+    }
+
+    /**
+     * Creates a {@link java.lang.reflect.Proxy} that implements every interface
+     * found in {@code realListener}'s class hierarchy and forwards all calls to it.
+     *
+     * <p>The proxy has a different object identity from {@code realListener}, so
+     * {@link java.util.concurrent.CopyOnWriteArraySet#add} always succeeds even when
+     * {@code realListener} is already in the set.  ExoPlayer's listener dispatch
+     * uses {@code invoke-interface} against the stored Object, so a Proxy that
+     * implements the same interfaces receives the call correctly.</p>
+     *
+     * @return the proxy, or {@code null} if no interfaces are discoverable (should never happen).
+     */
+    private static Object createForwardingProxy(Object realListener) {
+        java.util.Set<Class<?>> ifaceSet = new java.util.LinkedHashSet<>();
+        for (Class<?> cls = realListener.getClass(); cls != null && cls != Object.class;
+                cls = cls.getSuperclass()) {
+            for (Class<?> iface : cls.getInterfaces()) {
+                ifaceSet.add(iface);
+            }
+        }
+        if (ifaceSet.isEmpty()) return null;
+        Class<?>[] ifaces = ifaceSet.toArray(new Class<?>[0]);
+        try {
+            return java.lang.reflect.Proxy.newProxyInstance(
+                    realListener.getClass().getClassLoader(),
+                    ifaces,
+                    new ForwardingHandler(realListener));
+        } catch (Exception e) {
+            logWarn("createForwardingProxy failed: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Transfers the coordinator's UI listener (and any other external Player.Listener
+     * registrations) from the outgoing player to the incoming player, then clears the
+     * outgoing player's listener set so it no longer emits events.
+     *
+     * <p>Called on 9.x only, at STATE_READY time (after the native
+     * stopVideo→loadVideo→playVideo chain has fully completed on the new player).
+     *
+     * <h3>Why this is needed on 9.x</h3>
+     * {@code patch_setPlayerWithBindings} writes the new player into the coordinator's
+     * {@code exoPlayer} field.  When the coordinator's internal player-transition method
+     * is not found at patch time, the bridge falls back to a raw {@code iput-object} that
+     * performs NO listener migration.  The coordinator's MedialibPlayerEvents listener
+     * (which drives the seekbar and play/pause state) therefore remains on the OLD player's
+     * {@link java.util.concurrent.CopyOnWriteArraySet}, causing UI disconnection.
+     *
+     * <h3>Strategy (B2 proxy approach)</h3>
+     * <ol>
+     *   <li>Snapshot the old player's listener set (cats = ListenerHolder wrappers).</li>
+     *   <li>Clear the old player's set — silences it immediately.</li>
+     *   <li>Collect the real bxi from each cat, unwrapping any prior proxy layers
+     *       (avoids proxy-of-proxy accumulation on consecutive skips).</li>
+     *   <li>Build the set of bxi already registered on the new player (factory listeners)
+     *       so we can skip duplicates.</li>
+     *   <li>For each bxi NOT already in the new player: wrap it in a
+     *       {@link ForwardingHandler} {@link java.lang.reflect.Proxy} and register via
+     *       {@code cau.add}.  The proxy has a fresh object identity, bypassing
+     *       {@link java.util.concurrent.CopyOnWriteArraySet}'s equality check, while
+     *       ExoPlayer's {@code invoke-interface} dispatch still reaches the real listener.</li>
+     *   <li>Fallback: if proxy creation or {@code cau.add} fails for every listener,
+     *       copy the original cat objects directly (v151 behaviour).</li>
+     * </ol>
+     */
+    @SuppressWarnings("unchecked")
+    private static void migrateListeners(ExoPlayerAccess fromPlayer, ExoPlayerAccess toPlayer) {
+        try {
+            Object fromSetObj = fromPlayer.patch_getListenerSet();
+            if (!(fromSetObj instanceof java.util.concurrent.CopyOnWriteArraySet)) {
+                logWarn("migrateListeners: unexpected set type — clearing only");
+                detachPlayerListeners(fromPlayer);
+                return;
+            }
+            java.util.concurrent.CopyOnWriteArraySet<Object> from =
+                    (java.util.concurrent.CopyOnWriteArraySet<Object>) fromSetObj;
+
+            // Snapshot before clearing so we have the original cat objects for the fallback.
+            java.util.List<Object> catSnapshot = new java.util.ArrayList<>(from);
+
+            // Extract real listeners (unwrap any proxy layers from prior skips).
+            java.util.List<Object> realListeners = new java.util.ArrayList<>(catSnapshot.size());
+            for (Object cat : catSnapshot) {
+                if (cat instanceof ListenerWrapperAccess) {
+                    Object raw = ((ListenerWrapperAccess) cat).patch_getWrappedListener();
+                    if (raw != null) realListeners.add(unwrapForwardingTarget(raw));
+                }
+            }
+
+            // Silence old player immediately.
+            from.clear();
+
+            // Inspect new player's existing listener set.
+            Object toSetObj = toPlayer.patch_getListenerSet();
+            java.util.concurrent.CopyOnWriteArraySet<Object> toSet =
+                    (toSetObj instanceof java.util.concurrent.CopyOnWriteArraySet)
+                    ? (java.util.concurrent.CopyOnWriteArraySet<Object>) toSetObj : null;
+            int toSizeBefore = toSet != null ? toSet.size() : -1;
+
+            // Build the set of real listeners already in the new player so we can skip
+            // factory duplicates (they are already registered at construction time).
+            java.util.Set<Object> alreadyPresent = new java.util.HashSet<>();
+            if (toSet != null) {
+                for (Object cat : new java.util.ArrayList<>(toSet)) {
+                    if (cat instanceof ListenerWrapperAccess) {
+                        Object raw = ((ListenerWrapperAccess) cat).patch_getWrappedListener();
+                        if (raw != null) alreadyPresent.add(unwrapForwardingTarget(raw));
+                    }
+                }
+            }
+
+            // Identify and proxy only the coordinator's UI listener.
+            //
+            // Two filter passes:
+            //  1. Identity check against new player's factory cats (shared-static bxi):
+            //     filters factory listeners whose bxi is the same instance across all players.
+            //  2. Coordinator-identity check (coordinatorListenerBxi):
+            //     filters per-player factory listeners whose bxi is a fresh instance per
+            //     ExoPlayer and therefore NOT caught by pass 1.  Once we identify the
+            //     coordinator bxi on the first crossfade we record it and only migrate
+            //     that exact object on all subsequent crossfades.
+            int registered = 0;
+            int skipped = 0;
+            for (Object real : realListeners) {
+                if (alreadyPresent.contains(real)) {
+                    // Shared-static factory listener — already in new player, skip.
+                    skipped++;
+                    continue;
+                }
+                if (coordinatorListenerBxi != null && real != coordinatorListenerBxi) {
+                    // Per-player factory listener (different instance per ExoPlayer).
+                    // Migrating it would leak old-player state and cause accumulation.
+                    skipped++;
+                    continue;
+                }
+                // Either coordinatorListenerBxi is null (first crossfade) or real IS it.
+                Object proxy = createForwardingProxy(real);
+                if (proxy == null) {
+                    logWarn("migrateListeners: proxy creation returned null for "
+                            + real.getClass().getName());
+                    continue;
+                }
+                try {
+                    toPlayer.patch_addListener(proxy);
+                    registered++;
+                    if (coordinatorListenerBxi == null) {
+                        // Record the coordinator bxi on first successful migration.
+                        coordinatorListenerBxi = real;
+                        logInfo("migrateListeners: identified coordinator bxi: "
+                                + real.getClass().getName()
+                                + "@" + System.identityHashCode(real));
+                    }
+                } catch (Exception e) {
+                    logWarn("migrateListeners: cau.add threw: " + e.getMessage());
+                }
+            }
+
+            if (registered > 0 || skipped > 0) {
+                logInfo("migrateListeners: registered=" + registered
+                        + " skipped=" + skipped
+                        + " total=" + realListeners.size()
+                        + " toPlayer had=" + toSizeBefore
+                        + " @" + System.identityHashCode(fromPlayer)
+                        + " → @" + System.identityHashCode(toPlayer));
+            } else {
+                // All proxy creations or cau.add calls failed — fall back to v151 behaviour:
+                // copy the original cat objects directly into the new player's set.
+                logWarn("migrateListeners: proxy path failed — copying " + catSnapshot.size()
+                        + " original cats to toPlayer (had " + toSizeBefore + ")");
+                if (toSet != null) toSet.addAll(catSnapshot);
+            }
+        } catch (Exception e) {
+            logWarn("migrateListeners failed", e);
+            detachPlayerListeners(fromPlayer);
+        }
+    }
+
+    /**
+     * Clears the external Player.Listener set on a player being retired from active duty.
+     * Used as a fallback or for players that were never promoted (chained skips).
+     */
+    private static void detachPlayerListeners(ExoPlayerAccess player) {
+        try {
+            Object listenerSet = player.patch_getListenerSet();
+            if (listenerSet instanceof java.util.concurrent.CopyOnWriteArraySet) {
+                ((java.util.concurrent.CopyOnWriteArraySet<?>) listenerSet).clear();
+                logInfo("Detached @" + System.identityHashCode(player)
+                        + " from UI listeners (cleared listener set)");
+            }
+        } catch (Exception e) {
+            logWarn("Could not detach player from UI listeners", e);
         }
     }
 
@@ -1205,7 +1824,7 @@ public class CrossfadeManager {
         if (p == null) return;
 
         playersReleased++;
-        Logger.printDebug(() -> "releasePlayer: @" + System.identityHashCode(p)
+        logInfo("releasePlayer: @" + System.identityHashCode(p)
                 + " [created=" + playersCreated + " released=" + playersReleased
                 + " outstanding=" + (playersCreated - playersReleased) + "]");
 
@@ -1216,16 +1835,12 @@ public class CrossfadeManager {
             savedDlt = callback.patch_getDlt();
         }
 
-        try {
-            p.patch_setDltCallback(null);
-        } catch (Exception ex) {
-            Logger.printDebug(() -> "Ignoring p.patch_setDltCallback exception", ex);
-        }
+        try { p.patch_setDltCallback(null); } catch (Exception ignored) {}
 
         try {
             p.patch_release();
-        } catch (Exception ex) {
-            Logger.printDebug(() -> "releasePlayer: release() threw exception", ex);
+        } catch (Exception e) {
+            logDebug("releasePlayer: release() threw: " + e.getMessage());
         }
 
         if (callback != null) {
@@ -1233,11 +1848,11 @@ public class CrossfadeManager {
             Object postDlt = callback.patch_getDlt();
             if (savedCqb != null && postCqb == null) {
                 callback.patch_setCqb(savedCqb);
-                Logger.printDebug(() -> "releasePlayer: restored shared cqb");
+                logDebug("releasePlayer: restored shared cqb");
             }
             if (savedDlt != null && postDlt == null) {
                 callback.patch_setDlt(savedDlt);
-                Logger.printDebug(() -> "releasePlayer: restored shared dlt");
+                logDebug("releasePlayer: restored shared dlt");
             }
         }
     }
@@ -1245,11 +1860,7 @@ public class CrossfadeManager {
     private static void releaseAllFadingPlayers() {
         synchronized (fadingOutPlayers) {
             for (FadingPlayer fp : fadingOutPlayers) {
-                try {
-                    fp.player.patch_setVolume(0.0f);
-                } catch (Exception ex) {
-                    Logger.printDebug(() -> "Ignoring fp.player.patch_setVolume exception", ex);
-                }
+                try { fp.player.patch_setVolume(0.0f); } catch (Exception ignored) {}
                 releasePlayer(fp.player);
             }
             fadingOutPlayers.clear();
@@ -1262,21 +1873,21 @@ public class CrossfadeManager {
      * Used on errors and when crossfade is disabled/paused.
      */
     private static void cleanupAllPlayers() {
+        if (deferredSwapRunnable != null) {
+            mainHandler.removeCallbacks(deferredSwapRunnable);
+            deferredSwapRunnable = null;
+        }
         releaseAllFadingPlayers();
         ExoPlayerAccess pi = pendingInPlayer;
-        if (pi != null) {
-            releasePlayer(pi);
-            pendingInPlayer = null;
-        }
+        if (pi != null) { releasePlayer(pi); pendingInPlayer = null; }
         ExoPlayerAccess po = pendingOutPlayer;
-        if (po != null) {
-            releasePlayer(po);
-            pendingOutPlayer = null;
-        }
+        if (po != null) { releasePlayer(po); pendingOutPlayer = null; }
         crossfadeInPlayer = null;
         activeCoordinator = null;
         crossfadeInProgress = false;
+        deferredSwapPending = false;
         currentFadeInVolume = 0.0f;
+        coordinatorListenerBxi = null;
     }
 
     /**
@@ -1298,33 +1909,23 @@ public class CrossfadeManager {
                 FadingPlayer fp = it.next();
                 float vol = fp.currentVolume();
                 int playerState = -1;
-                try {
-                    playerState = fp.player.patch_getPlaybackState();
-                } catch (Exception ex) {
-                    Logger.printDebug(() -> "Ignoring fp.player.patch_getPlaybackState exception", ex);
-                }
-                final int playerStateFinal = playerState;
-
+                try { playerState = fp.player.patch_getPlaybackState(); } catch (Exception ignored) {}
                 try {
                     fp.player.patch_setVolume(Math.max(0.0f, vol));
                     long elapsed = System.currentTimeMillis() - fp.startTimeMs;
                     if (elapsed % 500 < TICK_MS) {
-                        Logger.printDebug(() -> String.format(Locale.US,
+                        logDebug(String.format(
                                 "fade-out: @%d vol=%.2f state=%d elapsed=%dms",
-                                System.identityHashCode(fp.player), vol, playerStateFinal, elapsed));
+                                System.identityHashCode(fp.player), vol, playerState, elapsed));
                     }
-                } catch (Exception ex) {
-                    Logger.printDebug(() -> "fade-out setVolume threw: " + ex.getMessage()
+                } catch (Exception e) {
+                    logWarn("fade-out setVolume threw: " + e.getMessage()
                             + " player=@" + System.identityHashCode(fp.player)
-                            + " state=" + playerStateFinal);
+                            + " state=" + playerState);
                 }
 
                 if (fp.isComplete()) {
-                    try {
-                        fp.player.patch_setVolume(0.0f);
-                    } catch (Exception ex) {
-                        Logger.printDebug(() -> "Ignoring fp.player.patch_setVolume exception", ex);
-                    }
+                    try { fp.player.patch_setVolume(0.0f); } catch (Exception ignored) {}
                     releasePlayer(fp.player);
                     it.remove();
                 }
@@ -1335,58 +1936,48 @@ public class CrossfadeManager {
             mainHandler.postDelayed(CrossfadeManager::tickFadingLoop, TICK_MS);
         } else {
             fadingLoopRunning = false;
-            Logger.printDebug(() -> "Fading loop stopped — all fade-outs complete");
+            logDebug("Fading loop stopped — all fade-outs complete");
         }
     }
 
-    /**
-     * Injection point.
-     */
-    public static void onActivityStop() {
-        if (!CROSSFADE_ENABLED) return;
+    // ------------------------------------------------------------------ //
+    //  Settings                                                           //
+    // ------------------------------------------------------------------ //
 
+    // ------------------------------------------------------------------ //
+    //  Activity lifecycle                                                 //
+    // ------------------------------------------------------------------ //
+
+    public static void onActivityStop() {
         activityRunning = false;
-        // Do not stop the auto-advance monitor here — crossfade must continue
-        // working when the screen is locked or the player is minimized (#1311).
+        // Do not stop the auto-advance monitor here — crossfade should continue
+        // even when the screen locks or the app is minimised (#1311).
         if (crossfadeInProgress) {
-            Logger.printDebug(() -> "onActivityStop: aborting crossfade");
+            logInfo("onActivityStop: aborting crossfade");
             abortCrossfadeNow();
         }
     }
 
-    /**
-     * Injection point.
-     */
     public static void onActivityStart() {
-        if (!CROSSFADE_ENABLED) return;
-
         activityRunning = true;
-        if (!sessionPaused.get()) {
+        if (isEnabled() && !sessionPaused) {
             startAutoAdvanceMonitor();
         }
     }
 
     public static boolean isSessionPaused() {
-        return sessionPaused.get();
+        return sessionPaused;
     }
 
     @SuppressWarnings("deprecation")
     @SuppressLint("MissingPermission")
     public static void toggleSessionPause() {
-        boolean current;
-        boolean isNowPaused;
-
-        do {
-            current = sessionPaused.get();
-            isNowPaused = !current;
-        } while (!sessionPaused.compareAndSet(current, isNowPaused));
-
-        boolean finalIsNowPaused = isNowPaused;
-        Logger.printDebug(() -> "Session " + (finalIsNowPaused ? "PAUSED" : "RESUMED")
+        sessionPaused = !sessionPaused;
+        logInfo("Session " + (sessionPaused ? "PAUSED" : "RESUMED")
                 + " [inVideo=" + isCurrentlyInVideoMode()
                 + " inProgress=" + crossfadeInProgress + "]");
 
-        if (isNowPaused) {
+        if (sessionPaused) {
             abortCrossfadeNow();
             stopAutoAdvanceMonitor();
         } else {
@@ -1412,29 +2003,24 @@ public class CrossfadeManager {
                                     VibrationEffect.DEFAULT_AMPLITUDE);
                     vib.vibrate(effect);
                 }
-            } catch (Exception ex) {
-                Logger.printDebug(() -> "Ignoring vibration exception", ex);
-            }
+            } catch (Exception ignored) {}
 
-            Utils.showToastShort(str(isNowPaused
+            Utils.showToastShort(str(sessionPaused
                     ? "morphe_music_crossfade_paused_toast"
                     : "morphe_music_crossfade_resumed_toast"));
         }
     }
 
     public static boolean isCrossfadeActive() {
-        return !sessionPaused.get();
+        return isEnabled() && !sessionPaused;
     }
 
     /**
-     * Injection point.
      * Called by the bytecode hook on the audio/video toggle.
      * Blocks audio→video transitions when crossfade is active.
      * Video→audio transitions are always allowed.
      */
     public static boolean shouldBlockVideoToggle(Object nba) {
-        if (!CROSSFADE_ENABLED) return false;
-
         lastNbaRef = new WeakReference<>(nba);
         if (internalToggle) return false;
         tryAttachLongPressHandler();
@@ -1442,29 +2028,30 @@ public class CrossfadeManager {
             VideoToggleAccess toggle = (VideoToggleAccess) nba;
             boolean isAudioMode = toggle.patch_isAudioMode();
 
-            Logger.printDebug(() -> "videoToggle: isAudioMode=" + isAudioMode
-                    + " paused=" + sessionPaused.get() + " inVideoMode(before)=" + inVideoMode);
+            logInfo("videoToggle: isAudioMode=" + isAudioMode
+                    + " enabled=" + isEnabled() + " paused=" + sessionPaused
+                    + " inVideoMode(before)=" + inVideoMode);
 
-            if (sessionPaused.get()) {
+            if (!isEnabled() || sessionPaused) {
                 if (!isAudioMode) {
                     manualToggleSuppressionUntil = System.currentTimeMillis() + 500;
                 }
-                Logger.printDebug(() -> "videoToggle → ALLOW (crossfade inactive)");
+                logInfo("videoToggle → ALLOW (crossfade inactive)");
                 return false;
             }
 
             if (isAudioMode) {
-                Logger.printDebug(() -> "videoToggle → BLOCK (audio→video while crossfade active)");
+                logInfo("videoToggle → BLOCK (audio→video while crossfade active)");
                 Utils.showToastShort(str("morphe_music_crossfade_video_mode_disabled_toast"));
                 return true;
             }
 
             inVideoMode = false;
             manualToggleSuppressionUntil = System.currentTimeMillis() + 500;
-            Logger.printDebug(() -> "videoToggle → ALLOW (video→audio, suppressing crossfade for 500ms)");
+            logInfo("videoToggle → ALLOW (video→audio, suppressing crossfade for 500ms)");
             return false;
-        } catch (Exception ex) {
-            Logger.printDebug(() -> "Could not check video toggle state", ex);
+        } catch (Exception e) {
+            logWarn("Could not check video toggle state", e);
             return false;
         }
     }
@@ -1478,10 +2065,10 @@ public class CrossfadeManager {
                 toggle.patch_forceAudioModeSilent();
                 inVideoMode = false;
                 audioModeWasForced = true;
-                Logger.printDebug(() -> "Silently forced audio mode (no reactive broadcast to nmi)");
+                logInfo("Silently forced audio mode (no reactive broadcast to nmi)");
             }
-        } catch (Exception ex) {
-            Logger.printDebug(() -> "Could not force audio mode", ex);
+        } catch (Exception e) {
+            logWarn("Could not force audio mode: " + e.getMessage());
         }
     }
 
@@ -1491,9 +2078,9 @@ public class CrossfadeManager {
         try {
             ((VideoToggleAccess) nba).patch_restoreVideoModeSilent();
             inVideoMode = true;
-            Logger.printDebug(() -> "Silently restored video mode preference (ready for next crossfade)");
-        } catch (Exception ex) {
-            Logger.printDebug(() -> "Could not restore video mode", ex);
+            logInfo("Silently restored video mode preference (ready for next crossfade)");
+        } catch (Exception e) {
+            logWarn("Could not restore video mode: " + e.getMessage());
         }
     }
 
@@ -1505,11 +2092,15 @@ public class CrossfadeManager {
                 boolean isAudio = toggle.patch_isAudioMode();
                 inVideoMode = !isAudio;
                 return !isAudio;
-            } catch (Exception ex) {
-                Logger.printDebug(() -> "Could not query live video mode", ex);
+            } catch (Exception e) {
+                logDebug("Could not query live video mode: " + e.getMessage());
             }
         }
         return inVideoMode;
+    }
+
+    private static boolean isEnabled() {
+        return Settings.CROSSFADE_ENABLED.get();
     }
 
     private static boolean isSessionControlEnabled() {
@@ -1524,6 +2115,10 @@ public class CrossfadeManager {
         return 800;
     }
 
+    // ------------------------------------------------------------------ //
+    //  Long-press shuffle button to toggle crossfade session               //
+    // ------------------------------------------------------------------ //
+
     private static final String[] SHUFFLE_IDS = {
             "queue_shuffle_button",
             "queue_shuffle",
@@ -1533,10 +2128,9 @@ public class CrossfadeManager {
 
     private static Runnable pendingLongPress;
     private static volatile boolean longPressHandled = false;
-    private static Runnable longPressAttachRetry;
 
     private static void tryAttachLongPressHandler() {
-        if (!isSessionControlEnabled()) return;
+        if (!isSessionControlEnabled() || !isEnabled()) return;
 
         boolean allAlive = !longPressRefs.isEmpty();
         for (WeakReference<View> ref : longPressRefs) {
@@ -1548,95 +2142,62 @@ public class CrossfadeManager {
         }
         if (allAlive && !longPressRefs.isEmpty()) return;
 
-        // Cancel any pending retry before scheduling a fresh attempt.
-        if (longPressAttachRetry != null) {
-            mainHandler.removeCallbacks(longPressAttachRetry);
-        }
-        longPressAttachRetry = new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    Activity activity = Utils.getActivity();
-                    if (activity == null || activity.getWindow() == null) return;
+        mainHandler.post(() -> {
+            try {
+                Activity activity = Utils.getActivity();
+                if (activity == null || activity.getWindow() == null) return;
 
-                    Resources res = activity.getResources();
-                    String pkg = activity.getPackageName();
+                View decorView = activity.getWindow().getDecorView();
+                Resources res = activity.getResources();
+                String pkg = activity.getPackageName();
 
-                    // Collect all root views across every open window (main activity +
-                    // any BottomSheetDialogs or overlays). The queue panel opens in its
-                    // own Window, so activity.getWindow().getDecorView() alone misses it.
-                    List<View> roots = getAllWindowRoots(activity);
-
-                    List<View> allButtons = new ArrayList<>();
-                    for (String idName : SHUFFLE_IDS) {
-                        @SuppressLint("DiscouragedApi")
-                        int id = res.getIdentifier(idName, "id", pkg);
-                        if (id == 0) {
-                            Logger.printDebug(() -> "  shuffle id '" + idName + "' → not found in resources");
-                            continue;
-                        }
-                        for (View root : roots) {
-                            List<View> matched = new ArrayList<>();
-                            findAllViewsById(root, id, matched);
-                            for (View v : matched) {
-                                Logger.printDebug(() -> "  shuffle id '" + idName + "' → "
-                                        + v.getClass().getSimpleName()
-                                        + " vis=" + v.getVisibility()
-                                        + " attached=" + v.isAttachedToWindow()
-                                        + " parent=" + (v.getParent() != null
-                                            ? v.getParent().getClass().getSimpleName() : "null"));
-                                if (v.isAttachedToWindow()) {
-                                    allButtons.add(v);
-                                }
-                            }
-                        }
+                java.util.List<View> allButtons = new java.util.ArrayList<>();
+                for (String idName : SHUFFLE_IDS) {
+                    int id = res.getIdentifier(idName, "id", pkg);
+                    if (id == 0) {
+                        logDebug("  shuffle id '" + idName + "' → not found in resources");
+                        continue;
                     }
-
-                    Logger.printDebug(() -> "Found " + allButtons.size()
-                            + " attached shuffle button instances");
-
-                    if (allButtons.isEmpty()) {
-                        // No attached buttons found — retry in 500ms in case the
-                        // queue panel is still opening or the view hasn't attached yet.
-                        mainHandler.postDelayed(this, 500);
-                        return;
+                    java.util.List<View> matched = new java.util.ArrayList<>();
+                    findAllViewsById(decorView, id, matched);
+                    for (View v : matched) {
+                        logDebug("  shuffle id '" + idName + "' → "
+                                + v.getClass().getSimpleName()
+                                + " vis=" + v.getVisibility()
+                                + " attached=" + v.isAttachedToWindow()
+                                + " parent=" + (v.getParent() != null
+                                    ? v.getParent().getClass().getSimpleName() : "null"));
                     }
-
-                    longPressRefs.clear();
-                    longPressAttachRetry = null;
-
-                    for (View shuffleBtn : allButtons) {
-                        attachTouchLongPress(shuffleBtn);
-                        longPressRefs.add(new WeakReference<>(shuffleBtn));
-
-                        View parent = (View) shuffleBtn.getParent();
-                        if (parent != null && parent.getParent() != null) {
-                            attachTouchLongPress(parent);
-                            longPressRefs.add(new WeakReference<>(parent));
-                        }
-                    }
-                } catch (Exception ex) {
-                    Logger.printDebug(() -> "Long-press attach skipped", ex);
+                    allButtons.addAll(matched);
                 }
+
+                logDebug("Found " + allButtons.size()
+                        + " shuffle button instances");
+
+                longPressRefs.clear();
+
+                for (View shuffleBtn : allButtons) {
+                    attachTouchLongPress(shuffleBtn);
+                    longPressRefs.add(new WeakReference<>(shuffleBtn));
+
+                    View parent = (View) shuffleBtn.getParent();
+                    if (parent != null && parent != decorView) {
+                        attachTouchLongPress(parent);
+                        longPressRefs.add(new WeakReference<>(parent));
+                    }
+                }
+            } catch (Exception e) {
+                logDebug("Long-press attach skipped: " + e.getMessage());
             }
-        };
-        mainHandler.post(longPressAttachRetry);
-    }
-
-    private static List<View> getAllWindowRoots(Activity activity) {
-        List<View> roots = new ArrayList<>();
-        if (activity != null && activity.getWindow() != null) {
-            roots.add(activity.getWindow().getDecorView());
-        }
-
-        return roots;
+        });
     }
 
     private static void findAllViewsById(View root, int id,
-                                          List<View> out) {
+                                          java.util.List<View> out) {
         if (root.getId() == id) out.add(root);
-        if (root instanceof ViewGroup vg) {
-            for (int i = 0, childCount = vg.getChildCount(); i < childCount; i++) {
+        if (root instanceof ViewGroup) {
+            ViewGroup vg = (ViewGroup) root;
+            for (int i = 0; i < vg.getChildCount(); i++) {
                 findAllViewsById(vg.getChildAt(i), id, out);
             }
         }
@@ -1661,8 +2222,8 @@ public class CrossfadeManager {
                         longPressHandled = true;
                         longPressTriggered[0] = true;
                         toggleSessionPause();
-                        Logger.printDebug(() -> "Shuffle long-press fired ("
-                                                + getLongPressThresholdMs() + "ms)");
+                        logInfo("Shuffle long-press fired ("
+                                + getLongPressThresholdMs() + "ms)");
                     };
                     mainHandler.postDelayed(pendingLongPress,
                             getLongPressThresholdMs());

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
@@ -660,19 +660,35 @@ public class CrossfadeManager {
                 return false;
             }
 
-            boolean isAutoAdvance = false;
+            // Primary signal: the monitor explicitly set queueAdvancedByMonitor=true
+            // before dispatching MEDIA_NEXT.  This is definitive — it doesn't depend
+            // on the position-at-stopVideo-time relative to AUTO_ADVANCE_THRESHOLD_MS,
+            // which fails for any fade duration ≥ 5 s (the monitor triggers at
+            // remaining = fadeDuration + buffer, so for an 8 s fade the stopVideo
+            // arrives with ~8 s remaining and the old remaining-only check
+            // misclassified it as a manual skip — leaving cwh attached on the
+            // outgoing and causing a double-advance when the outgoing naturally
+            // ends in the fade pool).
+            boolean isAutoAdvance = queueAdvancedByMonitor;
             try {
                 long pos = currentExo.patch_getCurrentPosition();
                 long duration = currentExo.patch_getDuration();
                 long remaining = (duration > 0) ? duration - pos : Long.MAX_VALUE;
-                isAutoAdvance = duration > 0 && remaining >= 0
-                        && remaining < AUTO_ADVANCE_THRESHOLD_MS;
+                // Fallback heuristic: covers paths where the monitor flag wasn't set
+                // (e.g. YTM's own natural-end fired before our monitor could).
+                if (!isAutoAdvance) {
+                    isAutoAdvance = duration > 0 && remaining >= 0
+                            && remaining < AUTO_ADVANCE_THRESHOLD_MS;
+                }
                 final boolean isAutoAdvanceFinal = isAutoAdvance;
                 logDebug(() -> "stopVideo(5): pos=" + pos + "ms dur=" + duration
                         + "ms remaining=" + remaining
-                        + "ms → " + (isAutoAdvanceFinal ? "AUTO-ADVANCE" : "MANUAL SKIP"));
+                        + "ms queueAdvancedByMonitor=" + queueAdvancedByMonitor
+                        + " → " + (isAutoAdvanceFinal ? "AUTO-ADVANCE" : "MANUAL SKIP"));
             } catch (Exception e) {
-                logWarn(()-> "Could not read position/duration, assuming manual skip", e);
+                final boolean isAutoAdvanceFinal = isAutoAdvance;
+                logWarn(() -> "Could not read position/duration, assuming "
+                        + (isAutoAdvanceFinal ? "auto-advance" : "manual skip"), e);
             }
 
             if (isAutoAdvance && !Settings.CROSSFADE_ON_AUTO_ADVANCE.get()) {

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
@@ -897,6 +897,17 @@ public class CrossfadeManager {
      * naturally loads the next track onto it.
      */
     private static boolean handleChainedSkip(Object atadInstance) {
+        // When the activity is stopped/destroyed (recents-view, swipe-clear), YTM
+        // emits rapid stopVideo(5) bursts as part of its own teardown.  Treating
+        // those as user chained skips creates factory players that can never
+        // reach READY (the activity is going away), leading to a 10 s timeout
+        // and emergency cleanup.  Decline chained-skip engagement during these
+        // windows and let native through — onActivityDestroy will clean up the
+        // existing in-flight crossfade.
+        if (!activityRunning) {
+            logInfo(() -> "CHAINED SKIP suppressed — activity not running (likely teardown)");
+            return false;
+        }
         logDebug(() -> "stopVideo(5): CHAINED SKIP — creating new player, deferring demotion until READY");
 
         if (is9x) {
@@ -2314,6 +2325,7 @@ public class CrossfadeManager {
 
     public static void onActivityStop() {
         activityRunning = false;
+        logInfo(() -> "onActivityStop");
         // Do not stop the auto-advance monitor here — crossfade should continue
         // even when the screen locks or the app is minimised (#1311).
         //
@@ -2325,8 +2337,55 @@ public class CrossfadeManager {
         // (#1442).
     }
 
+    /**
+     * Called when the MusicActivity is being destroyed (swipe-clear from recents,
+     * explicit finish, OS reclaim).  Distinct from {@link #onActivityStop} which
+     * also fires on screen-lock and minimize.  The process itself may survive via
+     * the foreground service, so we must clean up our static state — otherwise
+     * the next activity instance inherits orphaned references to released or
+     * unreachable players.
+     *
+     * <p>We do NOT release {@code crossfadeInPlayer} because it is the active
+     * coordinator player which YTM owns and manages across activity recreation.
+     * We only release the players we created (factory pendings + fade-outs) and
+     * clear our state flags.
+     */
+    public static void onActivityDestroy() {
+        activityRunning = false;
+        if (!crossfadeInProgress
+                && pendingInPlayer == null
+                && pendingOutPlayer == null
+                && fadingOutPlayers.isEmpty()) {
+            logInfo(() -> "onActivityDestroy — no in-flight crossfade state to release");
+            return;
+        }
+        logInfo(() -> "onActivityDestroy — releasing in-flight crossfade state " + dumpState());
+        stopAutoAdvanceMonitor();
+        if (deferredSwapRunnable != null) {
+            mainHandler.removeCallbacks(deferredSwapRunnable);
+            deferredSwapRunnable = null;
+        }
+        releaseAllFadingPlayers();
+        ExoPlayerAccess pi = pendingInPlayer;
+        if (pi != null) { releasePlayer(pi); pendingInPlayer = null; }
+        ExoPlayerAccess po = pendingOutPlayer;
+        if (po != null) { releasePlayer(po); pendingOutPlayer = null; }
+        crossfadeInPlayer = null;
+        activeCoordinator = null;
+        crossfadeInProgress = false;
+        autoAdvanceCrossfadeActive = false;
+        queueAdvancedByMonitor = false;
+        monitorTriggeredSkip = false;
+        monitorCrossfadeActive = false;
+        outgoingFadePreStarted = false;
+        deferredSwapPending = false;
+        currentFadeInVolume = 0.0f;
+        coordinatorListenerBxi = null;
+    }
+
     public static void onActivityStart() {
         activityRunning = true;
+        logInfo(() -> "onActivityStart");
 
         // Pause is per-session: reset on every activity start so a stale paused state
         // can't survive a process that wasn't actually killed on swipe.

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/CrossfadeManager.java
@@ -11,7 +11,9 @@ import static app.morphe.extension.shared.StringRef.str;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
+import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
+import android.media.AudioPlaybackConfiguration;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
@@ -371,6 +373,14 @@ public class CrossfadeManager {
     private static volatile boolean outgoingFadePreStarted = false;
 
     /**
+     * #1549 cast-investigation placeholder. Currently unused — kept here for the
+     * future Option C fix (skip crossfade while an MDX session is active).  The
+     * flag is not yet wired up to MDX events; the v229 investigation captures
+     * cast disconnects via adb logcat correlation rather than direct hooks.
+     */
+    private static volatile boolean isCasting = false;
+
+    /**
      * Set at patch time via sput-boolean — true when running on YTM 9.x.
      * On 9.x, blocking stopVideo also blocks playVideo (same call chain),
      * so we use a deferred coordinator swap instead of blocking native.
@@ -545,6 +555,16 @@ public class CrossfadeManager {
 
     public static boolean onBeforeStopVideo(Object atadInstance, int reason) {
         if (!CROSSFADE_ENABLED) return false;
+
+        // #1549: skip crossfade when audio is routed to a cast/mirror receiver.
+        // Lets YTM's native gapless transition handle the song change so the
+        // cast layer doesn't see our coordinator-swap MediaSession flicker.
+        // Only gate when no crossfade is already in flight — if one is in
+        // progress (cast started mid-fade), let it complete normally.
+        if (!crossfadeInProgress && isAudioRoutedToCast()) {
+            logInfo("stopVideo(" + reason + "): skip — audio routed to cast/mirror (#1549)");
+            return false;
+        }
 
         int atadId = System.identityHashCode(atadInstance);
         if (atadId != lastAtadIdentity && lastAtadIdentity != 0) {
@@ -1029,6 +1049,13 @@ public class CrossfadeManager {
     public static boolean onBeforePlayNext(Object coordinatorInstance) {
         if (!CROSSFADE_ENABLED) return false;
 
+        // #1549: skip crossfade when audio is routed to a cast/mirror receiver.
+        // Native gapless transition runs unchanged.
+        if (!crossfadeInProgress && isAudioRoutedToCast()) {
+            logInfo("playNext: skip — audio routed to cast/mirror (#1549)");
+            return false;
+        }
+
         // Monitor-triggered native skip: let auih.y()V run so it calls stopVideo(5),
         // which onBeforeStopVideo will intercept for a true overlap crossfade.
         if (monitorTriggeredSkip) {
@@ -1445,6 +1472,15 @@ public class CrossfadeManager {
                         || !Settings.CROSSFADE_ON_AUTO_ADVANCE.get()
                         || crossfadeInProgress
                         || autoAdvanceCrossfadeActive) {
+                    return;
+                }
+
+                // #1549: while audio is routed to a cast/mirror receiver, keep
+                // re-polling but never dispatch MEDIA_NEXT — native gapless
+                // handles the natural-end transition cleanly for the cast layer.
+                // The monitor will pick up again once cast disconnects.
+                if (isAudioRoutedToCast()) {
+                    mainHandler.postDelayed(this, MONITOR_POLL_MS);
                     return;
                 }
 
@@ -2262,6 +2298,118 @@ public class CrossfadeManager {
 
     public static boolean isSessionPaused() {
         return isCrossfadePaused;
+    }
+
+    private static volatile long lastCastCheckMs = 0;
+    private static volatile boolean lastCastResult = false;
+    private static final long CAST_CHECK_TTL_MS = 250;
+
+    /**
+     * #1549: Detect when audio is being routed to a cast/mirror receiver
+     * (Chromecast, Samsung audio mirroring, HDMI mirror, etc.). Crossfade is
+     * disabled in those scenarios because our coordinator player swap causes
+     * MediaSession state thrashing (PAUSED → PLAYING → PAUSED flicker) that
+     * the cast/mirror layer forwards to the receiver as PAUSE+PLAY commands.
+     * Forgiving receivers (e.g. Google Home Mini) absorb this as a brief
+     * audio glitch; stricter ones (e.g. Sony AVRs) treat it as session-end
+     * and drop the cast connection entirely.
+     *
+     * <p>This skip is the defensive fix.  The deeper fix would intercept the
+     * MediaSession state writes during our swap so the cast layer never sees
+     * the flicker — see future task.
+     *
+     * <p>Whitelist of device types that trigger the skip: HDMI, HDMI_ARC,
+     * HDMI_EARC, REMOTE_SUBMIX (Samsung audio mirroring), IP (network audio),
+     * BUS (system bus devices).  Bluetooth A2DP, wired headsets, USB audio,
+     * and BLE audio are NOT in this list — those tolerate the swap fine.
+     *
+     * <p>Returns false on API < 28 (the {@link AudioPlaybackConfiguration#getAudioDeviceInfo()}
+     * method isn't available); pre-Pie devices are rare enough that we accept
+     * the cast-disconnect risk for them.
+     *
+     * <p>Cached with a {@value #CAST_CHECK_TTL_MS}ms TTL since this is queried
+     * on every crossfade-engagement hook fire (manual skip, auto-advance,
+     * monitor tick).
+     */
+    @SuppressWarnings("deprecation")
+    private static boolean isAudioRoutedToCast() {
+        if (Build.VERSION.SDK_INT < 28) return false;
+
+        long now = System.currentTimeMillis();
+        if (now - lastCastCheckMs < CAST_CHECK_TTL_MS) {
+            return lastCastResult;
+        }
+        lastCastCheckMs = now;
+
+        boolean casting = false;
+        StringBuilder probe = new StringBuilder();
+        try {
+            Context ctx = Utils.getContext();
+            if (ctx != null) {
+                // Primary signal: MediaRouter says the selected audio route is REMOTE.
+                // Definition (per Android docs): "the route controls playback on a
+                // remote device" — i.e. decoding happens on the receiver, not locally.
+                // This is exactly the boundary that matters for #1549: when audio is
+                // decoded remotely, the receiver runs its own state machine and our
+                // coordinator-swap MediaSession flicker corrupts its session.  When
+                // decoding happens locally (built-in speaker, BT A2DP, wired, USB),
+                // crossfade works fine — so we LEAVE those alone.
+                //
+                // android.media.MediaRouter is deprecated since API 30 but still
+                // works through API 36+.  The newer MediaRouter2 lives in a separate
+                // module we'd have to bring in via the patcher classpath; deprecated
+                // is the simpler choice here.
+                android.media.MediaRouter mr =
+                        (android.media.MediaRouter) ctx.getSystemService(Context.MEDIA_ROUTER_SERVICE);
+                if (mr != null) {
+                    android.media.MediaRouter.RouteInfo selected = mr.getSelectedRoute(
+                            android.media.MediaRouter.ROUTE_TYPE_LIVE_AUDIO);
+                    if (selected != null) {
+                        int pt = selected.getPlaybackType();
+                        probe.append("route{name=").append(selected.getName(ctx))
+                                .append(",pbType=").append(pt).append("} ");
+                        if (pt == android.media.MediaRouter.RouteInfo.PLAYBACK_TYPE_REMOTE) {
+                            casting = true;
+                        }
+                    } else {
+                        probe.append("route{null} ");
+                    }
+                }
+                // Secondary signal: AudioDeviceInfo-level remote outputs (HDMI mirror,
+                // explicit remote-submix, IP audio, system bus).  These are caught even
+                // if MediaRouter doesn't reflect the routing.
+                if (!casting) {
+                    AudioManager am = (AudioManager) ctx.getSystemService(Context.AUDIO_SERVICE);
+                    if (am != null) {
+                        for (AudioDeviceInfo info : am.getDevices(AudioManager.GET_DEVICES_OUTPUTS)) {
+                            int type = info.getType();
+                            probe.append("dev{type=").append(type)
+                                    .append(",id=").append(info.getId()).append("} ");
+                            if (type == AudioDeviceInfo.TYPE_HDMI
+                                    || type == AudioDeviceInfo.TYPE_HDMI_ARC
+                                    || type == 29 /* TYPE_HDMI_EARC, API 31+ */
+                                    || type == AudioDeviceInfo.TYPE_REMOTE_SUBMIX
+                                    || type == AudioDeviceInfo.TYPE_IP
+                                    || type == AudioDeviceInfo.TYPE_BUS) {
+                                casting = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logDebug("isAudioRoutedToCast check failed: " + e.getMessage());
+        }
+
+        if (casting != lastCastResult) {
+            logInfo("Cast routing " + (casting ? "ENGAGED" : "RELEASED")
+                    + " — crossfade " + (casting ? "disabled" : "re-enabled")
+                    + " [" + probe.toString().trim() + "]");
+        }
+
+        lastCastResult = casting;
+        return casting;
     }
 
     @SuppressWarnings("deprecation")

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/VersionCheckPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/VersionCheckPatch.java
@@ -8,4 +8,5 @@ public class VersionCheckPatch {
     }
 
     public static final boolean IS_8_40_OR_GREATER = isVersionOrGreater("8.40.00");
+    public static final boolean IS_9_00_OR_GREATER = isVersionOrGreater("9.00.00");
 }

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -12,6 +12,7 @@ import app.morphe.extension.music.patches.CrossfadeManager.FadeCurve;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.settings.BooleanSetting;
 import app.morphe.extension.shared.settings.EnumSetting;
+import app.morphe.extension.shared.settings.IntegerSetting;
 import app.morphe.extension.shared.settings.SharedYouTubeSettings;
 import app.morphe.extension.shared.spoof.ClientType;
 
@@ -46,7 +47,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting PERMANENT_REPEAT = new BooleanSetting("morphe_music_play_permanent_repeat", FALSE, true);
 
     // Crossfade
-    public static final BooleanSetting CROSSFADE_ENABLED = new BooleanSetting("morphe_music_crossfade_enabled", FALSE, true);
+    public static final BooleanSetting CROSSFADE_ENABLED = new BooleanSetting("morphe_music_crossfade_enabled", FALSE);
     public static final EnumSetting<FadeCurve> CROSSFADE_CURVE = new EnumSetting<>("morphe_music_crossfade_curve", FadeCurve.EQUAL_POWER);
     public static final EnumSetting<CrossFadeDuration> CROSSFADE_DURATION = new EnumSetting<>("morphe_music_crossfade_duration", CrossFadeDuration.MILLISECONDS_3000);
     public static final BooleanSetting CROSSFADE_ON_SKIP = new BooleanSetting("morphe_music_crossfade_on_skip", TRUE);

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -47,7 +47,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting PERMANENT_REPEAT = new BooleanSetting("morphe_music_play_permanent_repeat", FALSE, true);
 
     // Crossfade
-    public static final BooleanSetting CROSSFADE_ENABLED = new BooleanSetting("morphe_music_crossfade_enabled", FALSE);
+    public static final BooleanSetting CROSSFADE_ENABLED = new BooleanSetting("morphe_music_crossfade_enabled", FALSE, true);
     public static final EnumSetting<FadeCurve> CROSSFADE_CURVE = new EnumSetting<>("morphe_music_crossfade_curve", FadeCurve.EQUAL_POWER);
     public static final EnumSetting<CrossFadeDuration> CROSSFADE_DURATION = new EnumSetting<>("morphe_music_crossfade_duration", CrossFadeDuration.MILLISECONDS_3000);
     public static final BooleanSetting CROSSFADE_ON_SKIP = new BooleanSetting("morphe_music_crossfade_on_skip", TRUE);

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/preference/CrossfadeCurvePreference.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/preference/CrossfadeCurvePreference.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
 package app.morphe.extension.music.settings.preference;
 
 import static app.morphe.extension.shared.StringRef.str;

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/crossfade/CrossfadePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/crossfade/CrossfadePatch.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
 package app.morphe.patches.music.interaction.crossfade
 
 import app.morphe.patcher.Fingerprint
@@ -223,8 +229,7 @@ val crossfadePatch = bytecodePatch(
         //  Hook injection                                                 //
         // -------------------------------------------------------------- //
 
-        // On 9.x, inject sput-boolean to set CrossfadeManager.is9x = true.
-        // Prepend to StopVideoFingerprint so it's set before any crossfade logic runs.
+        // On 9.x, set CrossfadeManager.is9x = true before any crossfade logic runs.
         // sput-boolean is idempotent — safe to execute on every stopVideo call.
         val is9xSmali = if (is_9_00_or_greater) {
             """
@@ -286,6 +291,16 @@ val crossfadePatch = bytecodePatch(
             0,
             """
                 invoke-static { p0 }, $EXTENSION_CLASS->onPlayVideo(Ljava/lang/Object;)V
+            """,
+        )
+
+        // On 9.20.52, atzq.loadVideo has enough locals that `p0` resolves past v15,
+        // exceeding invoke-static's 4-bit register limit. Use invoke-static/range
+        // which supports 16-bit registers so the injection holds on any version.
+        LoadVideoFingerprint.method.addInstructions(
+            0,
+            """
+                invoke-static/range { p0 .. p0 }, $EXTENSION_CLASS->onBeforeLoadVideo(Ljava/lang/Object;)V
             """,
         )
 
@@ -556,8 +571,12 @@ val crossfadePatch = bytecodePatch(
                 // crh.h: the per-player Lcgd event dispatch set.
                 // coordinator_cwh is registered here; we need to remove it before releasing the
                 // outgoing player so its release-time isPlayingChanged(false) doesn't reach
-                // MediaSession via cwh.b. Identify Lcgd by: non-static field on crh whose type
-                // has both a(Object)V (add) and e(Object)V (remove) methods.
+                // MediaSession via cwh.b.
+                //
+                // Identify Lcgd structurally (avoid relying on R8-obfuscated method names
+                // like "a" / "e" which can drift across major YTM versions): the class wraps a
+                // CopyOnWriteArraySet and has at least two methods of signature (Object):V —
+                // one adds, the other removes.  This is the listener-set wrapper pattern.
                 eventDispatchField9x = exoPlayerImplClass.fields.firstOrNull { f ->
                     !AccessFlags.STATIC.isSet(f.accessFlags)
                         && f.type != lctrType
@@ -565,15 +584,13 @@ val crossfadePatch = bytecodePatch(
                         && f.type != EXO_PLAYER_TYPE
                         && try {
                             val cls = classDefBy(f.type)
-                            cls.methods.any { m ->
-                                m.name == "a" && m.parameterTypes.size == 1
-                                    && m.parameterTypes[0].toString() == "Ljava/lang/Object;"
-                                    && m.returnType == "V"
-                            } && cls.methods.any { m ->
-                                m.name == "e" && m.parameterTypes.size == 1
+                            val hasCopyOnWriteSet = cls.fields.any { it.type == "Ljava/util/concurrent/CopyOnWriteArraySet;" }
+                            val objectVoidMethodCount = cls.methods.count { m ->
+                                m.parameterTypes.size == 1
                                     && m.parameterTypes[0].toString() == "Ljava/lang/Object;"
                                     && m.returnType == "V"
                             }
+                            hasCopyOnWriteSet && objectVoidMethodCount >= 2
                         } catch (_: Exception) { false }
                 }.also { f ->
                     if (f == null) log.warning("9.x: crh.h (Lcgd event dispatch) not found — detach-cwh fix skipped")
@@ -833,6 +850,12 @@ val crossfadePatch = bytecodePatch(
 
         // Listener element class (cat) - stored inside cau's CopyOnWriteArraySet.
         // Found by looking for NEW_INSTANCE instructions in cau's methods.
+        //
+        // Match the element class structurally (avoid R8 name "a"): any class allocated
+        // via NEW_INSTANCE inside cau's methods that has an Object-typed field — that
+        // field holds the actual listener reference.  Use the FIRST Object-typed field
+        // (typically there's only one; if there are more, the first is the listener slot
+        // because R8 puts the constructor-assigned field first).
         val cauClass = classDefBy(listenerWrapperField.type)
         val listenerElementType = cauClass.methods
             .filter { it.name != "<clinit>" }
@@ -846,12 +869,12 @@ val crossfadePatch = bytecodePatch(
             .distinct()
             .first { type ->
                 try {
-                    classDefBy(type).fields.any { it.name == "a" && it.type == "Ljava/lang/Object;" }
+                    classDefBy(type).fields.any { it.type == "Ljava/lang/Object;" }
                 } catch (_: Exception) { false }
             }
         val listenerElementClass = mutableClassDefBy(listenerElementType)
         val listenerElementField = listenerElementClass.fields.first {
-            it.name == "a" && it.type == "Ljava/lang/Object;"
+            it.type == "Ljava/lang/Object;"
         }
 
         // -------------------------------------------------------------- //
@@ -897,6 +920,33 @@ val crossfadePatch = bytecodePatch(
         coordinatorClass.addFieldGetter("patch_getSharedCallback", sharedCallbackFieldRef)
 
         coordinatorClass.addFieldGetter("patch_getVideoSurface", videoSurfaceField)
+
+        // patch_playNextInQueueDirect: calls the coordinator's own playNextInQueue (auih.y()V)
+        // directly via invoke-virtual. This is required because the auto-advance monitor and
+        // onBeforePlayNext re-invoke cannot use atad.patch_playNextInQueue() (atzq.p()V) —
+        // that method calls invoke-interface Lausd->y()V, but auih does NOT implement Lausd,
+        // so the call never reaches the hooked auih.y()V and onBeforePlayNext never fires.
+        val coordinatorPlayNextMethod = PlayNextInQueueFingerprint.method
+        coordinatorClass.methods.add(
+            ImmutableMethod(
+                coordinatorType,
+                "patch_playNextInQueueDirect",
+                listOf(),
+                "V",
+                AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+                null,
+                null,
+                MutableMethodImplementation(1)
+            ).toMutable().apply {
+                addInstructions(
+                    0,
+                    """
+                        invoke-virtual { p0 }, $coordinatorPlayNextMethod
+                        return-void
+                    """
+                )
+            }
+        )
 
         // --- Coordinator player-transition bridge (9.x UI binding fix) ---
         // Find the coordinator's internal method that properly handles player transitions.
@@ -1283,8 +1333,28 @@ val crossfadePatch = bytecodePatch(
         // ExoPlayer's crh.h:Lcgd event dispatch set. Called on the OUTGOING player before
         // it is released so its release-time isPlayingChanged(false) doesn't reach MediaSession
         // via cwh.b (the boolean is captured at source and never re-queried from cwh.g).
+        //
+        // The "remove" method on Lcgd is found by bytecode inspection (not by hardcoded
+        // name "e"): among the (Object):V methods on Lcgd, the remove method is the one
+        // whose body invokes CopyOnWriteArraySet.remove() on the wrapped set.  This makes
+        // the patch resilient to R8 renaming "e" to something else across YTM versions.
         if (is_9_00_or_greater && eventDispatchField9x != null && exoPlayerCwhField9x != null) {
             val cgdType = eventDispatchField9x!!.type
+            val cgdClass = classDefBy(cgdType)
+            val cgdRemoveMethodName = cgdClass.methods.firstOrNull { m ->
+                m.parameterTypes.size == 1
+                    && m.parameterTypes[0].toString() == "Ljava/lang/Object;"
+                    && m.returnType == "V"
+                    && m.implementation?.instructions
+                        ?.filterIsInstance<ReferenceInstruction>()
+                        ?.any {
+                            val ref = it.reference.toString()
+                            ref.contains("Ljava/util/concurrent/CopyOnWriteArraySet;->remove(")
+                        } == true
+            }?.name ?: "e"  // fallback to historical name if bytecode scan fails
+
+            log.fine { "9.x: Lcgd remove method resolved → $cgdType->$cgdRemoveMethodName(Object):V" }
+
             exoPlayerImplClass.methods.add(
                 ImmutableMethod(
                     exoPlayerImplClass.type, "patch_detachCwhFromEventDispatch",
@@ -1298,13 +1368,69 @@ val crossfadePatch = bytecodePatch(
                         """
                             iget-object v0, p0, $eventDispatchField9x
                             iget-object v1, p0, $exoPlayerCwhField9x
-                            invoke-virtual { v0, v1 }, $cgdType->e(Ljava/lang/Object;)V
+                            invoke-virtual { v0, v1 }, $cgdType->$cgdRemoveMethodName(Ljava/lang/Object;)V
                             return-void
                         """
                     )
                 }
             )
             log.fine { "9.x: injected patch_detachCwhFromEventDispatch on ${exoPlayerImplClass.type} (crh.h=${eventDispatchField9x}, cwh=${exoPlayerCwhField9x})" }
+        }
+
+        // 9.x only: suppress cwh.U() during crossfade releases.
+        //
+        // Root cause of the pause/seek UI regression:
+        //   crh.P() (ExoPlayer.release()) calls crh.j.U()V on the SHARED singleton cwh.
+        //   cwh.U() posts a Lcvu Runnable to cwh.h (the handler).
+        //   cvu.run() then calls cwh.b.d() — releasing the Lcgd that holds cwh's Lctu
+        //   listeners, including auih.k (the MediaSession listener).
+        //   cgd.d() calls CopyOnWriteArraySet.clear() AND sets cgd.i = true (prevents
+        //   future adds). All listeners are gone; MediaSession can no longer receive any
+        //   events (isPlayingChanged, onPositionDiscontinuity, etc.).
+        //
+        // In normal (non-crossfade) operation there is only one ExoPlayer, so destroying
+        // cwh.b on release is fine — there is no subsequent player to receive events.
+        // In crossfade, two ExoPlayer instances share the SAME cwh singleton. Releasing
+        // the old player must NOT destroy the shared listener infrastructure used by
+        // the new player.
+        //
+        // Fix: inject an early-return at the top of cwh.U()V that checks the static
+        // CrossfadeManager.suppressCwhU flag. releasePlayer() sets it true before
+        // calling patch_release() and false in a finally block — synchronously blocking
+        // the Runnable from ever being posted, leaving cwh.b intact.
+        if (is_9_00_or_greater && eventDispatchField9x != null && forwardingPlayerField9x != null) {
+            val cgdType = eventDispatchField9x!!.type
+            val cwhLctrType = forwardingPlayerField9x!!.type  // = Lctr interface type
+            try {
+                // Find cwh.U()V: the method named "U" with no params/void return on the concrete
+                // class that (a) implements the Lctr interface and (b) has a non-static Lcgd field.
+                // cwh.U() posts a Lcvu Runnable that calls cwh.b.d() destroying the shared
+                // listener set. Inject an early-return guard that checks suppressCwhU.
+                Fingerprint(
+                    name = "U",
+                    returnType = "V",
+                    parameters = emptyList(),
+                    custom = { _, classDef ->
+                        classDef != null &&
+                            cwhLctrType in classDef.interfaces &&
+                            classDef.fields.any { f ->
+                                f.type == cgdType && !AccessFlags.STATIC.isSet(f.accessFlags)
+                            }
+                    }
+                ).method.addInstructions(
+                    0,
+                    """
+                        sget-boolean v0, $EXTENSION_CLASS->suppressCwhU:Z
+                        if-eqz v0, :no_suppress
+                        return-void
+                        :no_suppress
+                        nop
+                    """,
+                )
+                log.fine { "9.x: injected suppressCwhU into cwh.U()V (lctrType=$cwhLctrType, cgdType=$cgdType)" }
+            } catch (e: Exception) {
+                log.warning("9.x: suppressCwhU injection failed: ${e.message}")
+            }
         }
 
         // --- SessionAccess on atgd ---
@@ -1390,6 +1516,54 @@ val crossfadePatch = bytecodePatch(
                     0,
                     """
                         invoke-virtual { p0 }, $playNextInQueueMethod
+                        return-void
+                    """
+                )
+            }
+        )
+        // patch_forceStopVideo: calls atad.stopVideo(REASON_DIRECTOR_RESET=5) through the
+        // hooked method. Used by the 8.x and 9.x auto-advance monitor to trigger early crossfade setup.
+        medialibPlayerClass.methods.add(
+            ImmutableMethod(
+                medialibPlayerClass.type,
+                "patch_forceStopVideo",
+                listOf(),
+                "V",
+                AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+                null,
+                null,
+                MutableMethodImplementation(2)
+            ).toMutable().apply {
+                addInstructions(
+                    0,
+                    """
+                        const/4 v0, 0x5
+                        invoke-virtual { p0, v0 }, ${StopVideoFingerprint.method}
+                        return-void
+                    """
+                )
+            }
+        )
+        // patch_forceLoadVideo: calls atad.stopVideo(REASON_STOP=1) through the hooked method.
+        // On 9.x the monitor calls this after patch_forceStopVideo to drive the loadVideo
+        // chain on the freshly-swapped new player (since stopVideo(5) alone does not call
+        // stopVideo(1), and patch_playNextInQueueDirect defers until natural track end).
+        medialibPlayerClass.methods.add(
+            ImmutableMethod(
+                medialibPlayerClass.type,
+                "patch_forceLoadVideo",
+                listOf(),
+                "V",
+                AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+                null,
+                null,
+                MutableMethodImplementation(2)
+            ).toMutable().apply {
+                addInstructions(
+                    0,
+                    """
+                        const/4 v0, 0x1
+                        invoke-virtual { p0, v0 }, ${StopVideoFingerprint.method}
                         return-void
                     """
                 )
@@ -1680,6 +1854,50 @@ val crossfadePatch = bytecodePatch(
                 )
             }
         )
+
+        // patch_restoreVideoMode (BROADCAST variant) — used when the user pauses crossfade
+        // to resync YTM's subscribers (nmi etc.) that may have stale cached state from
+        // prior silent toggles.  Calling the broadcast setStateMethod fires chxp.mo6606iF
+        // which iterates subscribers; subscribers reconcile, and the next user-initiated
+        // video toggle works properly (no black screen from a no-op short-circuit because
+        // subscribers thought they were already in the target state).
+        videoToggleClass.methods.add(
+            ImmutableMethod(
+                videoToggleClass.type,
+                "patch_restoreVideoMode",
+                listOf(),
+                "V",
+                AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+                null,
+                null,
+                MutableMethodImplementation(3)
+            ).toMutable().apply {
+                addInstructions(
+                    0,
+                    """
+                        iget-object v0, p0, $videoToggleClassStateProviderField
+                        sget-object v1, $omvPreferredField
+                        invoke-virtual { v0, v1 }, $setStateMethod
+                        return-void
+                    """
+                )
+            }
+        )
+
+        // Hook nba constructor so we capture the instance immediately on creation.
+        // Songs loaded from the main feed never trigger shouldBlockVideoToggle (which
+        // only fires on an explicit audio/video toggle interaction), leaving lastNbaRef
+        // null for the entire session. The constructor hook ensures onNbaCreated() runs
+        // as soon as nba is instantiated — before any crossfade is attempted.
+        videoToggleClass.methods
+            .filter { AccessFlags.CONSTRUCTOR.isSet(it.accessFlags) && it.name == "<init>" }
+            .maxByOrNull { it.implementation?.instructions?.size ?: 0 }
+            ?.addInstructions(
+                1, // position 1 = after super.<init> call
+                """
+                    invoke-static { p0 }, $EXTENSION_CLASS->onNbaCreated(Ljava/lang/Object;)V
+                """,
+            ) ?: error("nba <init> not found in ${videoToggleClass.type}")
 
         // --- DelegateAccess on atux (delegate chain base class) ---
         delegateBaseClass.apply {

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/crossfade/CrossfadePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/crossfade/CrossfadePatch.kt
@@ -308,6 +308,17 @@ val crossfadePatch = bytecodePatch(
                     invoke-static {}, $EXTENSION_CLASS->onActivityStart()V
                 """
             )
+        // Hook onDestroy so we can release in-flight crossfade state when the
+        // user swipe-clears from recents (process may survive via foreground
+        // service; without cleanup our statics inherit orphaned player refs
+        // into the next activity instance).
+        musicActivityClass.methods.firstOrNull { it.name == "onDestroy" && it.parameterTypes.isEmpty() }
+            ?.addInstructions(
+                0,
+                """
+                    invoke-static {}, $EXTENSION_CLASS->onActivityDestroy()V
+                """,
+            )
 
         // -------------------------------------------------------------- //
         //  Discover obfuscated classes and fields                         //

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/crossfade/CrossfadePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/crossfade/CrossfadePatch.kt
@@ -17,10 +17,12 @@ import app.morphe.patches.music.misc.settings.PreferenceScreen
 import app.morphe.patches.music.misc.settings.settingsPatch
 import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
 import app.morphe.patches.music.shared.MusicActivityOnCreateFingerprint
+import app.morphe.patches.shared.misc.settings.preference.InputType
 import app.morphe.patches.shared.misc.settings.preference.ListPreference
 import app.morphe.patches.shared.misc.settings.preference.NonInteractivePreference
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import app.morphe.patches.shared.misc.settings.preference.TextPreference
 import app.morphe.util.getReference
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
@@ -37,27 +39,27 @@ private const val EXTENSION_CLASS =
     "Lapp/morphe/extension/music/patches/CrossfadeManager;"
 
 private const val COORDINATOR_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/CrossfadeManager$PlayerCoordinatorAccess;"
+    "Lapp/morphe/extension/music/patches/CrossfadeManager\$PlayerCoordinatorAccess;"
 private const val EXO_PLAYER_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/CrossfadeManager$ExoPlayerAccess;"
+    "Lapp/morphe/extension/music/patches/CrossfadeManager\$ExoPlayerAccess;"
 private const val SESSION_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/CrossfadeManager$SessionAccess;"
+    "Lapp/morphe/extension/music/patches/CrossfadeManager\$SessionAccess;"
 private const val FACTORY_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/CrossfadeManager$PlayerFactoryAccess;"
+    "Lapp/morphe/extension/music/patches/CrossfadeManager\$PlayerFactoryAccess;"
 private const val SHARED_STATE_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/CrossfadeManager$SharedStateAccess;"
+    "Lapp/morphe/extension/music/patches/CrossfadeManager\$SharedStateAccess;"
 private const val SHARED_CALLBACK_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/CrossfadeManager$SharedCallbackAccess;"
+    "Lapp/morphe/extension/music/patches/CrossfadeManager\$SharedCallbackAccess;"
 private const val VIDEO_SURFACE_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/CrossfadeManager$VideoSurfaceAccess;"
+    "Lapp/morphe/extension/music/patches/CrossfadeManager\$VideoSurfaceAccess;"
 private const val MEDIALIB_PLAYER_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/CrossfadeManager$MedialibPlayerAccess;"
+    "Lapp/morphe/extension/music/patches/CrossfadeManager\$MedialibPlayerAccess;"
 private const val VIDEO_TOGGLE_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/CrossfadeManager$VideoToggleAccess;"
+    "Lapp/morphe/extension/music/patches/CrossfadeManager\$VideoToggleAccess;"
 private const val DELEGATE_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/CrossfadeManager$DelegateAccess;"
+    "Lapp/morphe/extension/music/patches/CrossfadeManager\$DelegateAccess;"
 private const val LISTENER_WRAPPER_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/CrossfadeManager$ListenerWrapperAccess;"
+    "Lapp/morphe/extension/music/patches/CrossfadeManager\$ListenerWrapperAccess;"
 
 private const val EXO_PLAYER_TYPE = "Landroidx/media3/exoplayer/ExoPlayer;"
 
@@ -148,7 +150,7 @@ private fun MutableClass.addFieldSetter(
 @Suppress("unused")
 val crossfadePatch = bytecodePatch(
     name = "Track crossfade",
-    description = "Adds a true dual-player crossfade between consecutive tracks. This patch currently requires YouTube 8.x",
+    description = "Adds a true dual-player crossfade between consecutive tracks.",
 ) {
     dependsOn(
         sharedExtensionPatch,
@@ -160,10 +162,9 @@ val crossfadePatch = bytecodePatch(
 
     execute {
         val log = Logger.getLogger(this::class.java.name)
-        if (!is_8_05_or_greater || is_9_00_or_greater) {
+        if (!is_8_05_or_greater) {
             return@execute log.warning(
-                "Track crossfade is not yet available for YouTube Music 9.x. " +
-                    "Patch YouTube Music 8.44.54–8.50.51 for crossfade.",
+                "Track crossfade requires YouTube Music 8.05 or newer.",
             )
         }
 
@@ -182,8 +183,8 @@ val crossfadePatch = bytecodePatch(
 
         fun allFieldsInHierarchy(
             startType: String,
-        ): List<Field> {
-            val result = mutableListOf<Field>()
+        ): List<com.android.tools.smali.dexlib2.iface.Field> {
+            val result = mutableListOf<com.android.tools.smali.dexlib2.iface.Field>()
             var current: String? = startType
             while (current != null && current != "Ljava/lang/Object;") {
                 val classDef = try { classDefBy(current) } catch (_: Exception) { break }
@@ -192,6 +193,10 @@ val crossfadePatch = bytecodePatch(
             }
             return result
         }
+
+        // -------------------------------------------------------------- //
+        //  Settings UI                                                    //
+        // -------------------------------------------------------------- //
 
         PreferenceScreen.PLAYER.addPreferences(
             PreferenceScreenPreference(
@@ -214,9 +219,24 @@ val crossfadePatch = bytecodePatch(
             )
         )
 
+        // -------------------------------------------------------------- //
+        //  Hook injection                                                 //
+        // -------------------------------------------------------------- //
+
+        // On 9.x, inject sput-boolean to set CrossfadeManager.is9x = true.
+        // Prepend to StopVideoFingerprint so it's set before any crossfade logic runs.
+        // sput-boolean is idempotent — safe to execute on every stopVideo call.
+        val is9xSmali = if (is_9_00_or_greater) {
+            """
+                const/4 v0, 0x1
+                sput-boolean v0, $EXTENSION_CLASS->is9x:Z
+            """
+        } else ""
+
         StopVideoFingerprint.method.addInstructions(
             0,
             """
+                $is9xSmali
                 invoke-static { p0, p1 }, $EXTENSION_CLASS->onBeforeStopVideo(Ljava/lang/Object;I)Z
                 move-result v0
                 if-eqz v0, :allow_stop
@@ -269,7 +289,7 @@ val crossfadePatch = bytecodePatch(
             """,
         )
 
-        val musicActivityClass = MusicActivityOnCreateFingerprint.classDef
+        val musicActivityClass = mutableClassDefBy(MusicActivityOnCreateFingerprint.classDef.type)
         musicActivityClass.methods.first { it.name == "onStop" && it.parameterTypes.isEmpty() }
             .addInstructions(
                 0,
@@ -285,11 +305,20 @@ val crossfadePatch = bytecodePatch(
                 """,
             )
 
+        // -------------------------------------------------------------- //
+        //  Discover obfuscated classes and fields                         //
+        // -------------------------------------------------------------- //
+
         val coordinatorClass = PlayNextInQueueFingerprint.classDef
         val coordinatorType = coordinatorClass.type
         val medialibPlayerClass = StopVideoFingerprint.classDef
         val videoToggleClass = AudioVideoToggleFingerprint.classDef
+
+        // --- ExoPlayer / Player interface hierarchy ---
         val playerInterfaceType = classDefBy(EXO_PLAYER_TYPE).interfaces.first()
+
+        // --- Coordinator fields ---
+
         val exoPlayerField = coordinatorClass.fields.singleOrNull {
             it.type == EXO_PLAYER_TYPE
         } ?: error("ExoPlayer field of type $EXO_PLAYER_TYPE not found on ${coordinatorClass.type}")
@@ -324,9 +353,11 @@ val crossfadePatch = bytecodePatch(
             }
         ).method
 
+        // ExoPlayer concrete impl - fingerprinted via the unique "ExoPlayerImpl" log tag.
         val exoPlayerImplClass = mutableClassDefBy(ExoPlayerImplFingerprint.classDef.type)
         val exoImplMethods = allMethodsInHierarchy(exoPlayerImplClass.type)
 
+        // Helper: checks if `type` appears anywhere in the superclass chain starting at `startType`.
         fun isInHierarchyOf(type: String, startType: String): Boolean {
             var current: String? = startType
             while (current != null && current != "Ljava/lang/Object;") {
@@ -335,6 +366,7 @@ val crossfadePatch = bytecodePatch(
             }
             return false
         }
+
 
         val loadControlType = factoryMethod.parameterTypes[1].toString()
         val loadControlField = coordinatorClass.fields.singleOrNull {
@@ -345,14 +377,13 @@ val crossfadePatch = bytecodePatch(
             } catch (_: Exception) { false }
         } ?: error("LoadControl field (type $loadControlType or implementor) not found on ${coordinatorClass.type}")
 
+        // Shared state / shared callback - find from factory method body.
         val factoryBodyCoordinatorFields = factoryMethod.implementation!!.instructions
-            .asSequence()
             .filterIsInstance<ReferenceInstruction>()
             .filter { it.opcode == Opcode.IGET_OBJECT }
             .map { it.reference }
             .filterIsInstance<FieldReference>()
             .filter { it.definingClass == coordinatorType }
-            .toList()
 
         val knownFieldTypes = setOf(
             sessionFieldRef.type, exoPlayerField.type, loadControlField.type,
@@ -362,6 +393,9 @@ val crossfadePatch = bytecodePatch(
             it.type !in knownFieldTypes
         }
         val sharedStateInterfaceClass = classDefBy(sharedStateFieldRef.type)
+
+        // If the coordinator declares its shared-state field as an interface,
+        // resolve to the concrete implementation via Fingerprint.
         val sharedStateClass = if (AccessFlags.INTERFACE.isSet(sharedStateInterfaceClass.accessFlags)) {
             Fingerprint(
                 custom = { _, classDef ->
@@ -378,6 +412,8 @@ val crossfadePatch = bytecodePatch(
             it.type !in knownFieldTypes && it.type != sharedStateFieldRef.type
         }
         val sharedCallbackInterfaceClass = classDefBy(sharedCallbackFieldRef.type)
+
+        // Same for shared callback - resolve abstract/interface to concrete.
         val sharedCallbackClass = if (
             AccessFlags.INTERFACE.isSet(sharedCallbackInterfaceClass.accessFlags)
             || AccessFlags.ABSTRACT.isSet(sharedCallbackInterfaceClass.accessFlags)
@@ -394,6 +430,38 @@ val crossfadePatch = bytecodePatch(
             mutableClassDefBy(sharedCallbackFieldRef.type)
         }
 
+        // 9.x single-attachment guard field — present only on 9.x.
+        // The ExoPlayer constructor checks this field (on an abstract superclass of
+        // sharedState) and refuses to attach if already set. We clear it before
+        // calling the factory so the new player can attach to the coordinator.
+        var guardField: com.android.tools.smali.dexlib2.iface.Field? = null
+        var guardAbstractType: String? = null
+        if (is_9_00_or_greater) {
+            var current: String? = sharedStateClass.superclass
+            while (current != null && current != "Ljava/lang/Object;") {
+                val cls = try { classDefBy(current) } catch (_: Exception) { null } ?: break
+                if (AccessFlags.ABSTRACT.isSet(cls.accessFlags)) {
+                    val instanceField = cls.fields.firstOrNull {
+                        !AccessFlags.STATIC.isSet(it.accessFlags)
+                    }
+                    if (instanceField != null) {
+                        guardField = instanceField
+                        guardAbstractType = current
+                        break
+                    }
+                }
+                current = cls.superclass
+            }
+            if (guardField == null) {
+                log.warning(
+                    "9.x guard field not found in ${sharedStateClass.type} superclass chain — " +
+                        "second player creation may fail. Fields searched from superclass of ${sharedStateClass.type}",
+                )
+            }
+        }
+
+        // Video surface - resolved by finding a class that holds an ExoPlayer field
+        // and is itself a field on the coordinator (not one of the already-known types).
         val videoSurfaceClass = Fingerprint(
             custom = { _, classDef ->
                 !AccessFlags.INTERFACE.isSet(classDef.accessFlags)
@@ -408,6 +476,115 @@ val crossfadePatch = bytecodePatch(
         val videoSurfaceExoField = videoSurfaceClass.fields.first {
             it.type == EXO_PLAYER_TYPE
         }
+
+        // 9.x only: ForwardingPlayer (cwh) field on coordinator (auge.c:Lctr).
+        // cwh wraps the ExoPlayer via cwh.g:Lcct (Player interface delegate field).
+        // MediaSession queries player state through coordinator → cwh → cwh.g.isPlaying().
+        // When patch_setPlayerWithBindings only writes auge.h (coordinator's ExoPlayer field),
+        // cwh.g still points to the old released player → isPlaying()=false → MediaSession PAUSED
+        // on skip 2+ (first skip works because the old player is still alive during its fade-out).
+        // 9.x event dispatch fix: crh.j (ExoPlayer field) + auih.k (coordinator listener).
+        // Factory ExoPlayer has crh.j = factory_cwh (final, set in constructor, never changes).
+        // crb (ExoPlayer's ComponentListener) reads crh.j to dispatch playback events to cwh.
+        // coordinator_cwh (auih.c) has auih.k registered on its listener set.
+        // After patch_setPlayerWithBindings swaps auih.h to factory_exo, events go to
+        // factory_cwh — NOT coordinator_cwh — so auih.k never gets notified and
+        // MediaSession stays permanently PAUSED.
+        // Fix: read factory_cwh from factory_exo.j, then register auih.k on factory_cwh.
+        val forwardingPlayerField9x: com.android.tools.smali.dexlib2.iface.Field?
+        var exoPlayerCwhField9x: com.android.tools.smali.dexlib2.iface.Field? = null
+        var cwhListenerType: String? = null
+        var coordinatorCwhListenerField9x: com.android.tools.smali.dexlib2.iface.Field? = null
+        // crh.h:Lcgd — per-player event dispatch set; coordinator_cwh is registered here via crh.C().
+        // Removing coordinator_cwh from the outgoing player's crh.h before release prevents the
+        // release's isPlayingChanged(false) from propagating to MediaSession via cwh.b.
+        var eventDispatchField9x: com.android.tools.smali.dexlib2.iface.Field? = null
+        if (is_9_00_or_greater) {
+            // Find coordinator's cwh field (auih.c:Lctr) to identify the Lctr interface type.
+            val playerDelegateTypes = setOf(playerInterfaceType, EXO_PLAYER_TYPE)
+            val looperType = "Landroid/os/Looper;"
+            forwardingPlayerField9x = allFieldsInHierarchy(coordinatorType).firstOrNull { field ->
+                !AccessFlags.STATIC.isSet(field.accessFlags)
+                    && field.type.startsWith("L")
+                    && field.type != coordinatorType
+                    && try {
+                        classDefBy(field.type).methods.any { method ->
+                            !AccessFlags.CONSTRUCTOR.isSet(method.accessFlags)
+                                && method.returnType == "V"
+                                && method.parameterTypes.size == 2
+                                && method.parameterTypes[1].toString() == looperType
+                                && method.parameterTypes[0].toString() in playerDelegateTypes
+                        }
+                    } catch (_: Exception) { false }
+            }.also { f ->
+                if (f == null) log.warning(
+                    "9.x: Lctr (cwh interface) field not found on coordinator — crh.j fix skipped"
+                ) else log.fine { "9.x: coordinator cwh field (auih.c) = $f" }
+            }
+
+            val lctrType = forwardingPlayerField9x?.type
+            if (lctrType != null) {
+                // crh.j: Lctr-typed field on ExoPlayer — crb reads this to dispatch events.
+                exoPlayerCwhField9x = exoPlayerImplClass.fields.firstOrNull { f ->
+                    !AccessFlags.STATIC.isSet(f.accessFlags) && f.type == lctrType
+                }.also { f ->
+                    if (f == null) log.warning("9.x: crh.j (Lctr on ExoPlayer) not found — crh.j fix skipped")
+                    else log.fine { "9.x: ExoPlayer cwh field (crh.j) = $f" }
+                }
+
+                // Lctu: listener interface — parameter of Lctr.B(Lctu)V (addListener).
+                cwhListenerType = try {
+                    classDefBy(lctrType).methods
+                        .firstOrNull { m -> m.name == "B" && m.parameterTypes.size == 1 && m.returnType == "V" }
+                        ?.parameterTypes?.first()?.toString()
+                } catch (_: Exception) { null }
+                log.fine { "9.x: cwh listener interface (Lctu) = $cwhListenerType" }
+
+                // auih.k: coordinator field of type implementing Lctu (connects cwh to system).
+                if (cwhListenerType != null) {
+                    coordinatorCwhListenerField9x = coordinatorClass.fields.firstOrNull { f ->
+                        !AccessFlags.STATIC.isSet(f.accessFlags)
+                            && f.type != exoPlayerField.type
+                            && f.type != lctrType
+                            && try { cwhListenerType!! in classDefBy(f.type).interfaces } catch (_: Exception) { false }
+                    }.also { f ->
+                        if (f == null) log.warning("9.x: coordinator cwh listener field (auih.k) not found — crh.j fix skipped")
+                        else log.fine { "9.x: coordinator cwh listener field (auih.k) = $f" }
+                    }
+                }
+
+                // crh.h: the per-player Lcgd event dispatch set.
+                // coordinator_cwh is registered here; we need to remove it before releasing the
+                // outgoing player so its release-time isPlayingChanged(false) doesn't reach
+                // MediaSession via cwh.b. Identify Lcgd by: non-static field on crh whose type
+                // has both a(Object)V (add) and e(Object)V (remove) methods.
+                eventDispatchField9x = exoPlayerImplClass.fields.firstOrNull { f ->
+                    !AccessFlags.STATIC.isSet(f.accessFlags)
+                        && f.type != lctrType
+                        && f.type != exoPlayerField.type
+                        && f.type != EXO_PLAYER_TYPE
+                        && try {
+                            val cls = classDefBy(f.type)
+                            cls.methods.any { m ->
+                                m.name == "a" && m.parameterTypes.size == 1
+                                    && m.parameterTypes[0].toString() == "Ljava/lang/Object;"
+                                    && m.returnType == "V"
+                            } && cls.methods.any { m ->
+                                m.name == "e" && m.parameterTypes.size == 1
+                                    && m.parameterTypes[0].toString() == "Ljava/lang/Object;"
+                                    && m.returnType == "V"
+                            }
+                        } catch (_: Exception) { false }
+                }.also { f ->
+                    if (f == null) log.warning("9.x: crh.h (Lcgd event dispatch) not found — detach-cwh fix skipped")
+                    else log.fine { "9.x: ExoPlayer event dispatch field (crh.h:Lcgd) = $f" }
+                }
+            }
+        } else {
+            forwardingPlayerField9x = null
+        }
+
+        // --- Discover ExoPlayer method names from the media3 interfaces ---
 
         val setVolumeName = Fingerprint(
             definingClass = playerInterfaceType,
@@ -430,6 +607,8 @@ val crossfadePatch = bytecodePatch(
             }
         ).method.name
 
+        // PlaybackInfo class (crf) - field on ExoPlayer impl hierarchy with >=3 int + >=1 long fields
+        // and no interfaces (rules out the inner engine handler cqb which also matches field counts).
         val exoImplFields = allFieldsInHierarchy(exoPlayerImplClass.type)
         val playbackInfoClass = Fingerprint(
             custom = { _, classDef ->
@@ -440,6 +619,9 @@ val crossfadePatch = bytecodePatch(
             }
         ).classDef
         val playbackStateFieldName = playbackInfoClass.fields.first { it.type == "I" }.name
+
+        // getPlaybackState - ()I on the ExoPlayer impl hierarchy that reads PlaybackInfo + first int field.
+        // Uses Option A: no definingClass, custom checks hierarchy membership.
         val getPlaybackStateName = Fingerprint(
             returnType = "I",
             parameters = emptyList(),
@@ -459,10 +641,12 @@ val crossfadePatch = bytecodePatch(
             }
         ).method.name
 
+
         val getDurationName = Fingerprint(
             returnType = "J",
             parameters = emptyList(),
             filters = listOf(
+                // getDuration - ()J containing the C.TIME_UNSET literal (-9223372036854775807L).
                 literal(-9223372036854775807L)
             ),
             custom = { _, classDef ->
@@ -470,6 +654,7 @@ val crossfadePatch = bytecodePatch(
             }
         ).method.name
 
+        // getCurrentPosition - ()J that invokes a helper taking PlaybackInfo and returning long.
         val getCurrentPositionName = Fingerprint(
             returnType = "J",
             parameters = emptyList(),
@@ -486,6 +671,8 @@ val crossfadePatch = bytecodePatch(
             }
         ).method.name
 
+        // Listener wrapper (cau) - has a CopyOnWriteArraySet field and is
+        // referenced as a field on the ExoPlayer impl class.
         val listenerWrapperClass = Fingerprint(
             accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
             custom = { _, classDef ->
@@ -501,6 +688,11 @@ val crossfadePatch = bytecodePatch(
             it.type == listenerWrapperClass.type
         } ?: error("Listener wrapper field of type ${listenerWrapperClass.type} not found on ${exoPlayerImplClass.type}")
 
+        // cqbField - the dlk-typed field on the shared callback hierarchy.
+        // cqb implements dlk, and dll.h is declared as type dlk.  The cqb
+        // constructor checks checkState(dll.h == null), so we must null this.
+        // Find it by locating the field whose type is an interface that cqb
+        // (the class thrown in the stack trace at cqb.<init>) implements.
         val allCallbackFields = allFieldsInHierarchy(sharedCallbackClass.type)
         val cqbField = allCallbackFields.firstOrNull { field ->
             if (!field.type.startsWith("L") || field.type == "Ljava/lang/Object;") return@firstOrNull false
@@ -512,6 +704,9 @@ val crossfadePatch = bytecodePatch(
         } ?: error("cqbField (interface-typed field for dlk) not found in ${sharedCallbackClass.type} hierarchy. " +
             "Fields: ${allCallbackFields.map { "${it.definingClass}->${it.name}:${it.type}" }}")
 
+        // dltField - the dlt-typed field on the shared callback hierarchy.
+        // dll.i is declared as type dlt.  Find it as the non-cqb, non-List,
+        // non-session L-typed field with an abstract class type.
         val dltCallbackTypeOnShared = allCallbackFields.firstOrNull { field ->
             field != cqbField
                 && field.type.startsWith("L")
@@ -529,11 +724,18 @@ val crossfadePatch = bytecodePatch(
         val dltFieldOnExo = exoPlayerImplClass.fields.firstOrNull { it.type == dltCallbackTypeOnShared.type }
             ?: error("DLT field of type ${dltCallbackTypeOnShared.type} not found on ${exoPlayerImplClass.type}")
 
+        // Internal listener field - the field immediately after the dlt field.
         val allExoFields = exoPlayerImplClass.fields.toList()
         val dltIdx = allExoFields.indexOf(dltFieldOnExo)
         val internalListenerField = allExoFields.getOrNull(dltIdx + 1)
             ?: error("Internal listener field (after DLT at index $dltIdx) not found on ${exoPlayerImplClass.type}")
 
+        // Shared state bxk field - the playlist/timeline handle that cup.V()
+        // assigns. Find it by locating the V(bxk, Looper) method: the non-Looper
+        // parameter type is bxk, and the field of that type is what VazerOG
+        // nulls as "crz.g" before calling the factory.
+        // Search the concrete class, its superclass hierarchy, its interfaces,
+        // and the field's declared type for the V(bxk, Looper) method.
         val sharedStateMethodPool = buildList {
             addAll(sharedStateClass.methods)
             addAll(allMethodsInHierarchy(sharedStateClass.type))
@@ -555,6 +757,7 @@ val crossfadePatch = bytecodePatch(
                 } catch (_: Exception) { break }
             }
         }
+        // Strategy 1: look for V(bxk, Looper) in the full method pool.
         var bxkType = sharedStateMethodPool.firstNotNullOfOrNull { method ->
             if (method.parameterTypes.size != 2) return@firstNotNullOfOrNull null
             val types = method.parameterTypes.map { it.toString() }
@@ -565,6 +768,11 @@ val crossfadePatch = bytecodePatch(
             }
         }
 
+        // Strategy 2: if V(bxk, Looper) not found, look for any method with
+        // a single Looper parameter - the other fields accessed in its body
+        // may reveal the bxk type.  Fallback: find the field on the shared
+        // state class whose type is a concrete (non-interface, non-abstract)
+        // class NOT in the set of known types and NOT a standard Java type.
         if (bxkType == null) {
             val standardTypes = setOf(
                 "Ljava/lang/Object;", "Ljava/lang/String;",
@@ -595,6 +803,7 @@ val crossfadePatch = bytecodePatch(
         val timelineField = sharedStateClass.fields.firstOrNull { it.type == bxkType }
             ?: error("Timeline field of type $bxkType not found on ${sharedStateClass.type}")
 
+        // MedialibPlayer fields - must be an instance field.
         val playerChainField = medialibPlayerClass.fields.first {
             !AccessFlags.STATIC.isSet(it.accessFlags)
                 && it.type.startsWith("L") && it.type != "Ljava/lang/Object;"
@@ -609,6 +818,8 @@ val crossfadePatch = bytecodePatch(
                 } == true
         }
 
+        // Delegate base class (atux) - implements the playerChain interface
+        // and has a self-typed delegate field (the decorator pattern base).
         val playerChainInterfaceType = playerChainField.type
         val delegateBaseClass = Fingerprint(
             custom = { _, classDef ->
@@ -619,6 +830,9 @@ val crossfadePatch = bytecodePatch(
             }
         ).classDef
         val delegateField = delegateBaseClass.fields.first { it.type == playerChainInterfaceType }
+
+        // Listener element class (cat) - stored inside cau's CopyOnWriteArraySet.
+        // Found by looking for NEW_INSTANCE instructions in cau's methods.
         val cauClass = classDefBy(listenerWrapperField.type)
         val listenerElementType = cauClass.methods
             .filter { it.name != "<clinit>" }
@@ -639,6 +853,10 @@ val crossfadePatch = bytecodePatch(
         val listenerElementField = listenerElementClass.fields.first {
             it.name == "a" && it.type == "Ljava/lang/Object;"
         }
+
+        // -------------------------------------------------------------- //
+        //  Patch-time discovery summary                                   //
+        // -------------------------------------------------------------- //
 
         log.fine {
             """
@@ -661,9 +879,15 @@ val crossfadePatch = bytecodePatch(
                 internalLsnr   = $internalListenerField
                 listenerWrap   = $listenerWrapperField → $listenerSetInWrapper
                 playerChain    = $playerChainField
+                guardField     = ${guardField?.let { "$guardAbstractType->${it.name}:${it.type}" } ?: "n/a (8.x)"}
             """.trimIndent()
         }
 
+        // -------------------------------------------------------------- //
+        //  Add interfaces and bridge methods                              //
+        // -------------------------------------------------------------- //
+
+        // --- PlayerCoordinatorAccess on athu ---
         coordinatorClass.interfaces.add(COORDINATOR_INTERFACE)
         coordinatorClass.addFieldGetter("patch_getExoPlayer", exoPlayerField)
         coordinatorClass.addFieldSetter("patch_setExoPlayer", exoPlayerField)
@@ -671,8 +895,114 @@ val crossfadePatch = bytecodePatch(
         coordinatorClass.addFieldGetter("patch_getLoadControl", loadControlField)
         coordinatorClass.addFieldGetter("patch_getSharedState", sharedStateFieldRef)
         coordinatorClass.addFieldGetter("patch_getSharedCallback", sharedCallbackFieldRef)
+
         coordinatorClass.addFieldGetter("patch_getVideoSurface", videoSurfaceField)
 
+        // --- Coordinator player-transition bridge (9.x UI binding fix) ---
+        // Find the coordinator's internal method that properly handles player transitions.
+        // Unlike a raw iput-object, this method: reads the old player from the field,
+        // calls removeListener on it, writes the new player, calls addListener on the new
+        // player — keeping the coordinator's MedialibPlayerEvents listener properly bound.
+        // Identified by: (a) writes to exoPlayerField, (b) has virtual/interface calls.
+        val exoFieldName = exoPlayerField.name
+        // Compatible types: the exact ExoPlayer type, the Player interface, or Object.
+        // Also accept any type whose class hierarchy includes EXO_PLAYER_TYPE.
+        val exoCompatibleTypes = buildSet {
+            add(EXO_PLAYER_TYPE)
+            add(playerInterfaceType)
+            add("Ljava/lang/Object;")
+            // Include the exoPlayerField.type itself (should be EXO_PLAYER_TYPE, but be safe)
+            add(exoPlayerField.type)
+        }
+        val coordinatorPlayerTransitionMethod = coordinatorClass.methods
+            .filter { method ->
+                !AccessFlags.CONSTRUCTOR.isSet(method.accessFlags)
+                    && !AccessFlags.STATIC.isSet(method.accessFlags)
+                    && method.parameterTypes.size == 1
+                    && method.implementation != null
+                    && method.parameterTypes.first().toString() in exoCompatibleTypes
+            }
+            .firstOrNull { method ->
+                val insns = method.implementation!!.instructions
+                // The iput-object must write to the exact same field (match name AND defining class)
+                val hasExoFieldWrite = insns.any { insn ->
+                    insn is ReferenceInstruction
+                        && insn.opcode == Opcode.IPUT_OBJECT
+                        && (insn.reference as? FieldReference)?.let { fr ->
+                            fr.name == exoFieldName && fr.definingClass == coordinatorType
+                        } == true
+                }
+                val virtualCallCount = insns.count { insn ->
+                    insn.opcode == Opcode.INVOKE_VIRTUAL || insn.opcode == Opcode.INVOKE_INTERFACE
+                }
+                hasExoFieldWrite && virtualCallCount >= 1
+            }
+
+        val transitionParamType = coordinatorPlayerTransitionMethod
+            ?.parameterTypes?.first()?.toString()
+            ?: exoPlayerField.type
+
+        log.fine {
+            if (coordinatorPlayerTransitionMethod != null)
+                "Coordinator player-transition method found: $coordinatorPlayerTransitionMethod"
+            else
+                "Coordinator player-transition method NOT found — patch_setPlayerWithBindings uses raw iput-object fallback"
+        }
+
+        // patch_setPlayerWithBindings: calls the internal transition method (preferred)
+        // or falls back to raw iput-object if the method was not found.
+        coordinatorClass.methods.add(
+            ImmutableMethod(
+                coordinatorType,
+                "patch_setPlayerWithBindings",
+                listOf(ImmutableMethodParameter("Ljava/lang/Object;", null, null)),
+                "V",
+                AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+                null,
+                null,
+                MutableMethodImplementation(4)
+            ).toMutable().apply {
+                addInstructions(
+                    0,
+                    if (coordinatorPlayerTransitionMethod != null) {
+                        """
+                            check-cast p1, $transitionParamType
+                            invoke-virtual { p0, p1 }, $coordinatorPlayerTransitionMethod
+                            return-void
+                        """
+                    } else if (forwardingPlayerField9x != null && exoPlayerCwhField9x != null && coordinatorCwhListenerField9x != null && cwhListenerType != null) {
+                        // 9.x fix: register coordinator's cwh listener (auih.k) on factory_cwh.
+                        // crb (ExoPlayer's ComponentListener) dispatches ALL playback events to
+                        // crh.j — a public final field on ExoPlayer set once in the constructor.
+                        // After swapping auih.h to factory_exo, events go to factory_cwh (crh.j),
+                        // but auih.k was only registered on coordinator_cwh.b — so MediaSession
+                        // never got PLAYING events.
+                        // Fix: read factory_cwh from factory_exo.j, then call factory_cwh.B(auih.k).
+                        // Cast to concrete crh type so verifier allows iget-object on crh.j.
+                        // transitionParamType is the ExoPlayer interface — not enough for
+                        // iget on a field declared on the concrete impl class Lcrh;.
+                        val lctrType = forwardingPlayerField9x.type
+                        val concreteExoType = exoPlayerImplClass.type
+                        """
+                            check-cast p1, $concreteExoType
+                            iget-object v0, p1, $exoPlayerCwhField9x
+                            iget-object v1, p0, $coordinatorCwhListenerField9x
+                            invoke-interface { v0, v1 }, $lctrType->B($cwhListenerType)V
+                            iput-object p1, p0, $exoPlayerField
+                            return-void
+                        """
+                    } else {
+                        """
+                            check-cast p1, $transitionParamType
+                            iput-object p1, p0, $exoPlayerField
+                            return-void
+                        """
+                    }
+                )
+            }
+        )
+
+        // --- ExoPlayerAccess on cpp ---
         exoPlayerImplClass.interfaces.add(EXO_PLAYER_INTERFACE)
 
         fun MutableClass.addExoBridgeInt(bridgeName: String, targetName: String) {
@@ -780,6 +1110,82 @@ val crossfadePatch = bytecodePatch(
         exoPlayerImplClass.addExoBridgeVoid("patch_setPlayWhenReady", setPlayWhenReadyName, "Z")
         exoPlayerImplClass.addExoBridgeVoid("patch_release", releaseName)
 
+        // patch_addListener — calls cau.add(rawListener) on this player's listener wrapper,
+        // creating a fresh cat wrapper properly bound to the new player.
+        //
+        // The NEW_INSTANCE of cat lives inside cau.add() (the ListenerHolderSet.add method),
+        // NOT inside ExoPlayerImpl.addListener() which merely delegates to cau.add().
+        // We therefore search cauClass.methods for the add method, then emit smali that:
+        //   1. iget-object the listenerWrapperField (cau instance) from this player
+        //   2. invoke-virtual cau.add(p1) to register the listener (creates fresh cat)
+        val cauAddMethod = cauClass.methods.firstOrNull { method ->
+            !AccessFlags.STATIC.isSet(method.accessFlags)
+                && !AccessFlags.CONSTRUCTOR.isSet(method.accessFlags)
+                && method.parameterTypes.size == 1
+                && method.implementation?.instructions?.any { insn ->
+                    insn is ReferenceInstruction
+                        && insn.opcode == Opcode.NEW_INSTANCE
+                        && insn.reference.toString() == listenerElementType
+                } == true
+        }
+        val cauAddParamType = cauAddMethod?.parameterTypes?.first()?.toString()
+        log.fine {
+            if (cauAddMethod != null)
+                "patch_addListener → ${listenerWrapperClass.type}->${cauAddMethod.name}($cauAddParamType) [via wrapper]"
+            else
+                "patch_addListener: cau.add method not found — injecting no-op fallback"
+        }
+
+        // 9.x: direct listener set (Lcrh.N) — a CopyOnWriteArraySet field directly on
+        // ExoPlayerImpl (NOT the cau ListenerHolderSet). The coordinator's b:Lcou listener
+        // is registered here via O(Lcou;)V. We need direct access to move it on player swap.
+        val directListenerSetField = if (is_9_00_or_greater) {
+            exoImplFields.firstOrNull {
+                it.type == "Ljava/util/concurrent/CopyOnWriteArraySet;"
+            }.also { f ->
+                if (f == null) log.warning("9.x: direct listener set field (Lcrh.N) not found on ${exoPlayerImplClass.type}")
+                else log.fine { "9.x: direct listener set field = $f" }
+            }
+        } else null
+
+        // 9.x: coordinator's Player.Listener field (auge.b:Lcou) — Player.Listener type
+        // is the same as cauAddParamType (the type cau.add() accepts).
+        val coordinatorListenerField = if (is_9_00_or_greater && cauAddParamType != null) {
+            (coordinatorClass.fields.firstOrNull { it.type == cauAddParamType }
+                ?: coordinatorClass.fields.firstOrNull { field ->
+                    field.type.startsWith("L") && try {
+                        cauAddParamType in classDefBy(field.type).interfaces
+                    } catch (_: Exception) { false }
+                }
+            ).also { f ->
+                if (f == null) log.warning("9.x: coordinator listener field (type $cauAddParamType or implementor) not found on ${coordinatorClass.type}")
+                else log.fine { "9.x: coordinator listener field = $f" }
+            }
+        } else null
+        exoPlayerImplClass.methods.add(
+            ImmutableMethod(
+                exoPlayerImplClass.type, "patch_addListener",
+                listOf(ImmutableMethodParameter("Ljava/lang/Object;", null, null)),
+                "V", AccessFlags.PUBLIC.value or AccessFlags.FINAL.value, null, null,
+                MutableMethodImplementation(3)
+            ).toMutable().apply {
+                addInstructions(
+                    0,
+                    if (cauAddMethod != null) {
+                        """
+                            iget-object v0, p0, $listenerWrapperField
+                            check-cast p1, $cauAddParamType
+                            invoke-virtual { v0, p1 }, $cauAddMethod
+                            return-void
+                        """
+                    } else {
+                        "return-void" // no-op fallback; migrateListeners will warn
+                    }
+                )
+            }
+        )
+
+        // patch_getListenerSet navigates through the wrapper: cpp.h → cau.c
         exoPlayerImplClass.methods.add(
             ImmutableMethod(
                 exoPlayerImplClass.type,
@@ -805,10 +1211,121 @@ val crossfadePatch = bytecodePatch(
         exoPlayerImplClass.addFieldGetter("patch_getInternalListener", internalListenerField)
         exoPlayerImplClass.addFieldSetter("patch_setDltCallback", dltFieldOnExo)
 
+        // 9.x only: patch_getCoordinatorListener returns coordinator.b:Lcou (Player.Listener)
+        // registered into ExoPlayer's direct N set. Not present on 8.x.
+        if (is_9_00_or_greater && coordinatorListenerField != null) {
+            coordinatorClass.addFieldGetter("patch_getCoordinatorListener", coordinatorListenerField)
+            log.fine { "9.x: injected patch_getCoordinatorListener on ${coordinatorClass.type} (field: $coordinatorListenerField)" }
+        }
+
+        // 9.x only: patch_addDirectListener / patch_removeDirectListener operate on Lcrh.N
+        // (the direct CopyOnWriteArraySet, bypassing the cau ListenerHolderSet).
+        // Used to move the coordinator's b:Lcou listener between players on player swap.
+        if (is_9_00_or_greater && directListenerSetField != null) {
+            exoPlayerImplClass.methods.add(
+                ImmutableMethod(
+                    exoPlayerImplClass.type, "patch_addDirectListener",
+                    listOf(ImmutableMethodParameter("Ljava/lang/Object;", null, null)),
+                    "V", AccessFlags.PUBLIC.value or AccessFlags.FINAL.value, null, null,
+                    MutableMethodImplementation(3)
+                ).toMutable().apply {
+                    addInstructions(
+                        0,
+                        """
+                            iget-object v0, p0, $directListenerSetField
+                            invoke-virtual { v0, p1 }, Ljava/util/concurrent/CopyOnWriteArraySet;->add(Ljava/lang/Object;)Z
+                            return-void
+                        """
+                    )
+                }
+            )
+            exoPlayerImplClass.methods.add(
+                ImmutableMethod(
+                    exoPlayerImplClass.type, "patch_removeDirectListener",
+                    listOf(ImmutableMethodParameter("Ljava/lang/Object;", null, null)),
+                    "V", AccessFlags.PUBLIC.value or AccessFlags.FINAL.value, null, null,
+                    MutableMethodImplementation(3)
+                ).toMutable().apply {
+                    addInstructions(
+                        0,
+                        """
+                            iget-object v0, p0, $directListenerSetField
+                            invoke-virtual { v0, p1 }, Ljava/util/concurrent/CopyOnWriteArraySet;->remove(Ljava/lang/Object;)Z
+                            return-void
+                        """
+                    )
+                }
+            )
+            // patch_getDirectListenerCount — returns Lcrh.N.size() for diagnostic logging.
+            // Lets us verify that patch_addDirectListener actually registered the listener.
+            exoPlayerImplClass.methods.add(
+                ImmutableMethod(
+                    exoPlayerImplClass.type, "patch_getDirectListenerCount",
+                    listOf(),
+                    "I", AccessFlags.PUBLIC.value or AccessFlags.FINAL.value, null, null,
+                    MutableMethodImplementation(2)
+                ).toMutable().apply {
+                    addInstructions(
+                        0,
+                        """
+                            iget-object v0, p0, $directListenerSetField
+                            invoke-virtual { v0 }, Ljava/util/concurrent/CopyOnWriteArraySet;->size()I
+                            move-result v0
+                            return v0
+                        """
+                    )
+                }
+            )
+            log.fine { "9.x: injected patch_addDirectListener / patch_removeDirectListener / patch_getDirectListenerCount on ${exoPlayerImplClass.type}" }
+        }
+
+        // 9.x only: patch_detachCwhFromEventDispatch — removes coordinator_cwh from this
+        // ExoPlayer's crh.h:Lcgd event dispatch set. Called on the OUTGOING player before
+        // it is released so its release-time isPlayingChanged(false) doesn't reach MediaSession
+        // via cwh.b (the boolean is captured at source and never re-queried from cwh.g).
+        if (is_9_00_or_greater && eventDispatchField9x != null && exoPlayerCwhField9x != null) {
+            val cgdType = eventDispatchField9x!!.type
+            exoPlayerImplClass.methods.add(
+                ImmutableMethod(
+                    exoPlayerImplClass.type, "patch_detachCwhFromEventDispatch",
+                    listOf(), "V",
+                    AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+                    null, null,
+                    MutableMethodImplementation(3)
+                ).toMutable().apply {
+                    addInstructions(
+                        0,
+                        """
+                            iget-object v0, p0, $eventDispatchField9x
+                            iget-object v1, p0, $exoPlayerCwhField9x
+                            invoke-virtual { v0, v1 }, $cgdType->e(Ljava/lang/Object;)V
+                            return-void
+                        """
+                    )
+                }
+            )
+            log.fine { "9.x: injected patch_detachCwhFromEventDispatch on ${exoPlayerImplClass.type} (crh.h=${eventDispatchField9x}, cwh=${exoPlayerCwhField9x})" }
+        }
+
+        // --- SessionAccess on atgd ---
         sessionClass.interfaces.add(SESSION_INTERFACE)
         sessionClass.addFieldGetter("patch_getFactory", factoryFieldRef)
 
+        // --- PlayerFactoryAccess on atih ---
+        // On 9.x, the ExoPlayer constructor checks a single-attachment guard field on
+        // the sharedState's abstract superclass and refuses to attach if it's already
+        // set. We clear it before calling the factory so the new player can attach.
+        // On 8.x no guard exists — simple 4-register bridge.
         factoryClass.interfaces.add(FACTORY_INTERFACE)
+        val needsGuardClear = guardField != null && guardAbstractType != null
+        val guardClearSmali = if (needsGuardClear) {
+            """
+                iget-object v0, p1, $sharedStateFieldRef
+                check-cast v0, $guardAbstractType
+                const/4 v1, 0x0
+                iput-object v1, v0, $guardField
+            """
+        } else ""
         factoryClass.methods.add(
             ImmutableMethod(
                 factoryClass.type, "patch_createPlayer",
@@ -821,13 +1338,16 @@ val crossfadePatch = bytecodePatch(
                 AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
                 null,
                 null,
-                MutableMethodImplementation(4)
+                // 9.x needs 7 registers: v0-v2 free locals, p0-p3 = v3-v6
+                // 8.x only needs 4: v0 result local, p0-p3 = v0-v3 (reused)
+                MutableMethodImplementation(if (needsGuardClear) 7 else 4)
             ).toMutable().apply {
                 addInstructions(
                     0,
                     """
                         check-cast p1, $coordinatorType
                         check-cast p2, $loadControlType
+                        $guardClearSmali
                         invoke-virtual { p0, p1, p2, p3 }, $factoryMethod
                         move-result-object v0
                         return-object v0
@@ -836,19 +1356,23 @@ val crossfadePatch = bytecodePatch(
             }
         )
 
+        // --- SharedStateAccess on concrete shared state class ---
         sharedStateClass.interfaces.add(SHARED_STATE_INTERFACE)
         sharedStateClass.addFieldGetter("patch_getTimeline", timelineField)
         sharedStateClass.addFieldSetter("patch_setTimeline", timelineField)
 
+        // --- SharedCallbackAccess on concrete shared callback class ---
         sharedCallbackClass.interfaces.add(SHARED_CALLBACK_INTERFACE)
         sharedCallbackClass.addFieldGetter("patch_getCqb", cqbField)
         sharedCallbackClass.addFieldSetter("patch_setCqb", cqbField)
         sharedCallbackClass.addFieldGetter("patch_getDlt", dltCallbackTypeOnShared)
         sharedCallbackClass.addFieldSetter("patch_setDlt", dltCallbackTypeOnShared)
 
+        // --- VideoSurfaceAccess ---
         videoSurfaceClass.interfaces.add(VIDEO_SURFACE_INTERFACE)
         videoSurfaceClass.addFieldSetter("patch_setPlayerReference", videoSurfaceExoField)
 
+        // --- MedialibPlayerAccess on atad ---
         medialibPlayerClass.interfaces.add(MEDIALIB_PLAYER_INTERFACE)
         medialibPlayerClass.addFieldGetter("patch_getPlayerChain", playerChainField)
         medialibPlayerClass.methods.add(
@@ -872,11 +1396,16 @@ val crossfadePatch = bytecodePatch(
             }
         )
 
+        // --- VideoToggleAccess on nba ---
         videoToggleClass.interfaces.add(VIDEO_TOGGLE_INTERFACE)
         val videoToggleClassStateProviderField = videoToggleClass.fields.first {
             it.type.startsWith("L")
         }
         val stateProviderClass = mutableClassDefBy(videoToggleClassStateProviderField.type)
+
+        // getState returns an enum (nlv) representing the current playback
+        // content mode.  We find it as the first no-arg method returning a
+        // non-Object, non-primitive type.
         val getStateMethod = Fingerprint(
             definingClass = stateProviderClass.type,
             parameters = listOf(),
@@ -886,6 +1415,10 @@ val crossfadePatch = bytecodePatch(
             }
         ).method
         val stateType = getStateMethod.returnType
+
+        // isAudioMode is the static (stateType)Z method with MORE enum
+        // comparisons (checks 3 audio-only states vs 2 video states).
+        // We pick the longest implementation among the static (T)Z methods.
         val isAudioModeMethod = Fingerprint(
             definingClass = stateProviderClass.type,
             returnType = "Z",
@@ -920,6 +1453,7 @@ val crossfadePatch = bytecodePatch(
             }
         )
 
+        // setState is the instance void method on nlw that takes one nlv param.
         val setStateMethodFingerprint = Fingerprint(
             definingClass = stateProviderClass.type,
             returnType = "V",
@@ -933,6 +1467,8 @@ val crossfadePatch = bytecodePatch(
             }
         )
         val setStateMethod = setStateMethodFingerprint.method
+
+        // ATV_PREFERRED is the first enum constant (ordinal 0) on the nlv class.
         val atvPreferredField = classDefBy(stateType).fields.first { field ->
             field.type == stateType
                     && AccessFlags.STATIC.isSet(field.accessFlags)
@@ -962,6 +1498,8 @@ val crossfadePatch = bytecodePatch(
             }
         )
 
+        // patch_triggerToggle calls the actual nba toggle method so the full
+        // UI update path fires (reactive observers, button states, content mode).
         val toggleMethod = AudioVideoToggleFingerprint.method
         videoToggleClass.methods.add(
             ImmutableMethod(
@@ -984,9 +1522,23 @@ val crossfadePatch = bytecodePatch(
             }
         )
 
+        // --- Silent mode set: bypass reactive broadcast (chxp) ---
+        //
+        // patch_forceAudioMode() calls nlw.setState → chxp.mo6606iF which
+        // broadcasts to ALL subscribers including nmi, which triggers a
+        // navigation/jump that fires stopVideo(5). On repeated video→audio
+        // crossfades, the blocked jumps corrupt the loading pipeline.
+        //
+        // We discover chxp.m34891ax - the internal setter that writes the
+        // value via AtomicReference.lazySet WITHOUT iterating subscribers.
+        // Bridge methods let CrossfadeManager silently set/restore mode.
+
+        // 1. From setStateMethod's bytecode, find the chxp field on nlw
         val chxpFieldRef = setStateMethodFingerprint.instructionMatches.first()
             .getInstruction<ReferenceInstruction>().getReference<FieldReference>()!!
         val chxpType = chxpFieldRef.type
+
+        // 2. Find the broadcast method (mo6606iF) called from setStateMethod
         val broadcastMethodRef = setStateMethod.instructions
             .filterIsInstance<ReferenceInstruction>()
             .first {
@@ -995,6 +1547,7 @@ val crossfadePatch = bytecodePatch(
             }
             .reference as MethodReference
 
+        // 3. Find the broadcast method implementation on the chxp class
         val broadcastMethodFingerprint = Fingerprint(
             definingClass = chxpType,
             name = broadcastMethodRef.name,
@@ -1009,9 +1562,12 @@ val crossfadePatch = bytecodePatch(
             )
         )
 
+        // 4. From broadcast method's bytecode, find the silent setter (m34891ax)
+        //    - the first invoke on a non-Object class that takes Object
         val silentSetMethodRef = broadcastMethodFingerprint.instructionMatches.first()
             .getInstruction<ReferenceInstruction>().getReference<MethodReference>()!!
 
+        // 5. Find OMV_PREFERRED - the second enum constant (ordinal 1)
         val stateEnumStaticFields = classDefBy(stateType).fields.filter { field ->
             field.type == stateType
                 && AccessFlags.STATIC.isSet(field.accessFlags)
@@ -1030,6 +1586,7 @@ val crossfadePatch = bytecodePatch(
             """.trimIndent()
         }
 
+        // 6. Add public wrapper on chxp class for the silent setter
         val mutableChxpClass = mutableClassDefBy(chxpType)
         mutableChxpClass.methods.add(
             ImmutableMethod(
@@ -1052,6 +1609,7 @@ val crossfadePatch = bytecodePatch(
             }
         )
 
+        // 7. Add patch_silentSetState on the state provider class (nlw)
         val silentSetOnChxp = "$chxpType->patch_silentSet(Ljava/lang/Object;)V"
         stateProviderClass.methods.add(
             ImmutableMethod(
@@ -1075,6 +1633,7 @@ val crossfadePatch = bytecodePatch(
             }
         )
 
+        // 8. Add patch_forceAudioModeSilent and patch_restoreVideoModeSilent on nba
         val silentSetOnProvider = "${stateProviderClass.type}->patch_silentSetState(Ljava/lang/Object;)V"
         videoToggleClass.methods.add(
             ImmutableMethod(
@@ -1122,11 +1681,13 @@ val crossfadePatch = bytecodePatch(
             }
         )
 
+        // --- DelegateAccess on atux (delegate chain base class) ---
         delegateBaseClass.apply {
             interfaces.add(DELEGATE_INTERFACE)
             addFieldGetter("patch_getDelegate", delegateField)
         }
 
+        // --- ListenerWrapperAccess on cat (listener element class) ---
         listenerElementClass.apply {
             interfaces.add(LISTENER_WRAPPER_INTERFACE)
             addFieldGetter("patch_getWrappedListener", listenerElementField)

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/crossfade/CrossfadePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/crossfade/CrossfadePatch.kt
@@ -23,17 +23,16 @@ import app.morphe.patches.music.misc.settings.PreferenceScreen
 import app.morphe.patches.music.misc.settings.settingsPatch
 import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
 import app.morphe.patches.music.shared.MusicActivityOnCreateFingerprint
-import app.morphe.patches.shared.misc.settings.preference.InputType
 import app.morphe.patches.shared.misc.settings.preference.ListPreference
 import app.morphe.patches.shared.misc.settings.preference.NonInteractivePreference
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
-import app.morphe.patches.shared.misc.settings.preference.TextPreference
 import app.morphe.util.getReference
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
 import com.android.tools.smali.dexlib2.iface.Field
+import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
@@ -176,8 +175,8 @@ val crossfadePatch = bytecodePatch(
 
         fun allMethodsInHierarchy(
             startType: String,
-        ): List<com.android.tools.smali.dexlib2.iface.Method> {
-            val result = mutableListOf<com.android.tools.smali.dexlib2.iface.Method>()
+        ): List<Method> {
+            val result = mutableListOf<Method>()
             var current: String? = startType
             while (current != null && current != "Ljava/lang/Object;") {
                 val classDef = try { classDefBy(current) } catch (_: Exception) { break }
@@ -189,8 +188,8 @@ val crossfadePatch = bytecodePatch(
 
         fun allFieldsInHierarchy(
             startType: String,
-        ): List<com.android.tools.smali.dexlib2.iface.Field> {
-            val result = mutableListOf<com.android.tools.smali.dexlib2.iface.Field>()
+        ): List<Field> {
+            val result = mutableListOf<Field>()
             var current: String? = startType
             while (current != null && current != "Ljava/lang/Object;") {
                 val classDef = try { classDefBy(current) } catch (_: Exception) { break }
@@ -229,19 +228,9 @@ val crossfadePatch = bytecodePatch(
         //  Hook injection                                                 //
         // -------------------------------------------------------------- //
 
-        // On 9.x, set CrossfadeManager.is9x = true before any crossfade logic runs.
-        // sput-boolean is idempotent — safe to execute on every stopVideo call.
-        val is9xSmali = if (is_9_00_or_greater) {
-            """
-                const/4 v0, 0x1
-                sput-boolean v0, $EXTENSION_CLASS->is9x:Z
-            """
-        } else ""
-
         StopVideoFingerprint.method.addInstructions(
             0,
             """
-                $is9xSmali
                 invoke-static { p0, p1 }, $EXTENSION_CLASS->onBeforeStopVideo(Ljava/lang/Object;I)Z
                 move-result v0
                 if-eqz v0, :allow_stop
@@ -291,7 +280,7 @@ val crossfadePatch = bytecodePatch(
             0,
             """
                 invoke-static { p0 }, $EXTENSION_CLASS->onPlayVideo(Ljava/lang/Object;)V
-            """,
+            """
         )
 
         // On 9.20.52, atzq.loadVideo has enough locals that `p0` resolves past v15,
@@ -301,23 +290,23 @@ val crossfadePatch = bytecodePatch(
             0,
             """
                 invoke-static/range { p0 .. p0 }, $EXTENSION_CLASS->onBeforeLoadVideo(Ljava/lang/Object;)V
-            """,
+            """
         )
 
-        val musicActivityClass = mutableClassDefBy(MusicActivityOnCreateFingerprint.classDef.type)
+        val musicActivityClass = MusicActivityOnCreateFingerprint.classDef
         musicActivityClass.methods.first { it.name == "onStop" && it.parameterTypes.isEmpty() }
             .addInstructions(
                 0,
                 """
                     invoke-static {}, $EXTENSION_CLASS->onActivityStop()V
-                """,
+                """
             )
         musicActivityClass.methods.first { it.name == "onStart" && it.parameterTypes.isEmpty() }
             .addInstructions(
                 0,
                 """
                     invoke-static {}, $EXTENSION_CLASS->onActivityStart()V
-                """,
+                """
             )
 
         // -------------------------------------------------------------- //
@@ -369,7 +358,7 @@ val crossfadePatch = bytecodePatch(
         ).method
 
         // ExoPlayer concrete impl - fingerprinted via the unique "ExoPlayerImpl" log tag.
-        val exoPlayerImplClass = mutableClassDefBy(ExoPlayerImplFingerprint.classDef.type)
+        val exoPlayerImplClass = ExoPlayerImplFingerprint.classDef
         val exoImplMethods = allMethodsInHierarchy(exoPlayerImplClass.type)
 
         // Helper: checks if `type` appears anywhere in the superclass chain starting at `startType`.
@@ -449,7 +438,7 @@ val crossfadePatch = bytecodePatch(
         // The ExoPlayer constructor checks this field (on an abstract superclass of
         // sharedState) and refuses to attach if already set. We clear it before
         // calling the factory so the new player can attach to the coordinator.
-        var guardField: com.android.tools.smali.dexlib2.iface.Field? = null
+        var guardField: Field? = null
         var guardAbstractType: String? = null
         if (is_9_00_or_greater) {
             var current: String? = sharedStateClass.superclass
@@ -506,14 +495,14 @@ val crossfadePatch = bytecodePatch(
         // factory_cwh — NOT coordinator_cwh — so auih.k never gets notified and
         // MediaSession stays permanently PAUSED.
         // Fix: read factory_cwh from factory_exo.j, then register auih.k on factory_cwh.
-        val forwardingPlayerField9x: com.android.tools.smali.dexlib2.iface.Field?
-        var exoPlayerCwhField9x: com.android.tools.smali.dexlib2.iface.Field? = null
+        val forwardingPlayerField9x: Field?
+        var exoPlayerCwhField9x: Field? = null
         var cwhListenerType: String? = null
-        var coordinatorCwhListenerField9x: com.android.tools.smali.dexlib2.iface.Field? = null
+        var coordinatorCwhListenerField9x: Field? = null
         // crh.h:Lcgd — per-player event dispatch set; coordinator_cwh is registered here via crh.C().
         // Removing coordinator_cwh from the outgoing player's crh.h before release prevents the
         // release's isPlayingChanged(false) from propagating to MediaSession via cwh.b.
-        var eventDispatchField9x: com.android.tools.smali.dexlib2.iface.Field? = null
+        var eventDispatchField9x: Field? = null
         if (is_9_00_or_greater) {
             // Find coordinator's cwh field (auih.c:Lctr) to identify the Lctr interface type.
             val playerDelegateTypes = setOf(playerInterfaceType, EXO_PLAYER_TYPE)
@@ -561,7 +550,7 @@ val crossfadePatch = bytecodePatch(
                         !AccessFlags.STATIC.isSet(f.accessFlags)
                             && f.type != exoPlayerField.type
                             && f.type != lctrType
-                            && try { cwhListenerType!! in classDefBy(f.type).interfaces } catch (_: Exception) { false }
+                            && try { cwhListenerType in classDefBy(f.type).interfaces } catch (_: Exception) { false }
                     }.also { f ->
                         if (f == null) log.warning("9.x: coordinator cwh listener field (auih.k) not found — crh.j fix skipped")
                         else log.fine { "9.x: coordinator cwh listener field (auih.k) = $f" }
@@ -1339,7 +1328,7 @@ val crossfadePatch = bytecodePatch(
         // whose body invokes CopyOnWriteArraySet.remove() on the wrapped set.  This makes
         // the patch resilient to R8 renaming "e" to something else across YTM versions.
         if (is_9_00_or_greater && eventDispatchField9x != null && exoPlayerCwhField9x != null) {
-            val cgdType = eventDispatchField9x!!.type
+            val cgdType = eventDispatchField9x.type
             val cgdClass = classDefBy(cgdType)
             val cgdRemoveMethodName = cgdClass.methods.firstOrNull { m ->
                 m.parameterTypes.size == 1

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/crossfade/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/crossfade/Fingerprints.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
 package app.morphe.patches.music.interaction.crossfade
 
 import app.morphe.patcher.Fingerprint
@@ -95,4 +101,11 @@ internal object ListenerWrapperClassFingerprint : Fingerprint(
             classDef.fields.any { it.type == "Ljava/util/concurrent/CopyOnWriteArraySet;" } &&
             classDef.fields.count() in 2..6
     },
+)
+
+/** MedialibPlayer loadVideo method (atzq.o). Scoped to StopVideoFingerprint class. */
+internal object LoadVideoFingerprint : Fingerprint(
+    classFingerprint = StopVideoFingerprint,
+    returnType = "V",
+    strings = listOf("MedialibPlayer.loadVideo("),
 )

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/crossfade/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/crossfade/Fingerprints.kt
@@ -2,13 +2,33 @@ package app.morphe.patches.music.interaction.crossfade
 
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.opcode
+import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 
+/**
+ * Crossfade discovery uses three tiers of fingerprints:
+ *
+ * 1. **Anchor fingerprints** — unique log/error strings that resolve stable classes and hook sites.
+ * 2. **Scoped fingerprints** — use [classFingerprint] so resolution stays on a known class.
+ * 3. **Execute-time fingerprints** — inline [Fingerprint] instances in `crossfadePatch` for types
+ *    only known after anchors resolve.
+ *
+ * Three method discoveries (`getPlaybackState`, `getDuration`, `getCurrentPosition`) use manual
+ * hierarchy-walking instead of `Fingerprint(definingClass=...)` because the methods may be
+ * defined on a superclass of the ExoPlayer impl, not on the impl itself.
+ */
+
+// =====================================================================
+//  Tier 1 — Anchor fingerprints (unique strings, match exactly one class)
+// =====================================================================
+
+/** Medialib outer player (atad): `stopVideo`. */
 internal object StopVideoFingerprint : Fingerprint(
     returnType = "V",
     strings = listOf("stopVideo", "MedialibPlayer.stopVideo"),
 )
 
+/** Inner coordinator (athu): `playNextInQueue` / gapless. */
 internal object PlayNextInQueueFingerprint : Fingerprint(
     returnType = "V",
     filters = listOf(
@@ -17,6 +37,7 @@ internal object PlayNextInQueueFingerprint : Fingerprint(
     strings = listOf("gapless.seek.next", "playNextInQueue."),
 )
 
+/** Audio/video toggle button class (nba). */
 internal object AudioVideoToggleFingerprint : Fingerprint(
     returnType = "V",
     strings = listOf("Failed to update user last selected audio"),
@@ -32,9 +53,46 @@ internal object PlayVideoFingerprint : Fingerprint(
     strings = listOf("playVideo", "MedialibPlayer.playVideo()"),
 )
 
+/**
+ * ExoPlayer concrete implementation (cpp) — unique "ExoPlayerImpl" log tag.
+ * Must also check that the class implements ExoPlayer, because a synthetic Runnable
+ * (coz) also references "ExoPlayerImpl" as a log tag.
+ */
 internal object ExoPlayerImplFingerprint : Fingerprint(
     strings = listOf("ExoPlayerImpl"),
     custom = { _, classDef ->
         classDef.interfaces.any { it == "Landroidx/media3/exoplayer/ExoPlayer;" }
+    },
+)
+
+// =====================================================================
+//  Tier 2 — Scoped fingerprints (classFingerprint narrows to a known class)
+// =====================================================================
+
+/**
+ * Medialib outer `playNextInQueue()V` forwarding into the inner coordinator.
+ * Scoped to [StopVideoFingerprint] (atad) so we match the outer method, not athu's.
+ */
+internal object MedialibPlayNextInQueueMethodFingerprint : Fingerprint(
+    classFingerprint = StopVideoFingerprint,
+    returnType = "V",
+    parameters = emptyList(),
+    strings = listOf("playNextInQueue"),
+)
+
+// =====================================================================
+//  Tier 3 — Structural fingerprints (superclass / interface / custom)
+// =====================================================================
+
+/**
+ * Listener wrapper class (cau) — the wrapper around CopyOnWriteArraySet on the ExoPlayer impl.
+ * Matched by having a CopyOnWriteArraySet field and NOT being ExoPlayer itself.
+ */
+internal object ListenerWrapperClassFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    custom = { _, classDef ->
+        !classDef.type.contains("ExoPlayer") &&
+            classDef.fields.any { it.type == "Ljava/util/concurrent/CopyOnWriteArraySet;" } &&
+            classDef.fields.count() in 2..6
     },
 )

--- a/patches/src/main/resources/addresources/values/music/arrays.xml
+++ b/patches/src/main/resources/addresources/values/music/arrays.xml
@@ -103,6 +103,7 @@
         <item>@string/morphe_crossfade_duration_8000ms</item>
         <item>@string/morphe_crossfade_duration_9000ms</item>
         <item>@string/morphe_crossfade_duration_10000ms</item>
+        <item>@string/morphe_crossfade_duration_12000ms</item>
     </string-array>
     <string-array name="morphe_music_crossfade_duration_entry_values">
         <item>MILLISECONDS_250</item>
@@ -118,6 +119,7 @@
         <item>MILLISECONDS_8000</item>
         <item>MILLISECONDS_9000</item>
         <item>MILLISECONDS_10000</item>
+        <item>MILLISECONDS_12000</item>
     </string-array>
 
     <!-- misc.fix.playback.spoofVideoStreamsPatch -->

--- a/patches/src/main/resources/addresources/values/music/strings.xml
+++ b/patches/src/main/resources/addresources/values/music/strings.xml
@@ -68,6 +68,7 @@ Second \"item\" text"</string>
     <string name="morphe_crossfade_duration_8000ms">8 seconds</string>
     <string name="morphe_crossfade_duration_9000ms">9 seconds</string>
     <string name="morphe_crossfade_duration_10000ms">10 seconds</string>
+    <string name="morphe_crossfade_duration_12000ms">12 seconds</string>
     <string name="morphe_music_crossfade_on_skip_title">Crossfade on manual skip</string>
     <string name="morphe_music_crossfade_on_skip_summary">Applies the crossfade effect when you manually skip to the next track</string>
     <string name="morphe_music_crossfade_on_auto_advance_title">Crossfade on auto-advance</string>
@@ -78,9 +79,7 @@ Second \"item\" text"</string>
     <string name="morphe_music_crossfade_resumed_toast">Crossfade resumed</string>
     <string name="morphe_music_crossfade_video_mode_disabled_toast">Video mode is not available while crossfade is enabled</string>
     <string name="morphe_music_crossfade_about_title">About</string>
-    <string name="morphe_music_crossfade_about_summary">"Crossfade is available with YouTube Music 8.x
-
-Long press the shuffle button to disable/enable
+    <string name="morphe_music_crossfade_about_summary">"Long press the shuffle button to disable/enable
 
 Feature implementation by VazerOG"</string>
 


### PR DESCRIPTION
## Description

Adds crossfade support for the YouTube Music 9.x line (9.18.50, 9.19.50, 9.20.52).
On 9.x YTM refactored the ExoPlayer listener architecture: the direct
`CopyOnWriteArraySet` on the player impl was wrapped by a separate event-dispatch
class (`crh.h:Lcgd`), and the coordinator acquired a new player-transition method
that performs listener migration and field-write atomically. The existing 8.x implementation
depended on directly manipulating the impl's listener set and is entirely incompatible
with YTM 9.x.

In a future update, we may be able to utilize YTM's gapless playback system to
our advantage, but for now, we have something that is good enough for release.

All 9.x logic is gated behind an `is9x` flag. **8.x bytecode and behavior are
byte-for-byte identical after this change.**

The 9.x flow:

- **Auto-advance overlap** is triggered by simulating a `MEDIA_NEXT` key event
  through `MediaSession.dispatchMediaKeyEvent` so the queue advance and
  `loadVideo` are driven by YTM's own gapless path. `onBeforeStopVideo`
  intercepts the resulting `stopVideo(5)` and sets up the true overlap. This method
  of doing things comes with it's own limitations, but this is good enough for now.
- **Coordinator player swap** is done via `patch_setPlayerWithBindings` (the
  coordinator's internal transition method), which migrates `cau`-level
  listeners and rewrites the player field in one step.
- **UI listener (Lcou) migration:** the coordinator's UI listener lives in
  the player impl's `Lcrh.N` (CopyOnWriteArraySet). `patch_setPlayerWithBindings`
  does not touch `Lcrh.N`, so we pre-remove `Lcou` from the outgoing player
  and re-register it into the incoming player via `patch_addDirectListener`
  to avoid premature `clearQueue` and to keep MediaSession receiving
  `onIsPlayingChanged`.
- **MediaSession PAUSED-after-crossfade fix:** `coordinator_cwh` remained
  registered in the outgoing player's `crh.h:Lcgd` dispatch set after the
  swap, firing `isPlayingChanged(false)` on release. The flag is captured
  at source and never re-queried, leaving the lockscreen UI in PAUSED state.
  `patch_detachCwhFromEventDispatch` removes `coordinator_cwh` from the
  outgoing player's dispatch set before each coordinator swap.

Polish in commit 2:

- Adds a 12-second crossfade duration option.
- `tickFadingLoop`: defers `releasePlayer()` by 150ms after `setVolume(0)` so
  the AudioTrack buffer drains naturally before the player is torn down —
  prevents an audible click at fade-end (most pronounced on the 200ms
  chained-skip quick-fade).
- Long-press shuffle handler hardened against YTM 9.x's reactive UI rebind
  cycles: `setOnLongClickListener` (coexists with other handlers) plus
  continuous re-attach via `ViewTreeObserver.OnGlobalLayoutListener` with a
  debounce flag.
- All hardcoded R8-obfuscated class/method names in the crossfade discovery
  path used during development have been replaced with structural fingerprints.
- Strips "Crossfade is available with YouTube Music 8.x" from the English
  `about_summary` and removes the now-stale localized overrides from 45
  `values-*/music/strings.xml` files so all locales fall back to English
  (Crowdin will refresh translations naturally).
- Comment sweep across `CrossfadeManager.java` / `CrossfadePatch.kt` —
  removes diagnostic-only logging blocks and restate-the-code inline
  comments. R8 mappings, hooked-method Javadoc, YTM bug docs, and section
  dividers are preserved.
- Adds Morphe GPLv3 copyright headers to Morphe-authored crossfade files.

Commit 3: 
- Fixed an issue discovered during testing that caused auto-advancement to not fade-out
   the outgoing track when the incoming track hasn't finished loading yet. Outgoing track 
   will now fade out regardless of when the incoming track is ready to ensure a smoother 
   transition. between tracks. 

Commit 4 — bug fixes from community feedback:

- When the device screen locked via the power button (or the app
was minimized) during an active crossfade, the outgoing track cut off
abruptly instead of fading out. Root cause: `onActivityStop` unconditionally
called `abortCrossfadeNow()`, which immediately releases all fading players
and snaps the incoming to volume 1.0. with the stated goal of "stop music 
when app is closed" but `onActivityStop` fires for **all** lifecycle-stop events
(screen lock, minimize, configuration change, app close), not just app close.
later fixed the auto-advance monitor to keep running across screen-lock
but left this in-progress-abort block in place, with the comment block
above it now contradicting the code two lines below.
- Fix: remove the in-progress abort. YTM is a music app with a foreground
service — playback continues after `onStop` and our fade animations on
`mainHandler` keep ticking. The crossfade now completes naturally in the
background. Applies to 8.x and 9.x

Commit 5 — fix cast/mirror disconnect:

- When audio is routed to a Chromecast / Google Cast / Samsung
Audio Mirroring / HDMI mirror receiver, our coordinator-player swap emits a
MediaSession state burst (`PAUSED → PLAYING → PAUSED → PLAYING` flicker
within ~30ms) plus a ~25ms window where the new factory player's AudioTrack
starts with no output device routed. The cast/mirror layer reads this
stream and forwards rapid PAUSE+PLAY commands to the receiver. Forgiving
receivers (e.g. Google Home Mini) absorb this as a brief audio glitch;
stricter receivers (e.g. Sony AVRs per the original report) interpret it
as session-end and drop the cast connection.
- Fix: detect when audio is bound for a cast/mirror destination via
`MediaRouter.RouteInfo.getPlaybackType() == PLAYBACK_TYPE_REMOTE` plus a
whole-system `AudioManager.getDevices` scan for HDMI / REMOTE_SUBMIX / IP /
BUS device types. When detected, skip crossfade engagement at the three
hot-path hooks (`onBeforeStopVideo`, `onBeforePlayNext`, auto-advance
monitor). YTM's native gapless / skip path then handles the song change
without our additional state thrashing. Locally-decoded routes
(Bluetooth A2DP, wired headset, USB audio) keep `PLAYBACK_TYPE_LOCAL` and
are **not** affected — crossfade continues to work there.

This is the defensive fix — eliminates the disconnect at the cost of the
fade effect while casting. A deeper fix (suppressing the MediaSession
state thrashing during the swap so crossfade can keep working while
casting) is parked as a future enhancement.

## Closes: 
- #1549 
- #1442
- #1311

## Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)

Tested:
- 8.47.56: PASS
- 8.44.54: PASS
--
- 9.21.51: PASS
- 9.20.52: PASS
- 9.19.50: PASS
- 9.18.50: PASS

Testing conducted on each version:
- manual skip
- auto-advance between tracks
- chained rapid skip (quick-fade path)
- long-press shuffle to
- pause/resume crossfade
- video playback when crossfade is paused
and the user switches to video mode manually
- album art loads properly depending on UI state

Tests conducted on a Samsung Galaxy S25 Ultra
- OS: Android 16 / One UI 8.5
- External equalizer: Sound Assistant via Good Lock
- Rooted: NO
- System modifications: None
- System augmentations: None
- Device Variant: USA-Factory-Unlocked