### PR TITLE
fix(YouTube - Return YouTube Dislike): Unnecessary RYD API requests in playlist

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ReturnYouTubeDislikePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ReturnYouTubeDislikePatch.java
@@ -21,8 +21,6 @@ import android.widget.TextView;
 import androidx.annotation.GuardedBy;
 import androidx.annotation.Nullable;
 
-import java.util.Objects;
-
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.youtube.patches.components.ReturnYouTubeDislikeFilter;
@@ -498,11 +496,16 @@ public class ReturnYouTubeDislikePatch {
      * <p>
      * Called when the user likes or dislikes.
      *
-     * @param vote int that matches {@link Vote#value}
+     * @param endpoint      string that matches {@link Vote#endpoint}
+     * @param videoId       video ID included in the endpoint request body
      */
-    public static void sendVote(int vote) {
+    public static void sendVote(String endpoint, String videoId) {
         try {
             if (!Settings.RYD_ENABLED.get()) {
+                return;
+            }
+            if (!Utils.isNotEmpty(videoId)) {
+                Logger.printDebug(() -> "Ignore playlist votes");
                 return;
             }
 
@@ -515,16 +518,20 @@ public class ReturnYouTubeDislikePatch {
             if (videoData == null) {
                 Logger.printDebug(() -> "Cannot send vote, as current video data is null");
                 return; // User enabled RYD while a regular video was minimized.
+            } else if (!videoIdIsSame(videoData, videoId)) {
+                Logger.printDebug(() -> "Cannot vote for video, as video id does not match"
+                        + " videoData: " + videoData.getVideoId() + ", endPoint: " + videoId);
+                return;
             }
 
             for (Vote v : Vote.values()) {
-                if (v.value == vote) {
+                if (v.endpoint.equals(endpoint)) {
                     videoData.sendVote(v);
                     return;
                 }
             }
 
-            Logger.printException(() -> "Unknown vote type: " + vote);
+            Logger.printException(() -> "Unknown endpoint: " + endpoint);
         } catch (Exception ex) {
             Logger.printException(() -> "sendVote failure", ex);
         }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -54,13 +54,15 @@ import app.morphe.extension.youtube.shared.PlayerType;
 public class ReturnYouTubeDislike {
 
     public enum Vote {
-        LIKE(1),
-        DISLIKE(-1),
-        LIKE_REMOVE(0);
+        LIKE("like/like", 1),
+        DISLIKE("like/dislike", -1),
+        LIKE_REMOVE("like/removelike", 0);
 
+        public final String endpoint;
         public final int value;
 
-        Vote(int value) {
+        Vote(String endpoint, int value) {
+            this.endpoint = endpoint;
             this.value = value;
         }
     }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/returnyoutubedislike/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/returnyoutubedislike/Fingerprints.kt
@@ -73,34 +73,81 @@ internal fun requestParameterCheckFingerprint(definingClass: String) = object : 
     )
 ) {}
 
+/**
+ * 21.25+
+ */
 internal object RollingNumberMeasureAnimatedTextFingerprint : Fingerprint(
+    classFingerprint = RollingNumberMeasureStaticLabelParentFingerprint,
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "F",
+    parameters = listOf("Ljava/lang/String;"),
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            definingClass = "this",
+            location = MatchFirst(),
+        ),
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            type = "[F",
+            location = MatchAfterWithin(3),
+        ),
+        opcode(
+            opcode = Opcode.AGET,
+            location = MatchAfterWithin(5),
+        ),
+        literal(
+            literal = 0,
+            location = MatchAfterImmediately(),
+        ),
+        // Measured text width
+        literal(
+            literal = 0,
+            location = MatchAfterImmediately(),
+        )
+    )
+)
+
+/**
+ * ~ 21.24
+ */
+internal object RollingNumberMeasureAnimatedTextLegacyFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
     returnType = "Lj$/util/Optional;",
     parameters = listOf("L", "Ljava/lang/String;", "L"),
-    // Same as below, but code was removed with 21.25+ and doesn't seem to be required anymore.
-//    filters = listOf(
-//        fieldAccess(
-//            opcode = Opcode.IGET,
-//            type = "F",
-//            location = MatchFirst()
-//        ),
-//        literal(1.0f),
-//        methodCall("Ljava/lang/Math;->max(FF)F"),
-//        opcode(Opcode.AGET),
-//        literal(0),
-//        literal(0)
-//    )
-    filters = OpcodesFilter.opcodesToFilters(
-        Opcode.IGET, // First instruction of method
-        Opcode.IGET_OBJECT,
-        Opcode.IGET_OBJECT,
-        Opcode.CONST_HIGH16,
-        Opcode.INVOKE_STATIC,
-        Opcode.MOVE_RESULT,
-        Opcode.CONST_4,
-        Opcode.AGET,
-        Opcode.CONST_4,
-        Opcode.CONST_4, // Measured text width
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IGET,
+            type = "F",
+            location = MatchFirst(),
+        ),
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            type = "[F",
+            location = MatchAfterWithin(3),
+        ),
+        literal(
+            literal = 1.0f,
+            location = MatchAfterWithin(3),
+        ),
+        methodCall(
+            opcode = Opcode.INVOKE_STATIC,
+            smali = "Ljava/lang/Math;->max(FF)F",
+            location = MatchAfterWithin(3),
+        ),
+        opcode(
+            opcode = Opcode.AGET,
+            location = MatchAfterWithin(5),
+        ),
+        literal(
+            literal = 0,
+            location = MatchAfterImmediately(),
+        ),
+        // Measured text width
+        literal(
+            literal = 0,
+            location = MatchAfterImmediately(),
+        )
     )
 )
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/returnyoutubedislike/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/returnyoutubedislike/Fingerprints.kt
@@ -1,11 +1,15 @@
 package app.morphe.patches.youtube.layout.returnyoutubedislike
 
 import app.morphe.patcher.Fingerprint
-import app.morphe.patcher.InstructionLocation
+import app.morphe.patcher.InstructionLocation.MatchAfterImmediately
+import app.morphe.patcher.InstructionLocation.MatchAfterWithin
+import app.morphe.patcher.InstructionLocation.MatchFirst
 import app.morphe.patcher.OpcodesFilter
+import app.morphe.patcher.fieldAccess
 import app.morphe.patcher.literal
 import app.morphe.patcher.methodCall
 import app.morphe.patcher.newInstance
+import app.morphe.patcher.opcode
 import app.morphe.patcher.string
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
@@ -17,19 +21,57 @@ internal object DislikeFingerprint : Fingerprint(
     )
 )
 
