### PR TITLE
fix(YouTube - Override YouTube Music buttons): Target app opens when clicking on 'YouTube Music' button inside explore menu

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/OverrideYouTubeMusicButtonsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/OverrideYouTubeMusicButtonsPatch.java
@@ -7,6 +7,7 @@
 
 package app.morphe.extension.youtube.patches;
 
+import android.content.ComponentName;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
@@ -59,8 +60,12 @@ public class OverrideYouTubeMusicButtonsPatch {
             return intent.setData(uri);
         }
 
+        if (intent.getBooleanExtra(HIJACK_FLAG, false)) {
+            return intent;
+        }
+
         String uriString = uri.toString();
-        if (uriString.contains(YOUTUBE_MUSIC_PACKAGE_NAME)) {
+        if (uriString.contains(YOUTUBE_MUSIC_PACKAGE_NAME) || uriString.contains("music.youtube.com")) {
 
             String target = Settings.MORPHE_MUSIC_PACKAGE_NAME.get().trim();
             if (Utils.isNotEmpty(target) && isAppInstalled(target)) {
@@ -70,13 +75,18 @@ public class OverrideYouTubeMusicButtonsPatch {
                     musicUri = uri;
                 }
 
-                intent.setAction(Intent.ACTION_VIEW);
-                intent.setData(musicUri);
-                intent.setPackage(target);
-                intent.setComponent(null);
-                intent.putExtra(HIJACK_FLAG, true);
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                return intent;
+                PackageManager pm = Utils.getContext().getPackageManager();
+                Intent launchIntent = pm.getLaunchIntentForPackage(target);
+
+                if (launchIntent != null) {
+                    intent.setAction(launchIntent.getAction());
+                    intent.setData(musicUri);
+                    intent.setPackage(target);
+                    intent.setComponent(launchIntent.getComponent());
+                    intent.putExtra(HIJACK_FLAG, true);
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    return intent;
+                }
             }
 
             intent.setData(Uri.parse("https://music.youtube.com/"));
@@ -86,6 +96,20 @@ public class OverrideYouTubeMusicButtonsPatch {
         }
 
         return intent.setData(uri);
+    }
+
+    public static Intent overrideSetComponent(Intent intent, ComponentName component) {
+        if (intent == null) return null;
+
+        if (!Settings.OVERRIDE_YOUTUBE_MUSIC_BUTTONS.get()) {
+            return intent.setComponent(component);
+        }
+
+        if (intent.getBooleanExtra(HIJACK_FLAG, false)) {
+            return intent;
+        }
+
+        return intent.setComponent(component);
     }
 
     private static boolean isAppInstalled(String packageName) {

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/music/OverrideYouTubeMusicButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/music/OverrideYouTubeMusicButtonsPatch.kt
@@ -75,7 +75,7 @@ val overrideYouTubeMusicButtonsPatch = bytecodePatch(
                                 (it as? ReferenceInstruction)?.reference?.let { ref ->
                                     val mRef = ref as? MethodReference
                                     mRef?.definingClass == "Landroid/content/Intent;" &&
-                                            (mRef.name == "setPackage" || mRef.name == "setData")
+                                            (mRef.name == "setPackage" || mRef.name == "setData" || mRef.name == "setComponent")
                                 } == true
                     } == true) {
                     needsPatch = true
@@ -94,6 +94,8 @@ val overrideYouTubeMusicButtonsPatch = bytecodePatch(
                                     index to "overrideSetPackage(Landroid/content/Intent;Ljava/lang/String;)Landroid/content/Intent;"
                                 } else if (ref.name == "setData" && ref.parameterTypes == listOf("Landroid/net/Uri;")) {
                                     index to "overrideSetData(Landroid/content/Intent;Landroid/net/Uri;)Landroid/content/Intent;"
+                                } else if (ref.name == "setComponent" && ref.parameterTypes == listOf("Landroid/content/ComponentName;")) {
+                                    index to "overrideSetComponent(Landroid/content/Intent;Landroid/content/ComponentName;)Landroid/content/Intent;"
                                 } else null
                             } else null
                         } else null


### PR DESCRIPTION
### Description

N/A

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
