### PR TITLE
fix(YouTube - SponsorBlock): Send correct user agent when submitting segments

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/sponsorblock/requests/SBRequester.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/sponsorblock/requests/SBRequester.java
@@ -199,7 +199,8 @@ public class SBRequester {
             String duration = String.format(Locale.US, TIME_TEMPLATE, videoLength / 1000f);
 
             HttpURLConnection connection = getConnectionFromRoute(SBRoutes.SUBMIT_SEGMENTS,
-                    privateUserID, videoId, category.keyValue, start, end, duration, action.type);
+                    privateUserID, videoId, category.keyValue, start, end, duration, action.type,
+                    "Morphe/" + Utils.getAppVersionName());
             final int responseCode = connection.getResponseCode();
 
             if (responseCode == HTTP_STATUS_CODE_SUCCESS) {

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/sponsorblock/requests/SBRoutes.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/sponsorblock/requests/SBRoutes.java
@@ -11,7 +11,7 @@ public class SBRoutes {
     public static final Route VIEWED_SEGMENT = new Route(POST, "/api/viewedVideoSponsorTime?UUID={segment_id}");
     public static final Route GET_USER_STATS = new Route(GET, "/api/userInfo?userID={user_id}&values=[\"userID\",\"userName\",\"reputation\",\"segmentCount\",\"ignoredSegmentCount\",\"viewCount\",\"minutesSaved\"]");
     public static final Route CHANGE_USERNAME = new Route(POST, "/api/setUsername?userID={user_id}&username={username}");
-    public static final Route SUBMIT_SEGMENTS = new Route(POST, "/api/skipSegments?userID={user_id}&videoID={video_id}&category={category}&startTime={start_time}&endTime={end_time}&videoDuration={duration}&actionType={action_type}");
+    public static final Route SUBMIT_SEGMENTS = new Route(POST, "/api/skipSegments?userID={user_id}&videoID={video_id}&category={category}&startTime={start_time}&endTime={end_time}&videoDuration={duration}&actionType={action_type}&userAgent={user_agent}");
     public static final Route VOTE_ON_SEGMENT_QUALITY = new Route(POST, "/api/voteOnSponsorTime?userID={user_id}&UUID={segment_id}&type={type}");
     public static final Route VOTE_ON_SEGMENT_CATEGORY = new Route(POST, "/api/voteOnSponsorTime?userID={user_id}&UUID={segment_id}&category={category}");
 


### PR DESCRIPTION
### Description

Closes #1854.

Fixes segments submitted by Morphe appearing as `Vanced/undefined` in the SponsorBlock browser by passing `userAgent=Morphe/{version}` explicitly as a query parameter on submission, which the server reads with priority over the HTTP header.

### Additional context

<details><summary>Screenshot</summary>
<p>

<img width="324" height="70" src="https://github.com/user-attachments/assets/11cd43f9-d046-423b-925b-3ef8e046ddfd" />

</p>
</details> 

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
