### PR TITLE
fix(YouTube - Miniplayer): Restore play/pause icons for minimal miniplayer on 21.17+

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MiniplayerPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MiniplayerPatch.java
@@ -10,10 +10,14 @@ import static app.morphe.extension.youtube.patches.MiniplayerPatch.MiniplayerTyp
 import static app.morphe.extension.youtube.patches.MiniplayerPatch.MiniplayerType.MODERN_4;
 
 import android.content.res.ColorStateList;
+import android.graphics.drawable.Drawable;
 import android.util.DisplayMetrics;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
+
+import app.morphe.extension.shared.ResourceType;
+import app.morphe.extension.shared.ResourceUtils;
 
 import androidx.annotation.Nullable;
 
@@ -419,6 +423,30 @@ public final class MiniplayerPatch {
     public static void hideMiniplayerActionButton(View view) {
         if (CURRENT_TYPE == MODERN_4) {
             Utils.hideViewByRemovingFromParentUnderCondition(HIDE_OVERLAY_BUTTONS_ENABLED, view);
+        }
+    }
+
+    /**
+     * Injection point.
+     */
+    public static void overrideMiniplayerActionButtonDrawable(ImageView view, int contentDescriptionId) {
+        if (CURRENT_TYPE != MINIMAL) return;
+
+        String drawableName;
+        if (contentDescriptionId == ResourceUtils.getIdentifier(ResourceType.STRING, "accessibility_pause")) {
+            drawableName = "yt_fill_pause_vd_theme_24";
+        } else if (contentDescriptionId == ResourceUtils.getIdentifier(ResourceType.STRING, "accessibility_play")) {
+            drawableName = "yt_fill_play_arrow_vd_theme_24";
+        } else {
+            return;
+        }
+
+        int drawableId = ResourceUtils.getIdentifier(ResourceType.DRAWABLE, drawableName);
+        if (drawableId == 0) return;
+
+        Drawable drawable = Utils.getContext().getDrawable(drawableId);
+        if (drawable != null) {
+            view.setImageDrawable(drawable);
         }
     }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MiniplayerPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MiniplayerPatch.java
@@ -437,6 +437,8 @@ public final class MiniplayerPatch {
             drawableName = "yt_fill_pause_vd_theme_24";
         } else if (contentDescriptionId == ResourceUtils.getIdentifier(ResourceType.STRING, "accessibility_play")) {
             drawableName = "yt_fill_play_arrow_vd_theme_24";
+        } else if (contentDescriptionId == ResourceUtils.getIdentifier(ResourceType.STRING, "accessibility_replay")) {
+            drawableName = "yt_outline_replay_arrow_vd_theme_24";
         } else {
             return;
         }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MiniplayerPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MiniplayerPatch.java
@@ -19,10 +19,10 @@ import android.widget.TextView;
 import androidx.annotation.Nullable;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import app.morphe.extension.shared.Logger;
-import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.Setting;
@@ -145,6 +145,15 @@ public final class MiniplayerPatch {
 
     private static final boolean MINIPLAYER_HORIZONTAL_DRAG_ENABLED =
             DRAG_AND_DROP_ENABLED && !Settings.MINIPLAYER_DISABLE_HORIZONTAL_DRAG.get();
+
+    private static final Map<Integer, String> MINIMAL_PLAYER_DRAWABLES = Map.of(
+            ResourceUtils.getStringIdentifier("accessibility_pause"),
+            "yt_fill_pause_vd_theme_24",
+            ResourceUtils.getStringIdentifier("accessibility_play"),
+            "yt_fill_play_arrow_vd_theme_24",
+            ResourceUtils.getStringIdentifier("accessibility_replay"),
+            "yt_outline_replay_arrow_vd_theme_24"
+    );
 
     private static final int OPACITY_LEVEL;
 
@@ -427,20 +436,12 @@ public final class MiniplayerPatch {
             return;
         }
 
-        String drawableName;
-        if (contentDescriptionId == ResourceUtils.getIdentifier(ResourceType.STRING, "accessibility_pause")) {
-            drawableName = "yt_fill_pause_vd_theme_24";
-        } else if (contentDescriptionId == ResourceUtils.getIdentifier(ResourceType.STRING, "accessibility_play")) {
-            drawableName = "yt_fill_play_arrow_vd_theme_24";
-        } else if (contentDescriptionId == ResourceUtils.getIdentifier(ResourceType.STRING, "accessibility_replay")) {
-            drawableName = "yt_outline_replay_arrow_vd_theme_24";
-        } else {
-            return;
-        }
-
-        Drawable drawable = ResourceUtils.getDrawable(drawableName);
-        if (drawable != null) {
-            view.setImageDrawable(drawable);
+        String drawableName = MINIMAL_PLAYER_DRAWABLES.get(contentDescriptionId);
+        if (drawableName != null) {
+            Drawable drawable = ResourceUtils.getDrawable(drawableName);
+            if (drawable != null) {
+                view.setImageDrawable(drawable);
+            }
         }
     }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MiniplayerPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MiniplayerPatch.java
@@ -16,15 +16,14 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import app.morphe.extension.shared.ResourceType;
-import app.morphe.extension.shared.ResourceUtils;
-
 import androidx.annotation.Nullable;
 
 import java.util.List;
 import java.util.Objects;
 
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.ResourceType;
+import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.Setting;
 import app.morphe.extension.youtube.settings.Settings;
@@ -42,12 +41,6 @@ public final class MiniplayerPatch {
         DISABLED(false, null),
         /** Unmodified type, and same as un-patched. */
         DEFAULT(null, null),
-        /**
-         * Exactly the same as MINIMAL and only here for migration of user settings.
-         * Eventually this should be deleted.
-         */
-        @Deprecated
-        PHONE(false, null),
         MINIMAL(false, null),
         TABLET(true, null),
         MODERN_1(null, 1),
@@ -430,7 +423,9 @@ public final class MiniplayerPatch {
      * Injection point.
      */
     public static void overrideMiniplayerActionButtonDrawable(ImageView view, int contentDescriptionId) {
-        if (CURRENT_TYPE != MINIMAL) return;
+        if (!VersionCheckPatch.IS_21_17_OR_GREATER || CURRENT_TYPE != MINIMAL) {
+            return;
+        }
 
         String drawableName;
         if (contentDescriptionId == ResourceUtils.getIdentifier(ResourceType.STRING, "accessibility_pause")) {
@@ -443,10 +438,7 @@ public final class MiniplayerPatch {
             return;
         }
 
-        int drawableId = ResourceUtils.getIdentifier(ResourceType.DRAWABLE, drawableName);
-        if (drawableId == 0) return;
-
-        Drawable drawable = Utils.getContext().getDrawable(drawableId);
+        Drawable drawable = ResourceUtils.getDrawable(drawableName);
         if (drawable != null) {
             view.setImageDrawable(drawable);
         }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VersionCheckPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VersionCheckPatch.java
@@ -15,10 +15,10 @@ public class VersionCheckPatch {
 
     public static final boolean IS_20_39_OR_GREATER = isVersionOrGreater("20.39.00");
 
-    public static final boolean IS_20_45_OR_GREATER = isVersionOrGreater("20.45.00");
-
     public static final boolean IS_21_10_OR_GREATER = isVersionOrGreater("21.10.00");
 
     public static final boolean IS_21_15_OR_GREATER = isVersionOrGreater("21.15.00");
+
+    public static final boolean IS_21_17_OR_GREATER = isVersionOrGreater("21.17.00");
 
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/Fingerprints.kt
@@ -196,26 +196,30 @@ internal object MiniplayerOnCloseHandlerFingerprint : Fingerprint(
     )
 )
 
+// 21.17+
 internal object MiniplayerSetIconsFingerprint : Fingerprint(
+    classFingerprint = Fingerprint(
+        accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+        returnType = "Landroid/graphics/drawable/Drawable;",
+        filters = listOf(
+            resourceLiteral(ResourceType.DRAWABLE, "floatybar_progress_circle_autonav")
+        )
+    ),
+    returnType = "V",
+    parameters = listOf("Landroid/graphics/drawable/Drawable;", "I"),
+    filters = listOf(
+        methodCall(smali = "Landroid/widget/ImageView;->setImageDrawable(Landroid/graphics/drawable/Drawable;)V")
+    )
+)
+
+// 21.16 and lower
+internal object MiniplayerSetIconsLegacyFingerprint : Fingerprint(
     returnType = "V",
     parameters = listOf("I", "Ljava/lang/Runnable;"),
     filters = listOf(
         resourceLiteral(ResourceType.DRAWABLE, "yt_fill_pause_white_36"),
         resourceLiteral(ResourceType.DRAWABLE, "yt_fill_pause_black_36")
     )
-)
-
-// 21.17+ removed the non-bold icon variants used by MiniplayerSetIconsFingerprint.
-private object MiniplayerSetIconsParentFingerprint2117 : Fingerprint(
-    filters = listOf(
-        resourceLiteral(ResourceType.DRAWABLE, "floatybar_progress_circle_autonav")
-    )
-)
-
-internal object MiniplayerSetIconsFingerprint2117 : Fingerprint(
-    classFingerprint = MiniplayerSetIconsParentFingerprint2117,
-    returnType = "V",
-    parameters = listOf("Landroid/graphics/drawable/Drawable;", "I"),
 )
 
 internal object ShowMiniplayerCommandFingerprint: Fingerprint(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/Fingerprints.kt
@@ -19,9 +19,6 @@ import com.android.tools.smali.dexlib2.Opcode
 
 internal const val MINIPLAYER_MODERN_FEATURE_KEY = 45622882L
 internal const val MINIPLAYER_MODERN_TYPE_1_FEATURE_KEY = 45623000L
-internal const val MINIPLAYER_MODERN_TYPE_2_FEATURE_KEY = 45623273L
-internal const val MINIPLAYER_MODERN_TYPE_3_FEATURE_KEY = 45623076L
-internal const val MINIPLAYER_MODERN_TYPE_4_FEATURE_KEY = 45674402L
 internal const val MINIPLAYER_DOUBLE_TAP_FEATURE_KEY = 45628823L
 internal const val MINIPLAYER_DRAG_DROP_FEATURE_KEY = 45628752L
 internal const val MINIPLAYER_HORIZONTAL_DRAG_FEATURE_KEY = 45658112L
@@ -206,6 +203,19 @@ internal object MiniplayerSetIconsFingerprint : Fingerprint(
         resourceLiteral(ResourceType.DRAWABLE, "yt_fill_pause_white_36"),
         resourceLiteral(ResourceType.DRAWABLE, "yt_fill_pause_black_36")
     )
+)
+
+// 21.17+ removed the non-bold icon variants used by MiniplayerSetIconsFingerprint.
+private object MiniplayerSetIconsParentFingerprint2117 : Fingerprint(
+    filters = listOf(
+        resourceLiteral(ResourceType.DRAWABLE, "floatybar_progress_circle_autonav")
+    )
+)
+
+internal object MiniplayerSetIconsFingerprint2117 : Fingerprint(
+    classFingerprint = MiniplayerSetIconsParentFingerprint2117,
+    returnType = "V",
+    parameters = listOf("Landroid/graphics/drawable/Drawable;", "I"),
 )
 
 internal object ShowMiniplayerCommandFingerprint: Fingerprint(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/MiniplayerPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/MiniplayerPatch.kt
@@ -38,7 +38,6 @@ import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
-import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 internal const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/MiniplayerPatch;"
 
@@ -300,43 +299,42 @@ val miniplayerPatch = bytecodePatch(
 
         // region fix minimal miniplayer using the wrong pause/play bold icons.
 
-        if (is_20_31_or_greater && !is_21_17_or_greater) {
-            // 21.17+ removed the code to set the non-bold miniplayer pause/play icon,
-            // and removed the non bold yt_fill_pause_white_36 icons.
-            MiniplayerSetIconsFingerprint.method.apply {
-                findInstructionIndicesReversedOrThrow(
-                    methodCall(
-                        opcode = Opcode.INVOKE_INTERFACE,
-                        returnType = "Z",
-                        parameters = listOf()
-                    )
-                ).forEach { index ->
-                    val register = getInstruction<OneRegisterInstruction>(index + 1).registerA
+        if (is_20_31_or_greater) {
+            if (is_21_17_or_greater) {
+                // 21.17+ removed the code to set the non-bold miniplayer pause/play icon,
+                // and removed the non bold yt_fill_pause_white_36 icons.
+                MiniplayerSetIconsFingerprint.let {
+                    it.method.apply {
+                        val setImageDrawableIndex = it.instructionMatches.first().index
 
-                    addInstructions(
-                        index + 2,
-                        """
-                            invoke-static { v$register }, $EXTENSION_CLASS->allowBoldIcons(Z)Z
-                            move-result v$register
-                        """
-                    )
+                        addInstruction(
+                            setImageDrawableIndex + 1,
+                            "invoke-static { p0, p2 }, $EXTENSION_CLASS->" +
+                                    "overrideMiniplayerActionButtonDrawable(Landroid/widget/ImageView;I)V",
+                        )
+                    }
                 }
-            }
-        }
+            } else {
+                // Fix bold icons always shown for 20.31 to 21.16
+                MiniplayerSetIconsLegacyFingerprint.method.apply {
+                    findInstructionIndicesReversedOrThrow(
+                        methodCall(
+                            opcode = Opcode.INVOKE_INTERFACE,
+                            returnType = "Z",
+                            parameters = listOf()
+                        )
+                    ).forEach { index ->
+                        val register = getInstruction<OneRegisterInstruction>(index + 1).registerA
 
-        // 21.17+ uses a different code path to set the play/pause icon.
-        if (is_21_17_or_greater) {
-            MiniplayerSetIconsFingerprint2117.method.apply {
-                val setImageDrawableIndex = indexOfFirstInstructionOrThrow {
-                    opcode == Opcode.INVOKE_VIRTUAL &&
-                        getReference<MethodReference>()?.name == "setImageDrawable"
+                        addInstructions(
+                            index + 2,
+                            """
+                                invoke-static { v$register }, $EXTENSION_CLASS->allowBoldIcons(Z)Z
+                                move-result v$register
+                            """
+                        )
+                    }
                 }
-
-                addInstruction(
-                    setImageDrawableIndex + 1,
-                    "invoke-static { p0, p2 }, $EXTENSION_CLASS->" +
-                        "overrideMiniplayerActionButtonDrawable(Landroid/widget/ImageView;I)V",
-                )
             }
         }
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/MiniplayerPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/MiniplayerPatch.kt
@@ -38,6 +38,7 @@ import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 internal const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/MiniplayerPatch;"
 
@@ -320,6 +321,22 @@ val miniplayerPatch = bytecodePatch(
                         """
                     )
                 }
+            }
+        }
+
+        // 21.17+ uses a different code path to set the play/pause icon.
+        if (is_21_17_or_greater) {
+            MiniplayerSetIconsFingerprint2117.method.apply {
+                val setImageDrawableIndex = indexOfFirstInstructionOrThrow {
+                    opcode == Opcode.INVOKE_VIRTUAL &&
+                        getReference<MethodReference>()?.name == "setImageDrawable"
+                }
+
+                addInstruction(
+                    setImageDrawableIndex + 1,
+                    "invoke-static { p0, p2 }, $EXTENSION_CLASS->" +
+                        "overrideMiniplayerActionButtonDrawable(Landroid/widget/ImageView;I)V",
+                )
             }
         }
 


### PR DESCRIPTION
### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
