### PR TITLE
fix(YouTube - Save to watch later): Handle saved playlist is no longer available

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/requests/StreamOrDetailsDataRequest.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/requests/StreamOrDetailsDataRequest.java
@@ -467,7 +467,7 @@ public class StreamOrDetailsDataRequest {
             // and never block the main thread.
             // But if debugging, then still verify this is the situation.
             if (BaseSettings.DEBUG.get() && !fetchIsDone() && Utils.isCurrentlyOnMainThread()) {
-                Logger.printException(() -> "Debug: StreamOrDetailsDataRequest blocking main thread");
+                Logger.printException(() -> "Debug: blocking main thread");
             }
             return future.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/requests/StreamOrDetailsDataRequest.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/requests/StreamOrDetailsDataRequest.java
@@ -208,9 +208,9 @@ public class StreamOrDetailsDataRequest {
                                           boolean showErrorToasts) {
         Objects.requireNonNull(clientType);
         Objects.requireNonNull(videoId);
+        Utils.verifyOffMainThread();
 
         final boolean isStream = clientType.endpoint == GET_PLAYER_STREAMING_DATA || clientType.endpoint == GET_REEL_STREAMING_DATA;
-
         final long startTime = System.currentTimeMillis();
 
         try {
@@ -467,7 +467,7 @@ public class StreamOrDetailsDataRequest {
             // and never block the main thread.
             // But if debugging, then still verify this is the situation.
             if (BaseSettings.DEBUG.get() && !fetchIsDone() && Utils.isCurrentlyOnMainThread()) {
-                Logger.printException(() -> "Debug: Blocking main thread");
+                Logger.printException(() -> "Debug: StreamOrDetailsDataRequest blocking main thread");
             }
             return future.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/requests/StreamOrDetailsDataRequest.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/requests/StreamOrDetailsDataRequest.java
@@ -467,7 +467,7 @@ public class StreamOrDetailsDataRequest {
             // and never block the main thread.
             // But if debugging, then still verify this is the situation.
             if (BaseSettings.DEBUG.get() && !fetchIsDone() && Utils.isCurrentlyOnMainThread()) {
-                Logger.printException(() -> "Debug: blocking main thread");
+                Logger.printException(() -> "Debug: Blocking main thread");
             }
             return future.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/RememberPlaybackSpeedPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/RememberPlaybackSpeedPatch.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.youtube.patches.playback.speed;
 
 import static app.morphe.extension.shared.StringRef.str;
@@ -83,7 +93,6 @@ public final class RememberPlaybackSpeedPatch {
             newVideoStarted = false;
 
             final float defaultSpeed = Settings.PLAYBACK_SPEED_DEFAULT.get();
-
             if (DISABLE_PLAYBACK_SPEED_MUSIC) {
                 if (defaultSpeed == 1.0f) {
                     return 1.0f;
@@ -91,7 +100,7 @@ public final class RememberPlaybackSpeedPatch {
 
                 String videoId = VideoInformation.getVideoId();
                 GetMixPlaylistRequest request = GetMixPlaylistRequest.getRequestForVideoId(videoId);
-                boolean isMusic = request != null && Boolean.TRUE.equals(request.getResult());
+                final boolean isMusic = request != null && Boolean.TRUE.equals(request.getResult());
                 if (isMusic) {
                     return 1.0f;
                 }
@@ -107,9 +116,13 @@ public final class RememberPlaybackSpeedPatch {
 
     public static void newVideoStarted(String videoId, boolean isShortAndOpeningOrPlaying) {
         if (DISABLE_PLAYBACK_SPEED_MUSIC && !VideoInformation.lastPlayerResponseIsShort() &&
-                !lastFetchedVideoId.equals(videoId)) {
+                !lastFetchedVideoId.equals(videoId) && Settings.PLAYBACK_SPEED_DEFAULT.get() != 1.0f) {
             lastFetchedVideoId = videoId;
-            GetMixPlaylistRequest.fetchRequestIfNeeded(videoId, Collections.emptyMap());
+            GetMixPlaylistRequest request = GetMixPlaylistRequest.fetchRequestIfNeeded(
+                    videoId, Collections.emptyMap());
+            // Must block here off the main thread until fetch is finished,
+            // because the speed override happens on main thread after playback has started.
+            request.getResult();
         }
     }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/RememberPlaybackSpeedPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/RememberPlaybackSpeedPatch.java
@@ -102,6 +102,7 @@ public final class RememberPlaybackSpeedPatch {
                 GetMixPlaylistRequest request = GetMixPlaylistRequest.getRequestForVideoId(videoId);
                 final boolean isMusic = request != null && Boolean.TRUE.equals(request.getResult());
                 if (isMusic) {
+                    Logger.printDebug(() -> "Overriding music video speed to 1.0x: " + videoId);
                     return 1.0f;
                 }
             }
@@ -114,9 +115,10 @@ public final class RememberPlaybackSpeedPatch {
         return -2.0f;
     }
 
-    public static void newVideoStarted(String videoId, boolean isShortAndOpeningOrPlaying) {
+    public static void preloadMusicVideoFetch(String videoId, boolean isShortAndOpeningOrPlaying) {
         if (DISABLE_PLAYBACK_SPEED_MUSIC && !VideoInformation.lastPlayerResponseIsShort() &&
                 !lastFetchedVideoId.equals(videoId) && Settings.PLAYBACK_SPEED_DEFAULT.get() != 1.0f) {
+            Logger.printDebug(() -> "Prefetching music video status: " + videoId);
             lastFetchedVideoId = videoId;
             GetMixPlaylistRequest request = GetMixPlaylistRequest.fetchRequestIfNeeded(
                     videoId, Collections.emptyMap());

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/PlaylistPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/PlaylistPatch.java
@@ -58,52 +58,31 @@ import kotlin.Pair;
 public class PlaylistPatch {
     private static final long DELAY_MILLISECONDS = 1500L;
 
-    private static String initPlaylistId() {
-        if (Settings.QUEUE_RESTORE.get()) {
-            return Settings.QUEUE_PLAYLIST_ID.get();
-        }
-        Settings.QUEUE_PLAYLIST_ID.save("");
-        return "";
-    }
+    private static final String checkFailedAuth = str("morphe_queue_manager_check_failed_auth");
+    private static final String checkFailedPlaylistId = str("morphe_queue_manager_check_failed_playlist_id");
+    private static final String checkFailedQueue = str("morphe_queue_manager_check_failed_queue");
+    private static final String checkFailedVideoId = str("morphe_queue_manager_check_failed_video_id");
+    private static final String checkFailedGeneric = str("morphe_queue_manager_check_failed_generic");
 
-    private static volatile String playlistId = initPlaylistId();
+    private static final String fetchFailedAdd = str("morphe_queue_manager_fetch_failed_add");
+    private static final String fetchFailedCreate = str("morphe_queue_manager_fetch_failed_create");
+    private static final String fetchFailedRemove = str("morphe_queue_manager_fetch_failed_remove");
+    private static final String fetchFailedSave = str("morphe_queue_manager_fetch_failed_save");
+
+    private static final String fetchSucceededAdd = str("morphe_queue_manager_fetch_succeeded_add");
+    private static final String fetchSucceededCreate = str("morphe_queue_manager_fetch_succeeded_create");
+    private static final String fetchSucceededRemove = str("morphe_queue_manager_fetch_succeeded_remove");
+    private static final String fetchSucceededSave = str("morphe_queue_manager_fetch_succeeded_save");
+
+    private static volatile String playlistId;
     private static volatile String videoId = "";
-    private static volatile boolean syncStarted = false;
-
-    private static String checkFailedAuth = "";
-    private static String checkFailedPlaylistId = "";
-    private static String checkFailedQueue = "";
-    private static String checkFailedVideoId = "";
-    private static String checkFailedGeneric = "Failed: %s";
-
-    private static String fetchFailedAdd = "";
-    private static String fetchFailedCreate = "";
-    private static String fetchFailedRemove = "";
-    private static String fetchFailedSave = "";
-
-    private static String fetchSucceededAdd = "";
-    private static String fetchSucceededCreate = "";
-    private static String fetchSucceededRemove = "";
-    private static String fetchSucceededSave = "%s";
+    private static volatile boolean syncStarted;
 
     static {
-        Context context = Utils.getContext();
-        if (context != null && context.getResources() != null) {
-            checkFailedAuth = str("morphe_queue_manager_check_failed_auth");
-            checkFailedPlaylistId = str("morphe_queue_manager_check_failed_playlist_id");
-            checkFailedQueue = str("morphe_queue_manager_check_failed_queue");
-            checkFailedVideoId = str("morphe_queue_manager_check_failed_video_id");
-            checkFailedGeneric = str("morphe_queue_manager_check_failed_generic");
-
-            fetchFailedAdd = str("morphe_queue_manager_fetch_failed_add");
-            fetchFailedCreate = str("morphe_queue_manager_fetch_failed_create");
-            fetchFailedRemove = str("morphe_queue_manager_fetch_failed_remove");
-            fetchFailedSave = str("morphe_queue_manager_fetch_failed_save");
-
-            fetchSucceededAdd = str("morphe_queue_manager_fetch_succeeded_add");
-            fetchSucceededCreate = str("morphe_queue_manager_fetch_succeeded_create");
-            fetchSucceededRemove = str("morphe_queue_manager_fetch_succeeded_remove");
-            fetchSucceededSave = str("morphe_queue_manager_fetch_succeeded_save");
+        if (Settings.QUEUE_RESTORE.get()) {
+            playlistId = Settings.QUEUE_PLAYLIST_ID.get();
+        } else {
+            playlistId = Settings.QUEUE_PLAYLIST_ID.resetToDefault();
         }
     }
 
@@ -227,77 +206,82 @@ public class PlaylistPatch {
     }
 
     private static void fetchQueue(Context context, boolean remove, boolean openPlaylist,
-                                   boolean openVideo, boolean reload) {
-        try {
-            String currentPlaylistId = playlistId;
-            String currentVideoId = videoId;
+                                   boolean openVideo, boolean reload, boolean retry) {
+        String currentPlaylistId = playlistId;
+        String currentVideoId = videoId;
+        Utils.runOnBackgroundThread(() -> {
             synchronized (lastVideoIds) {
                 if (currentPlaylistId.isEmpty()) {
                     CreatePlaylistRequest.fetchRequestIfNeeded(currentVideoId, getRequestHeader());
-                    runOnMainThreadDelayed(() -> {
-                        CreatePlaylistRequest request = CreatePlaylistRequest.getRequestForVideoId(currentVideoId);
-                        if (request != null) {
-                            Pair<String, String> playlistIds = request.getPlaylistId();
-                            if (playlistIds != null) {
-                                String createdPlaylistId = playlistIds.getFirst();
-                                String setVideoId = playlistIds.getSecond();
-                                if (createdPlaylistId != null && setVideoId != null) {
-                                    playlistId = createdPlaylistId;
-                                    if (Settings.QUEUE_RESTORE.get()) {
-                                        Settings.QUEUE_PLAYLIST_ID.save(createdPlaylistId);
-                                    }
-                                    lastVideoIds.putIfAbsent(currentVideoId, setVideoId);
-                                    showToast(fetchSucceededCreate);
-                                    Logger.printDebug(() -> "Queue created, playlistId: " + createdPlaylistId + ", setVideoId: " + setVideoId);
-                                    if (openPlaylist) {
-                                        openQueue(context, currentVideoId, openVideo, reload);
-                                    }
-                                    return;
+                    CreatePlaylistRequest request = CreatePlaylistRequest.getRequestForVideoId(currentVideoId);
+                    if (request != null) {
+                        Pair<String, String> playlistIds = request.getPlaylistId();
+                        if (playlistIds != null) {
+                            String createdPlaylistId = playlistIds.getFirst();
+                            String setVideoId = playlistIds.getSecond();
+                            if (createdPlaylistId != null && setVideoId != null) {
+                                playlistId = createdPlaylistId;
+                                if (Settings.QUEUE_RESTORE.get()) {
+                                    Settings.QUEUE_PLAYLIST_ID.save(createdPlaylistId);
                                 }
+                                lastVideoIds.putIfAbsent(currentVideoId, setVideoId);
+                                showToast(fetchSucceededCreate);
+                                Logger.printDebug(() -> "Queue created, playlistId: "
+                                        + createdPlaylistId + ", setVideoId: " + setVideoId);
+                                if (openPlaylist) {
+                                    openQueue(context, currentVideoId, openVideo, reload);
+                                }
+                                return;
                             }
                         }
-                        showToast(fetchFailedCreate);
-                    }, DELAY_MILLISECONDS);
+                    }
+                    showToast(fetchFailedCreate);
                 } else {
                     String setVideoId = lastVideoIds.get(currentVideoId);
-                    EditPlaylistRequest.fetchRequestIfNeeded(currentVideoId, currentPlaylistId, setVideoId, getRequestHeader());
+                    EditPlaylistRequest.fetchRequestIfNeeded(currentVideoId, currentPlaylistId,
+                            setVideoId, getRequestHeader());
+                    EditPlaylistRequest request = EditPlaylistRequest.getRequestForVideoId(currentVideoId);
+                    if (request != null) {
+                        String fetchedSetVideoId = request.getResult();
+                        Logger.printDebug(() -> "fetchedSetVideoId: " + fetchedSetVideoId);
+                        if (remove) {
+                            if ("".equals(fetchedSetVideoId)) {
+                                lastVideoIds.remove(currentVideoId, setVideoId);
+                                EditPlaylistRequest.clearVideoId(currentVideoId);
+                                showToast(fetchSucceededRemove);
+                                if (openPlaylist) {
+                                    openQueue(context, currentVideoId, openVideo, reload);
+                                }
+                                return;
+                            }
+                            showToast(fetchFailedRemove);
+                        } else {
+                            if (fetchedSetVideoId == null || fetchedSetVideoId.isEmpty()) {
+                                Logger.printDebug(() -> "Playlist not available fetchedSetVideoId: "
+                                        + fetchedSetVideoId);
+                                if (!retry) {
+                                    // Already retried, give up.
+                                    showToast(fetchFailedAdd);
+                                    return;
+                                }
+                                // Clear saved playlist and try again.
+                                playlistId = Settings.QUEUE_PLAYLIST_ID.resetToDefault();
+                                fetchQueue(context, false, openPlaylist, openVideo, reload, false);
+                                return;
+                            }
 
-                    runOnMainThreadDelayed(() -> {
-                        EditPlaylistRequest request = EditPlaylistRequest.getRequestForVideoId(currentVideoId);
-                        if (request != null) {
-                            String fetchedSetVideoId = request.getResult();
-                            Logger.printDebug(() -> "fetchedSetVideoId: " + fetchedSetVideoId);
-                            if (remove) {
-                                if ("".equals(fetchedSetVideoId)) {
-                                    lastVideoIds.remove(currentVideoId, setVideoId);
-                                    EditPlaylistRequest.clearVideoId(currentVideoId);
-                                    showToast(fetchSucceededRemove);
-                                    if (openPlaylist) {
-                                        openQueue(context, currentVideoId, openVideo, reload);
-                                    }
-                                    return;
-                                }
-                                showToast(fetchFailedRemove);
-                            } else {
-                                if (fetchedSetVideoId != null && !fetchedSetVideoId.isEmpty()) {
-                                    lastVideoIds.putIfAbsent(currentVideoId, fetchedSetVideoId);
-                                    EditPlaylistRequest.clearVideoId(currentVideoId);
-                                    showToast(fetchSucceededAdd);
-                                    Logger.printDebug(() -> "Video added, setVideoId: " + fetchedSetVideoId);
-                                    if (openPlaylist) {
-                                        openQueue(context, currentVideoId, openVideo, reload);
-                                    }
-                                    return;
-                                }
-                                showToast(fetchFailedAdd);
+                            lastVideoIds.putIfAbsent(currentVideoId, fetchedSetVideoId);
+                            EditPlaylistRequest.clearVideoId(currentVideoId);
+                            Logger.printDebug(() -> "Video added, setVideoId: " + fetchedSetVideoId);
+                            showToast(fetchSucceededAdd);
+                            if (openPlaylist) {
+                                openQueue(context, currentVideoId, openVideo, reload);
                             }
                         }
-                    }, DELAY_MILLISECONDS);
+                    }
                 }
             }
-        } catch (Exception ex) {
-            Logger.printException(() -> "fetchQueue failure", ex);
-        }
+        });
     }
 
     private static void saveToPlaylist(Context context) {
@@ -307,57 +291,55 @@ public class PlaylistPatch {
             return;
         }
         try {
-            GetPlaylistsRequest.fetchRequestIfNeeded(currentPlaylistId, getRequestHeader());
-            runOnMainThreadDelayed(() -> {
-                GetPlaylistsRequest request = GetPlaylistsRequest.getRequestForPlaylistId(currentPlaylistId);
-                if (request == null) {
-                    return;
-                }
+            GetPlaylistsRequest request = GetPlaylistsRequest.fetchRequestIfNeeded(
+                    currentPlaylistId, getRequestHeader());
+            if (request == null) {
+                return;
+            }
+            Utils.runOnBackgroundThread(() ->  {
                 Pair<String, String>[] playlists = request.getPlaylists();
-                if (playlists == null) {
-                    return;
-                }
+                Utils.runOnMainThread(() -> {
+                    SheetBottomDialog.DraggableLinearLayout mainLayout = SheetBottomDialog
+                            .createMainLayout(context, null);
+                    Map<View, Runnable> actionsMap = new LinkedHashMap<>(2 * playlists.length);
+                    int libraryIconId = QueueManager.SAVE_QUEUE.drawableId;
 
-                SheetBottomDialog.DraggableLinearLayout mainLayout = SheetBottomDialog
-                        .createMainLayout(context, null);
-                Map<View, Runnable> actionsMap = new LinkedHashMap<>(2 * playlists.length);
-                int libraryIconId = QueueManager.SAVE_QUEUE.drawableId;
+                    LinearLayout listContainer = new LinearLayout(context);
+                    listContainer.setOrientation(LinearLayout.VERTICAL);
 
-                LinearLayout listContainer = new LinearLayout(context);
-                listContainer.setOrientation(LinearLayout.VERTICAL);
-
-                for (Pair<String, String> playlist : playlists) {
-                    String listId = playlist.getFirst();
-                    String title = playlist.getSecond();
-                    Runnable action = () -> saveToPlaylist(listId, title);
-                    View itemLayout = createItemLayout(context, title, libraryIconId);
-                    actionsMap.put(itemLayout, action);
-                    listContainer.addView(itemLayout);
-                }
-
-                ScrollView scrollView = new ScrollView(context) {
-                    @Override
-                    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-                        heightMeasureSpec = MeasureSpec.makeMeasureSpec(Dim.pctHeight(50), MeasureSpec.AT_MOST);
-                        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+                    for (Pair<String, String> playlist : playlists) {
+                        String listId = playlist.getFirst();
+                        String title = playlist.getSecond();
+                        Runnable action = () -> saveToPlaylist(listId, title);
+                        View itemLayout = createItemLayout(context, title, libraryIconId);
+                        actionsMap.put(itemLayout, action);
+                        listContainer.addView(itemLayout);
                     }
-                };
-                scrollView.setVerticalScrollBarEnabled(false);
-                scrollView.addView(listContainer);
-                mainLayout.addView(scrollView);
 
-                SheetBottomDialog.SlideDialog dialog = SheetBottomDialog
-                        .createSlideDialog(context, mainLayout, 300);
-                for (Map.Entry<View, Runnable> entry : actionsMap.entrySet()) {
-                    Runnable action = entry.getValue();
-                    entry.getKey().setOnClickListener(v -> {
-                        dialog.dismiss();
-                        action.run();
-                    });
-                }
-                dialog.show();
-                GetPlaylistsRequest.clear();
-            }, DELAY_MILLISECONDS);
+                    ScrollView scrollView = new ScrollView(context) {
+                        @Override
+                        protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+                            heightMeasureSpec = MeasureSpec.makeMeasureSpec(Dim.pctHeight(50), MeasureSpec.AT_MOST);
+                            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+                        }
+                    };
+                    scrollView.setVerticalScrollBarEnabled(false);
+                    scrollView.addView(listContainer);
+                    mainLayout.addView(scrollView);
+
+                    SheetBottomDialog.SlideDialog dialog = SheetBottomDialog
+                            .createSlideDialog(context, mainLayout, 300);
+                    for (Map.Entry<View, Runnable> entry : actionsMap.entrySet()) {
+                        Runnable action = entry.getValue();
+                        entry.getKey().setOnClickListener(v -> {
+                            dialog.dismiss();
+                            action.run();
+                        });
+                    }
+                    dialog.show();
+                    GetPlaylistsRequest.clear();
+                });
+            });
         } catch (Exception ex) {
             Logger.printException(() -> "saveToPlaylist failure", ex);
         }
@@ -369,14 +351,12 @@ public class PlaylistPatch {
                 handleCheckError(checkFailedPlaylistId);
                 return;
             }
-            SavePlaylistRequest.fetchRequestIfNeeded(playlistId, libraryId, getRequestHeader());
-
-            runOnMainThreadDelayed(() -> {
-                SavePlaylistRequest request = SavePlaylistRequest.getRequestForLibraryId(libraryId);
-                if (request == null) {
-                    return;
-                }
-
+            SavePlaylistRequest request = SavePlaylistRequest.fetchRequestIfNeeded(
+                    playlistId, libraryId, getRequestHeader());
+            if (request == null) {
+                return;
+            }
+            Utils.runOnBackgroundThread(() -> {
                 Boolean result = request.getResult();
                 if (Boolean.TRUE.equals(result)) {
                     showToast(String.format(fetchSucceededSave, libraryTitle));
@@ -384,7 +364,7 @@ public class PlaylistPatch {
                     return;
                 }
                 showToast(fetchFailedSave);
-            }, DELAY_MILLISECONDS);
+            });
         } catch (Exception ex) {
             Logger.printException(() -> "saveToPlaylist failure", ex);
         }
@@ -395,35 +375,37 @@ public class PlaylistPatch {
     }
 
     private static void openQueue(Context context, String currentVideoId, boolean openVideo, boolean reload) {
-        String currentPlaylistId = playlistId;
-        if (currentPlaylistId.isEmpty()) {
-            handleCheckError(checkFailedQueue);
-            return;
-        }
-        try {
-            String url;
-            if (openVideo) {
-                if (StringUtils.isEmpty(currentVideoId)) {
-                    handleCheckError(checkFailedVideoId);
-                    return;
-                }
-                if (reload) {
-                    url = "https://youtu.be/" + VideoInformation.getVideoId()
-                            + "?list=" + currentPlaylistId;
-                } else {
-                    url = "https://youtu.be/" + currentVideoId + "?list=" + currentPlaylistId;
-                }
-            } else {
-                url = "https://www.youtube.com/playlist?list=" + currentPlaylistId;
+        Utils.runOnMainThreadNowOrLater(() -> {
+            String currentPlaylistId = playlistId;
+            if (currentPlaylistId.isEmpty()) {
+                handleCheckError(checkFailedQueue);
+                return;
             }
+            try {
+                String url;
+                if (openVideo) {
+                    if (StringUtils.isEmpty(currentVideoId)) {
+                        handleCheckError(checkFailedVideoId);
+                        return;
+                    }
+                    if (reload) {
+                        url = "https://youtu.be/" + VideoInformation.getVideoId()
+                                + "?list=" + currentPlaylistId;
+                    } else {
+                        url = "https://youtu.be/" + currentVideoId + "?list=" + currentPlaylistId;
+                    }
+                } else {
+                    url = "https://www.youtube.com/playlist?list=" + currentPlaylistId;
+                }
 
-            Intent intent = new Intent("android.intent.action.VIEW", Uri.parse(url));
-            intent.setPackage(context.getPackageName());
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            context.startActivity(intent);
-        } catch (Exception ex) {
-            Logger.printException(() -> "openQueue failure", ex);
-        }
+                Intent intent = new Intent("android.intent.action.VIEW", Uri.parse(url));
+                intent.setPackage(context.getPackageName());
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                context.startActivity(intent);
+            } catch (Exception ex) {
+                Logger.printException(() -> "openQueue failure", ex);
+            }
+        });
     }
 
     private static void handleCheckError(String reason) {
@@ -440,7 +422,7 @@ public class PlaylistPatch {
                 "yt_outline_list_add_black_24",
                 "yt_outline_experimental_playlist_add_vd_theme_24",
                 context -> {
-                    fetchQueue(context, false, false, false, false);
+                    fetchQueue(context, false, false, false, false, true);
                     return null;
                 }
         ),
@@ -449,7 +431,7 @@ public class PlaylistPatch {
                 "yt_outline_list_add_black_24",
                 "yt_outline_experimental_playlist_add_vd_theme_24",
                 context -> {
-                    fetchQueue(context, false, true, false, false);
+                    fetchQueue(context, false, true, false, false, true);
                     return null;
                 }
         ),
@@ -458,7 +440,7 @@ public class PlaylistPatch {
                 "yt_outline_list_play_arrow_black_24",
                 "yt_outline_experimental_playlist_vd_theme_24",
                 context -> {
-                    fetchQueue(context, false, true, true, false);
+                    fetchQueue(context, false, true, true, false, true);
                     return null;
                 }
         ),
@@ -467,7 +449,7 @@ public class PlaylistPatch {
                 "yt_outline_arrow_circle_black_24",
                 "yt_outline_experimental_replay_vd_theme_24",
                 context -> {
-                    fetchQueue(context, false, true, true, true);
+                    fetchQueue(context, false, true, true, true, true);
                     return null;
                 }
         ),
@@ -476,7 +458,7 @@ public class PlaylistPatch {
                 "yt_outline_trash_can_black_24",
                 "yt_outline_experimental_circle_slash_vd_theme_24",
                 context -> {
-                    fetchQueue(context, true, false, false, false);
+                    fetchQueue(context, true, false, false, false, true);
                     return null;
                 }
         ),
@@ -485,7 +467,7 @@ public class PlaylistPatch {
                 "yt_outline_trash_can_black_24",
                 "yt_outline_experimental_circle_slash_vd_theme_24",
                 context -> {
-                    fetchQueue(context, true, true, false, false);
+                    fetchQueue(context, true, true, false, false, true);
                     return null;
                 }
         ),
@@ -494,7 +476,7 @@ public class PlaylistPatch {
                 "yt_outline_arrow_circle_black_24",
                 "yt_outline_experimental_replay_vd_theme_24",
                 context -> {
-                    fetchQueue(context, true, true, true, true);
+                    fetchQueue(context, true, true, true, true, true);
                     return null;
                 }
         ),

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/PlaylistPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/PlaylistPatch.java
@@ -8,7 +8,6 @@
 package app.morphe.extension.youtube.patches.utils;
 
 import static app.morphe.extension.shared.StringRef.str;
-import static app.morphe.extension.shared.Utils.runOnMainThreadDelayed;
 import static app.morphe.extension.shared.innertube.utils.AuthUtils.getRequestHeader;
 import static app.morphe.extension.shared.innertube.utils.AuthUtils.isNotLoggedIn;
 
@@ -26,7 +25,6 @@ import android.widget.ScrollView;
 import android.widget.TextView;
 
 import androidx.annotation.GuardedBy;
-import androidx.annotation.NonNull;
 
 import org.apache.commons.collections4.BidiMap;
 import org.apache.commons.collections4.bidimap.DualHashBidiMap;
@@ -74,17 +72,11 @@ public class PlaylistPatch {
     private static final String fetchSucceededRemove = str("morphe_queue_manager_fetch_succeeded_remove");
     private static final String fetchSucceededSave = str("morphe_queue_manager_fetch_succeeded_save");
 
-    private static volatile String playlistId;
+    private static volatile String playlistId = Settings.QUEUE_RESTORE.get()
+            ? Settings.QUEUE_PLAYLIST_ID.get()
+            : Settings.QUEUE_PLAYLIST_ID.resetToDefault();
     private static volatile String videoId = "";
     private static volatile boolean syncStarted;
-
-    static {
-        if (Settings.QUEUE_RESTORE.get()) {
-            playlistId = Settings.QUEUE_PLAYLIST_ID.get();
-        } else {
-            playlistId = Settings.QUEUE_PLAYLIST_ID.resetToDefault();
-        }
-    }
 
     @GuardedBy("itself")
     private static final BidiMap<String, String> lastVideoIds = new DualHashBidiMap<>();
@@ -92,7 +84,9 @@ public class PlaylistPatch {
     /**
      * Invoked by extension.
      */
-    public static void prepareDialogBuilder(Context context, @NonNull String currentVideoId) {
+    public static void prepareDialogBuilder(Context context, String currentVideoId) {
+        Utils.verifyOnMainThread();
+
         if (isNotLoggedIn()) {
             handleCheckError(checkFailedAuth);
             return;
@@ -100,8 +94,8 @@ public class PlaylistPatch {
         if (currentVideoId.isEmpty()) {
             buildBottomSheetDialog(context, QueueManager.noVideoIdQueueEntries);
         } else {
-            videoId = currentVideoId;
             synchronized (lastVideoIds) {
+                videoId = currentVideoId;
                 QueueManager[] customActionsEntries;
                 boolean canReload = PlayerType.getCurrent().isMaximizedOrFullscreen() &&
                         lastVideoIds.get(VideoInformation.getVideoId()) != null;
@@ -166,7 +160,7 @@ public class PlaylistPatch {
             });
         }
 
-        Utils.runOnMainThread(dialog::show);
+        dialog.show();
     }
 
     @SuppressLint("ResourceType")

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/PlaylistPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/PlaylistPatch.java
@@ -54,8 +54,6 @@ import kotlin.Pair;
 
 @SuppressWarnings({"unused", "StaticFieldLeak"})
 public class PlaylistPatch {
-    private static final long DELAY_MILLISECONDS = 1500L;
-
     private static final String checkFailedAuth = str("morphe_queue_manager_check_failed_auth");
     private static final String checkFailedPlaylistId = str("morphe_queue_manager_check_failed_playlist_id");
     private static final String checkFailedQueue = str("morphe_queue_manager_check_failed_queue");

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/CreatePlaylistRequest.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/CreatePlaylistRequest.java
@@ -45,7 +45,7 @@ public class CreatePlaylistRequest {
     public Pair<String, String> getPlaylistId() {
         try {
             if (BaseSettings.DEBUG.get() && !future.isDone() && Utils.isCurrentlyOnMainThread()) {
-                Logger.printException(() -> "Debug: CreatePlaylistRequest blocking main thread");
+                Logger.printException(() -> "Debug: Blocking main thread");
             }
             return future.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/CreatePlaylistRequest.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/CreatePlaylistRequest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeoutException;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.requests.Requester;
+import app.morphe.extension.shared.settings.BaseSettings;
 import kotlin.Pair;
 
 public class CreatePlaylistRequest {
@@ -43,6 +44,9 @@ public class CreatePlaylistRequest {
     @Nullable
     public Pair<String, String> getPlaylistId() {
         try {
+            if (BaseSettings.DEBUG.get() && !future.isDone() && Utils.isCurrentlyOnMainThread()) {
+                Logger.printException(() -> "Debug: CreatePlaylistRequest blocking main thread");
+            }
             return future.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {
             Logger.printInfo(() -> "getPlaylistId timed out", ex);
@@ -81,6 +85,8 @@ public class CreatePlaylistRequest {
             Map<String, String> requestHeader
     ) {
         Objects.requireNonNull(videoId);
+        Utils.verifyOffMainThread();
+
         final long startTime = System.currentTimeMillis();
         Logger.printDebug(() -> "Fetching create playlist request for: " + videoId);
 
@@ -113,6 +119,8 @@ public class CreatePlaylistRequest {
             Map<String, String> requestHeader
     ) {
         Objects.requireNonNull(playlistId);
+        Utils.verifyOffMainThread();
+
         final long startTime = System.currentTimeMillis();
         Logger.printDebug(() -> "Fetching set video id request for: " + playlistId);
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/EditPlaylistRequest.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/EditPlaylistRequest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeoutException;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.requests.Requester;
+import app.morphe.extension.shared.settings.BaseSettings;
 
 public class EditPlaylistRequest {
     private static final int MAX_MILLISECONDS_TO_WAIT_FOR_FETCH = 20 * 1000;
@@ -47,6 +48,9 @@ public class EditPlaylistRequest {
     @Nullable
     public String getResult() {
         try {
+            if (BaseSettings.DEBUG.get() && !future.isDone() && Utils.isCurrentlyOnMainThread()) {
+                Logger.printException(() -> "Debug: EditPlaylistRequest blocking main thread");
+            }
             return future.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {
             Logger.printInfo(() -> "getResult timed out", ex);
@@ -96,6 +100,8 @@ public class EditPlaylistRequest {
             Map<String, String> requestHeader
     ) {
         Objects.requireNonNull(videoId);
+        Utils.verifyOffMainThread();
+
         final long startTime = System.currentTimeMillis();
         Logger.printDebug(() -> "Fetching edit playlist request, videoId: " + videoId +
                 ", playlistId: " + playlistId + ", setVideoId: " + setVideoId);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/EditPlaylistRequest.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/EditPlaylistRequest.java
@@ -49,7 +49,7 @@ public class EditPlaylistRequest {
     public String getResult() {
         try {
             if (BaseSettings.DEBUG.get() && !future.isDone() && Utils.isCurrentlyOnMainThread()) {
-                Logger.printException(() -> "Debug: EditPlaylistRequest blocking main thread");
+                Logger.printException(() -> "Debug: Blocking main thread");
             }
             return future.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/GetMixPlaylistRequest.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/GetMixPlaylistRequest.java
@@ -28,27 +28,43 @@ import app.morphe.extension.shared.requests.Requester;
 import app.morphe.extension.shared.settings.BaseSettings;
 
 public class GetMixPlaylistRequest {
-    private static final long MAX_MILLISECONDS_TO_WAIT_FOR_FETCH = 20 * 1000; // 20 seconds
+    /**
+     * Maximum amount of time to block the UI from updates while waiting for network call to complete.
+     *
+     * Must be less than 5 seconds, as per:
+     * https://developer.android.com/topic/performance/vitals/anr
+     */
+    private static final long MAX_MILLISECONDS_TO_BLOCK_UI_WAITING_FOR_FETCH = 4500;
+
+    private static final long MAX_MILLISECONDS_TO_WAIT_FOR_FETCH = 10 * 1000; // 10 seconds
 
     private static final Map<String, GetMixPlaylistRequest> cache =
             Utils.createSizeRestrictedMap(30);
 
+    public final String videoId;
     private final Future<Boolean> future;
 
     private GetMixPlaylistRequest(String videoId, Map<String, String> requestHeader) {
+        this.videoId = videoId;
         this.future = Utils.submitOnBackgroundThread(() -> fetch(videoId, requestHeader));
     }
 
     public Boolean getResult() {
         try {
-            if (BaseSettings.DEBUG.get() && !future.isDone() && Utils.isCurrentlyOnMainThread()) {
-                Logger.printException(() -> "Debug: GetMixPlaylistRequest blocking main thread");
+            // Speed override can be called concurrently while prefetch is still running.
+            // If on main thread then must use shorter max wait otherwise Android can show ANR warning.
+            final long maxWaitTime = Utils.isCurrentlyOnMainThread()
+                    ? MAX_MILLISECONDS_TO_BLOCK_UI_WAITING_FOR_FETCH
+                    : MAX_MILLISECONDS_TO_WAIT_FOR_FETCH;
+            if (BaseSettings.DEBUG.get() && !future.isDone()) {
+                Logger.printDebug(() -> "Waiting until fetch is complete: " + videoId
+                        + " maxWait: " + maxWaitTime);
             }
-            return future.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
+            return future.get(maxWaitTime, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {
-            Logger.printInfo(() -> "getResult timed out", ex);
+            Logger.printInfo(() -> "getResult timed out: " + videoId, ex);
         } catch (InterruptedException ex) {
-            Logger.printException(() -> "getResult interrupted", ex);
+            Logger.printException(() -> "getResult interrupted: " + videoId, ex);
             Thread.currentThread().interrupt();
         } catch (ExecutionException ex) {
             Logger.printException(() -> "getResult failure", ex);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/GetMixPlaylistRequest.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/GetMixPlaylistRequest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeoutException;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.requests.Requester;
+import app.morphe.extension.shared.settings.BaseSettings;
 
 public class GetMixPlaylistRequest {
     private static final long MAX_MILLISECONDS_TO_WAIT_FOR_FETCH = 20 * 1000; // 20 seconds
@@ -40,6 +41,9 @@ public class GetMixPlaylistRequest {
 
     public Boolean getResult() {
         try {
+            if (BaseSettings.DEBUG.get() && !future.isDone() && Utils.isCurrentlyOnMainThread()) {
+                Logger.printException(() -> "Debug: GetMixPlaylistRequest blocking main thread");
+            }
             return future.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {
             Logger.printInfo(() -> "getResult timed out", ex);
@@ -53,11 +57,12 @@ public class GetMixPlaylistRequest {
         return null;
     }
 
-    public static void fetchRequestIfNeeded(String videoId, Map<String, String> requestHeader) {
+    public static GetMixPlaylistRequest fetchRequestIfNeeded(String videoId, Map<String, String> requestHeader) {
         cache.computeIfAbsent(
                 Objects.requireNonNull(videoId),
                 k -> new GetMixPlaylistRequest(videoId, requestHeader)
         );
+        return cache.get(videoId);
     }
 
     @Nullable
@@ -72,6 +77,7 @@ public class GetMixPlaylistRequest {
     @Nullable
     private static JSONObject sendRequest(String videoId, Map<String, String> requestHeader) {
         Objects.requireNonNull(videoId);
+        Utils.verifyOffMainThread();
 
         final long startTime = System.currentTimeMillis();
         Logger.printDebug(() -> "Fetching get mix playlist, videoId: " + videoId);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/GetPlaylistItemsRequest.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/GetPlaylistItemsRequest.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.requests.Requester;
 
 public class GetPlaylistItemsRequest {
@@ -29,6 +30,7 @@ public class GetPlaylistItemsRequest {
 
     @Nullable
     public static Map<String, String> fetch(String playlistId, Map<String, String> requestHeader) {
+        Utils.verifyOffMainThread();
         final long startTime = System.currentTimeMillis();
         Logger.printDebug(() -> "Fetching playlist items for: " + playlistId);
 
@@ -78,6 +80,10 @@ public class GetPlaylistItemsRequest {
     @Nullable
     private static Map<String, String> parseResponse(JSONObject json) {
         try {
+            if (!json.has("contents")) {
+                Logger.printDebug(() -> "JSON contents are missing, cannot parse response");
+                return null;
+            }
             JSONObject contents = json.getJSONObject("contents");
             JSONObject columnRenderer = contents.optJSONObject("singleColumnBrowseResultsRenderer");
             if (columnRenderer == null) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/GetPlaylistsRequest.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/GetPlaylistsRequest.java
@@ -48,7 +48,7 @@ public class GetPlaylistsRequest {
     public Pair<String, String>[] getPlaylists() {
         try {
             if (BaseSettings.DEBUG.get() && !future.isDone() && Utils.isCurrentlyOnMainThread()) {
-                Logger.printException(() -> "Debug: GetPlaylistsRequest blocking main thread");
+                Logger.printException(() -> "Debug: Blocking main thread");
             }
             return future.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/GetPlaylistsRequest.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/GetPlaylistsRequest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeoutException;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.requests.Requester;
+import app.morphe.extension.shared.settings.BaseSettings;
 import kotlin.Pair;
 
 public class GetPlaylistsRequest {
@@ -46,6 +47,9 @@ public class GetPlaylistsRequest {
     @Nullable
     public Pair<String, String>[] getPlaylists() {
         try {
+            if (BaseSettings.DEBUG.get() && !future.isDone() && Utils.isCurrentlyOnMainThread()) {
+                Logger.printException(() -> "Debug: GetPlaylistsRequest blocking main thread");
+            }
             return future.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {
             Logger.printInfo(() -> "getPlaylists timed out", ex);
@@ -62,11 +66,12 @@ public class GetPlaylistsRequest {
         cache.clear();
     }
 
-    public static void fetchRequestIfNeeded(String playlistId, Map<String, String> requestHeader) {
+    public static GetPlaylistsRequest fetchRequestIfNeeded(String playlistId, Map<String, String> requestHeader) {
         cache.computeIfAbsent(
                 Objects.requireNonNull(playlistId),
                 k -> new GetPlaylistsRequest(playlistId, requestHeader)
         );
+        return cache.get(playlistId);
     }
 
     @Nullable
@@ -81,6 +86,8 @@ public class GetPlaylistsRequest {
     @Nullable
     private static JSONObject sendRequest(String playlistId, Map<String, String> requestHeader) {
         Objects.requireNonNull(playlistId);
+        Utils.verifyOffMainThread();
+
         final long startTime = System.currentTimeMillis();
         Logger.printDebug(() -> "Fetching get playlists request, playlistId: " + playlistId);
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/SavePlaylistRequest.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/SavePlaylistRequest.java
@@ -44,7 +44,7 @@ public class SavePlaylistRequest {
     public Boolean getResult() {
         try {
             if (BaseSettings.DEBUG.get() && !future.isDone() && Utils.isCurrentlyOnMainThread()) {
-                Logger.printException(() -> "Debug: SavePlaylistRequest blocking main thread");
+                Logger.printException(() -> "Debug: Blocking main thread");
             }
             return future.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/SavePlaylistRequest.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/SavePlaylistRequest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeoutException;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.requests.Requester;
+import app.morphe.extension.shared.settings.BaseSettings;
 
 public class SavePlaylistRequest {
     private static final int MAX_MILLISECONDS_TO_WAIT_FOR_FETCH = 20 * 1000;
@@ -42,6 +43,9 @@ public class SavePlaylistRequest {
     @Nullable
     public Boolean getResult() {
         try {
+            if (BaseSettings.DEBUG.get() && !future.isDone() && Utils.isCurrentlyOnMainThread()) {
+                Logger.printException(() -> "Debug: SavePlaylistRequest blocking main thread");
+            }
             return future.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {
             Logger.printInfo(() -> "getResult timed out", ex);
@@ -58,13 +62,13 @@ public class SavePlaylistRequest {
         cache.clear();
     }
 
-    public static void fetchRequestIfNeeded(
+    public static SavePlaylistRequest fetchRequestIfNeeded(
             String playlistId,
             String libraryId,
             Map<String, String> requestHeader
     ) {
         Objects.requireNonNull(playlistId);
-        cache.put(libraryId, new SavePlaylistRequest(playlistId, libraryId, requestHeader));
+        return cache.put(libraryId, new SavePlaylistRequest(playlistId, libraryId, requestHeader));
     }
 
     @Nullable

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/AddBrandLicensePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/AddBrandLicensePatch.kt
@@ -25,7 +25,15 @@ internal val addLicensePatch = rawResourcePatch {
             // Check if target file exists and give a more informative error
             // because Files.copy throws an exception if the file already exists.
             if (Files.exists(targetFile)) {
-                throw PatchException("App is already modified with Morphe patches ($targetFile already exists)")
+                throw PatchException(
+                    "\n\n\n" +
+                            "!!!\n" +
+                            "!!!\n" +
+                            "!!! Provided APK is already modified with Morphe patches\n" +
+                            "!!! (File already exists in target app: $sourceFileName)\n" +
+                            "!!!\n" +
+                            "!!!\n\n"
+                )
             }
 
             Files.copy(inputFileStream, targetFile)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/remember/RememberPlaybackSpeedPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/remember/RememberPlaybackSpeedPatch.kt
@@ -66,7 +66,7 @@ internal val rememberPlaybackSpeedPatch = bytecodePatch {
             "userSelectedPlaybackSpeed",
         )
 
-        hookPlayerResponseVideoId("$EXTENSION_CLASS->newVideoStarted(Ljava/lang/String;Z)V")
+        hookPlayerResponseVideoId("$EXTENSION_CLASS->preloadMusicVideoFetch(Ljava/lang/String;Z)V")
 
         /*
          * Hook the code that is called when the playback speeds are initialized, and sets the playback speed


### PR DESCRIPTION
### Description

Fixes add to queue error if "Keep queue between sessions" is enabled, but the original playlist is no longer available.

Also fixes some network calls that may block the main thread.

Closes #1697

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
