### PR TITLE
feat(YouTube - Hide layout components): Add path `&` syntax to custom filters

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/CustomFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/CustomFilter.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.youtube.patches.components;
 
 import static app.morphe.extension.shared.StringRef.str;
@@ -22,6 +32,51 @@ import app.morphe.extension.youtube.shared.ConversionContext.ContextInterface;
 
 /**
  * Allows custom filtering using a path and optionally a proto buffer string.
+ *
+ * <h5>Optional syntax operators</h5>
+ *
+ * <pre>
+ * <code>^</code> Starts with, where the path must start with a string.
+ * Must be the first operator of the custom filter.
+ *
+ * <code>&</code> Path logic and operator. Any number of additional path strings that must
+ * also appear in the path. Order of the substrings does not matter.
+ * <code>thumbnails&large</code> means the path must contain both 'thumbnails' and 'large' anywhere.
+ * Order does not matter and <code>large&thumbnails</code> is identical in function.
+ * For slight performance reasons, it's best to use the rarest path string first as it's
+ * the path component that causes the filtering callback to start.
+ *
+ * <code>#</code> Accessibility string. Any string that must appear inside the accessibility
+ * string. This is not common to use because most components do not have an accessibility string.
+ *
+ * <code>$</code> Buffer string. Any string that must appear inside the protocol buffer.
+ * Buffer strings are case-sensitive. May contain uni-code characters, spaces,
+ * and any syntax characters as the entire string is matched exactly as-is.
+ * </pre>
+ *
+ * <h5>Examples</h5>
+ * <pre>
+ * <code>video_action_bar</code>
+ * Hides the entire player action bar.
+ *
+ * <code>video_action_bar#id.video.share.button</code>
+ * Hides the player action bar share button.
+ *
+ * <code>video_action_bar#share.button</code>
+ * Functionally identical to example above, since partial pattern matches are allowed.
+ *
+ * <code>^video_lockup_with_attachment.e&thumbnail.e</code>
+ * Hides all thumbnails in feed/search, but shows thumbnails everywhere else such as Shorts,
+ * watch history, playlists, etc.
+ *
+ * <code>^video_lockup_with_attachment.e$Mr. Beast</code>
+ * Hides a feed/search video, but only if the buffer contains "Mr. Beast" anywhere
+ * (video title, video description, channel name, etc).
+ *
+ * <code>^video_lockup_with_attachment.e$- MrBeast -</code>
+ * Hides videos by the channel MrBeast (but not videos that just use MrBeast in the title),
+ * by using a channel specific string.
+ * </pre>
  */
 @SuppressWarnings("unused")
 final class CustomFilter extends Filter {
@@ -35,17 +90,22 @@ final class CustomFilter extends Filter {
          * Optional character for the path that indicates the custom filter path must match the start.
          * Must be the first character of the expression.
          */
-        public static final String SYNTAX_STARTS_WITH = "^";
+        static final String SYNTAX_STARTS_WITH = "^";
+
+        /**
+         * Optional character to indicate multiple path expressions.
+         */
+        static final String SYNTAX_PATH_AND_SYMBOL = "&";
 
         /**
          * Optional character that separates the path from an accessibility string pattern.
          */
-        public static final String SYNTAX_ACCESSIBILITY_SYMBOL = "#";
+        static final String SYNTAX_ACCESSIBILITY_SYMBOL = "#";
 
         /**
          * Optional character that separates the path/accessibility from a proto buffer string pattern.
          */
-        public static final String SYNTAX_BUFFER_SYMBOL = "$";
+        static final String SYNTAX_BUFFER_SYMBOL = "$";
 
         /**
          * @return the parsed objects
@@ -58,27 +118,31 @@ final class CustomFilter extends Filter {
                 return Collections.emptyList();
             }
 
-            // Map key is the full path including optional special characters (^, #, $),
-            // and any accessibility pattern, but does not contain any buffer patterns.
+            // Map key is the full path including optional special characters (^, #, &),
+            // any accessibility pattern, and the optional buffer symbol ($),
+            // but does not contain any buffer patterns.
             Map<String, CustomFilterGroup> result = new HashMap<>();
 
             Pattern pattern = Pattern.compile(
-                    "(" // Map key group.
+                    "^(" // Map key group.
                             // Optional starts with.
                             + "(\\Q" + SYNTAX_STARTS_WITH + "\\E?)"
                             // Path string.
-                            + "([^\\Q" + SYNTAX_ACCESSIBILITY_SYMBOL + SYNTAX_BUFFER_SYMBOL + "\\E]*)"
+                            + "([^" + Pattern.quote(SYNTAX_ACCESSIBILITY_SYMBOL + SYNTAX_BUFFER_SYMBOL) + "]*)"
                             // Optional accessibility string.
-                            + "(?:\\Q" + SYNTAX_ACCESSIBILITY_SYMBOL + "\\E([^\\Q" + SYNTAX_BUFFER_SYMBOL + "\\E]*))?"
-                            // Optional buffer string.
-                            + "(?:\\Q" + SYNTAX_BUFFER_SYMBOL + "\\E(.*))?"
-                            + ")"); // end map key group
+                            + "(?:\\Q" + SYNTAX_ACCESSIBILITY_SYMBOL + "\\E([^" + Pattern.quote(SYNTAX_BUFFER_SYMBOL) + "]*))?"
+                            // Optional buffer symbol.
+                            + "(\\Q" + SYNTAX_BUFFER_SYMBOL + "\\E?)"
+                            + ")" // end map key group
+                            // Buffer pattern.
+                            + "(.*)$"
+            );
 
             for (String expression : rawCustomFilterText.split("\n")) {
                 if (expression.isBlank()) continue;
 
                 Matcher matcher = pattern.matcher(expression);
-                if (!matcher.find()) {
+                if (!matcher.matches()) {
                     showInvalidSyntaxToast(expression);
                     continue;
                 }
@@ -87,11 +151,33 @@ final class CustomFilter extends Filter {
                 final boolean pathStartsWith = !matcher.group(2).isEmpty();
                 final String path = matcher.group(3);
                 final String accessibility = matcher.group(4); // null if not present
-                final String buffer = matcher.group(5); // null if not present
+                final boolean hasBufferSymbol = !matcher.group(5).isEmpty();
+                final String buffer = hasBufferSymbol ? matcher.group(6) : null;
 
                 if (path.isBlank()
+                        || path.contains(SYNTAX_STARTS_WITH)
                         || (accessibility != null && accessibility.isEmpty())
-                        || (buffer != null && buffer.isEmpty())) {
+                        || (hasBufferSymbol && (buffer == null || buffer.isEmpty()))) {
+                    showInvalidSyntaxToast(expression);
+                    continue;
+                }
+
+                // Split path components.
+                String[] allComponents = path.split(Pattern.quote(SYNTAX_PATH_AND_SYMBOL), -1);
+                final String firstComponent = allComponents[0];
+                final String[] extraComponents = allComponents.length > 1
+                        ? Arrays.copyOfRange(allComponents, 1, allComponents.length)
+                        : new String[0];
+
+                // Validate no component is blank (e.g. "A&&B")
+                boolean blankComponent = false;
+                for (String component : allComponents) {
+                    if (component.isBlank()) {
+                        blankComponent = true;
+                        break;
+                    }
+                }
+                if (blankComponent) {
                     showInvalidSyntaxToast(expression);
                     continue;
                 }
@@ -101,7 +187,7 @@ final class CustomFilter extends Filter {
                 // when multiple paths are used with different buffer strings.
                 CustomFilterGroup group = result.get(mapKey);
                 if (group == null) {
-                    group = new CustomFilterGroup(pathStartsWith, path);
+                    group = new CustomFilterGroup(pathStartsWith, firstComponent, extraComponents);
                     result.put(mapKey, group);
                 }
 
@@ -118,12 +204,14 @@ final class CustomFilter extends Filter {
         }
 
         final boolean startsWith;
+        final String[] extraPathComponents;
         StringTrieSearch accessibilitySearch;
         ByteTrieSearch bufferSearch;
 
-        CustomFilterGroup(boolean startsWith, String path) {
-            super(Settings.CUSTOM_FILTER, path);
+        CustomFilterGroup(boolean startsWith, String firstComponent, String[] extraPathComponents) {
+            super(Settings.CUSTOM_FILTER, firstComponent);
             this.startsWith = startsWith;
+            this.extraPathComponents = extraPathComponents;
         }
 
         void addAccessibilityString(String accessibilityString) {
@@ -153,11 +241,14 @@ final class CustomFilter extends Filter {
             builder.append("path=");
             if (startsWith) builder.append(SYNTAX_STARTS_WITH);
             builder.append(filters[0]);
+            for (String component : extraPathComponents) {
+                builder.append(SYNTAX_PATH_AND_SYMBOL);
+                builder.append(component);
+            }
 
             if (bufferSearch != null) {
                 String delimitingCharacter = "❙";
                 builder.append(", bufferStrings=");
-                builder.append(delimitingCharacter);
                 for (byte[] bufferString : bufferSearch.getPatterns()) {
                     builder.append(new String(bufferString));
                     builder.append(delimitingCharacter);
@@ -194,6 +285,13 @@ final class CustomFilter extends Filter {
         // Check path start requirement.
         if (custom.startsWith && contentIndex != 0) {
             return false;
+        }
+
+        // Check for extra path components.
+        for (String component : custom.extraPathComponents) {
+            if (!path.contains(component)) {
+                return false;
+            }
         }
 
         // Check accessibility string if specified.


### PR DESCRIPTION
### Description

Adds `&` syntax to custom filter, allowing filters that require multiple path substrings.

Order of multiple paths in the custom filter does not matter.

All other syntax can still be used, such as starts with:`^` accessibility: `#` and buffer: `$`

### Example:
Hide thumbnails for videos in the feed/search, but do not hide any other thumbnails (Shorts, playlists, watch history, etc).
`^video_lockup_with_attachment&thumbnail`

This will filter and hide a path such as:
> **video_lockup_with_attachment**.eml-fe|712e3b36e4239645|CellType|video_lockup.eml-fe|8e2fd6388863f811|ContainerType|video_lockup_**thumbnail**.eml-fe|24816d304521c4d3|ContainerType|217374632|

But will not filter paths such as the watch history:
> horizontal_shelf.eml-fe|d500efaebc8a3cdd|CellType|horizontal_shelf_content.eml-fe|e200509da66edf05|ContainerType|ContainerType|CollectionType|video_card.eml-fe|af1b5e1b4a56d243|CellType|video_card_content.eml-fe|6d452c55af67612|ContainerType|ContainerType|ContainerType|**thumbnail**.eml-fe|e05714c1b800a094|ContainerType|ContainerType|`


### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
