### PR TITLE
fix(YouTube - Bypass link redirects): Resolve patch not working on community posts and video descriptions

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/BypassLinkRedirectsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/BypassLinkRedirectsPatch.java
@@ -9,7 +9,6 @@ import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
 public class BypassLinkRedirectsPatch {
-    private static final String YOUTUBE_REDIRECT_PATH = "/redirect";
 
     /**
      * Convert the YouTube redirect URI string to the redirect query URI.
@@ -17,17 +16,12 @@ public class BypassLinkRedirectsPatch {
      * @param uri The YouTube redirect URI string.
      * @return The redirect query URI.
      */
-    public static Uri parseRedirectUri(String uri) {
-        final var parsed = Uri.parse(uri);
-
-        if (Settings.BYPASS_LINK_REDIRECTS.get() && Objects.equals(parsed.getPath(), YOUTUBE_REDIRECT_PATH)) {
-            var query = Uri.parse(Uri.decode(parsed.getQueryParameter("q")));
-
+    public static Uri parseRedirectUri(Uri uri) {
+        if (Settings.BYPASS_LINK_REDIRECTS.get() && Objects.equals(uri.getPath(), "/redirect")) {
+            var query = Uri.parse(Uri.decode(uri.getQueryParameter("q")));
             Logger.printDebug(() -> "Bypassing YouTube redirect URI: " + query);
-
             return query;
         }
-
-        return parsed;
+        return uri;
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/links/BypassLinkRedirectsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/links/BypassLinkRedirectsPatch.kt
@@ -1,16 +1,20 @@
 package app.morphe.patches.youtube.misc.links
 
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
-import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.methodCall
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.string
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
-import app.morphe.patches.youtube.misc.playservice.is_20_37_or_greater
-import app.morphe.patches.youtube.misc.playservice.is_20_49_or_greater
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction35c
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/BypassLinkRedirectsPatch;"
 
@@ -31,31 +35,55 @@ val bypassLinkRedirectsPatch = bytecodePatch(
             SwitchPreference("morphe_bypass_link_redirects", summary = true),
         )
 
-        arrayOf(
-            HttpUriParserFingerprint to 0,
-
-            if (is_20_49_or_greater) {
-                // Code has moved, and now seems to be an account link
-                // and may not be anything to do with sharing links.
-                null to -1
-            } else if (is_20_37_or_greater) {
-                AbUriParserFingerprint to 2
-            } else {
-                AbUriParserLegacyFingerprint to 2
-            }
-        ).forEach { (fingerprint, index) ->
-            if (fingerprint == null) return@forEach
-
-            fingerprint.method.apply {
-                val insertIndex = fingerprint.instructionMatches[index].index
-                val uriStringRegister = getInstruction<FiveRegisterInstruction>(insertIndex).registerC
-
-                replaceInstruction(
-                    insertIndex,
-                    "invoke-static { v$uriStringRegister }, $EXTENSION_CLASS->" +
-                            "parseRedirectUri(Ljava/lang/String;)Landroid/net/Uri;",
-                )
-            }
+        fun patchLogic(instructionRegister: String): String {
+            return """
+                invoke-static { $instructionRegister }, $EXTENSION_CLASS->parseRedirectUri(Landroid/net/Uri;)Landroid/net/Uri;
+                move-result-object $instructionRegister
+            """
         }
+
+        // Override URI for video comments
+        Fingerprint(
+            accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+            parameters = listOf("L", "Ljava/util/Map;"),
+            returnType = "V",
+            strings = listOf(
+                "parentCsn",
+                "URL_KEY",
+                "navigation_endpoint",
+                "WEB_VIEW_BOTTOM_SHEET_TAG",
+            ),
+            filters = listOf(
+                string("android.intent.action.VIEW"),
+                methodCall(
+                    opcode = Opcode.INVOKE_DIRECT,
+                    smali = "Landroid/content/Intent;-><init>(Ljava/lang/String;Landroid/net/Uri;)V",
+                    location = InstructionLocation.MatchAfterImmediately(),
+                ),
+            )
+        ).apply {
+            val instructionIndex = instructionMatches.last().index
+            val instructionRegister = method.getInstruction<BuilderInstruction35c>(instructionIndex).registerE
+
+            method.addInstructions(
+                instructionIndex,
+                patchLogic("v$instructionRegister"),
+            )
+        }
+
+        // Override URI for video descriptions and community posts
+        Fingerprint(
+            accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
+            parameters = listOf("Landroid/content/Context;", "Landroid/net/Uri;"),
+            returnType = "Z",
+            strings = listOf(
+                "android.intent.action.VIEW",
+                "text/html",
+                "Activity not found to view uri",
+            ),
+        ).method.addInstructions(
+            0,
+            patchLogic("p1"),
+        )
     }
 }


### PR DESCRIPTION
Working on 20.21.xx, 20.51.xx and 21.xx.xx

Closes: https://github.com/MorpheApp/morphe-patches/issues/1631