### PR TITLE
chore(YouTube - Remember video quality): Refactor toast notification strings

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/quality/RememberVideoQualityPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/quality/RememberVideoQualityPatch.java
@@ -48,13 +48,11 @@ public class RememberVideoQualityPatch {
 
     public static void saveDefaultQuality(int qualityResolution) {
         final boolean shortPlayerOpen = ShortsPlayerState.isOpen();
-        String networkTypeMessage;
+        final boolean isMobile = Utils.getNetworkType() == NetworkType.MOBILE;
         IntegerSetting qualitySetting;
-        if (Utils.getNetworkType() == NetworkType.MOBILE) {
-            networkTypeMessage = str("morphe_remember_video_quality_mobile");
+        if (isMobile) {
             qualitySetting = shortPlayerOpen ? shortsQualityMobile : videoQualityMobile;
         } else {
-            networkTypeMessage = str("morphe_remember_video_quality_wifi");
             qualitySetting = shortPlayerOpen ? shortsQualityWifi : videoQualityWifi;
         }
 
@@ -67,13 +65,17 @@ public class RememberVideoQualityPatch {
 
         if (Settings.REMEMBER_VIDEO_QUALITY_LAST_SELECTED_TOAST.get()) {
             String qualityLabel = qualityResolution + "p";
-            Utils.showToastShort(str(
-                    shortPlayerOpen
-                            ? "morphe_remember_video_quality_toast_shorts"
-                            : "morphe_remember_video_quality_toast",
-                    networkTypeMessage,
-                    qualityLabel)
-            );
+            final String toastStringId;
+            if (shortPlayerOpen && isMobile) {
+                toastStringId = "morphe_remember_video_quality_toast_shorts_mobile";
+            } else if (shortPlayerOpen) {
+                toastStringId = "morphe_remember_video_quality_toast_shorts_wifi";
+            } else if (isMobile) {
+                toastStringId = "morphe_remember_video_quality_toast_mobile";
+            } else {
+                toastStringId = "morphe_remember_video_quality_toast_wifi";
+            }
+            Utils.showToastShort(str(toastStringId, qualityLabel));
         }
     }
 

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1160,10 +1160,10 @@ Tap here to open DeArrow.ajay.app"</string>
     <string name="morphe_remember_shorts_quality_last_selected_summary">Applies your manual quality selection to all future Shorts</string>
     <string name="morphe_shorts_quality_default_wifi_title">Default Shorts quality on Wi-Fi network</string>
     <string name="morphe_shorts_quality_default_mobile_title">Default Shorts quality on mobile network</string>
-    <string name="morphe_remember_video_quality_toast_mobile">Changed default mobile quality to: %1$s</string>
-    <string name="morphe_remember_video_quality_toast_wifi">Changed default Wi-Fi quality to: %1$s</string>
-    <string name="morphe_remember_video_quality_toast_shorts_mobile">Changed Shorts mobile quality to: %1$s</string>
-    <string name="morphe_remember_video_quality_toast_shorts_wifi">Changed Shorts Wi-Fi quality to: %1$s</string>
+    <string name="morphe_remember_video_quality_toast_mobile">Changed default mobile quality to: %s</string>
+    <string name="morphe_remember_video_quality_toast_wifi">Changed default Wi-Fi quality to: %s</string>
+    <string name="morphe_remember_video_quality_toast_shorts_mobile">Changed Shorts mobile quality to: %s</string>
+    <string name="morphe_remember_video_quality_toast_shorts_wifi">Changed Shorts Wi-Fi quality to: %s</string>
 
     <!-- video.speed.button.playbackSpeedButtonPatch -->
     <string name="morphe_playback_speed_dialog_button_title">Show Playback speed button</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1160,10 +1160,10 @@ Tap here to open DeArrow.ajay.app"</string>
     <string name="morphe_remember_shorts_quality_last_selected_summary">Applies your manual quality selection to all future Shorts</string>
     <string name="morphe_shorts_quality_default_wifi_title">Default Shorts quality on Wi-Fi network</string>
     <string name="morphe_shorts_quality_default_mobile_title">Default Shorts quality on mobile network</string>
-    <string name="morphe_remember_video_quality_mobile">mobile</string>
-    <string name="morphe_remember_video_quality_wifi">wifi</string>
-    <string name="morphe_remember_video_quality_toast">Changed default %1$s quality to: %2$s</string>
-    <string name="morphe_remember_video_quality_toast_shorts">Changed Shorts %1$s quality to: %2$s</string>
+    <string name="morphe_remember_video_quality_toast_mobile">Changed default mobile quality to: %1$s</string>
+    <string name="morphe_remember_video_quality_toast_wifi">Changed default Wi-Fi quality to: %1$s</string>
+    <string name="morphe_remember_video_quality_toast_shorts_mobile">Changed Shorts mobile quality to: %1$s</string>
+    <string name="morphe_remember_video_quality_toast_shorts_wifi">Changed Shorts Wi-Fi quality to: %1$s</string>
 
     <!-- video.speed.button.playbackSpeedButtonPatch -->
     <string name="morphe_playback_speed_dialog_button_title">Show Playback speed button</string>


### PR DESCRIPTION
### Description

Replaces the two-part toast composition (separate `mobile`/`wifi` noun + generic `%1$s … %2$s` template) with four independent, context-specific strings - one per combination of network type and player type (Shorts vs. regular video). This makes each string a complete, translatable sentence and reduces the format argument count from two to one.

Closes #

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
