### PR TITLE
chore(YouTube - SponsorBlock): Load `UNSUBMITTED` category settings so preview segment auto-skips and renders white

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/sponsorblock/MusicSponsorBlockConfig.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/sponsorblock/MusicSponsorBlockConfig.java
@@ -95,6 +95,7 @@ public final class MusicSponsorBlockConfig implements Configuration {
 
     @Override public boolean undoToastEnabled()            { return false; }
     @Override public boolean includesHighlight()           { return false; }
+    @Override public boolean supportsSegmentCreation()     { return false; }
     @Override public boolean compactSkipButtonEnabled()    { return false; }
     @Override public boolean viewTrackingEnabled()         { return false; }
 

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/sponsorblock/SponsorBlockApi.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/sponsorblock/SponsorBlockApi.java
@@ -71,6 +71,12 @@ public final class SponsorBlockApi {
         /** Include the {@code HIGHLIGHT} segment category in active iteration and API requests. */
         boolean includesHighlight();
 
+        /**
+         * Whether this host app supports creating new SponsorBlock segments. Gates loading of
+         * the {@link SegmentCategory#UNSUBMITTED} category's persisted color and behavior.
+         */
+        boolean supportsSegmentCreation();
+
         /** Compact skip-button text. When false, position-aware text (beginning/middle/end) is used. */
         boolean compactSkipButtonEnabled();
 

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/sponsorblock/objects/SegmentCategory.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/sponsorblock/objects/SegmentCategory.java
@@ -161,6 +161,11 @@ public enum SegmentCategory {
         for (SegmentCategory category : activeCategories()) {
             category.loadFromSettings();
         }
+        // UNSUBMITTED is host-internal (not in the API request set) and excluded from
+        // activeCategories(), so its persisted color/behavior must be loaded explicitly.
+        if (SponsorBlockApi.config().supportsSegmentCreation()) {
+            UNSUBMITTED.loadFromSettings();
+        }
         updateEnabledCategories();
     }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/YouTubeSponsorBlockConfig.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/YouTubeSponsorBlockConfig.java
@@ -155,6 +155,7 @@ public final class YouTubeSponsorBlockConfig implements Configuration {
 
     @Override public boolean undoToastEnabled()            { return true; }
     @Override public boolean includesHighlight()           { return true; }
+    @Override public boolean supportsSegmentCreation()     { return true; }
     @Override public boolean compactSkipButtonEnabled()    { return Settings.SB_COMPACT_SKIP_BUTTON.get(); }
     @Override public boolean viewTrackingEnabled()         { return true; }
 


### PR DESCRIPTION
Closes https://github.com/MorpheApp/morphe-patches/issues/1882