### PR TITLE
feat(YouTube - Save to watch later): Add option to swap Save and Queue actions

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -216,7 +216,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting RESTORE_OLD_PLAYER_BUTTONS = new BooleanSetting("morphe_restore_old_player_buttons", FALSE, true, new RestoreOldPlayerButtonsAvailability());
     public static final BooleanSetting SAVE_TO_WATCH_LATER_BUTTON = new BooleanSetting("morphe_save_to_watch_later_button", FALSE);
     public static final BooleanSetting QUEUE_RESTORE = new BooleanSetting("morphe_queue_restore", FALSE, parent(SAVE_TO_WATCH_LATER_BUTTON));
-    public static final BooleanSetting SWAP_SAVE_AND_QUEUE_ACTIONS = new BooleanSetting("morphe_swap_save_and_queue_actions", TRUE, parent(SAVE_TO_WATCH_LATER_BUTTON));
+    public static final BooleanSetting SWAP_SAVE_AND_QUEUE_ACTIONS = new BooleanSetting("morphe_swap_save_and_queue_actions", TRUE, true, parent(SAVE_TO_WATCH_LATER_BUTTON));
     public static final StringSetting QUEUE_PLAYLIST_ID = new StringSetting("morphe_queue_playlist_id", "");
     public static final BooleanSetting OPEN_CHANNEL_OF_LIVE_AVATAR = new BooleanSetting("morphe_open_channel_of_live_avatar", FALSE);
     public static final BooleanSetting VIDEO_QUALITY_DIALOG_BUTTON = new BooleanSetting("morphe_video_quality_dialog_button", FALSE, true);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -216,6 +216,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting RESTORE_OLD_PLAYER_BUTTONS = new BooleanSetting("morphe_restore_old_player_buttons", FALSE, true, new RestoreOldPlayerButtonsAvailability());
     public static final BooleanSetting SAVE_TO_WATCH_LATER_BUTTON = new BooleanSetting("morphe_save_to_watch_later_button", FALSE);
     public static final BooleanSetting QUEUE_RESTORE = new BooleanSetting("morphe_queue_restore", FALSE, parent(SAVE_TO_WATCH_LATER_BUTTON));
+    public static final BooleanSetting SWAP_SAVE_AND_QUEUE_ACTIONS = new BooleanSetting("morphe_swap_save_and_queue_actions", TRUE, parent(SAVE_TO_WATCH_LATER_BUTTON));
     public static final StringSetting QUEUE_PLAYLIST_ID = new StringSetting("morphe_queue_playlist_id", "");
     public static final BooleanSetting OPEN_CHANNEL_OF_LIVE_AVATAR = new BooleanSetting("morphe_open_channel_of_live_avatar", FALSE);
     public static final BooleanSetting VIDEO_QUALITY_DIALOG_BUTTON = new BooleanSetting("morphe_video_quality_dialog_button", FALSE, true);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LegacyPlayerControlButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LegacyPlayerControlButton.java
@@ -315,6 +315,7 @@ public class LegacyPlayerControlButton {
         View button = buttonRef.get();
         if (button instanceof ImageView imageButton) {
             imageButton.setImageResource(resourceId);
+            imageButton.setImageTintList(null);
         }
     }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/SaveToWatchLaterButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/SaveToWatchLaterButton.java
@@ -11,7 +11,11 @@ import android.view.View;
 
 import androidx.annotation.Nullable;
 
+import static app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS;
+
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.ResourceType;
+import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.youtube.patches.SaveToWatchLaterPatch;
 import app.morphe.extension.youtube.patches.VideoInformation;
 import app.morphe.extension.youtube.patches.utils.PlaylistPatch;
