### PR TITLE
feat(YouTube - Hide layout components): Add "Hide 'Sync to video' button" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -961,4 +961,11 @@ public final class LayoutComponentsFilter extends Filter {
             view.setVisibility(View.GONE);
         }
     }
+
+    /**
+     * Injection point.
+     */
+    public static void hideSyncButton(View view) {
+        Utils.hideViewBy0dpUnderCondition(Settings.HIDE_SYNC_BUTTON, view);
+    }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -189,7 +189,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_SETTINGS_BUTTON = new BooleanSetting("morphe_hide_settings_button", FALSE, true);
     public static final BooleanSetting HIDE_SNACKBAR = new BooleanSetting("morphe_hide_snackbar", FALSE, true);
     public static final BooleanSetting HIDE_SUBSCRIBERS_COMMUNITY_GUIDELINES = new BooleanSetting("morphe_hide_subscribers_community_guidelines", TRUE);
-    public static final BooleanSetting HIDE_SYNC_BUTTON = new BooleanSetting("morphe_hide_sync_button", TRUE);
+    public static final BooleanSetting HIDE_SYNC_BUTTON = new BooleanSetting("morphe_hide_sync_button", FALSE, true);
     public static final BooleanSetting HIDE_TIMED_REACTIONS = new BooleanSetting("morphe_hide_timed_reactions", TRUE);
     public static final BooleanSetting HIDE_VIDEO_TITLE = new BooleanSetting("morphe_hide_video_title", FALSE);
     public static final BooleanSetting OPEN_VIDEOS_FULLSCREEN_PORTRAIT = new BooleanSetting("morphe_open_videos_fullscreen_portrait", FALSE);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -189,6 +189,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_SETTINGS_BUTTON = new BooleanSetting("morphe_hide_settings_button", FALSE, true);
     public static final BooleanSetting HIDE_SNACKBAR = new BooleanSetting("morphe_hide_snackbar", FALSE, true);
     public static final BooleanSetting HIDE_SUBSCRIBERS_COMMUNITY_GUIDELINES = new BooleanSetting("morphe_hide_subscribers_community_guidelines", TRUE);
+    public static final BooleanSetting HIDE_SYNC_BUTTON = new BooleanSetting("morphe_hide_sync_button", TRUE);
     public static final BooleanSetting HIDE_TIMED_REACTIONS = new BooleanSetting("morphe_hide_timed_reactions", TRUE);
     public static final BooleanSetting HIDE_VIDEO_TITLE = new BooleanSetting("morphe_hide_video_title", FALSE);
     public static final BooleanSetting OPEN_VIDEOS_FULLSCREEN_PORTRAIT = new BooleanSetting("morphe_open_videos_fullscreen_portrait", FALSE);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
@@ -644,3 +644,16 @@ internal object QuantumSnackbarFingerprint : Fingerprint(
         )
     )
 )
+
+internal object SyncButtonFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PROTECTED, AccessFlags.FINAL),
+    filters = listOf(
+        resourceLiteral(ResourceType.LAYOUT, "sync_button"),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            name = "inflate",
+            returnType = "Landroid/view/View;",
+        ),
+        opcode(Opcode.MOVE_RESULT_OBJECT, location = MatchAfterImmediately())
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -176,6 +176,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
             SwitchPreference("morphe_hide_medical_panels"),
             SwitchPreference("morphe_hide_snackbar"),
             SwitchPreference("morphe_hide_subscribers_community_guidelines"),
+            SwitchPreference("morphe_hide_sync_button"),
             SwitchPreference("morphe_hide_timed_reactions", summary = true),
             SwitchPreference("morphe_hide_video_title", summary = true),
         )
@@ -994,6 +995,18 @@ val hideLayoutComponentsPatch = bytecodePatch(
                     )
                 }
             }
+        }
+
+        // endregion
+
+        // region hide sync button
+
+        SyncButtonFingerprint.let {
+            it.method.injectHideViewCall(
+                it.instructionMatches.last().index,
+                LAYOUT_COMPONENTS_FILTER,
+                "hideSyncButton"
+            )
         }
 
         // endregion

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -137,6 +137,7 @@ Changes include:
     <string name="morphe_hide_medical_panels_title">Hide medical panels</string>
     <string name="morphe_hide_snackbar_title">Hide snackbar</string>
     <string name="morphe_hide_subscribers_community_guidelines_title">Hide subscribers guidelines</string>
+    <string name="morphe_hide_sync_video_title">Hide \'Sync to video\' button</string>
     <string name="morphe_hide_timed_reactions_title">Hide timed reactions</string>
     <string name="morphe_hide_timed_reactions_summary">Hides the feature that allows users to react with emojis in the comments section and live chat</string>
     <string name="morphe_hide_video_title_title">Hide video title</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -137,7 +137,7 @@ Changes include:
     <string name="morphe_hide_medical_panels_title">Hide medical panels</string>
     <string name="morphe_hide_snackbar_title">Hide snackbar</string>
     <string name="morphe_hide_subscribers_community_guidelines_title">Hide subscribers guidelines</string>
-    <string name="morphe_hide_sync_video_title">Hide \'Sync to video\' button</string>
+    <string name="morphe_hide_sync_button_title">Hide \'Sync to video\' button</string>
     <string name="morphe_hide_timed_reactions_title">Hide timed reactions</string>
     <string name="morphe_hide_timed_reactions_summary">Hides the feature that allows users to react with emojis in the comments section and live chat</string>
     <string name="morphe_hide_video_title_title">Hide video title</string>


### PR DESCRIPTION
### Description

Closes #1075.

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
