### PR TITLE
fix(YouTube - Hide layout components):  Match `RD` playlist URLs to improve "Hide mix playlists" filter

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -44,13 +44,10 @@ public final class LayoutComponentsFilter extends Filter {
             "cell_description_body",
             "channel_profile"
     );
-    private static final ByteArrayFilterGroup mix8Buffer = new ByteArrayFilterGroup(
+    private static final ByteArrayFilterGroup mixPlaylistUrlBuffer = new ByteArrayFilterGroup(
             null,
-            "Mix8"
-    );
-    private static final ByteArrayFilterGroup playlistListTagBuffer = new ByteArrayFilterGroup(
-            null,
-            "&list="
+            "?list=RD",
+            "&list=RD"
     );
 
     private static final List<String> channelTabFilterStrings = getFilterStrings(Settings.HIDE_CHANNEL_TAB_FILTER_STRINGS);
@@ -499,8 +496,7 @@ public final class LayoutComponentsFilter extends Filter {
             }
 
             if (!mixPlaylistsBuffersExceptions.check(buffer).isFiltered() &&
-                    mix8Buffer.check(buffer).isFiltered() &&
-                    playlistListTagBuffer.check(buffer).isFiltered()) {
+                    mixPlaylistUrlBuffer.check(buffer).isFiltered()) {
                 Logger.printDebug(() -> "Filtered mix playlist");
                 return true;
             }


### PR DESCRIPTION
### Description

Fixes mix playlist filtering by matching the playlist URL identifier instead of the old `Mix8` buffer marker.

The previous implementation looked for `Mix8` in the parsed Element buffer together with `&list=`, but `Mix8` does not seem to be a stable app-side identifier. I could not find it as a resource or constant in the checked YouTube versions, so the filter can fail when feed data differs by locale.

This updates the check to match `?list=RD` / `&list=RD`, which is the playlist id format used for YouTube mix/radio playlists. This avoids relying on localized UI text such as `Play Mix`.

Closes #1834
Refs #509

### Additional context

This keeps the check narrower than a generic `&list=` match while avoiding the locale-sensitive `Mix8` marker.

I checked the decompiled YouTube sources for 20.21.37, 20.51.39 and 21.25.523. `Mix8` was not present in either version, while the existing mix playlist routing in the patches already uses `RD + videoId` as the playlist id format.

### Test results

* [x] Tested on both the **minimum** and **maximum** supported versions
* [x] Tested on **experimental** supported versions (Optional)