### PR TITLE
feat(YouTube - Change form factor): Add "Enable tablet layout in player" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ChangeFormFactorPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ChangeFormFactorPatch.java
@@ -10,12 +10,15 @@
 
 package app.morphe.extension.youtube.patches;
 
+import static app.morphe.extension.youtube.patches.ChangeFormFactorPatch.FormFactor.LARGE;
 import static app.morphe.extension.youtube.shared.NavigationBar.NavigationButton;
 
 import androidx.annotation.Nullable;
 
+import java.util.List;
 import java.util.Optional;
 
+import app.morphe.extension.shared.settings.Setting;
 import app.morphe.extension.youtube.settings.Settings;
 import app.morphe.extension.youtube.shared.NavigationBar;
 import app.morphe.extension.youtube.shared.PlayerType;
@@ -61,6 +64,20 @@ public class ChangeFormFactorPatch {
     @Nullable
     private static final Integer FORM_FACTOR_TYPE = FORM_FACTOR.formFactorType;
     private static final boolean IS_BROKEN_FORM_FACTOR = FORM_FACTOR.isBroken;
+    private static final boolean TABLET_LAYOUT_IN_PLAYER =
+            FORM_FACTOR != LARGE && Settings.TABLET_LAYOUT_IN_PLAYER.get();
+
+    public static final class TabletLayoutInPlayerAvailability implements Setting.Availability {
+        @Override
+        public boolean isAvailable() {
+            return Settings.CHANGE_FORM_FACTOR.get() != LARGE;
+        }
+
+        @Override
+        public List<Setting<?>> getParentSettings() {
+            return List.of(Settings.CHANGE_FORM_FACTOR);
+        }
+    }
 
     /**
      * Injection point.
@@ -84,7 +101,7 @@ public class ChangeFormFactorPatch {
                     // Do this check last since the current navigation button is required.
                     || NavigationButton.getSelectedNavigationButton() == NavigationButton.LIBRARY) {
                 // The form factor most similar to AUTOMOTIVE is LARGE, so it is replaced with LARGE.
-                return Optional.ofNullable(FormFactor.LARGE.formFactorType).orElse(original);
+                return Optional.ofNullable(LARGE.formFactorType).orElse(original);
             }
         }
 
@@ -110,12 +127,9 @@ public class ChangeFormFactorPatch {
      * the Shorts comment panel will not open.
      */
     public static int replaceBrokenFormFactor(int original) {
-        if (FORM_FACTOR_TYPE == null) {
-            return original;
-        }
-        if (IS_BROKEN_FORM_FACTOR) {
+        if (IS_BROKEN_FORM_FACTOR || TABLET_LAYOUT_IN_PLAYER) {
             // The form factor most similar to AUTOMOTIVE is LARGE, so it is replaced with LARGE.
-            return Optional.ofNullable(FormFactor.LARGE.formFactorType).orElse(original);
+            return Optional.ofNullable(LARGE.formFactorType).orElse(original);
         } else {
             return original;
         }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -48,6 +48,7 @@ import app.morphe.extension.youtube.patches.AlternativeThumbnailsPatch.StillImag
 import app.morphe.extension.youtube.patches.AlternativeThumbnailsPatch.ThumbnailOption;
 import app.morphe.extension.youtube.patches.AlternativeThumbnailsPatch.ThumbnailStillTime;
 import app.morphe.extension.youtube.patches.AutoCaptionsPatch.AutoCaptionsStyle;
+import app.morphe.extension.youtube.patches.ChangeFormFactorPatch.TabletLayoutInPlayerAvailability;
 import app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch.RestoreOldPlayerButtonsAvailability;
 import app.morphe.extension.youtube.patches.VersionCheckPatch;
 import app.morphe.extension.youtube.patches.components.LayoutComponentsFilter;
@@ -350,6 +351,7 @@ public class Settings extends SharedYouTubeSettings {
             "morphe_disable_translucent_status_bar_user_dialog_message");
     public static final BooleanSetting RESTORE_OLD_SETTINGS_MENUS = new BooleanSetting("morphe_restore_old_settings_menus", FALSE, true);
     public static final EnumSetting<FormFactor> CHANGE_FORM_FACTOR = new EnumSetting<>("morphe_change_form_factor", FormFactor.DEFAULT, true, "morphe_change_form_factor_user_dialog_message");
+    public static final BooleanSetting TABLET_LAYOUT_IN_PLAYER = new BooleanSetting("morphe_tablet_layout_in_player", FALSE, true, new TabletLayoutInPlayerAvailability());
     public static final BooleanSetting BYPASS_IMAGE_REGION_RESTRICTIONS = new BooleanSetting("morphe_bypass_image_region_restrictions", FALSE, true);
     public static final BooleanSetting GRADIENT_LOADING_SCREEN = new BooleanSetting("morphe_gradient_loading_screen", FALSE, true);
     public static final EnumSetting<SplashScreenAnimationStyle> SPLASH_SCREEN_ANIMATION_STYLE = new EnumSetting<>("morphe_splash_screen_animation_style", SplashScreenAnimationStyle.FPS_60_ONE_SECOND, true);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/formfactor/ChangeFormFactorPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/formfactor/ChangeFormFactorPatch.kt
@@ -17,6 +17,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.fieldAccess
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.shared.misc.settings.preference.ListPreference
+import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.contexthook.Endpoint
 import app.morphe.patches.youtube.misc.contexthook.addClientFormFactorHook
 import app.morphe.patches.youtube.misc.contexthook.clientContextHookPatch
@@ -47,7 +48,8 @@ val changeFormFactorPatch = bytecodePatch(
 
     execute {
         PreferenceScreen.GENERAL.addPreferences(
-            ListPreference("morphe_change_form_factor")
+            ListPreference("morphe_change_form_factor"),
+            SwitchPreference("morphe_tablet_layout_in_player", summary = true)
         )
 
         val createPlayerRequestBodyWithModelFingerprint = Fingerprint(

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1094,6 +1094,8 @@ Automotive layout
 • Remix button and Sound button are not available in Shorts
 • Shorts open in the regular player
 • Video action bar is not collapsed"</string>
+    <string name="morphe_tablet_layout_in_player_title">Enable tablet layout in player</string>
+    <string name="morphe_tablet_layout_in_player_summary">This might be useful for those who want a non-collapsed video action bar</string>
 
     <!-- layout.spoofappversion.spoofAppVersionPatch -->
     <string name="morphe_spoof_app_version_title">Spoof app version</string>


### PR DESCRIPTION
### Description

You can change to **Tablet layout** via the **Device layout** setting, but this applies everywhere, including `search results`, `YouTube settings`, `playlists`, `channels`, and `feeds`, not just the `player`.

Some people use the tablet layout simply for the **non-collapsed video action bar**, and they may not want the tablet layout to be used in `search results`, `YouTube settings`, `playlists`, `channels`, `feeds`, etc.

This PR is for these people.

The **Enable tablet layout in player** setting enables the tablet layout `only in the player`.

### Additional context

N/A

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
