### PR TITLE
feat(YouTube - Hide layout components): Add "Hide comments by keywords" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/KeywordContentFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/KeywordContentFilter.java
@@ -148,6 +148,11 @@ final class KeywordContentFilter extends Filter {
             "video_card.e" // Shorts that appear in a horizontal shelf.
     );
 
+    private final StringFilterGroup commentsFilter = new StringFilterGroup(
+            Settings.HIDE_KEYWORD_CONTENT_COMMENTS,
+                "comment_thread.eml"
+    );
+
     /**
      * Path components to not filter.  Cannot filter the buffer when these are present,
      * otherwise text in UI controls can be filtered as a keyword (such as using "Playlist" as a keyword).
@@ -532,7 +537,7 @@ final class KeywordContentFilter extends Filter {
 
     public KeywordContentFilter() {
         // Keywords are parsed on first call to isFiltered()
-        addPathCallbacks(startsWithFilter, containsFilter);
+        addPathCallbacks(startsWithFilter, containsFilter, commentsFilter);
     }
 
     private boolean hideKeywordSettingIsActive() {
@@ -618,7 +623,7 @@ final class KeywordContentFilter extends Filter {
             parseKeywords();
         }
 
-        if (!hideKeywordSettingIsActive()) return false;
+        if (matchedGroup != commentsFilter && !hideKeywordSettingIsActive()) return false;
 
         if (exceptions.matches(path)) {
             return false; // Do not update statistics.

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -147,8 +147,9 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_KEYWORD_CONTENT_HOME = new BooleanSetting("morphe_hide_keyword_content_home", FALSE);
     public static final BooleanSetting HIDE_KEYWORD_CONTENT_SUBSCRIPTIONS = new BooleanSetting("morphe_hide_keyword_content_subscriptions", FALSE);
     public static final BooleanSetting HIDE_KEYWORD_CONTENT_SEARCH = new BooleanSetting("morphe_hide_keyword_content_search", FALSE);
+    public static final BooleanSetting HIDE_KEYWORD_CONTENT_COMMENTS = new BooleanSetting("morphe_hide_keyword_content_comments", FALSE);
     public static final StringSetting HIDE_KEYWORD_CONTENT_PHRASES = new StringSetting("morphe_hide_keyword_content_phrases", "",
-            parentsAny(HIDE_KEYWORD_CONTENT_HOME, HIDE_KEYWORD_CONTENT_SUBSCRIPTIONS, HIDE_KEYWORD_CONTENT_SEARCH));
+            parentsAny(HIDE_KEYWORD_CONTENT_HOME, HIDE_KEYWORD_CONTENT_SUBSCRIPTIONS, HIDE_KEYWORD_CONTENT_COMMENTS, HIDE_KEYWORD_CONTENT_SEARCH));
 
     // Channel page
     public static final BooleanSetting HIDE_CHANNEL_TAB = new BooleanSetting("morphe_hide_channel_tab", FALSE);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -184,6 +184,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
                     SwitchPreference("morphe_hide_keyword_content_home"),
                     SwitchPreference("morphe_hide_keyword_content_subscriptions"),
                     SwitchPreference("morphe_hide_keyword_content_search"),
+                    SwitchPreference("morphe_hide_keyword_content_comments"),
                     TextPreference("morphe_hide_keyword_content_phrases", inputType = InputType.TEXT_MULTI_LINE),
                     NonInteractivePreference(
                         key = "morphe_hide_keyword_content_about",

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -245,7 +245,7 @@ Changes include:
     <string name="morphe_hide_keyword_content_home_title">Hide Home videos by keywords</string>
     <string name="morphe_hide_keyword_content_search_title">Hide search results by keywords</string>
     <string name="morphe_hide_keyword_content_subscriptions_title">Hide Subscriptions videos by keywords</string>
-    <string name="morphe_hide_keyword_content_comments_title">Hide video comments by keywords</string>
+    <string name="morphe_hide_keyword_content_comments_title">Hide comments by keywords</string>
     <string name="morphe_hide_keyword_content_phrases_title">Keywords to hide</string>
     <!-- For localization, it is preferred, but not required, if 'LeBlanc' is replaced with a localized name or a familiar word that has upper case letters in the middle of the word.
          This is because keywords can be in any language, and showing an example in the localized script helps convey this. -->
@@ -255,7 +255,7 @@ Keywords can be any text shown in video titles or channel names
 
 Words with uppercase letters in the middle must match exactly (ie: iPhone, TikTok, LeBlanc)"</string>
     <string name="morphe_hide_keyword_content_about_title">About keyword filtering</string>
-    <string name="morphe_hide_keyword_content_about_summary">"Home / Subscriptions / Search results are filtered to hide content that matches keyword phrases
+    <string name="morphe_hide_keyword_content_about_summary">"Home / Subscriptions / Search / Comments are filtered to hide content that matches keyword phrases
 
 Limitations:
 • Shorts cannot be hidden by channel name

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -245,6 +245,7 @@ Changes include:
     <string name="morphe_hide_keyword_content_home_title">Hide Home videos by keywords</string>
     <string name="morphe_hide_keyword_content_search_title">Hide search results by keywords</string>
     <string name="morphe_hide_keyword_content_subscriptions_title">Hide Subscriptions videos by keywords</string>
+    <string name="morphe_hide_keyword_content_comments_title">Hide video comments by keywords</string>
     <string name="morphe_hide_keyword_content_phrases_title">Keywords to hide</string>
     <!-- For localization, it is preferred, but not required, if 'LeBlanc' is replaced with a localized name or a familiar word that has upper case letters in the middle of the word.
          This is because keywords can be in any language, and showing an example in the localized script helps convey this. -->


### PR DESCRIPTION
Adds a comment filter setting to keyword content filter.

### Description

Closes #1758

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