@@ -38,18 +42,30 @@ public class SaveToWatchLaterButton {
             // the user opens the queue menu, lastVideoIds is already populated.
             PlaylistPatch.syncIfNeeded();
 
+            boolean swap = Settings.SWAP_SAVE_AND_QUEUE_ACTIONS.get();
+
             instance = new LegacyPlayerControlButton(
                     controlsView,
                     "morphe_save_to_watch_later_button",
                     null,
-                    "morphe_save_to_watch_later_button",
+                    swap ? null : "morphe_save_to_watch_later_button",
                     Settings.SAVE_TO_WATCH_LATER_BUTTON::get,
-                    v -> SaveToWatchLaterPatch.saveVideo(),
-                    v -> {
-                        PlaylistPatch.prepareDialogBuilder(VideoInformation.getVideoId());
-                        return true;
-                    }
+                    swap
+                            ? v -> PlaylistPatch.prepareDialogBuilder(VideoInformation.getVideoId())
+                            : v -> SaveToWatchLaterPatch.saveVideo(),
+                    swap
+                            ? v -> { SaveToWatchLaterPatch.saveVideo(); return true; }
+                            : v -> { PlaylistPatch.prepareDialogBuilder(VideoInformation.getVideoId()); return true; }
             );
+
+            if (swap) {
+                int iconId = ResourceUtils.getIdentifier(ResourceType.DRAWABLE,
+                        RESTORE_OLD_PLAYER_BUTTONS
+                                ? "yt_outline_list_add_black_24"
+                                : "yt_outline_experimental_playlist_add_vd_theme_24"
+                );
+                instance.setIcon(iconId);
+            }
         } catch (Exception ex) {
             Logger.printException(() -> "initialize failure", ex);
         }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/savetowatchlater/SaveToWatchLaterButtonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/savetowatchlater/SaveToWatchLaterButtonPatch.kt
@@ -76,7 +76,8 @@ val saveToWatchLaterButtonPatch = bytecodePatch(
                 tag = "app.morphe.extension.shared.settings.preference.NoTitlePreferenceCategory",
                 preferences = setOf(
                     SwitchPreference("morphe_save_to_watch_later_button", summary = true),
-                    SwitchPreference("morphe_queue_restore", summary = true)
+                    SwitchPreference("morphe_queue_restore", summary = true),
+                    SwitchPreference("morphe_swap_save_and_queue_actions", summary = true)
                 )
             )
         )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/savetowatchlater/SaveToWatchLaterButtonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/savetowatchlater/SaveToWatchLaterButtonPatch.kt
@@ -76,8 +76,8 @@ val saveToWatchLaterButtonPatch = bytecodePatch(
                 tag = "app.morphe.extension.shared.settings.preference.NoTitlePreferenceCategory",
                 preferences = setOf(
                     SwitchPreference("morphe_save_to_watch_later_button", summary = true),
-                    SwitchPreference("morphe_queue_restore", summary = true),
-                    SwitchPreference("morphe_swap_save_and_queue_actions", summary = true)
+                    SwitchPreference("morphe_swap_save_and_queue_actions", summary = true),
+                    SwitchPreference("morphe_queue_restore", summary = true)
                 )
             )
         )

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -389,6 +389,8 @@ Info: May not work on live streams"</string>
     <string name="morphe_save_to_watch_later_error_toast">Cannot save this video in watch later playlist</string>
     <string name="morphe_queue_restore_title">Keep queue between sessions</string>
     <string name="morphe_queue_restore_summary">Queue is kept after restarting the app</string>
+    <string name="morphe_swap_save_and_queue_actions_title">Swap Save and Queue actions</string>
+    <string name="morphe_swap_save_and_queue_actions_summary">Tap for queue options, tap and hold to save to watch later</string>
     <string name="morphe_queue_manager_check_failed_auth">Not logged in</string>
     <string name="morphe_queue_manager_check_failed_playlist_id">No playlist ID</string>
     <string name="morphe_queue_manager_check_failed_queue">Queue is empty</string>


### PR DESCRIPTION
Adds a new `Swap Save and Queue actions` setting that changes the primary button action from Save to watch later to queue management, and moves Save to watch later to long press.