### PR TITLE
chore(Reddit): Split navigation bar and sidebar into dedicated settings categories

### DIFF
--- a/extensions/reddit/src/main/java/app/morphe/extension/reddit/settings/preference/BooleanSettingPreference.java
+++ b/extensions/reddit/src/main/java/app/morphe/extension/reddit/settings/preference/BooleanSettingPreference.java
@@ -6,6 +6,7 @@
  */
 package app.morphe.extension.reddit.settings.preference;
 
+import app.morphe.extension.shared.ResourceUtils;
 import static app.morphe.extension.shared.StringRef.str;
 
 import android.content.Context;
@@ -19,7 +20,10 @@ public class BooleanSettingPreference extends SwitchPreference {
     public BooleanSettingPreference(Context context, BooleanSetting setting) {
         super(context);
         this.setTitle(str(setting.key + "_title"));
-        this.setSummary(str(setting.key + "_summary"));
+        String summaryKey = setting.key + "_summary";
+        if (ResourceUtils.getStringIdentifier(summaryKey) != 0) {
+            this.setSummary(str(summaryKey));
+        }
         this.setKey(setting.key);
         this.setChecked(setting.get());
     }

--- a/extensions/reddit/src/main/java/app/morphe/extension/reddit/settings/preference/RedditPreferenceFragment.java
+++ b/extensions/reddit/src/main/java/app/morphe/extension/reddit/settings/preference/RedditPreferenceFragment.java
@@ -14,6 +14,8 @@ import android.widget.ListView;
 import app.morphe.extension.reddit.settings.preference.categories.AdsPreferenceCategory;
 import app.morphe.extension.reddit.settings.preference.categories.LayoutPreferenceCategory;
 import app.morphe.extension.reddit.settings.preference.categories.MiscellaneousPreferenceCategory;
+import app.morphe.extension.reddit.settings.preference.categories.NavigationBarPreferenceCategory;
+import app.morphe.extension.reddit.settings.preference.categories.SidebarPreferenceCategory;
 import app.morphe.extension.shared.settings.preference.AbstractPreferenceFragment;
 
 /**
@@ -31,6 +33,8 @@ public class RedditPreferenceFragment extends AbstractPreferenceFragment {
 
         // Custom categories reference app specific Settings class.
         new AdsPreferenceCategory(context, preferenceScreen);
+        new NavigationBarPreferenceCategory(context, preferenceScreen);
+        new SidebarPreferenceCategory(context, preferenceScreen);
         new LayoutPreferenceCategory(context, preferenceScreen);
         new MiscellaneousPreferenceCategory(context, preferenceScreen);
     }

--- a/extensions/reddit/src/main/java/app/morphe/extension/reddit/settings/preference/categories/LayoutPreferenceCategory.java
+++ b/extensions/reddit/src/main/java/app/morphe/extension/reddit/settings/preference/categories/LayoutPreferenceCategory.java
@@ -6,7 +6,6 @@
  */
 package app.morphe.extension.reddit.settings.preference.categories;
 
-import static app.morphe.extension.reddit.patches.VersionCheckPatch.is_2025_52_or_greater;
 import static app.morphe.extension.shared.StringRef.str;
 
 import android.content.Context;
@@ -15,9 +14,7 @@ import android.preference.PreferenceScreen;
 import app.morphe.extension.reddit.patches.DisableModernHomePatch;
 import app.morphe.extension.reddit.patches.DisableScreenshotPopupPatch;
 import app.morphe.extension.reddit.patches.HideAskButtonPatch;
-import app.morphe.extension.reddit.patches.HideNavigationButtonsPatch;
 import app.morphe.extension.reddit.patches.HideRecommendedCommunitiesShelf;
-import app.morphe.extension.reddit.patches.HideSidebarComponentsPatch;
 import app.morphe.extension.reddit.patches.HideTrendingTodayShelfPatch;
 import app.morphe.extension.reddit.patches.RemoveSubRedditDialogPatch;
 import app.morphe.extension.reddit.patches.ShowViewCountPatch;
@@ -33,10 +30,9 @@ public class LayoutPreferenceCategory extends ConditionalPreferenceCategory {
 
     @Override
     public boolean getSettingsStatus() {
-        return DisableScreenshotPopupPatch.isPatchIncluded() ||
+        return DisableModernHomePatch.isPatchIncluded() ||
+                DisableScreenshotPopupPatch.isPatchIncluded() ||
                 HideAskButtonPatch.isPatchIncluded() ||
-                HideNavigationButtonsPatch.isPatchIncluded() ||
-                HideSidebarComponentsPatch.isPatchIncluded() ||
                 HideRecommendedCommunitiesShelf.isPatchIncluded() ||
                 HideTrendingTodayShelfPatch.isPatchIncluded() ||
                 RemoveSubRedditDialogPatch.isPatchIncluded();
@@ -63,55 +59,6 @@ public class LayoutPreferenceCategory extends ConditionalPreferenceCategory {
                     context,
                     Settings.HIDE_ASK_BUTTON
             ));
-        }
-
-        if (HideNavigationButtonsPatch.isPatchIncluded()) {
-            addPreference(new BooleanSettingPreference(
-                    context,
-                    Settings.HIDE_ANSWERS_BUTTON
-            ));
-            addPreference(new BooleanSettingPreference(
-                    context,
-                    Settings.HIDE_CHAT_BUTTON
-            ));
-            addPreference(new BooleanSettingPreference(
-                    context,
-                    Settings.HIDE_CREATE_BUTTON
-            ));
-            addPreference(new BooleanSettingPreference(
-                    context,
-                    Settings.HIDE_DISCOVER_BUTTON
-            ));
-            addPreference(new BooleanSettingPreference(
-                    context,
-                    Settings.HIDE_GAMES_BUTTON
-            ));
-        }
-
-        if (HideSidebarComponentsPatch.isPatchIncluded()) {
-            addPreference(new BooleanSettingPreference(
-                    context,
-                    Settings.HIDE_RECENTLY_VISITED_SHELF
-            ));
-            addPreference(new BooleanSettingPreference(
-                    context,
-                    Settings.HIDE_GAMES_ON_REDDIT_SHELF
-            ));
-            addPreference(new BooleanSettingPreference(
-                    context,
-                    Settings.HIDE_REDDIT_PRO_SHELF
-            ));
-
-            if (is_2025_52_or_greater) {
-                addPreference(new BooleanSettingPreference(
-                        context,
-                        Settings.HIDE_ABOUT_SHELF
-                ));
-                addPreference(new BooleanSettingPreference(
-                        context,
-                        Settings.HIDE_RESOURCES_SHELF
-                ));
-            }
         }
 
         if (HideRecommendedCommunitiesShelf.isPatchIncluded()) {

--- a/extensions/reddit/src/main/java/app/morphe/extension/reddit/settings/preference/categories/NavigationBarPreferenceCategory.java
+++ b/extensions/reddit/src/main/java/app/morphe/extension/reddit/settings/preference/categories/NavigationBarPreferenceCategory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.extension.reddit.settings.preference.categories;
+
+import static app.morphe.extension.shared.StringRef.str;
+
+import android.content.Context;
+import android.preference.PreferenceScreen;
+
+import app.morphe.extension.reddit.patches.HideNavigationButtonsPatch;
+import app.morphe.extension.reddit.settings.Settings;
+import app.morphe.extension.reddit.settings.preference.BooleanSettingPreference;
+
+@SuppressWarnings("deprecation")
+public class NavigationBarPreferenceCategory extends ConditionalPreferenceCategory {
+    public NavigationBarPreferenceCategory(Context context, PreferenceScreen screen) {
+        super(context, screen);
+        setTitle(str("morphe_screen_navigation_bar_title"));
+    }
+
+    @Override
+    public boolean getSettingsStatus() {
+        return HideNavigationButtonsPatch.isPatchIncluded();
+    }
+
+    @Override
+    public void addPreferences(Context context) {
+        addPreference(new BooleanSettingPreference(
+                context,
+                Settings.HIDE_ANSWERS_BUTTON
+        ));
+        addPreference(new BooleanSettingPreference(
+                context,
+                Settings.HIDE_CHAT_BUTTON
+        ));
+        addPreference(new BooleanSettingPreference(
+                context,
+                Settings.HIDE_CREATE_BUTTON
+        ));
+        addPreference(new BooleanSettingPreference(
+                context,
+                Settings.HIDE_DISCOVER_BUTTON
+        ));
+        addPreference(new BooleanSettingPreference(
+                context,
+                Settings.HIDE_GAMES_BUTTON
+        ));
+    }
+}

--- a/extensions/reddit/src/main/java/app/morphe/extension/reddit/settings/preference/categories/SidebarPreferenceCategory.java
+++ b/extensions/reddit/src/main/java/app/morphe/extension/reddit/settings/preference/categories/SidebarPreferenceCategory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.extension.reddit.settings.preference.categories;
+
+import static app.morphe.extension.reddit.patches.VersionCheckPatch.is_2025_52_or_greater;
+import static app.morphe.extension.shared.StringRef.str;
+
+import android.content.Context;
+import android.preference.PreferenceScreen;
+
+import app.morphe.extension.reddit.patches.HideSidebarComponentsPatch;
+import app.morphe.extension.reddit.settings.Settings;
+import app.morphe.extension.reddit.settings.preference.BooleanSettingPreference;
+
+@SuppressWarnings("deprecation")
+public class SidebarPreferenceCategory extends ConditionalPreferenceCategory {
+    public SidebarPreferenceCategory(Context context, PreferenceScreen screen) {
+        super(context, screen);
+        setTitle(str("morphe_screen_sidebar_title"));
+    }
+
+    @Override
+    public boolean getSettingsStatus() {
+        return HideSidebarComponentsPatch.isPatchIncluded();
+    }
+
+    @Override
+    public void addPreferences(Context context) {
+        if (HideSidebarComponentsPatch.isPatchIncluded()) {
+            addPreference(new BooleanSettingPreference(
+                    context,
+                    Settings.HIDE_RECENTLY_VISITED_SHELF
+            ));
+            addPreference(new BooleanSettingPreference(
+                    context,
+                    Settings.HIDE_GAMES_ON_REDDIT_SHELF
+            ));
+            addPreference(new BooleanSettingPreference(
+                    context,
+                    Settings.HIDE_REDDIT_PRO_SHELF
+            ));
+
+            if (is_2025_52_or_greater) {
+                addPreference(new BooleanSettingPreference(
+                        context,
+                        Settings.HIDE_ABOUT_SHELF
+                ));
+                addPreference(new BooleanSettingPreference(
+                        context,
+                        Settings.HIDE_RESOURCES_SHELF
+                ));
+            }
+        }
+
+    }
+}

--- a/patches/src/main/resources/addresources/values/reddit/strings.xml
+++ b/patches/src/main/resources/addresources/values/reddit/strings.xml
@@ -17,37 +17,28 @@ Second \"item\" text"</string>
 <resources>
     <string name="morphe_screen_ads_title">Ads</string>
     <string name="morphe_hide_post_ads_title">Hide feed ads</string>
-    <string name="morphe_hide_post_ads_summary">Hides ads in the feed</string>
     <string name="morphe_hide_comment_ads_title">Hide comment ads</string>
-    <string name="morphe_hide_comment_ads_summary">Hides ads in the comments section</string>
+
+    <string name="morphe_screen_navigation_bar_title">Navigation bar</string>
+    <string name="morphe_hide_answers_button_title">Hide Answers button</string>
+    <string name="morphe_hide_chat_button_title">Hide Chat button</string>
+    <string name="morphe_hide_create_button_title">Hide Create button</string>
+    <string name="morphe_hide_discover_button_title">Hide Discover or Communities button</string>
+    <string name="morphe_hide_games_button_title">Hide Games button</string>
+
+    <string name="morphe_screen_sidebar_title">Sidebar</string>
+    <string name="morphe_hide_recently_visited_shelf_title">Hide Recently Visited shelf</string>
+    <string name="morphe_hide_games_on_reddit_shelf_title">Hide Games on Reddit shelf</string>
+    <string name="morphe_hide_reddit_pro_shelf_title">Hide Reddit Pro shelf</string>
+    <string name="morphe_hide_about_shelf_title">Hide About shelf</string>
+    <string name="morphe_hide_resources_shelf_title">Hide Resources shelf</string>
 
     <string name="morphe_screen_layout_title">Layout</string>
-    <string name="morphe_disable_modern_home_title">Disable modern home</string>
-    <string name="morphe_disable_modern_home_summary">Disables the modern home UI</string>
+    <string name="morphe_disable_modern_home_title">Disable modern home UI</string>
     <string name="morphe_disable_screenshot_popup_title">Disable screenshot popup</string>
     <string name="morphe_disable_screenshot_popup_summary">Disables the popup that appears when taking a screenshot</string>
     <string name="morphe_hide_ask_button_title">Hide Ask button</string>
     <string name="morphe_hide_ask_button_summary">Hides the Ask button in the search bar</string>
-    <string name="morphe_hide_answers_button_title">Hide Answers button</string>
-    <string name="morphe_hide_answers_button_summary">Hides the Answers button in the navigation bar</string>
-    <string name="morphe_hide_chat_button_title">Hide Chat button</string>
-    <string name="morphe_hide_chat_button_summary">Hides the Chat button in the navigation bar</string>
-    <string name="morphe_hide_create_button_title">Hide Create button</string>
-    <string name="morphe_hide_create_button_summary">Hides the Create button in the navigation bar</string>
-    <string name="morphe_hide_discover_button_title">Hide Discover or Communities button</string>
-    <string name="morphe_hide_discover_button_summary">Hides the Discover or Communities button in the navigation bar</string>
-    <string name="morphe_hide_games_button_title">Hide Games button</string>
-    <string name="morphe_hide_games_button_summary">Hides the Games button in the navigation bar</string>
-    <string name="morphe_hide_recently_visited_shelf_title">Hide Recently Visited shelf</string>
-    <string name="morphe_hide_recently_visited_shelf_summary">Hides the Recently Visited shelf in the sidebar</string>
-    <string name="morphe_hide_games_on_reddit_shelf_title">Hide Games on Reddit shelf</string>
-    <string name="morphe_hide_games_on_reddit_shelf_summary">Hides the Games on Reddit shelf in the sidebar</string>
-    <string name="morphe_hide_reddit_pro_shelf_title">Hide Reddit Pro shelf</string>
-    <string name="morphe_hide_reddit_pro_shelf_summary">Hides the Reddit Pro shelf in the sidebar</string>
-    <string name="morphe_hide_about_shelf_title">Hide About shelf</string>
-    <string name="morphe_hide_about_shelf_summary">Hides the About shelf in the sidebar</string>
-    <string name="morphe_hide_resources_shelf_title">Hide Resources shelf</string>
-    <string name="morphe_hide_resources_shelf_summary">Hides the Resources shelf in the sidebar</string>
     <string name="morphe_hide_recommended_communities_shelf_title">Hide recommended communities</string>
     <string name="morphe_hide_recommended_communities_shelf_summary">Hides the recommended communities shelves in subreddits</string>
     <string name="morphe_hide_trending_today_shelf_title">Hide Trending Today shelf</string>


### PR DESCRIPTION
### Description

Moves navigation button and sidebar shelf settings out of the `Layout` category into two new dedicated categories: `Navigation bar` and `Sidebar`. Removes redundant summary strings whose meaning is already conveyed by the title.

### Additional context

<details><summary>Screenshot</summary>
<p>

<img width="1080" height="2040" alt="Screenshot_20260606-164241" src="https://github.com/user-attachments/assets/1a88afa3-71ff-4db1-8984-e4dc109a6b04" />

</p>
</details> 

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
