### PR TITLE
fix(YouTube - Remove background playback restrictions): Fix Shorts background playback not working

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 [versions]
 morphe-patcher = "1.5.1"
-morphe-patches-library = "1.4.0-dev.6"
+morphe-patches-library = "1.4.0-dev.8"
 # Tracking https://github.com/google/smali/issues/100.
 smali = "d92701d947"
 agp = "9.1.0"

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/backgroundplayback/BackgroundPlaybackPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/backgroundplayback/BackgroundPlaybackPatch.kt
@@ -57,11 +57,14 @@ val backgroundPlaybackPatch = bytecodePatch(
             SwitchPreference("morphe_remove_background_playback_restrictions")
         )
 
+        // Verify exactly one match exists because fingerprint is so simple.
+        fun Fingerprint.matchSingle() = matchAll(1 .. 1).first()
+
         arrayOf(
             BackgroundPlaybackManagerFingerprint to "isBackgroundPlaybackAllowed",
             BackgroundPlaybackManagerShortsFingerprint to "isBackgroundShortsPlaybackAllowed",
         ).forEach { (fingerprint, integrationsMethod) ->
-            fingerprint.method.apply {
+            fingerprint.matchSingle().method.apply {
                 findInstructionIndicesReversedOrThrow(Opcode.RETURN).forEach { index ->
                     val register = getInstruction<OneRegisterInstruction>(index).registerA
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/backgroundplayback/BackgroundPlaybackPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/backgroundplayback/BackgroundPlaybackPatch.kt
@@ -25,6 +25,7 @@ import app.morphe.util.findInstructionIndicesReversedOrThrow
 import app.morphe.util.getMutableMethod
 import app.morphe.util.getReference
 import app.morphe.util.insertLiteralOverride
+import app.morphe.util.matchSingle
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
@@ -56,9 +57,6 @@ val backgroundPlaybackPatch = bytecodePatch(
         PreferenceScreen.MISC.addPreferences(
             SwitchPreference("morphe_remove_background_playback_restrictions")
         )
-
-        // Verify exactly one match exists because fingerprint is so simple.
-        fun Fingerprint.matchSingle() = matchAll(1 .. 1).first()
 
         arrayOf(
             BackgroundPlaybackManagerFingerprint to "isBackgroundPlaybackAllowed",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/shared/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/shared/Fingerprints.kt
@@ -47,7 +47,8 @@ internal object BackgroundPlaybackManagerShortsFingerprint : Fingerprint(
     returnType = "Z",
     parameters = listOf("L"),
     filters = listOf(
-        literal(151635310)
+        literal(151635310),
+        opcode(Opcode.IGET_BOOLEAN, location = MatchAfterWithin(8)),
     )
 )
 


### PR DESCRIPTION
The Shorts-background-allowed check was split into two public static boolean(L) methods that both contain feature-flag literal 151635310: the original boolean-returning method and a new one that reads an int field. BackgroundPlaybackManagerShortsFingerprint only filtered on the literal, so it matched both and the patcher resolved to the wrong one. Added an IGET_BOOLEAN opcode filter so the fingerprint uniquely resolves to the correct method. Verified against 21.21.80.

### Description

<!-- ADD DETAILED DESCRIPTION HERE -->

Closes #289

### Additional context

<!-- ADD ADDITIONAL CONTEXT HERE -->

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