-internal object LikeFingerprint : Fingerprint(
-    returnType = "V",
+internal object EndpointServiceNameFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PROTECTED, AccessFlags.FINAL),
+    parameters = listOf(),
+    returnType = "L",
     filters = listOf(
-        string("like/like")
+        string("serviceName"),
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            definingClass = "this",
+            type = "Ljava/lang/String;"
+        )
     )
 )
 
-internal object RemoveLikeFingerprint : Fingerprint(
+internal fun likeEndpointParserFingerprint(definingClass: String) = object : Fingerprint(
+    definingClass = definingClass,
     returnType = "V",
     filters = listOf(
-        string("like/removelike")
+        fieldAccess(
+            opcode = Opcode.SGET_OBJECT,
+            location = MatchFirst()
+        ),
+        fieldAccess(
+            opcode = Opcode.IPUT_OBJECT,
+            definingClass = "this"
+        ),
+        string("")
     )
-)
+) {}
+
+internal fun requestParameterCheckFingerprint(definingClass: String) = object : Fingerprint(
+    definingClass = definingClass,
+    accessFlags = listOf(AccessFlags.PROTECTED, AccessFlags.FINAL),
+    parameters = listOf(),
+    filters = listOf(
+        // playlistId
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            type = "Ljava/lang/String;"
+        ),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            smali = "Ljava/lang/String;->isEmpty()Z"
+        ),
+        // videoId
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            type = "Ljava/lang/String;"
+        )
+    )
+) {}
 
 internal object RollingNumberMeasureAnimatedTextFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
