### PR TITLE
fix(YouTube - Add to queue): Show reload options when player is minimized

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/PlaylistPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/PlaylistPatch.java
@@ -94,7 +94,7 @@ public class PlaylistPatch {
             synchronized (lastVideoIds) {
                 videoId = currentVideoId;
                 QueueManager[] customActionsEntries;
-                boolean canReload = PlayerType.getCurrent().isMaximizedOrFullscreen() &&
+                boolean canReload = !PlayerType.getCurrent().isNoneOrHidden() &&
                         lastVideoIds.get(VideoInformation.getVideoId()) != null;
                 if (playlistId.isEmpty() || lastVideoIds.get(currentVideoId) == null) {
                     customActionsEntries = canReload


### PR DESCRIPTION
`Add/Remove and reload video` flyout options disappeared when the player was minimized (only shown in maximized/fullscreen). Now they also appear for minimized, PiP and inline‑minimal player states.