### PR TITLE
feat(YouTube Music - Settings): Add icons to Morphe preference screen

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/MusicActivityHook.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/MusicActivityHook.java
@@ -21,7 +21,6 @@ import app.morphe.extension.shared.settings.BaseActivityHook;
  * Hooks {@code com.google.android.gms.common.api.GoogleApiActivity}
  * to inject a custom {@link MusicPreferenceFragment} with a toolbar and search.
  */
-@SuppressWarnings("deprecation")
 public class MusicActivityHook extends BaseActivityHook {
 
     @SuppressLint("StaticFieldLeak")

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/YouTubeActivityHook.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/YouTubeActivityHook.java
@@ -122,7 +122,6 @@ public class YouTubeActivityHook extends BaseActivityHook {
      * @param toolbar  The configured toolbar.
      * @param fragment The PreferenceFragment associated with the activity.
      */
-    @SuppressWarnings("deprecation")
     @Override
     protected void onPostToolbarSetup(Activity activity, Toolbar toolbar, PreferenceFragment fragment) {
         if (fragment instanceof YouTubePreferenceFragment) {
@@ -134,7 +133,6 @@ public class YouTubeActivityHook extends BaseActivityHook {
     /**
      * Creates a new {@link YouTubePreferenceFragment} for the activity.
      */
-    @SuppressWarnings("deprecation")
     @Override
     protected PreferenceFragment createPreferenceFragment() {
         return new YouTubePreferenceFragment();

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/settings/SettingsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/settings/SettingsPatch.kt
@@ -141,6 +141,7 @@ val settingsPatch = bytecodePatch(
 
         PreferenceScreen.GENERAL.addPreferences(
             SwitchPreference("morphe_settings_search_history"),
+            SwitchPreference("morphe_show_menu_icons")
         )
 
         PreferenceScreen.MISC.addPreferences(

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/settings/SettingsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/settings/SettingsPatch.kt
@@ -31,6 +31,8 @@ import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.shared.misc.settings.preference.TextPreference
 import app.morphe.patches.shared.misc.settings.settingsPatch
 import app.morphe.patches.youtube.misc.settings.modifyActivityForSettingsInjection
+import app.morphe.util.ResourceGroup
+import app.morphe.util.copyResources
 import app.morphe.util.copyXmlNode
 import app.morphe.util.inputStreamFromBundledResource
 import app.morphe.util.insertLiteralOverride
@@ -55,6 +57,25 @@ private val settingsResourcePatch = resourcePatch {
     )
 
     execute {
+        copyResources(
+            "settings",
+            ResourceGroup("drawable",
+                "morphe_settings_screen_00_about.xml",
+                "morphe_settings_screen_00_about_bold.xml",
+                "morphe_settings_screen_01_ads.xml",
+                "morphe_settings_screen_01_ads_bold.xml",
+                "morphe_settings_screen_04_general.xml",
+                "morphe_settings_screen_04_general_bold.xml",
+                "morphe_settings_screen_05_player.xml",
+                "morphe_settings_screen_05_player_bold.xml",
+                "morphe_settings_screen_11_misc.xml",
+                "morphe_settings_screen_11_misc_bold.xml"
+            ),
+            ResourceGroup("layout",
+                "morphe_preference_with_icon.xml"
+            )
+        )
+
         // Set the style for the Morphe settings to follow the style of the music settings,
         // namely: action bar height, menu item padding and remove horizontal dividers.
         val targetResource = "values/styles.xml"
@@ -111,8 +132,11 @@ val settingsPatch = bytecodePatch(
         preferences += NonInteractivePreference(
             key = "morphe_settings_music_screen_0_about",
             summaryKey = null,
+            icon = "@drawable/morphe_settings_screen_00_about",
+            iconBold = "@drawable/morphe_settings_screen_00_about_bold",
+            layout = "@layout/morphe_preference_with_icon",
             tag = "app.morphe.extension.shared.settings.preference.about.MorpheAboutPreference",
-            selectable = true,
+            selectable = true
         )
 
         PreferenceScreen.GENERAL.addPreferences(
@@ -165,19 +189,31 @@ fun newIntent(settingsName: String) = IntentPreference.Intent(
 object PreferenceScreen : BasePreferenceScreen() {
     val ADS = Screen(
         key = "morphe_settings_music_screen_1_ads",
-        summaryKey = null
+        summaryKey = null,
+        icon = "@drawable/morphe_settings_screen_01_ads",
+        iconBold = "@drawable/morphe_settings_screen_01_ads_bold",
+        layout = "@layout/morphe_preference_with_icon"
     )
     val GENERAL = Screen(
         key = "morphe_settings_music_screen_2_general",
-        summaryKey = null
+        summaryKey = null,
+        icon = "@drawable/morphe_settings_screen_04_general",
+        iconBold = "@drawable/morphe_settings_screen_04_general_bold",
+        layout = "@layout/morphe_preference_with_icon"
     )
     val PLAYER = Screen(
         key = "morphe_settings_music_screen_3_player",
-        summaryKey = null
+        summaryKey = null,
+        icon = "@drawable/morphe_settings_screen_05_player",
+        iconBold = "@drawable/morphe_settings_screen_05_player_bold",
+        layout = "@layout/morphe_preference_with_icon"
     )
     val MISC = Screen(
         key = "morphe_settings_music_screen_4_misc",
-        summaryKey = null
+        summaryKey = null,
+        icon = "@drawable/morphe_settings_screen_11_misc",
+        iconBold = "@drawable/morphe_settings_screen_11_misc_bold",
+        layout = "@layout/morphe_preference_with_icon"
     )
 
     override fun commit(screen: PreferenceScreenPreference) {

--- a/patches/src/main/resources/settings/layout/morphe_preference_with_icon.xml
+++ b/patches/src/main/resources/settings/layout/morphe_preference_with_icon.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="54.0dip">
+
+    <ImageView
+        android:id="@android:id/icon"
+        android:layout_gravity="center_vertical"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@null"
+        android:layout_marginStart="18.0dip"
+        android:layout_marginEnd="18.0dip" />
+
+    <RelativeLayout
+        android:layout_width="0.0dip"
+        android:layout_height="wrap_content"
+        android:layout_weight="1.0"
+        android:layout_marginTop="6.0dip"
+        android:layout_marginEnd="6.0dip"
+        android:layout_marginBottom="6.0dip"
+        android:layout_gravity="center_vertical">
+
+        <TextView
+            android:id="@android:id/title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:textAppearanceListItem"
+            android:textColor="?android:textColorPrimary"
+            android:ellipsize="marquee"
+            android:fadingEdge="horizontal"
+            android:singleLine="true" />
+
+        <TextView
+            android:id="@android:id/summary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@android:id/title"
+            android:layout_alignStart="@android:id/title"
+            android:textAppearance="?android:textAppearanceSmall"
+            android:textColor="?android:textColorSecondary"
+            android:maxLines="4" />
+
+    </RelativeLayout>
+
+</LinearLayout>

--- a/patches/src/main/resources/settings/music/values/styles.xml
+++ b/patches/src/main/resources/settings/music/values/styles.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.Morphe.YouTubeMusic.Settings" parent="@style/Theme.YouTubeMusic">
+    <style name="Theme.Morphe.YouTubeMusic.Settings" parent="@style/Theme.YouTubeMusic.Settings.Compat.Base">
         <item name="android:actionBarSize">@dimen/action_bar_height</item>
-        <item name="android:listPreferredItemPaddingStart">@dimen/item_extra_extra_large_spacing</item>
+        <item name="android:textColorHint">@color/ytm_text_color_secondary</item>
         <item name="android:listDivider">@null</item>
     </style>
 </resources>

--- a/patches/src/main/resources/settings/music/values/styles.xml
+++ b/patches/src/main/resources/settings/music/values/styles.xml
@@ -3,6 +3,7 @@
     <style name="Theme.Morphe.YouTubeMusic.Settings" parent="@style/Theme.YouTubeMusic.Settings.Compat.Base">
         <item name="android:actionBarSize">@dimen/action_bar_height</item>
         <item name="android:textColorHint">@color/ytm_text_color_secondary</item>
+        <item name="android:textColorTertiary">@color/ytm_text_color_secondary</item>
         <item name="android:listDivider">@null</item>
     </style>
 </resources>


### PR DESCRIPTION
### Description

Add icons to Morphe settings preference screen. Includes a custom preference layout `morphe_preference_with_icon` for correct icon spacing, correct theme parent `Theme.YouTubeMusic.Settings.Compat.Base` for native switch colors and text styling. This PR does not add icons to the native YT Music settings.
___
![Screenshot_2026-06-01-18-52-27-939_com.google.android.apps.youtube.music.test-edit.jpg](https://github.com/user-attachments/assets/274e31e5-7628-4bed-9805-36ec2a5a7cde)

