### PR TITLE
feat(Reddit): Add `Incognito keyboard` patch

### DIFF
--- a/extensions/reddit/src/main/java/app/morphe/extension/reddit/patches/IncognitoKeyboardPatch.java
+++ b/extensions/reddit/src/main/java/app/morphe/extension/reddit/patches/IncognitoKeyboardPatch.java
@@ -13,36 +13,22 @@ import android.os.Bundle;
 import android.view.View;
 import android.view.ViewTreeObserver;
 import android.view.inputmethod.EditorInfo;
-import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 
 import java.lang.ref.WeakReference;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 import app.morphe.extension.reddit.settings.Settings;
-import app.morphe.extension.shared.Logger;
 
 @SuppressWarnings("unused")
 public final class IncognitoKeyboardPatch {
     private static boolean initialized;
 
-    /**
-     * @return If this patch was included during patching.
-     */
     public static boolean isPatchIncluded() {
         return false;  // Modified during patching.
     }
 
-    /**
-     * Injection point for direct EditorInfo modification in onCreateInputConnection.
-     * Called from injected bytecode - adds the incognito flag to the EditorInfo.
-     *
-     * @param editorInfo The EditorInfo to modify (may be null).
-     */
     public static void modifyEditorInfo(EditorInfo editorInfo) {
         if (editorInfo == null) return;
         if (!Settings.INCOGNITO_KEYBOARD.get()) return;
@@ -51,10 +37,6 @@ public final class IncognitoKeyboardPatch {
         editorInfo.imeOptions |= EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING;
     }
 
-    /**
-     * Initialize the keyboard lifecycle hooks.
-     * Called from application onCreate via injected bytecode.
-     */
     public static void initialize(Application application) {
         if (initialized) return;
         initialized = true;
@@ -63,8 +45,24 @@ public final class IncognitoKeyboardPatch {
                 new Application.ActivityLifecycleCallbacks() {
                     @Override
                     public void onActivityCreated(@NonNull Activity activity, Bundle savedInstanceState) {
-                        activity.getWindow().getDecorView().getViewTreeObserver()
-                                .addOnGlobalFocusChangeListener(new IncognitoFocusListener(activity));
+                        IncognitoFocusListener listener = new IncognitoFocusListener(activity);
+                        View decorView = activity.getWindow().getDecorView();
+                        
+                        decorView.getViewTreeObserver().addOnGlobalFocusChangeListener(listener);
+                        
+                        // Tag the listener onto the decor view so we can retrieve it safely on destroy
+                        decorView.setTag(Integer.MAX_VALUE, listener);
+                    }
+
+                    @Override
+                    public void onActivityDestroyed(@NonNull Activity activity) {
+                        View decorView = activity.getWindow().getDecorView();
+                        Object listener = decorView.getTag(Integer.MAX_VALUE);
+                        if (listener instanceof ViewTreeObserver.OnGlobalFocusChangeListener) {
+                            decorView.getViewTreeObserver().removeOnGlobalFocusChangeListener(
+                                    (ViewTreeObserver.OnGlobalFocusChangeListener) listener
+                            );
+                        }
                     }
 
                     @Override public void onActivityStarted(@NonNull Activity activity) {}
@@ -72,7 +70,6 @@ public final class IncognitoKeyboardPatch {
                     @Override public void onActivityPaused(@NonNull Activity activity) {}
                     @Override public void onActivityStopped(@NonNull Activity activity) {}
                     @Override public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle outState) {}
-                    @Override public void onActivityDestroyed(@NonNull Activity activity) {}
                 }
         );
     }
@@ -80,21 +77,17 @@ public final class IncognitoKeyboardPatch {
     private record IncognitoFocusListener(
             WeakReference<Activity> activityRef) implements ViewTreeObserver.OnGlobalFocusChangeListener {
 
-        private IncognitoFocusListener(Activity activityRef) {
-            this(new WeakReference<>(activityRef));
+        private IncognitoFocusListener(Activity activity) {
+            this(new WeakReference<>(activity));
         }
 
         @Override
         public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-            if (newFocus == null) return;
+            if (newFocus == null || oldFocus == newFocus) return; // Prevent identical re-entry
             if (!(newFocus instanceof TextView)) return;
             if (!Settings.INCOGNITO_KEYBOARD.get()) return;
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return;
 
-            restartInputWithIncognito((TextView) newFocus);
-        }
-
-        private void restartInputWithIncognito(TextView textView) {
             Activity activity = activityRef.get();
             if (activity == null) return;
 
@@ -102,27 +95,8 @@ public final class IncognitoKeyboardPatch {
                     activity.getSystemService(Activity.INPUT_METHOD_SERVICE);
             if (imm == null) return;
 
-            EditorInfo editorInfo = new EditorInfo();
-            InputConnection ic;
-            try {
-                ic = textView.onCreateInputConnection(editorInfo);
-            } catch (Exception ex) {
-                Logger.printException(() -> "onCreateInputConnection failed", ex);
-                return;
-            }
-            if (ic == null) return;
-
-            editorInfo.imeOptions |= EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING;
-
-            try {
-                Method startInputAsync = InputMethodManager.class.getMethod(
-                        "startInputAsync", View.class, EditorInfo.class
-                );
-                startInputAsync.invoke(imm, textView, editorInfo);
-            } catch (NoSuchMethodException | IllegalAccessException |
-                     InvocationTargetException ex) {
-                Logger.printException(() -> "startInputAsync reflection failed", ex);
-            }
+            // Natively triggers onCreateInputConnection -> modifyEditorInfo hooks automatically
+            imm.restartInput(newFocus);
         }
     }
 }

--- a/extensions/reddit/src/main/java/app/morphe/extension/reddit/patches/IncognitoKeyboardPatch.java
+++ b/extensions/reddit/src/main/java/app/morphe/extension/reddit/patches/IncognitoKeyboardPatch.java
@@ -115,29 +115,13 @@ public final class IncognitoKeyboardPatch {
             editorInfo.imeOptions |= EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING;
 
             try {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    imm.startInputAsync(ic, editorInfo);
-                } else {
-                    restartInputDeprecated(imm, textView, ic, editorInfo);
-                }
-            } catch (Exception ex) {
-                Logger.printException(() -> "restartInput failed", ex);
-            }
-        }
-
-        @SuppressWarnings("JavaReflectionMemberAccess")
-        private void restartInputDeprecated(
-                InputMethodManager imm, View view,
-                InputConnection ic, EditorInfo editorInfo
-        ) {
-            try {
-                Method startInput = InputMethodManager.class.getMethod(
-                        "startInput", View.class, InputConnection.class, EditorInfo.class
+                Method startInputAsync = InputMethodManager.class.getMethod(
+                        "startInputAsync", View.class, EditorInfo.class
                 );
-                startInput.invoke(imm, view, ic, editorInfo);
+                startInputAsync.invoke(imm, textView, editorInfo);
             } catch (NoSuchMethodException | IllegalAccessException |
                      InvocationTargetException ex) {
-                Logger.printException(() -> "startInput reflection failed", ex);
+                Logger.printException(() -> "startInputAsync reflection failed", ex);
             }
         }
     }

--- a/extensions/reddit/src/main/java/app/morphe/extension/reddit/patches/IncognitoKeyboardPatch.java
+++ b/extensions/reddit/src/main/java/app/morphe/extension/reddit/patches/IncognitoKeyboardPatch.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/1917
  *
- * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
 package app.morphe.extension.reddit.patches;
 

--- a/extensions/reddit/src/main/java/app/morphe/extension/reddit/patches/IncognitoKeyboardPatch.java
+++ b/extensions/reddit/src/main/java/app/morphe/extension/reddit/patches/IncognitoKeyboardPatch.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.extension.reddit.patches;
+
+import android.app.Activity;
+import android.app.Application;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.View;
+import android.view.ViewTreeObserver;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.view.inputmethod.InputMethodManager;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import app.morphe.extension.reddit.settings.Settings;
+import app.morphe.extension.shared.Logger;
+
+@SuppressWarnings("unused")
+public final class IncognitoKeyboardPatch {
+    private static final String TAG = "IncognitoKeyboard";
+    private static boolean initialized = false;
+
+    /**
+     * @return If this patch was included during patching.
+     */
+    public static boolean isPatchIncluded() {
+        return false;  // Modified during patching.
+    }
+
+    /**
+     * Injection point for direct EditorInfo modification in onCreateInputConnection.
+     * Called from injected bytecode - adds the incognito flag to the EditorInfo.
+     *
+     * @param editorInfo The EditorInfo to modify (may be null).
+     */
+    public static void modifyEditorInfo(EditorInfo editorInfo) {
+        if (editorInfo == null) return;
+        if (!Settings.INCOGNITO_KEYBOARD.get()) return;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return;
+
+        editorInfo.imeOptions |= EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING;
+    }
+
+    /**
+     * Initialize the keyboard lifecycle hooks.
+     * Called from application onCreate via injected bytecode.
+     */
+    public static void initialize(Application application) {
+        if (initialized) return;
+        initialized = true;
+
+        application.registerActivityLifecycleCallbacks(
+                new Application.ActivityLifecycleCallbacks() {
+                    @Override
+                    public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+                        activity.getWindow().getDecorView().getViewTreeObserver()
+                                .addOnGlobalFocusChangeListener(new IncognitoFocusListener(activity));
+                    }
+
+                    @Override public void onActivityStarted(Activity activity) {}
+                    @Override public void onActivityResumed(Activity activity) {}
+                    @Override public void onActivityPaused(Activity activity) {}
+                    @Override public void onActivityStopped(Activity activity) {}
+                    @Override public void onActivitySaveInstanceState(Activity activity, Bundle outState) {}
+                    @Override public void onActivityDestroyed(Activity activity) {}
+                }
+        );
+    }
+
+    private static class IncognitoFocusListener
+            implements ViewTreeObserver.OnGlobalFocusChangeListener {
+        private final WeakReference<Activity> activityRef;
+
+        IncognitoFocusListener(Activity activity) {
+            this.activityRef = new WeakReference<>(activity);
+        }
+
+        @Override
+        public void onGlobalFocusChanged(View oldFocus, View newFocus) {
+            if (newFocus == null) return;
+            if (!(newFocus instanceof android.widget.TextView)) return;
+            if (!Settings.INCOGNITO_KEYBOARD.get()) return;
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return;
+
+            restartInputWithIncognito((android.widget.TextView) newFocus);
+        }
+
+        private void restartInputWithIncognito(android.widget.TextView textView) {
+            Activity activity = activityRef.get();
+            if (activity == null) return;
+
+            InputMethodManager imm = (InputMethodManager)
+                    activity.getSystemService(Activity.INPUT_METHOD_SERVICE);
+            if (imm == null) return;
+
+            EditorInfo editorInfo = new EditorInfo();
+            InputConnection ic;
+            try {
+                ic = textView.onCreateInputConnection(editorInfo);
+            } catch (Exception e) {
+                Logger.printException(() -> TAG + ": onCreateInputConnection failed", e);
+                return;
+            }
+            if (ic == null) return;
+
+            editorInfo.imeOptions |= EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING;
+
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    imm.startInputAsync(ic, editorInfo);
+                } else {
+                    restartInputDeprecated(imm, textView, ic, editorInfo);
+                }
+            } catch (Exception e) {
+                Logger.printException(() -> TAG + ": restartInput failed", e);
+            }
+        }
+
+        @SuppressWarnings("JavaReflectionMemberAccess")
+        private void restartInputDeprecated(
+                InputMethodManager imm, View view,
+                InputConnection ic, EditorInfo editorInfo
+        ) {
+            try {
+                Method startInput = InputMethodManager.class.getMethod(
+                        "startInput", View.class, InputConnection.class, EditorInfo.class
+                );
+                startInput.invoke(imm, view, ic, editorInfo);
+            } catch (NoSuchMethodException | IllegalAccessException
+                     | InvocationTargetException e) {
+                Logger.printException(() -> TAG + ": startInput reflection failed", e);
+            }
+        }
+    }
+}

