### PR TITLE
fix(Reddit - Hide Trending shelves): Hide 'Trending on Reddit' shelf

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/trending/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/trending/Fingerprints.kt
@@ -87,3 +87,17 @@ internal object TypeaheadSuggestionItemFingerprint : Fingerprint(
         string("typeahead_suggestion_item")
     )
 )
+
+internal object TrendingFeedUnitSectionFingerprint : Fingerprint(
+    returnType = "V",
+    filters = listOf(
+        string("trending_feed_unit_section")
+    )
+)
+
+internal object TrendingFeedUnitDismissedSectionFingerprint : Fingerprint(
+    returnType = "V",
+    filters = listOf(
+        string("trending_feed_unit_dismissed_section")
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/trending/HideTrendingShelvesPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/trending/HideTrendingShelvesPatch.kt
@@ -15,6 +15,7 @@ import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMuta
 import app.morphe.patches.reddit.misc.settings.settingsPatch
 import app.morphe.patches.reddit.misc.version.is_2026_11_0_or_greater
 import app.morphe.patches.reddit.misc.version.is_2026_16_0_or_greater
+import app.morphe.patches.reddit.misc.version.is_2026_21_0_or_greater
 import app.morphe.patches.reddit.misc.version.versionCheckPatch
 import app.morphe.patches.reddit.shared.Constants.COMPATIBILITY_REDDIT
 import app.morphe.util.findFreeRegister
@@ -31,7 +32,7 @@ private const val EXTENSION_TRENDING_INTERFACE =
 @Suppress("unused")
 val hideTrendingShelvesPatch = bytecodePatch(
     name = "Hide Trending shelves",
-    description = "Adds an option to hide Trending shelves from search suggestions."
+    description = "Adds an option to hide the Trending shelves from feed and search suggestions."
 ) {
     compatibleWith(COMPATIBILITY_REDDIT)
 
@@ -153,6 +154,11 @@ val hideTrendingShelvesPatch = bytecodePatch(
                 nop
             """
         )
+
+        if (is_2026_21_0_or_greater) {
+            TrendingFeedUnitSectionFingerprint.applyHideTrending()
+            TrendingFeedUnitDismissedSectionFingerprint.applyHideTrending()
+        }
 
         // endregion
 

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/misc/version/VersionCheckPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/misc/version/VersionCheckPatch.kt
@@ -7,17 +7,15 @@ import kotlin.properties.Delegates
 
 // Use notNull delegate so an exception is thrown if these fields are accessed before they are set.
 
-var is_2025_48_0_or_greater: Boolean by Delegates.notNull()
-    private set
 var is_2026_04_0_or_greater: Boolean by Delegates.notNull()
     private set
 var is_2026_11_0_or_greater: Boolean by Delegates.notNull()
     private set
-var is_2026_15_0_or_greater: Boolean by Delegates.notNull()
-    private set
 var is_2026_16_0_or_greater: Boolean by Delegates.notNull()
     private set
 var is_2026_18_0_or_greater: Boolean by Delegates.notNull()
+    private set
+var is_2026_21_0_or_greater: Boolean by Delegates.notNull()
     private set
 var is_2026_25_0_or_greater: Boolean by Delegates.notNull()
     private set
@@ -29,12 +27,11 @@ val versionCheckPatch = bytecodePatch {
             return versionName >= version
         }
 
-        is_2025_48_0_or_greater = isEqualsOrGreaterThan("2025.48.0")
         is_2026_04_0_or_greater = isEqualsOrGreaterThan("2026.04.0")
         is_2026_11_0_or_greater = isEqualsOrGreaterThan("2026.11.0")
-        is_2026_15_0_or_greater = isEqualsOrGreaterThan("2026.15.0")
         is_2026_16_0_or_greater = isEqualsOrGreaterThan("2026.16.0")
         is_2026_18_0_or_greater = isEqualsOrGreaterThan("2026.18.0")
+        is_2026_21_0_or_greater = isEqualsOrGreaterThan("2026.21.0")
         is_2026_25_0_or_greater = isEqualsOrGreaterThan("2026.25.0")
     }
 }

--- a/patches/src/main/resources/addresources/values/reddit/strings.xml
+++ b/patches/src/main/resources/addresources/values/reddit/strings.xml
@@ -42,7 +42,7 @@ Second \"item\" text"</string>
     <string name="morphe_hide_communities_shelf_title">Hide communities shelf</string>
     <string name="morphe_hide_communities_shelf_summary">Hides the related or suggested communities shelf in subreddits</string>
     <string name="morphe_hide_trending_shelves_title">Hide Trending shelves</string>
-    <string name="morphe_hide_trending_shelves_summary">Hides Trending shelves from search suggestions</string>
+    <string name="morphe_hide_trending_shelves_summary">Hides the Trending shelves from feed and search suggestions</string>
     <string name="morphe_remove_notification_dialog_title">Remove notification suggestion dialog</string>
     <string name="morphe_remove_notification_dialog_summary">Automatically dismisses the notification suggestion dialog when visiting a subreddit</string>
     <string name="morphe_show_view_count_title">Show view count on posts</string>


### PR DESCRIPTION
### Description

<img width="1080" height="1636" alt="Screenshot_20260626_000945_Reddit" src="https://github.com/user-attachments/assets/61bc9e47-8796-42fb-8680-4570b5dcdc1b" />

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
