### PR TITLE
fix(YouTube Music - Scrobbling): Parse artist and track from video title

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/ScrobbleManager.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/ScrobbleManager.java
@@ -11,6 +11,7 @@ import android.media.MediaMetadata;
 import android.media.session.PlaybackState;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Pair;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -95,15 +96,17 @@ public class ScrobbleManager {
         return clean.replaceAll("\\s+", " ").trim();
     }
 
-    private String[] resolveTitleAndArtist(String rawTitle, String rawArtist) {
+    private Pair<String, String> resolveTitleAndArtist(String rawTitle, String rawArtist) {
         String title = cleanTitle(rawTitle);
         String artist = cleanArtist(rawArtist);
 
         if (Settings.SCROBBLING_PARSE_TITLE.get() && rawTitle != null) {
-            int separatorIndex = rawTitle.indexOf(" - ");
-            if (separatorIndex > 0 && separatorIndex < rawTitle.length() - 3) {
+            String separator = " - ";
+            final int separatorLength = 3;
+            final int separatorIndex = rawTitle.indexOf(separator);
+            if (separatorIndex > 0 && separatorIndex < rawTitle.length() - separatorLength) {
                 String parsedArtist = cleanArtist(rawTitle.substring(0, separatorIndex).trim());
-                String parsedTrack = cleanTitle(rawTitle.substring(separatorIndex + 3).trim());
+                String parsedTrack = cleanTitle(rawTitle.substring(separatorIndex + separatorLength).trim());
                 if (!parsedArtist.isEmpty() && !parsedTrack.isEmpty()) {
                     title = parsedTrack;
                     artist = parsedArtist;
@@ -111,7 +114,7 @@ public class ScrobbleManager {
             }
         }
 
-        return new String[]{title, artist};
+        return new Pair<>(title, artist);
     }
 
     private static String applyCustomRegex(String input) {
@@ -130,18 +133,15 @@ public class ScrobbleManager {
         if (metadata == null) return;
 
         try {
-            String rawTitle = metadata.getString(MediaMetadata.METADATA_KEY_TITLE);
-            String rawArtist = metadata.getString(MediaMetadata.METADATA_KEY_ARTIST);
-            String rawAlbum = metadata.getString(MediaMetadata.METADATA_KEY_ALBUM);
             String songId = metadata.getString(MediaMetadata.METADATA_KEY_MEDIA_ID);
-            long durationMs = metadata.getLong(MediaMetadata.METADATA_KEY_DURATION);
-            int duration = (int) (durationMs / 1000);
-
-            String[] resolved = resolveTitleAndArtist(rawTitle, rawArtist);
-            String title = resolved[0];
-            String artist = resolved[1];
-            String album = cleanAlbum(rawAlbum);
-
+            String album = cleanAlbum(metadata.getString(MediaMetadata.METADATA_KEY_ALBUM));
+            Pair<String, String> resolved = resolveTitleAndArtist(
+                    metadata.getString(MediaMetadata.METADATA_KEY_TITLE),
+                    metadata.getString(MediaMetadata.METADATA_KEY_ARTIST)
+            );
+            String title = resolved.first;
+            String artist = resolved.second;
+            final int duration = (int) (metadata.getLong(MediaMetadata.METADATA_KEY_DURATION) / 1000);
             if (title == null || title.isBlank() || artist == null || artist.isBlank()) {
                 return;
             }

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/ScrobbleManager.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/ScrobbleManager.java
@@ -95,6 +95,25 @@ public class ScrobbleManager {
         return clean.replaceAll("\\s+", " ").trim();
     }
 
+    private String[] resolveTitleAndArtist(String rawTitle, String rawArtist) {
+        String title = cleanTitle(rawTitle);
+        String artist = cleanArtist(rawArtist);
+
+        if (Settings.SCROBBLING_PARSE_TITLE.get() && rawTitle != null) {
+            int separatorIndex = rawTitle.indexOf(" - ");
+            if (separatorIndex > 0 && separatorIndex < rawTitle.length() - 3) {
+                String parsedArtist = cleanArtist(rawTitle.substring(0, separatorIndex).trim());
+                String parsedTrack = cleanTitle(rawTitle.substring(separatorIndex + 3).trim());
+                if (!parsedArtist.isEmpty() && !parsedTrack.isEmpty()) {
+                    title = parsedTrack;
+                    artist = parsedArtist;
+                }
+            }
+        }
+
+        return new String[]{title, artist};
+    }
+
     private static String applyCustomRegex(String input) {
         String customRegex = Settings.SCROBBLING_CUSTOM_REGEX.get();
         if (customRegex.isBlank()) return input;
@@ -111,12 +130,17 @@ public class ScrobbleManager {
         if (metadata == null) return;
 
         try {
-            String title = cleanTitle(metadata.getString(MediaMetadata.METADATA_KEY_TITLE));
-            String artist = cleanArtist(metadata.getString(MediaMetadata.METADATA_KEY_ARTIST));
-            String album = cleanAlbum(metadata.getString(MediaMetadata.METADATA_KEY_ALBUM));
+            String rawTitle = metadata.getString(MediaMetadata.METADATA_KEY_TITLE);
+            String rawArtist = metadata.getString(MediaMetadata.METADATA_KEY_ARTIST);
+            String rawAlbum = metadata.getString(MediaMetadata.METADATA_KEY_ALBUM);
             String songId = metadata.getString(MediaMetadata.METADATA_KEY_MEDIA_ID);
             long durationMs = metadata.getLong(MediaMetadata.METADATA_KEY_DURATION);
             int duration = (int) (durationMs / 1000);
+
+            String[] resolved = resolveTitleAndArtist(rawTitle, rawArtist);
+            String title = resolved[0];
+            String artist = resolved[1];
+            String album = cleanAlbum(rawAlbum);
 
             if (title == null || title.isBlank() || artist == null || artist.isBlank()) {
                 return;

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -85,6 +85,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final IntegerSetting LASTFM_DELAY_SECONDS = new IntegerSetting("morphe_music_lastfm_delay_seconds", 180, true, parent(LASTFM_SCROBBLING));
     public static final BooleanSetting SCROBBLING_METADATA_CLEANUP = new BooleanSetting("morphe_music_scrobbling_metadata_cleanup", TRUE, true, parentsAny(LISTENBRAINZ_SCROBBLING, LASTFM_SCROBBLING));
     public static final StringSetting SCROBBLING_CUSTOM_REGEX = new StringSetting("morphe_music_scrobbling_custom_regex", "", true, parentsAll(parent(SCROBBLING_METADATA_CLEANUP), parentsAny(LISTENBRAINZ_SCROBBLING, LASTFM_SCROBBLING)));
+    public static final BooleanSetting SCROBBLING_PARSE_TITLE = new BooleanSetting("morphe_music_scrobbling_parse_title", FALSE, true, parentsAny(LISTENBRAINZ_SCROBBLING, LASTFM_SCROBBLING));
 
     // SponsorBlock
     public static final BooleanSetting SB_ENABLED = new BooleanSetting("morphe_sb_enabled", TRUE);

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/scrobbling/ScrobblingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/scrobbling/ScrobblingPatch.kt
@@ -135,7 +135,8 @@ val scrobblingPatch = bytecodePatch(
                 key = "morphe_settings_music_scrobbling_metadata",
                 preferences = setOf(
                     SwitchPreference("morphe_music_scrobbling_metadata_cleanup"),
-                    TextPreference("morphe_music_scrobbling_custom_regex")
+                    TextPreference("morphe_music_scrobbling_custom_regex"),
+                    SwitchPreference("morphe_music_scrobbling_parse_title", summary = true)
                 )
             ),
             NonInteractivePreference(

--- a/patches/src/main/resources/addresources/values/music/strings.xml
+++ b/patches/src/main/resources/addresources/values/music/strings.xml
@@ -231,6 +231,8 @@ YouTube Music 8.x — crossfade only runs on 9.x and newer"</string>
     <string name="morphe_music_scrobbling_metadata_cleanup_summary">Automatically clean common clutter (like \"Official Video\", \"Remaster\", \"Live\") from titles, artists, and albums before scrobbling</string>
     <string name="morphe_music_scrobbling_custom_regex_title">Custom regex cleanup</string>
     <string name="morphe_music_scrobbling_custom_regex_summary">Enter a custom regular expression to remove additional text from song titles, artists, or albums. Example: (?i)\\s*\\((clean|explicit)\\)</string>
+    <string name="morphe_music_scrobbling_parse_title_title">Parse artist and track from title</string>
+    <string name="morphe_music_scrobbling_parse_title_summary">When enabled, extracts artist and track from the video title by splitting on " - " instead of using YouTube Music\'s metadata. Fixes reuploads where the channel name is used as the artist and the full video title is used as the track name. Combine with custom regex to strip remaining tags.</string>
 
     <!-- 'scrobbling' must be kept untranslated -->
     <string name="morphe_music_scrobbling_about_title">About scrobbling</string>

--- a/patches/src/main/resources/addresources/values/music/strings.xml
+++ b/patches/src/main/resources/addresources/values/music/strings.xml
@@ -232,7 +232,7 @@ YouTube Music 8.x — crossfade only runs on 9.x and newer"</string>
     <string name="morphe_music_scrobbling_custom_regex_title">Custom regex cleanup</string>
     <string name="morphe_music_scrobbling_custom_regex_summary">Enter a custom regular expression to remove additional text from song titles, artists, or albums. Example: (?i)\\s*\\((clean|explicit)\\)</string>
     <string name="morphe_music_scrobbling_parse_title_title">Parse artist and track from title</string>
-    <string name="morphe_music_scrobbling_parse_title_summary">When enabled, extracts artist and track from the video title by splitting on " - " instead of using YouTube Music\'s metadata. Fixes reuploads where the channel name is used as the artist and the full video title is used as the track name. Combine with custom regex to strip remaining tags.</string>
+    <string name="morphe_music_scrobbling_parse_title_summary">Extract artist and track name from the video title using " - " separator. Useful for reuploaded content where the channel name may be used as the artist.</string>
 
     <!-- 'scrobbling' must be kept untranslated -->
     <string name="morphe_music_scrobbling_about_title">About scrobbling</string>


### PR DESCRIPTION
**Problem:** For reuploaded content, YouTube Music's MediaSession provides the channel name as the artist and the full video title (e.g. "Artist - Track") as the track name, causing incorrect scrobbles.

**Solution:** Added a new opt-in setting `SCROBBLING_PARSE_TITLE` that, when enabled, splits the video title on " - " to extract the real artist and track name before scrobbling.

**Changes:**
- `Settings.java`: New `SCROBBLING_PARSE_TITLE` boolean setting (default: off)
- `ScrobbleManager.java`: Parsing logic in `resolveTitleAndArtist()` splits title on first " - ", applies existing cleanup to both parts
- `strings.xml`: Title and summary strings for the new setting
- `ScrobblingPatch.kt`: `SwitchPreference` added to the metadata cleanup category

**How to test:**
1. Enable scrobbling and the new "Parse artist and track from title" switch
2. Play a reuploaded track (where the channel name differs from the artist)
3. Check the scrobble; artist and track should now be correct