--- a/extensions/reddit/src/main/java/app/morphe/extension/reddit/patches/IncognitoKeyboardPatch.java
+++ b/extensions/reddit/src/main/java/app/morphe/extension/reddit/patches/IncognitoKeyboardPatch.java
@@ -15,6 +15,9 @@ import android.view.ViewTreeObserver;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
@@ -25,8 +28,7 @@ import app.morphe.extension.shared.Logger;
 
 @SuppressWarnings("unused")
 public final class IncognitoKeyboardPatch {
-    private static final String TAG = "IncognitoKeyboard";
-    private static boolean initialized = false;
+    private static boolean initialized;
 
     /**
      * @return If this patch was included during patching.
@@ -60,40 +62,39 @@ public final class IncognitoKeyboardPatch {
         application.registerActivityLifecycleCallbacks(
                 new Application.ActivityLifecycleCallbacks() {
                     @Override
-                    public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+                    public void onActivityCreated(@NonNull Activity activity, Bundle savedInstanceState) {
                         activity.getWindow().getDecorView().getViewTreeObserver()
                                 .addOnGlobalFocusChangeListener(new IncognitoFocusListener(activity));
                     }
 
-                    @Override public void onActivityStarted(Activity activity) {}
-                    @Override public void onActivityResumed(Activity activity) {}
-                    @Override public void onActivityPaused(Activity activity) {}
-                    @Override public void onActivityStopped(Activity activity) {}
-                    @Override public void onActivitySaveInstanceState(Activity activity, Bundle outState) {}
-                    @Override public void onActivityDestroyed(Activity activity) {}
+                    @Override public void onActivityStarted(@NonNull Activity activity) {}
+                    @Override public void onActivityResumed(@NonNull Activity activity) {}
+                    @Override public void onActivityPaused(@NonNull Activity activity) {}
+                    @Override public void onActivityStopped(@NonNull Activity activity) {}
+                    @Override public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle outState) {}
+                    @Override public void onActivityDestroyed(@NonNull Activity activity) {}
                 }
         );
     }
 
-    private static class IncognitoFocusListener
-            implements ViewTreeObserver.OnGlobalFocusChangeListener {
-        private final WeakReference<Activity> activityRef;
+    private record IncognitoFocusListener(
+            WeakReference<Activity> activityRef) implements ViewTreeObserver.OnGlobalFocusChangeListener {
 
-        IncognitoFocusListener(Activity activity) {
-            this.activityRef = new WeakReference<>(activity);
+        private IncognitoFocusListener(Activity activityRef) {
+            this(new WeakReference<>(activityRef));
         }
 
         @Override
         public void onGlobalFocusChanged(View oldFocus, View newFocus) {
             if (newFocus == null) return;
-            if (!(newFocus instanceof android.widget.TextView)) return;
+            if (!(newFocus instanceof TextView)) return;
             if (!Settings.INCOGNITO_KEYBOARD.get()) return;
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return;
 
-            restartInputWithIncognito((android.widget.TextView) newFocus);
+            restartInputWithIncognito((TextView) newFocus);
         }
 
-        private void restartInputWithIncognito(android.widget.TextView textView) {
+        private void restartInputWithIncognito(TextView textView) {
             Activity activity = activityRef.get();
             if (activity == null) return;
 
@@ -105,8 +106,8 @@ public final class IncognitoKeyboardPatch {
             InputConnection ic;
             try {
                 ic = textView.onCreateInputConnection(editorInfo);
-            } catch (Exception e) {
-                Logger.printException(() -> TAG + ": onCreateInputConnection failed", e);
+            } catch (Exception ex) {
+                Logger.printException(() -> "onCreateInputConnection failed", ex);
                 return;
             }
             if (ic == null) return;
@@ -119,8 +120,8 @@ public final class IncognitoKeyboardPatch {
                 } else {
                     restartInputDeprecated(imm, textView, ic, editorInfo);
                 }
-            } catch (Exception e) {
-                Logger.printException(() -> TAG + ": restartInput failed", e);
+            } catch (Exception ex) {
+                Logger.printException(() -> "restartInput failed", ex);
             }
         }
 
@@ -134,9 +135,9 @@ public final class IncognitoKeyboardPatch {
                         "startInput", View.class, InputConnection.class, EditorInfo.class
                 );
                 startInput.invoke(imm, view, ic, editorInfo);
-            } catch (NoSuchMethodException | IllegalAccessException
-                     | InvocationTargetException e) {
-                Logger.printException(() -> TAG + ": startInput reflection failed", e);
+            } catch (NoSuchMethodException | IllegalAccessException |
+                     InvocationTargetException ex) {
+                Logger.printException(() -> "startInput reflection failed", ex);
             }
         }
     }

--- a/extensions/reddit/src/main/java/app/morphe/extension/reddit/settings/Settings.java
+++ b/extensions/reddit/src/main/java/app/morphe/extension/reddit/settings/Settings.java
@@ -40,6 +40,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting REMOVE_NSFW_DIALOG = new BooleanSetting("morphe_remove_nsfw_dialog", FALSE, true);
     public static final BooleanSetting REMOVE_NOTIFICATION_DIALOG = new BooleanSetting("morphe_remove_notification_dialog", FALSE, true);
     public static final BooleanSetting SHOW_VIEW_COUNT = new BooleanSetting("morphe_show_view_count", FALSE, true);
+    public static final BooleanSetting INCOGNITO_KEYBOARD = new BooleanSetting("morphe_incognito_keyboard", FALSE, true);
 
     // Miscellaneous
     public static final BooleanSetting OPEN_LINKS_DIRECTLY = new BooleanSetting("morphe_open_links_directly", TRUE);

--- a/extensions/reddit/src/main/java/app/morphe/extension/reddit/settings/preference/categories/LayoutPreferenceCategory.java
+++ b/extensions/reddit/src/main/java/app/morphe/extension/reddit/settings/preference/categories/LayoutPreferenceCategory.java
@@ -16,6 +16,7 @@ import app.morphe.extension.reddit.patches.DisableScreenshotPopupPatch;
 import app.morphe.extension.reddit.patches.HideAskButtonPatch;
 import app.morphe.extension.reddit.patches.HideCommunitiesShelf;
 import app.morphe.extension.reddit.patches.HideTrendingShelvesPatch;
+import app.morphe.extension.reddit.patches.IncognitoKeyboardPatch;
 import app.morphe.extension.reddit.patches.RemoveSubRedditDialogPatch;
 import app.morphe.extension.reddit.patches.ShowViewCountPatch;
 import app.morphe.extension.reddit.settings.Settings;
@@ -35,6 +36,7 @@ public class LayoutPreferenceCategory extends ConditionalPreferenceCategory {
                 HideAskButtonPatch.isPatchIncluded() ||
                 HideCommunitiesShelf.isPatchIncluded() ||
                 HideTrendingShelvesPatch.isPatchIncluded() ||
+                IncognitoKeyboardPatch.isPatchIncluded() ||
                 RemoveSubRedditDialogPatch.isPatchIncluded();
     }
 
@@ -90,6 +92,13 @@ public class LayoutPreferenceCategory extends ConditionalPreferenceCategory {
             addPreference(new BooleanSettingPreference(
                     context,
                     Settings.SHOW_VIEW_COUNT
+            ));
+        }
+
+        if (IncognitoKeyboardPatch.isPatchIncluded()) {
+            addPreference(new BooleanSettingPreference(
+                    context,
+                    Settings.INCOGNITO_KEYBOARD
             ));
         }
     }

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/incognitokeyboard/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/incognitokeyboard/Fingerprints.kt
@@ -2,7 +2,7 @@
  * Copyright 2026 Morphe.
  * https://github.com/MorpheApp/morphe-patches
  *
- * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
 package app.morphe.patches.reddit.layout.incognitokeyboard
 

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/incognitokeyboard/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/incognitokeyboard/Fingerprints.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.patches.reddit.layout.incognitokeyboard
+
+import app.morphe.patcher.Fingerprint
+
+internal object FrontpageApplicationOnCreateFingerprint : Fingerprint(
+    definingClass = "Lcom/reddit/frontpage/FrontpageApplication;",
+    name = "onCreate",
+    returnType = "V",
+    parameters = listOf("Landroid/os/Bundle;"),
+)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/incognitokeyboard/IncognitoKeyboardPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/incognitokeyboard/IncognitoKeyboardPatch.kt
@@ -1,8 +1,8 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/1917
  *
- * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
 package app.morphe.patches.reddit.layout.incognitokeyboard
 

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/incognitokeyboard/IncognitoKeyboardPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/incognitokeyboard/IncognitoKeyboardPatch.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.patches.reddit.layout.incognitokeyboard
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.reddit.misc.settings.settingsPatch
+import app.morphe.patches.reddit.shared.Constants.COMPATIBILITY_REDDIT
+import app.morphe.util.setExtensionIsPatchIncluded
+
+private const val EXTENSION_CLASS =
+    "Lapp/morphe/extension/reddit/patches/IncognitoKeyboardPatch;"
+
+@Suppress("unused")
+val incognitoKeyboardPatch = bytecodePatch(
+    name = "Incognito keyboard",
+    description = "Adds an option to enable incognito keyboard mode."
+) {
+    compatibleWith(COMPATIBILITY_REDDIT)
+
+    dependsOn(settingsPatch)
+
+    execute {
+        FrontpageApplicationOnCreateFingerprint.method.apply {
+            addInstructions(
+                0,
+                """
+                    invoke-static { p0 }, $EXTENSION_CLASS->initialize(Landroid/app/Application;)V
+                """
+            )
+        }
+
+        setExtensionIsPatchIncluded(EXTENSION_CLASS)
+    }
+}

--- a/patches/src/main/resources/addresources/values/reddit/strings.xml
+++ b/patches/src/main/resources/addresources/values/reddit/strings.xml
@@ -49,6 +49,8 @@ Second \"item\" text"</string>
     <string name="morphe_show_view_count_summary">Limitation: Only available if the API response includes the view count</string>
     <string name="morphe_remove_nsfw_dialog_title">Remove NSFW warning dialog</string>
     <string name="morphe_remove_nsfw_dialog_summary">Automatically accepts the NSFW content warning when visiting a subreddit</string>
+    <string name="morphe_incognito_keyboard_title">Incognito keyboard</string>
+    <string name="morphe_incognito_keyboard_summary">Prevents keyboard from learning from your typing</string>
 
     <string name="morphe_screen_miscellaneous_title">Miscellaneous</string>
     <string name="morphe_about_title">About</string>


### PR DESCRIPTION
Adds a new `Incognito keyboard` toggle to the Reddit Layout settings (API 29+).

**Extension side**: New `IncognitoKeyboardPatch.java` registers an `ActivityLifecycleCallbacks` that detects focus changes on `TextView`s. When the toggle is enabled, it calls `TextView.onCreateInputConnection()` to generate the `EditorInfo`, adds `IME_FLAG_NO_PERSONALIZED_LEARNING`, and restarts the IME session via `startInputAsync()` (API 30+) or reflection-based `startInput()` (API 22-29).

**Patcher side**: Hooks into `FrontpageApplication.onCreate` to initialize the lifecycle hooks. Also provides a `modifyEditorInfo(EditorInfo)` injection point for future use with direct `onCreateInputConnection` hooks.
