### PR TITLE
ci: Use UTF8 file encoding for readme patch generator

### DIFF
--- a/.github/scripts/generate_patches_readme.py
+++ b/.github/scripts/generate_patches_readme.py
@@ -33,7 +33,7 @@ if "/" not in repo_full:
 owner, repo = repo_full.split("/", 1)
 
 
-with open(json_path) as f:
+with open(json_path, encoding="utf-8") as f:
     data = json.load(f)
 
 


### PR DESCRIPTION
There might be a small issue in generate_patches_readme: It relies on the process default encoding. this patch makes the file open explicit about utf-8 so it behaves the same across environments. Let me know if I’m missing context.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.