@@ -160,11 +202,11 @@ internal object LithoSpannableStringCreationFingerprint : Fingerprint(
         newInstance(type = "Landroid/text/SpannableString;"),
         methodCall(
             smali = "Landroid/text/SpannableString;-><init>(Ljava/lang/CharSequence;)V",
-            location = InstructionLocation.MatchAfterWithin(5)
+            location = MatchAfterWithin(5)
         ),
         methodCall(
             smali = "Landroid/text/SpannableString;->getSpans(IILjava/lang/Class;)[Ljava/lang/Object;",
-            location = InstructionLocation.MatchAfterWithin(5)
+            location = MatchAfterWithin(5)
         ),
 
         methodCall(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/returnyoutubedislike/ReturnYouTubeDislikePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/returnyoutubedislike/ReturnYouTubeDislikePatch.kt
@@ -239,13 +239,14 @@ val returnYouTubeDislikePatch = bytecodePatch(
 
         // Rolling Number text views use the measured width of the raw string for layout.
         // Modify the measure text calculation to include the left drawable separator if needed.
-        // 21.25+ removed the method and doesn't seem to have a replacement.
-        if (!is_21_25_or_greater) RollingNumberMeasureAnimatedTextFingerprint.let {
-            // Additional check to verify the opcodes are at the start of the method
-            if (it.instructionMatches.first().index != 0) throw PatchException("Unexpected opcode location")
-            val endIndex = it.instructionMatches.last().index
+        val rollingNumberMeasureAnimatedTextFingerprint = if (is_21_25_or_greater)
+            RollingNumberMeasureAnimatedTextFingerprint
+        else
+            RollingNumberMeasureAnimatedTextLegacyFingerprint
 
+        rollingNumberMeasureAnimatedTextFingerprint.let {
             it.method.apply {
+                val endIndex = it.instructionMatches.last().index
                 val measuredTextWidthRegister = getInstruction<OneRegisterInstruction>(endIndex).registerA
 
                 addInstructions(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/returnyoutubedislike/ReturnYouTubeDislikePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/returnyoutubedislike/ReturnYouTubeDislikePatch.kt
@@ -27,6 +27,7 @@ import app.morphe.patches.youtube.video.videoid.videoIdPatch
 import app.morphe.util.addInstructionsAtControlFlowLabel
 import app.morphe.util.cloneParameters
 import app.morphe.util.findFreeRegister
+import app.morphe.util.getFreeRegisterProvider
 import app.morphe.util.getReference
 import app.morphe.util.indexOfFirstInstructionOrThrow
 import app.morphe.util.insertLiteralOverride
@@ -94,18 +95,32 @@ val returnYouTubeDislikePatch = bytecodePatch(
 
         // region Hook like/dislike/remove like button clicks to send votes to the API.
 
-        arrayOf(
-            LikeFingerprint to Vote.LIKE,
-            DislikeFingerprint to Vote.DISLIKE,
-            RemoveLikeFingerprint to Vote.REMOVE_LIKE,
-        ).forEach { (fingerprint, vote) ->
-            fingerprint.method.addInstructions(
-                0,
-                """
-                    const/4 v0, ${vote.value}
-                    invoke-static { v0 }, $EXTENSION_CLASS->sendVote(I)V
-                """
-            )
+        val endPointServiceNameField = EndpointServiceNameFingerprint
+            .instructionMatches.last().instruction.getReference<FieldReference>()!!
+        val likeEndpointParserClass = DislikeFingerprint.classDef.superclass!!
+        val videoIdField = requestParameterCheckFingerprint(likeEndpointParserClass)
+            .instructionMatches.last().instruction.getReference<FieldReference>()!!
+
+        likeEndpointParserFingerprint(likeEndpointParserClass).let {
+            it.method.apply {
+                val insertIndex = it.instructionMatches[1].index + 1
+                val likeEndpointTargetClassRegister =
+                    getInstruction<TwoRegisterInstruction>(insertIndex - 1).registerA
+                val registerProvider = getFreeRegisterProvider(
+                    insertIndex, 2, likeEndpointTargetClassRegister
+                )
+                val endPointServiceNameRegister = registerProvider.getFreeRegister()
+                val videoIdRegister = registerProvider.getFreeRegister()
+
+                addInstructions(
+                    insertIndex,
+                    """
+                        iget-object v$endPointServiceNameRegister, p0, $endPointServiceNameField
+                        iget-object v$videoIdRegister, v$likeEndpointTargetClassRegister, $videoIdField
+                        invoke-static { v$endPointServiceNameRegister, v$videoIdRegister }, $EXTENSION_CLASS->sendVote(Ljava/lang/String;Ljava/lang/String;)V
+                    """
+                )
+            }
         }
 
         // endregion
@@ -289,10 +304,4 @@ val returnYouTubeDislikePatch = bytecodePatch(
 
         // endregion
     }
-}
-
-enum class Vote(val value: Int) {
-    LIKE(1),
-    DISLIKE(-1),
-    REMOVE_LIKE(0),
 }


### PR DESCRIPTION
### Description

Closes #1711, #1808.

### Additional context

YouTube has internal code that handles likes and dislikes on playlists as well (saving or removing a playlist from the library triggers `like/like` or `like/removelike` requests).

RYD does not provide a dislike count for playlists, but Morphe attempts to send votes on playlists as well (this leads to #1711).

This PR checks if the videoId included in the request body for the `like/like`, `like/dislike`, and `like/removelike` endpoints is valid. If the videoId is invalid, the RYD API request will not be sent.

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
