### PR TITLE
refactor(Spoof video streams): Override spoof header flags only if required

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
@@ -21,7 +21,6 @@ import app.morphe.extension.shared.spoof.requests.StreamOrDetailsDataRequest;
 
 @SuppressWarnings("unused")
 public class SpoofVideoStreamsPatch {
-    public static volatile Map<String, String> currentVideoRequestHeader;
 
     public static final class JavaScriptClientAvailability implements Setting.Availability {
         @Override
@@ -68,12 +67,23 @@ public class SpoofVideoStreamsPatch {
 
     private static final boolean SPOOF_VIDEO_STREAMS = SharedYouTubeSettings.SPOOF_VIDEO_STREAMS.get();
 
+    public static volatile Map<String, String> currentVideoRequestHeader;
+
+    public static boolean overrideSpoofStreamFlagsForHeaders = SPOOF_VIDEO_STREAMS;
+
     @Nullable
     private static volatile AppLanguage languageOverride;
 
     private static volatile ClientType preferredClient = ClientType.ANDROID_REEL_AUTH;
 
     private static WeakReference<Application> mainActivityRef = new WeakReference<>(null);
+
+    public static void setOverrideSpoofStreamFlagsForHeaders() {
+        if (!overrideSpoofStreamFlagsForHeaders) {
+            Logger.printDebug(() -> "Forcing override of spoof stream flags with spoofing off");
+            overrideSpoofStreamFlagsForHeaders = true;
+        }
+    }
 
     /**
      * Injection point.
@@ -245,14 +255,16 @@ public class SpoofVideoStreamsPatch {
     /**
      * Injection point.
      * Turns off a feature flag that interferes with spoofing.
-     * Note: Always keep this enabled to allow other patches to work properly.
      */
     public static boolean useMediaFetchHotConfigReplacement(boolean original) {
         if (original) {
             Logger.printDebug(() -> "useMediaFetchHotConfigReplacement is set on");
         }
 
-        return false;
+        if (overrideSpoofStreamFlagsForHeaders) {
+            return false;
+        }
+        return original;
     }
 
     /**
@@ -288,14 +300,16 @@ public class SpoofVideoStreamsPatch {
     /**
      * Injection point.
      * Turns off a feature flag that interferes with video playback.
-     * Note: Always keep this enabled to allow other patches to work properly.
      */
     public static boolean useMediaSessionFeatureFlag(boolean original) {
         if (original) {
             Logger.printDebug(() -> "useMediaSessionFeatureFlag is set on");
         }
 
-        return false;
+        if (overrideSpoofStreamFlagsForHeaders) {
+            return false;
+        }
+        return original;
     }
 
     /**
@@ -328,7 +342,7 @@ public class SpoofVideoStreamsPatch {
                     return;
                 }
 
-                StreamOrDetailsDataRequest.fetchStreamRequest(id, currentVideoRequestHeader);
+                StreamOrDetailsDataRequest.fetchStreamRequest(id, requestHeaders);
             } catch (Exception ex) {
                 Logger.printException(() -> "buildRequest failure", ex);
             }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/RestoreOldVideoActionBarPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/RestoreOldVideoActionBarPatch.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.spoof.SpoofVideoStreamsPatch;
 import app.morphe.extension.youtube.patches.utils.requests.ConfigRequest;
 import app.morphe.extension.youtube.settings.Settings;
 
@@ -31,6 +32,13 @@ public class RestoreOldVideoActionBarPatch {
     private static final String COLD_CONFIG_DATA_HEADER = "X-Youtube-Cold-Config-Data";
     private static final String VISITOR_ID_HEADER = "X-Goog-Visitor-Id";
     private static boolean needFetch = true;
+
+    static {
+        if (FIX_VIDEO_ACTION_BAR) {
+            // Must override some spoof stream flags so the headers are available.
+            SpoofVideoStreamsPatch.setOverrideSpoofStreamFlagsForHeaders();
+        }
+    }
 
     /**
      * Injection point.

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
@@ -210,7 +210,6 @@ val navigationBarPatch = bytecodePatch(
             }
         }
 
-        println("AutoHideNavigationBarOnDismissMiniplayerFingerprint: " + AutoHideNavigationBarOnDismissMiniplayerFingerprint.method)
         if (is_20_31_or_greater) {
             listOf(
                 AutoHideNavigationBarOnFeedScrollingFingerprint,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/headerhook/CronetHeaderHook.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/headerhook/CronetHeaderHook.kt
@@ -33,6 +33,6 @@ fun addHeaderHook(descriptor: String) {
         """
             invoke-static { p1, p2 }, $descriptor
             move-result-object p2
-        """,
+        """
     )
 }


### PR DESCRIPTION
### Description

Follow up to https://github.com/MorpheApp/morphe-patches/commit/6bc0eeefe02fa89a5d0669698ceb2fffc5bc51c7
to only force off spoof header flags if absolutely required.

This is a temporary change until something better can be done.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
