### PR TITLE
fix(YouTube - Remove background playback restrictions): Background playback is audio only

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/backgroundplayback/BackgroundPlaybackPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/backgroundplayback/BackgroundPlaybackPatch.kt
@@ -133,5 +133,8 @@ val backgroundPlaybackPatch = bytecodePatch(
             // must also be disabled, otherwise the player is a black screen with no buttons and no playback.
             NewPlayerOverlaysFeatureFlagFingerprint.addBackgroundPlaybackFeatureFlagHook(false)
         }
+
+        // New YouTube PiP auto-enter flag in the same controller as the PiP input consumer flag above.
+        PipAutoEnterFeatureFlagFingerprint.addBackgroundPlaybackFeatureFlagHook(false)
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/backgroundplayback/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/backgroundplayback/Fingerprints.kt
@@ -111,3 +111,9 @@ internal object NewPlayerOverlaysFeatureFlagFingerprint : Fingerprint(
         literal(45752335L)
     )
 )
+
+internal object PipAutoEnterFeatureFlagFingerprint : Fingerprint(
+    filters = listOf(
+        literal(45685828L)
+    )
+)


### PR DESCRIPTION
### Problem

YouTube background/Shorts PiP is now controlled by additional YouTube-side code. The previous overlay/native-PiP-retry approaches were dropped after maintainer feedback because the preferred fix is to force the relevant YouTube control-flow flags, matching the existing background playback patch style.

### Description

Adds a new background playback feature flag override:

- Adds `PipAutoEnterFeatureFlagFingerprint` for literal `45685828L`.
- Forces that flag off through the existing `addBackgroundPlaybackFeatureFlagHook(false)` path.
- Keeps the change inside `Remove background playback restrictions`.
- Builds on #1629 / current `dev`, including the corrected Shorts background playback hook.

This PR no longer adds overlay permissions, services, UI controls, or a direct `enterPictureInPictureMode` retry.

### Test results

- [x] Rebased on `dev` after #1629.
- [x] `:patches:compileKotlin`.
- [x] Static diff/privacy check: only two Kotlin background playback files changed.

### On-device notes

On the problem device, previous local experiments showed that forcing `45685828` on/off alone did not restore native PiP, and forcing `45685828` + `45408908` off together also did not restore PiP. The reliable signal on that device was that system PiP never became active (`mLastReportedPictureInPictureMode=false`).

Keeping this PR as draft until the flag direction and combined behavior are verified on a device where native PiP works, per maintainer guidance.