### PR TITLE
fix(YouTube Music - Downloads): Add "Override feed/search flyout button" setting

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/DownloadsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/DownloadsPatch.java
@@ -68,6 +68,9 @@ public final class DownloadsPatch {
     }
 
     private static void launchExternalDownloader(String videoId) {
+        cachedFlyoutVideoId = "";
+        downloadButtonLabel = "";
+
         ExternalDownloaderPreference.launchExternalDownloader(
                 videoId, Utils.getActivity(), "https://music.youtube.com/watch?v=" + videoId);
     }
@@ -204,6 +207,10 @@ public final class DownloadsPatch {
                 return true;
             }
 
+            if (!SharedYouTubeSettings.EXTERNAL_DOWNLOADER_FLYOUT_BUTTON.get()) {
+                return false;
+            }
+
             String p1String = p1.toString();
             Logger.printDebug(() -> "commandResolverOnClick: " + p1String);
 
@@ -221,7 +228,7 @@ public final class DownloadsPatch {
             }
 
             final boolean isDownloadClick = Utils.containsAny(p1String,
-                    "[133724106]", "[144224893]");
+                    "[133724106]", "[443434441]");
             if (isDownloadClick) {
                 Logger.printDebug(() -> "Flyout isDownloadClick");
                 final long now = System.currentTimeMillis();

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
@@ -65,6 +65,7 @@ public class SharedYouTubeSettings extends BaseSettings {
 
     public static final BooleanSetting EXTERNAL_DOWNLOADER = new BooleanSetting("morphe_external_downloader", FALSE);
     public static final BooleanSetting EXTERNAL_DOWNLOADER_ACTION_BUTTON = new BooleanSetting("morphe_external_downloader_action_button", FALSE);
+    public static final BooleanSetting EXTERNAL_DOWNLOADER_FLYOUT_BUTTON = new BooleanSetting("morphe_external_downloader_flyout_button", FALSE);
     public static final StringSetting EXTERNAL_DOWNLOADER_PACKAGE_NAME = new StringSetting("morphe_external_downloader_name", "com.deniscerri.ytdl" /* YTDLnis */, parentsAny(EXTERNAL_DOWNLOADER, EXTERNAL_DOWNLOADER_ACTION_BUTTON));
 
     // Renamed settings

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/downloads/DownloadsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/downloads/DownloadsPatch.kt
@@ -32,6 +32,7 @@ private val downloadsResourcePatch = resourcePatch {
                 sorting = Sorting.UNSORTED,
                 preferences = setOf(
                     SwitchPreference("morphe_external_downloader_action_button", summary = true),
+                    SwitchPreference("morphe_external_downloader_flyout_button"),
                     TextPreference(
                         "morphe_external_downloader_name",
                         tag = "app.morphe.extension.shared.settings.preference.ExternalDownloaderPreference"

--- a/patches/src/main/resources/addresources/values/music/strings.xml
+++ b/patches/src/main/resources/addresources/values/music/strings.xml
@@ -27,7 +27,6 @@ Second \"item\" text"</string>
     <string name="morphe_header_logo_entry_3">Custom</string>
 
     <!-- interaction.downloads.downloadsPatch -->
-    <string name="morphe_external_downloader_screen_title">External downloads</string>
     <string name="morphe_external_downloader_screen_summary">Download music videos, podcasts, or songs with third-party downloading apps</string>
     <string name="morphe_external_downloader_action_button_title">Override Download action button</string>
     <string name="morphe_external_downloader_action_button_summary">Replaces YouTube Music\'s built-in download function with your external downloader</string>

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -22,8 +22,10 @@ Second \"item\" text"</string>
     <string name="morphe_custom_branding_name_title">App name</string>
 
     <!-- interaction.downloads.downloadsPatch -->
+    <string name="morphe_external_downloader_screen_title">External downloads</string>
     <string name="morphe_external_downloader_name_title">Downloader package name</string>
     <string name="morphe_external_downloader_name_summary">Package name of your installed external downloader app</string>
+    <string name="morphe_external_downloader_flyout_button_title">Override feed/search flyout button</string>
     <string name="morphe_external_downloader_other_item_hint">Enter the package name</string>
     <string name="morphe_external_downloader_other_item">Other</string>
     <string name="morphe_external_downloader_not_found_title">App not installed</string>


### PR DESCRIPTION
- Fixes download action opening immediately for some users.
- Adds a separate setting to override flyout menu download action

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
