### PR TITLE
feat(YouTube Music): Add `Hide music action buttons` patch

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/components/MusicActionButtonsFilter.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/components/MusicActionButtonsFilter.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/1953
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.music.patches.components;
+
+import androidx.annotation.Nullable;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import app.morphe.extension.music.settings.Settings;
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.patches.TreeNodeElementPatch.LithoGetBufferContainerInterface;
+import app.morphe.extension.shared.patches.components.BufferAsciiStrings;
+import app.morphe.extension.shared.patches.components.ContextInterface;
+import app.morphe.extension.shared.patches.components.Filter;
+import app.morphe.extension.shared.patches.components.StringFilterGroup;
+import app.morphe.extension.shared.settings.BooleanSetting;
+
+@SuppressWarnings("unused")
+public final class MusicActionButtonsFilter extends Filter {
+
+    /**
+     * Injected by the patch onto the obfuscated litho message class that owns the button's
+     * serialized proto buffer, so extension code can read it without walking obfuscated
+     * field / method names.
+     */
+    public interface ButtonProtoBufferInterface {
+        // Method is added during patching.
+        byte[] patch_getBuffer();
+    }
+
+    private enum ActionButton {
+        LIKE_DISLIKE(Settings.HIDE_LIKE_DISLIKE_BUTTON),
+        DOWNLOAD(Settings.HIDE_DOWNLOAD_BUTTON),
+        COMMENTS(Settings.HIDE_COMMENTS_BUTTON),
+        LYRICS(Settings.HIDE_LYRICS_BUTTON),
+        SHARE(Settings.HIDE_SHARE_BUTTON),
+        RADIO(Settings.HIDE_RADIO_BUTTON),
+        SAVE(Settings.HIDE_SAVE_BUTTON);
+
+        final BooleanSetting setting;
+
+        ActionButton(BooleanSetting setting) {
+            this.setting = setting;
+        }
+    }
+
+    private static final String VIDEO_ACTION_BAR_PREFIX = "video_action_bar.e";
+    private static final String VIDEO_ACTION_BUTTON_WRAPPER_PREFIX = "video_action_button_with_vm_input.e";
+
+    // Base names of the litho components / endpoint identifiers used to identify buttons.
+    // Path callbacks append `.e` to bound the match to the litho identifier suffix.
+    private static final String LIKE_BUTTON_MARKER = "like_button";
+    private static final String DISLIKE_BUTTON_MARKER = "dislike_button";
+    private static final String SEGMENTED_LIKE_DISLIKE_MARKER = "segmented_like_dislike_button";
+    private static final String DOWNLOAD_MARKER = "download_button";
+    private static final String MUSIC_DOWNLOAD_MARKER = "music_download_button";
+    // Unique marker for the Download button in the parsed proto buffer - the litho EML
+    // name `music_download_button` is a render-time artifact and is not present in the raw
+    // proto stream that reaches the tree-node hook. Music's offline endpoint identifier
+    // (`offlinelist`) is the only download-specific string that survives into the buffer.
+    private static final String DOWNLOAD_PROTO_MARKER = "offlinelist";
+    private static final String COMMENTS_MARKER = "music-comment-panel";
+    private static final String LYRICS_MARKER = "music_watch_lyrics_panel";
+    private static final String SHARE_MARKER = "timestamp_share_switch_button_entity_key";
+    private static final String RADIO_MARKER = "RDAMVM";
+
+    // Icon markers used as a fallback when a button is disabled for the current track and
+    // therefore has no endpoint id in its proto buffer. Every button still carries its own
+    // icon as data, and the icon lives in the first ~500 bytes of the buffer, well before
+    // the shared icon catalogue that trails at the end.
+    private static final String COMMENTS_ICON = "_text_bubble_";
+    private static final String LYRICS_ICON = "_quote_";
+    private static final String THUMB_UP_ICON = "_thumb_up_";
+    private static final String THUMB_DOWN_ICON = "_thumb_down_";
+    private static final int ICON_SCAN_HEAD_LIMIT = 500;
+
+    private final StringFilterGroup actionBar;
+    private final StringFilterGroup genericActionButton;
+
+    public MusicActionButtonsFilter() {
+        actionBar = new StringFilterGroup(
+                Settings.HIDE_ACTION_BAR,
+                VIDEO_ACTION_BAR_PREFIX
+        );
+        addIdentifierCallbacks(actionBar);
+
+        addPathCallbacks(
+                new StringFilterGroup(
+                        Settings.HIDE_LIKE_DISLIKE_BUTTON,
+                        LIKE_BUTTON_MARKER + ".e",
+                        DISLIKE_BUTTON_MARKER + ".e",
+                        SEGMENTED_LIKE_DISLIKE_MARKER + ".e"
+                ),
+                new StringFilterGroup(
+                        Settings.HIDE_DOWNLOAD_BUTTON,
+                        DOWNLOAD_MARKER + ".e",
+                        MUSIC_DOWNLOAD_MARKER + ".e"
+                )
+        );
+
+        // Comments, Lyrics, Share, Save and Radio all render as generic `button.e` inside
+        // `video_action_button_with_vm_input.e` - identity is dispatched inside isFiltered
+        // from the button's ascii-string buffer.
+        genericActionButton = new StringFilterGroup(
+                null,
+                VIDEO_ACTION_BUTTON_WRAPPER_PREFIX
+        );
+        addPathCallbacks(genericActionButton);
+    }
+
+    @Override
+    public boolean isFiltered(ContextInterface contextInterface,
+                              String identifier,
+                              String accessibility,
+                              String path,
+                              byte[] buffer,
+                              BufferAsciiStrings asciiStrings,
+                              StringFilterGroup matchedGroup,
+                              FilterContentType contentType,
+                              int contentIndex) {
+        if (matchedGroup == actionBar) {
+            return true;
+        }
+        if (matchedGroup == genericActionButton) {
+            if (!path.contains(VIDEO_ACTION_BAR_PREFIX)) {
+                return false;
+            }
+            // Wrapper- and inner-level renders embed sibling data in their proto buffer, so
+            // a single marker would match the whole action bar. Only fire on the leaf-button
+            // render - path contains `|button.eml-fe|` but not the `button_inner` descendant.
+            if (!path.contains("|button.eml-fe|") || path.contains("button_inner")) {
+                return false;
+            }
+            // Dispatch by endpoint marker. Each of the four known buttons has a unique
+            // endpoint string in its buffer. The Save button has no unique endpoint of its
+            // own - its icon (`_playlist_add_`) also appears in every button's shared icon
+            // catalogue - so it is resolved by elimination as the fall-through branch.
+            String strings = asciiStrings.getStrings();
+            if (strings.contains(COMMENTS_MARKER)) {
+                return Settings.HIDE_COMMENTS_BUTTON.get();
+            }
+            if (strings.contains(LYRICS_MARKER)) {
+                return Settings.HIDE_LYRICS_BUTTON.get();
+            }
+            if (strings.contains(SHARE_MARKER)) {
+                return Settings.HIDE_SHARE_BUTTON.get();
+            }
+            if (strings.contains(RADIO_MARKER)) {
+                return Settings.HIDE_RADIO_BUTTON.get();
+            }
+            return Settings.HIDE_SAVE_BUTTON.get();
+        }
+        return path.contains(VIDEO_ACTION_BAR_PREFIX);
+    }
+
+    /**
+     * Injection point.
+     * Physically removes entries from the action-bar tree-node list so Litho never allocates
+     * their cells. Without this the litho identifier / path filters above only skip content
+     * and leave empty gaps where hidden buttons used to be.
+     * <p>
+     * The whole-bar toggle clears the list outright; per-button hides pull each item's proto
+     * payload via {@link #extractButtonProto} (patch-injected interface reached through a
+     * reflection walk) and dispatch on the same endpoint markers that {@link #isFiltered}
+     * uses for visual hiding.
+     */
+    public static void onLazilyConvertedElementLoaded(String identifier, List<Object> treeNodeResultList) {
+        try {
+            if (!identifier.startsWith(VIDEO_ACTION_BAR_PREFIX)) {
+                return;
+            }
+            if (Settings.HIDE_ACTION_BAR.get()) {
+                treeNodeResultList.clear();
+                return;
+            }
+            for (int i = treeNodeResultList.size() - 1; i >= 0; i--) {
+                byte[] buttonProto = extractButtonProto(treeNodeResultList.get(i));
+                if (buttonProto == null) continue;
+                ActionButton button = classify(buttonProto);
+                if (!button.setting.get()) continue;
+                // Music bakes the row's leading padding into item[0], so physically removing
+                // the first entry collapses the whole row against the screen edge. Keep it in
+                // the list and let isFiltered() do a visual-only hide instead - the empty cell
+                // preserves the padding.
+                if (i == 0 && button == ActionButton.LIKE_DISLIKE) continue;
+                treeNodeResultList.remove(i);
+            }
+        } catch (Exception ex) {
+            Logger.printException(() -> "onLazilyConvertedElementLoaded failure", ex);
+        }
+    }
+
+    @Nullable
+    private static byte[] extractButtonProto(@Nullable Object item) {
+        if (item instanceof ButtonProtoBufferInterface holder) {
+            return holder.patch_getBuffer();
+        }
+        if (item instanceof LithoGetBufferContainerInterface bufferInterface) {
+            return extractButtonProto(bufferInterface.patch_getContainer());
+        }
+
+        return null;
+    }
+
+    private static ActionButton classify(byte[] buffer) {
+        String contents = new String(buffer, StandardCharsets.ISO_8859_1);
+        // Order matters - the more-specific `segmented_like_dislike_button` and
+        // `music_download_button` come before `like_button` / `download_button` so the
+        // substring `like_button` inside `segmented_like_dislike_button` doesn't win.
+        if (contents.contains(SEGMENTED_LIKE_DISLIKE_MARKER)
+                || contents.contains(LIKE_BUTTON_MARKER)
+                || contents.contains(DISLIKE_BUTTON_MARKER)) {
+            return ActionButton.LIKE_DISLIKE;
+        }
+        if (contents.contains(MUSIC_DOWNLOAD_MARKER)
+                || contents.contains(DOWNLOAD_MARKER)
+                || contents.contains(DOWNLOAD_PROTO_MARKER)) {
+            return ActionButton.DOWNLOAD;
+        }
+        if (contents.contains(COMMENTS_MARKER)) return ActionButton.COMMENTS;
+        if (contents.contains(LYRICS_MARKER)) return ActionButton.LYRICS;
+        if (contents.contains(SHARE_MARKER)) return ActionButton.SHARE;
+        if (contents.contains(RADIO_MARKER)) return ActionButton.RADIO;
+        // Fallback for buttons that are disabled for this track: no endpoint id is present,
+        // so classify by the button's own icon which sits in the buffer head, before the
+        // shared icon catalogue.
+        String head = contents.length() > ICON_SCAN_HEAD_LIMIT
+                ? contents.substring(0, ICON_SCAN_HEAD_LIMIT) : contents;
+        if (head.contains(THUMB_UP_ICON) || head.contains(THUMB_DOWN_ICON)) {
+            return ActionButton.LIKE_DISLIKE;
+        }
+        if (head.contains(COMMENTS_ICON)) return ActionButton.COMMENTS;
+        if (head.contains(LYRICS_ICON)) return ActionButton.LYRICS;
+        // Save button has no unique endpoint marker of its own; it's the fall-through.
+        return ActionButton.SAVE;
+    }
+}

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/components/PlayerFlyoutMenuComponentsFilter.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/components/PlayerFlyoutMenuComponentsFilter.java
@@ -47,15 +47,13 @@ public final class PlayerFlyoutMenuComponentsFilter extends Filter {
         bufferGroupList.addAll(
                 new ByteArrayFilterGroup(
                         Settings.HIDE_FLYOUT_MENU_DOWNLOAD,
-                        // Regular download button and the Premium-upsell "experimental"
-                        // variant. `experimental_` breaks a single prefix match, so both
-                        // are listed.
                         "yt_outline_download",
                         "yt_outline_experimental_download"
                 ),
                 new ByteArrayFilterGroup(
                         Settings.HIDE_FLYOUT_MENU_TASTE_MATCH,
-                        "yt_outline_circles_overlap"
+                        "yt_outline_circles_overlap",
+                        "yt_outline_experimental_account_link_vd_theme_24"
                 )
         );
 

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -48,9 +48,6 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_NAVIGATION_BAR_LABEL = new BooleanSetting("morphe_music_hide_navigation_bar_labels", FALSE, true, parentNot(HIDE_NAVIGATION_BAR));
     public static final EnumSetting<HeaderLogo> HEADER_LOGO = new EnumSetting<>("morphe_header_logo", HeaderLogo.DEFAULT, true);
 
-    // Lyrics
-    public static final BooleanSetting HIDE_LYRICS_SHARE_BUTTON = new BooleanSetting("morphe_music_hide_lyrics_share_button", FALSE);
-    public static final BooleanSetting HIDE_LYRICS_TRANSLATE_BUTTON = new BooleanSetting("morphe_music_hide_lyrics_translate_button", FALSE);
 
     // Custom filter
     public static final BooleanSetting CUSTOM_FILTER = new BooleanSetting("morphe_music_custom_filter", FALSE);
@@ -64,6 +61,18 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting ENABLE_FORCED_MINIPLAYER = new BooleanSetting("morphe_music_enable_forced_miniplayer", FALSE, true);
     public static final BooleanSetting ENABLE_SWIPE_TO_DISMISS_MINIPLAYER = new BooleanSetting("morphe_music_enable_swipe_to_dismiss_miniplayer", FALSE, true);
     public static final BooleanSetting PERMANENT_REPEAT = new BooleanSetting("morphe_music_play_permanent_repeat", FALSE, true);
+
+    // Action buttons
+    public static final BooleanSetting HIDE_ACTION_BAR = new BooleanSetting("morphe_music_hide_action_bar", FALSE, true);
+    public static final BooleanSetting HIDE_LIKE_DISLIKE_BUTTON = new BooleanSetting("morphe_music_hide_like_dislike_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_COMMENTS_BUTTON = new BooleanSetting("morphe_music_hide_comments_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_LYRICS_BUTTON = new BooleanSetting("morphe_music_hide_lyrics_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_SHARE_BUTTON = new BooleanSetting("morphe_music_hide_share_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_SAVE_BUTTON = new BooleanSetting("morphe_music_hide_save_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_DOWNLOAD_BUTTON = new BooleanSetting("morphe_music_hide_download_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_RADIO_BUTTON = new BooleanSetting("morphe_music_hide_radio_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_LYRICS_SHARE_BUTTON = new BooleanSetting("morphe_music_hide_lyrics_share_button", FALSE, true);
+    public static final BooleanSetting HIDE_LYRICS_TRANSLATE_BUTTON = new BooleanSetting("morphe_music_hide_lyrics_translate_button", FALSE, true);
 
     // Flyout menu
     public static final BooleanSetting HIDE_FLYOUT_MENU_3_COLUMN_COMPONENT = new BooleanSetting("morphe_music_hide_flyout_menu_3_column_component", FALSE);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/ConversionContext.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/ConversionContext.java
@@ -4,8 +4,8 @@
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
- 
-package app.morphe.extension.youtube.shared;
+
+package app.morphe.extension.shared.patches;
 
 public final class ConversionContext {
     public static final String ELEMENT_IDENTIFIER_COMPONENT = "ComponentType";

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/TreeNodeElementPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/TreeNodeElementPatch.java
@@ -5,19 +5,24 @@
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
 
-package app.morphe.extension.youtube.patches;
+package app.morphe.extension.shared.patches;
 
-import static app.morphe.extension.youtube.shared.ConversionContext.ELEMENT_IDENTIFIER_COMPONENT;
-import static app.morphe.extension.youtube.shared.ConversionContext.ELEMENT_IDENTIFIER_LAZILY;
+import static app.morphe.extension.shared.patches.ConversionContext.ELEMENT_IDENTIFIER_COMPONENT;
+import static app.morphe.extension.shared.patches.ConversionContext.ELEMENT_IDENTIFIER_LAZILY;
 
 import java.util.List;
 
 import app.morphe.extension.shared.Logger;
-import app.morphe.extension.shared.patches.components.ContextInterface;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.patches.components.ContextInterface;
 
 @SuppressWarnings("unused")
 public class TreeNodeElementPatch {
+
+    public interface LithoGetBufferContainerInterface {
+        // Method is added during patching.
+        Object patch_getContainer();
+    }
 
     /**
      * Injection point.

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/HidePlayerFlyoutMenuPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/HidePlayerFlyoutMenuPatch.java
@@ -7,8 +7,8 @@
 
 package app.morphe.extension.youtube.patches;
 
-import static app.morphe.extension.youtube.shared.ConversionContext.ELEMENT_IDENTIFIER_COMPONENT;
-import static app.morphe.extension.youtube.shared.ConversionContext.ELEMENT_IDENTIFIER_CONTAINER;
+import static app.morphe.extension.shared.patches.ConversionContext.ELEMENT_IDENTIFIER_COMPONENT;
+import static app.morphe.extension.shared.patches.ConversionContext.ELEMENT_IDENTIFIER_CONTAINER;
 
 import android.view.View;
 import android.widget.ListView;

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LayoutReloadObserverPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LayoutReloadObserverPatch.java
@@ -42,8 +42,7 @@ public class LayoutReloadObserverPatch {
     private static final String VIDEO_ACTION_BAR_PREFIX = "video_action_bar.e";
     public static final AtomicBoolean isActionBarVisible = new AtomicBoolean(false);
 
-    public static void onLazilyConvertedElementLoaded(@NonNull String identifier,
-                                                      @NonNull List<Object> treeNodeResultList) {
+    public static void onLazilyConvertedElementLoaded(String identifier, List<Object> treeNodeResultList) {
         if (!Utils.startsWithAny(identifier, COMPACTIFY_VIDEO_ACTION_BAR_PREFIX, VIDEO_ACTION_BAR_PREFIX)) {
             return;
         }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/VideoActionButtonsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/VideoActionButtonsFilter.java
@@ -233,8 +233,7 @@ public final class VideoActionButtonsFilter extends Filter {
      * Injection point.
      * Called after {@link #onSingleColumnWatchNextResultsLoaded(MessageLite)}.
      */
-    public static void onLazilyConvertedElementLoaded(@NonNull String identifier,
-                                                      @NonNull List<Object> treeNodeResultList) {
+    public static void onLazilyConvertedElementLoaded(String identifier, List<Object> treeNodeResultList) {
         // Check if hide video action buttons is enabled.
         if (!HIDE_ACTION_BUTTON) {
             return;

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/buttons/action/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/buttons/action/Fingerprints.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+
+package app.morphe.patches.music.layout.buttons.action
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation.MatchAfterImmediately
+import app.morphe.patcher.InstructionLocation.MatchAfterWithin
+import app.morphe.patcher.InstructionLocation.MatchFirst
+import app.morphe.patcher.fieldAccess
+import app.morphe.patcher.literal
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.newInstance
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+internal object ButtonProtoBufferGetterFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "[B",
+    parameters = listOf(),
+    filters = listOf(
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            smali = "Lcom/google/android/libraries/elements/adl/UpbMessage;->jniEncode(JJ)[B"
+        )
+    )
+)
+
+internal object TreeNodeListFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PROTECTED, AccessFlags.FINAL),
+    returnType = "L",
+    parameters = listOf("L"),
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            definingClass = "this",
+            type = "L",
+            location = MatchAfterWithin(5) // Match close to start of method.
+        ),
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            type = "Ljava/util/concurrent/atomic/AtomicReference;",
+            location = MatchAfterWithin(5)
+        ),
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            type = "Ljava/util/concurrent/atomic/AtomicReference;",
+            location = MatchAfterWithin(2)
+        ),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            smali = "Ljava/util/concurrent/atomic/AtomicReference;->get()Ljava/lang/Object;",
+            location = MatchAfterWithin(2)
+        )
+    )
+)
+
+internal object TreeNodeListHelperConstructorFingerprint : Fingerprint(
+    classFingerprint = Fingerprint(
+        accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+        returnType = "L",
+        parameters = listOf("L", "L"),
+        filters = listOf(
+            newInstance("Ljava/util/ArrayList;", location = MatchFirst()),
+            methodCall(
+                opcode = Opcode.INVOKE_DIRECT,
+                smali = "Ljava/util/ArrayList;-><init>()V",
+                location = MatchAfterImmediately(),
+            ),
+            literal(0, location = MatchAfterWithin(10))
+        ),
+        custom = { _, classDef ->
+            classDef.methods.count() == 2
+        }
+    ),
+    name = "<init>"
+)

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/buttons/action/HideMusicActionButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/buttons/action/HideMusicActionButtonsPatch.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/1953
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+
+package app.morphe.patches.music.layout.buttons.action
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
+import app.morphe.patches.music.misc.extension.sharedExtensionPatch
+import app.morphe.patches.music.misc.litho.filter.lithoFilterPatch
+import app.morphe.patches.music.misc.litho.node.treeNodeElementHookPatch
+import app.morphe.patches.music.misc.settings.PreferenceScreen
+import app.morphe.patches.music.misc.settings.settingsPatch
+import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
+import app.morphe.patches.shared.misc.litho.filter.addLithoFilter
+import app.morphe.patches.shared.misc.litho.node.hookTreeNodeResult
+import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
+import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
+
+private const val ACTION_BUTTONS_FILTER =
+    "Lapp/morphe/extension/music/patches/components/MusicActionButtonsFilter;"
+
+private const val EXTENSION_BUTTON_PROTO_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/components/MusicActionButtonsFilter$ButtonProtoBufferInterface;"
+
+@Suppress("unused")
+val hideMusicActionButtonsPatch = bytecodePatch(
+    name = "Hide music action buttons",
+    description = "Adds options to hide action buttons under the player."
+) {
+    dependsOn(
+        sharedExtensionPatch,
+        settingsPatch,
+        lithoFilterPatch,
+        treeNodeElementHookPatch
+    )
+
+    compatibleWith(COMPATIBILITY_YOUTUBE_MUSIC)
+
+    execute {
+        PreferenceScreen.PLAYER.addPreferences(
+            PreferenceScreenPreference(
+                key = "morphe_music_action_buttons_screen",
+                preferences = setOf(
+                    SwitchPreference("morphe_music_hide_action_bar"),
+                    SwitchPreference("morphe_music_hide_like_dislike_button"),
+                    SwitchPreference("morphe_music_hide_comments_button"),
+                    SwitchPreference("morphe_music_hide_lyrics_button"),
+                    SwitchPreference("morphe_music_hide_share_button"),
+                    SwitchPreference("morphe_music_hide_save_button"),
+                    SwitchPreference("morphe_music_hide_download_button"),
+                    SwitchPreference("morphe_music_hide_radio_button")
+                )
+            )
+        )
+
+        addLithoFilter(ACTION_BUTTONS_FILTER)
+        hookTreeNodeResult("$ACTION_BUTTONS_FILTER->onLazilyConvertedElementLoaded")
+
+        // Add the ButtonProtoBufferInterface + patch_getButtonProto() delegate on the
+        // obfuscated litho message class that owns each button's serialized proto buffer.
+        // The extension iterates the reachable object graph of each tree-node entry and
+        // dispatches once it lands on an instance of this interface, so we don't need to
+        // hard-code obfuscated field / method names.
+        ButtonProtoBufferGetterFingerprint.let {
+            val getterMethod = it.method
+            it.classDef.apply {
+                interfaces.add(EXTENSION_BUTTON_PROTO_INTERFACE)
+                methods.add(
+                    ImmutableMethod(
+                        type,
+                        "patch_getBuffer",
+                        listOf(),
+                        "[B",
+                        AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+                        null,
+                        null,
+                        MutableMethodImplementation(2),
+                    ).toMutable().apply {
+                        addInstructions(
+                            0,
+                            """
+                                invoke-virtual { p0 }, $type->${getterMethod.name}()[B
+                                move-result-object v0
+                                return-object v0
+                            """
+                        )
+                    }
+                )
+            }
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/litho/node/TreeNodeElementHookPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/litho/node/TreeNodeElementHookPatch.kt
@@ -2,14 +2,14 @@
  * Copyright 2026 Morphe.
  * https://github.com/MorpheApp/morphe-patches
  *
- * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
  */
 
-package app.morphe.patches.youtube.misc.litho.node
+package app.morphe.patches.music.misc.litho.node
 
+import app.morphe.patches.music.misc.extension.sharedExtensionPatch
+import app.morphe.patches.music.misc.litho.context.conversionContextPatch
 import app.morphe.patches.shared.misc.litho.node.createTreeNodeElementHookPatch
-import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
-import app.morphe.patches.youtube.misc.litho.context.conversionContextPatch
 
 val treeNodeElementHookPatch = createTreeNodeElementHookPatch(
     sharedExtensionPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/proto/ElementProtoParserHookPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/proto/ElementProtoParserHookPatch.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+
+package app.morphe.patches.music.misc.proto
+
+import app.morphe.patches.music.misc.extension.sharedExtensionPatch
+import app.morphe.patches.shared.misc.proto.createElementProtoParserHookPatch
+
+val elementProtoParserHookPatch = createElementProtoParserHookPatch(sharedExtensionPatch)

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/fix/proto/FixProtoLibraryPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/fix/proto/FixProtoLibraryPatch.kt
@@ -13,7 +13,6 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
 import app.morphe.util.cloneMutable
-import app.morphe.util.getReference
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
@@ -22,8 +21,7 @@ import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
 import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
 import java.lang.ref.WeakReference
 
-internal lateinit var parseByteArrayMethod: MutableMethod
-
+internal lateinit var parseByteArrayMethodRef: WeakReference<MutableMethod>
 internal lateinit var immutableMethodRef : WeakReference<MethodReference>
 internal lateinit var mutableCopyMethodRef : WeakReference<MethodReference>
 
@@ -78,7 +76,7 @@ internal val fixProtoLibraryPatch = bytecodePatch(
             }
         }
 
-        parseByteArrayMethod = ProtobufClassParseByteArrayFingerprint.method
+        parseByteArrayMethodRef = WeakReference(ProtobufClassParseByteArrayFingerprint.method)
 
         StreamingDataOuterClassFingerprint.let {
             it.method.apply {

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/litho/node/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/litho/node/Fingerprints.kt
@@ -4,8 +4,8 @@
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
- 
-package app.morphe.patches.youtube.misc.litho.node
+
+package app.morphe.patches.shared.misc.litho.node
 
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.methodCall
@@ -26,7 +26,7 @@ internal object TreeNodeResultListFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.FINAL),
     returnType = "Ljava/util/List;",
     filters = listOf(
-        methodCall(name = "nCopies", opcode = Opcode.INVOKE_STATIC),
+        methodCall(name = "nCopies", opcode = Opcode.INVOKE_STATIC)
     )
 )
 

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/litho/node/TreeNodeElementHookPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/litho/node/TreeNodeElementHookPatch.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+
+package app.morphe.patches.shared.misc.litho.node
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.BytecodePatch
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableClass
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
+import app.morphe.patches.music.layout.buttons.action.TreeNodeListFingerprint
+import app.morphe.patches.music.layout.buttons.action.TreeNodeListHelperConstructorFingerprint
+import app.morphe.patches.shared.misc.litho.context.EXTENSION_CONTEXT_INTERFACE
+import app.morphe.util.addInstructionsAtControlFlowLabel
+import app.morphe.util.getFreeRegisterProvider
+import app.morphe.util.getReference
+import app.morphe.util.indexOfFirstInstructionOrThrow
+import app.morphe.util.p0Register
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
+import java.lang.ref.WeakReference
+
+internal const val EXTENSION_CLASS =
+    "Lapp/morphe/extension/shared/patches/TreeNodeElementPatch;"
+private const val EXTENSION_LITHO_CONTAINER_INTERFACE =
+    $$"Lapp/morphe/extension/shared/patches/TreeNodeElementPatch$LithoGetBufferContainerInterface;"
+
+private lateinit var componentLoadedMethodRef: WeakReference<MutableMethod>
+private lateinit var lazilyConvertedElementLoadedMethodRef: WeakReference<MutableMethod>
+
+/**
+ * Shared factory for the tree-node element hook patch used by both YouTube and YT Music.
+ *
+ * Hooks the tree-node result list from Litho so that patched extensions can inspect (and
+ * physically remove entries from) the list before it is converted into rendered components.
+ *
+ * @param sharedExtensionPatchDep The app-specific `sharedExtensionPatch`.
+ * @param conversionContextPatchDep The app-specific `conversionContextPatch`.
+ */
+internal fun createTreeNodeElementHookPatch(
+    sharedExtensionPatchDep: BytecodePatch,
+    conversionContextPatchDep: BytecodePatch,
+): BytecodePatch = bytecodePatch(
+    description = "Hooks the tree node element lists to the extension."
+) {
+    dependsOn(
+        sharedExtensionPatchDep,
+        conversionContextPatchDep,
+    )
+
+    execute {
+        TreeNodeResultListFingerprint.method.apply {
+            val insertIndex = implementation!!.instructions.lastIndex
+            val listRegister = getInstruction<OneRegisterInstruction>(insertIndex).registerA
+
+            val registerProvider = getFreeRegisterProvider(insertIndex, 1)
+            val freeRegister = registerProvider.getFreeRegister()
+
+            addInstructionsAtControlFlowLabel(
+                insertIndex,
+                """
+                    move-object/from16 v$freeRegister, p2
+                    invoke-static { v$freeRegister, v$listRegister }, $EXTENSION_CLASS->onTreeNodeResultLoaded(${EXTENSION_CONTEXT_INTERFACE}Ljava/util/List;)V
+                """
+            )
+        }
+
+        val componentLoadedMethod = ComponentPatchFingerprint.method
+        componentLoadedMethodRef = WeakReference(componentLoadedMethod)
+
+        val lazilyConvertedElementLoadedMethod = LazilyConvertedElementPatchFingerprint.method
+        lazilyConvertedElementLoadedMethodRef = WeakReference(lazilyConvertedElementLoadedMethod)
+
+        fun addLithoContainerInterface(
+            clazz: MutableClass,
+            reference: FieldReference
+        ) {
+            clazz.apply {
+                interfaces.add(EXTENSION_LITHO_CONTAINER_INTERFACE)
+                methods.add(
+                    ImmutableMethod(
+                        type,
+                        "patch_getContainer",
+                        listOf(),
+                        "Ljava/lang/Object;",
+                        AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+                        null,
+                        null,
+                        MutableMethodImplementation(2),
+                    ).toMutable().apply {
+                        addInstructions(
+                            0,
+                            """
+                                iget-object v0, p0, $reference
+                                return-object v0
+                            """
+                        )
+                    }
+                )
+            }
+        }
+
+        TreeNodeListFingerprint.let {
+            val field = it.instructionMatches.first().getFieldAccessed()
+            addLithoContainerInterface(it.classDef, field)
+        }
+
+        TreeNodeListHelperConstructorFingerprint.let {
+            val p2 = it.method.p0Register + 2
+            val index = it.method.indexOfFirstInstructionOrThrow {
+                opcode == Opcode.IPUT_OBJECT && (this as TwoRegisterInstruction).registerA == p2
+            }
+            val field = it.method.getInstruction<ReferenceInstruction>(index)
+                .getReference<FieldReference>()!!
+
+            addLithoContainerInterface(it.classDef, field)
+        }
+    }
+}
+
+fun hookTreeNodeResult(
+    descriptor: String,
+    isLazilyConvertedElement: Boolean = true
+) {
+    val method = if (isLazilyConvertedElement) lazilyConvertedElementLoadedMethodRef.get()!!
+    else componentLoadedMethodRef.get()!!
+
+    method.addInstruction(
+        0,
+        "invoke-static { p0, p1 }, $descriptor(Ljava/lang/String;Ljava/util/List;)V"
+    )
+}

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/proto/ElementProtoParserHookPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/proto/ElementProtoParserHookPatch.kt
@@ -2,39 +2,46 @@
  * Copyright 2026 Morphe.
  * https://github.com/MorpheApp/morphe-patches
  *
- * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
  */
-package app.morphe.patches.youtube.misc.proto
+
+package app.morphe.patches.shared.misc.proto
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.BytecodePatch
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import app.morphe.patches.shared.misc.fix.proto.fixProtoLibraryPatch
-import app.morphe.patches.shared.misc.proto.NewElementProtoParserFingerprint
-import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.util.cloneMutable
+import java.lang.ref.WeakReference
 
-private lateinit var elementProtoParserMethod: MutableMethod
+private lateinit var elementProtoParserMethodRef: WeakReference<MutableMethod>
 
-val elementProtoParserHookPatch = bytecodePatch(
+/**
+ * Shared factory for the element proto parser hook used by both YouTube and YT Music.
+ *
+ * Hooks the generic proto parser method so that patched extensions can inspect (and modify)
+ * the raw byte buffer of every parsed proto element.
+ *
+ * @param sharedExtensionPatchDep The app-specific `sharedExtensionPatch`.
+ */
+internal fun createElementProtoParserHookPatch(
+    sharedExtensionPatchDep: BytecodePatch,
+): BytecodePatch = bytecodePatch(
     description = "Hook to modify the proto message class, which can only be accessed through reflection.",
 ) {
     dependsOn(
-        sharedExtensionPatch,
+        sharedExtensionPatchDep,
         fixProtoLibraryPatch,
     )
 
     execute {
-
         NewElementProtoParserFingerprint.let {
             it.method.apply {
-                // Not enough registers in the method. Clone the method and use the
-                // original method as an intermediate to call extension code.
-
-                // Copy the method.
+                // Not enough registers in the method. Clone the method and use the original
+                // method as an intermediate to call extension code.
                 val helperMethod = cloneMutable(name = "patch_parseNewElement")
 
-                // Add the method.
                 it.classDef.methods.add(helperMethod)
 
                 addInstructions(
@@ -43,13 +50,13 @@ val elementProtoParserHookPatch = bytecodePatch(
                         # Invoke the copied method (helper method).
                         invoke-static { p0 }, $helperMethod
                         move-result-object p0
-                        
+
                         # Since the copied method (helper method) has already been invoked, it just returns.
                         return-object p0
                     """
                 )
 
-                elementProtoParserMethod = this
+                elementProtoParserMethodRef = WeakReference(this)
             }
         }
     }
@@ -57,7 +64,7 @@ val elementProtoParserHookPatch = bytecodePatch(
 
 fun hookElement(
     methodDescriptor: String
-) = elementProtoParserMethod.addInstructions(
+) = elementProtoParserMethodRef.get()!!.addInstructions(
     2,
     """
         invoke-static { p0 }, $methodDescriptor

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/proto/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/proto/Fingerprints.kt
@@ -2,10 +2,10 @@
  * Copyright 2026 Morphe.
  * https://github.com/MorpheApp/morphe-patches
  *
- * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
  */
 
-package app.morphe.patches.youtube.misc.proto
+package app.morphe.patches.shared.misc.proto
 
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.checkCast
@@ -22,7 +22,6 @@ internal object NewElementProtoParserFingerprint : Fingerprint(
         checkCast("[B")
     ),
     custom = { method, _ ->
-        // 'static' or 'public static'
         AccessFlags.STATIC.isSet(method.accessFlags)
     }
 )

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/SpoofVideoStreamsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/SpoofVideoStreamsPatch.kt
@@ -22,7 +22,7 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
 import app.morphe.patches.shared.misc.fix.proto.fixProtoLibraryPatch
-import app.morphe.patches.shared.misc.fix.proto.parseByteArrayMethod
+import app.morphe.patches.shared.misc.fix.proto.parseByteArrayMethodRef
 import app.morphe.util.ResourceGroup
 import app.morphe.util.addInstructionsAtControlFlowLabel
 import app.morphe.util.copyResources
@@ -237,7 +237,7 @@ internal fun spoofVideoStreamsPatch(
     
                             # Parse streaming data.
                             sget-object v4, $playerProtoClass->a:$playerProtoClass
-                            invoke-static { v4, v3 }, $parseByteArrayMethod
+                            invoke-static { v4, v3 }, ${parseByteArrayMethodRef.get()!!}
                             move-result-object v5
                             check-cast v5, $playerProtoClass
     

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/ad/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/ad/HideAdsPatch.kt
@@ -30,8 +30,8 @@ import app.morphe.patches.youtube.misc.engagement.engagementPanelHookPatch
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.litho.filter.lithoFilterPatch
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
+import app.morphe.patches.shared.misc.proto.hookElement
 import app.morphe.patches.youtube.misc.proto.elementProtoParserHookPatch
-import app.morphe.patches.youtube.misc.proto.hookElement
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/dialog/RemoveViewerDiscretionDialogPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/dialog/RemoveViewerDiscretionDialogPatch.kt
@@ -41,7 +41,7 @@ val removeViewerDiscretionDialogPatch = bytecodePatch(
             SwitchPreference("morphe_remove_viewer_discretion_dialog"),
         )
 
-        fun applyPatch(instructionIndex: Int, instructionRegister: Int, method: MutableMethod) {
+        fun applyPatch(method: MutableMethod, instructionIndex: Int, instructionRegister: Int) {
             method.addInstructions(
                 instructionIndex,
                 """
@@ -81,7 +81,7 @@ val removeViewerDiscretionDialogPatch = bytecodePatch(
                 val instructionRegister = fingerprint.method
                     .getInstruction<OneRegisterInstruction>(instructionIndex).registerA
 
-                applyPatch(instructionIndex + 1, instructionRegister, fingerprint.method)
+                applyPatch(fingerprint.method, instructionIndex + 1, instructionRegister)
             }
         }
 
@@ -117,7 +117,7 @@ val removeViewerDiscretionDialogPatch = bytecodePatch(
                 val instructionRegister = fingerprint.method
                     .getInstruction<TwoRegisterInstruction>(instructionIndex).registerA
 
-                applyPatch(instructionIndex, instructionRegister, fingerprint.method)
+                applyPatch(fingerprint.method, instructionIndex, instructionRegister)
             }
         }
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/HideVideoActionButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/HideVideoActionButtonsPatch.kt
@@ -15,6 +15,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.shared.misc.fix.proto.fixProtoLibraryPatch
 import app.morphe.patches.shared.misc.litho.filter.addLithoFilter
+import app.morphe.patches.shared.misc.litho.node.hookTreeNodeResult
 import app.morphe.patches.shared.misc.settings.preference.NonInteractivePreference
 import app.morphe.patches.shared.misc.settings.preference.PreferenceCategory
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
@@ -22,7 +23,6 @@ import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.fix.videoactionbar.restoreOldVideoActionBarPatch
 import app.morphe.patches.youtube.misc.litho.filter.lithoFilterPatch
-import app.morphe.patches.youtube.misc.litho.node.hookTreeNodeResult
 import app.morphe.patches.youtube.misc.litho.node.treeNodeElementHookPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
@@ -23,7 +23,7 @@ import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMuta
 import app.morphe.patches.shared.misc.fix.proto.fixProtoLibraryPatch
 import app.morphe.patches.shared.misc.fix.proto.immutableMethodRef
 import app.morphe.patches.shared.misc.fix.proto.mutableCopyMethodRef
-import app.morphe.patches.shared.misc.fix.proto.parseByteArrayMethod
+import app.morphe.patches.shared.misc.fix.proto.parseByteArrayMethodRef
 import app.morphe.patches.shared.misc.settings.preference.ListPreference
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference.Sorting
@@ -258,6 +258,7 @@ val navigationBarPatch = bytecodePatch(
                 val messageLiteRegister = pivotBarRendererConstructorStartRegister + messageLiteIndex + 1
                 val insertIndex = it.instructionMatches.last().index
                 val backupRegister = getFreeRegisterProvider(insertIndex, 1).getFreeRegister()
+                val parseByteArrayMethod = parseByteArrayMethodRef.get()!!
 
                 addInstructionsAtControlFlowLabel(
                     insertIndex,
@@ -579,7 +580,7 @@ val navigationBarPatch = bytecodePatch(
 
                         # Parse bytes back into native Buttons wrapper class
                         sget-object v$protoListFreeRegister, $buttonsClass->a:$buttonsClass
-                        invoke-static { v$protoListFreeRegister, v$byteRegister }, $parseByteArrayMethod
+                        invoke-static { v$protoListFreeRegister, v$byteRegister }, ${parseByteArrayMethodRef.get()!!}
                         move-result-object v$protoListFreeRegister
                         check-cast v$protoListFreeRegister, $buttonsClass
                         

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -23,6 +23,7 @@ import app.morphe.patcher.util.smali.ExternalLabel
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.patches.shared.misc.fix.proto.fixProtoLibraryPatch
 import app.morphe.patches.shared.misc.litho.filter.addLithoFilter
+import app.morphe.patches.shared.misc.litho.node.hookTreeNodeResult
 import app.morphe.patches.shared.misc.settings.preference.InputType
 import app.morphe.patches.shared.misc.settings.preference.ListPreference
 import app.morphe.patches.shared.misc.settings.preference.NonInteractivePreference
@@ -37,7 +38,6 @@ import app.morphe.patches.youtube.layout.hide.shelves.hideHorizontalShelvesPatch
 import app.morphe.patches.youtube.layout.hide.updatescreen.hideUpdateScreenPatch
 import app.morphe.patches.youtube.misc.engagement.engagementPanelHookPatch
 import app.morphe.patches.youtube.misc.litho.filter.lithoFilterPatch
-import app.morphe.patches.youtube.misc.litho.node.hookTreeNodeResult
 import app.morphe.patches.youtube.misc.litho.node.treeNodeElementHookPatch
 import app.morphe.patches.youtube.misc.navigation.navigationBarHookPatch
 import app.morphe.patches.youtube.misc.playservice.is_20_21_or_greater
@@ -46,8 +46,8 @@ import app.morphe.patches.youtube.misc.playservice.is_21_11_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_21_20_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_21_25_or_greater
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
+import app.morphe.patches.shared.misc.proto.hookElement
 import app.morphe.patches.youtube.misc.proto.elementProtoParserHookPatch
-import app.morphe.patches.youtube.misc.proto.hookElement
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/player/flyoutmenu/HidePlayerFlyoutMenuComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/player/flyoutmenu/HidePlayerFlyoutMenuComponentsPatch.kt
@@ -15,14 +15,14 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.patches.shared.misc.fix.proto.fixProtoLibraryPatch
 import app.morphe.patches.shared.misc.litho.filter.addLithoFilter
+import app.morphe.patches.shared.misc.litho.node.hookTreeNodeResult
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.litho.filter.lithoFilterPatch
-import app.morphe.patches.youtube.misc.litho.node.hookTreeNodeResult
 import app.morphe.patches.youtube.misc.litho.node.treeNodeElementHookPatch
 import app.morphe.patches.youtube.misc.playertype.playerTypeHookPatch
+import app.morphe.patches.shared.misc.proto.hookElement
 import app.morphe.patches.youtube.misc.proto.elementProtoParserHookPatch
-import app.morphe.patches.youtube.misc.proto.hookElement
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/engagement/EngagementPanelHookPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/engagement/EngagementPanelHookPatch.kt
@@ -11,19 +11,16 @@ import app.morphe.patches.youtube.shared.EngagementPanelControllerFingerprint
 import app.morphe.util.getReference
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import java.lang.ref.WeakReference
 import kotlin.properties.Delegates
 
 private const val EXTENSION_CLASS =
     "Lapp/morphe/extension/youtube/shared/EngagementPanel;"
 
-var panelControllerMethod: MutableMethod by Delegates.notNull()
-    private set
-var panelIdIndex = 0
-    private set
-var panelIdRegister = 0
-    private set
-var panelIdSmaliInstruction = ""
-    private set
+lateinit var panelControllerMethodRef: WeakReference<MutableMethod>
+private var panelIdIndex = -1
+private var panelIdRegister = -1
+private lateinit var panelIdSmaliInstruction : String
 
 val engagementPanelHookPatch = bytecodePatch(
     description = "Hook to get the current engagement panel state.",
@@ -32,17 +29,16 @@ val engagementPanelHookPatch = bytecodePatch(
 
     execute {
         EngagementPanelControllerFingerprint.let {
-            it.clearMatch()
             it.method.apply {
                 val panelIdField = it.instructionMatches.last().instruction.getReference<FieldReference>()!!
                 val insertIndex = it.instructionMatches[5].index
 
                 val (freeRegister, panelRegister) =
                     with (getInstruction<TwoRegisterInstruction>(insertIndex)) {
-                        Pair(registerA, registerB)
+                        registerA to registerB
                     }
 
-                panelControllerMethod = this
+                panelControllerMethodRef = WeakReference(this)
                 panelIdIndex = insertIndex
                 panelIdRegister = freeRegister
                 panelIdSmaliInstruction =
@@ -66,7 +62,7 @@ val engagementPanelHookPatch = bytecodePatch(
 }
 
 fun addEngagementPanelIdHook(descriptor: String) =
-    panelControllerMethod.addInstructionsWithLabels(
+    panelControllerMethodRef.get()!!.addInstructionsWithLabels(
         panelIdIndex,
         """
             $panelIdSmaliInstruction

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/litho/observer/LayoutReloadObserverPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/litho/observer/LayoutReloadObserverPatch.kt
@@ -10,15 +10,15 @@
 package app.morphe.patches.youtube.misc.litho.observer
 
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.misc.litho.node.hookTreeNodeResult
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.litho.node.treeNodeElementHookPatch
-import app.morphe.patches.youtube.misc.litho.node.hookTreeNodeResult
 
 private const val EXTENSION_CLASS =
     "Lapp/morphe/extension/youtube/patches/LayoutReloadObserverPatch;"
 
 val layoutReloadObserverPatch = bytecodePatch(
-    description = "Hooks a method to detect in the extension when the RecyclerView at the bottom of the player is redrawn.",
+    description = "Hooks a method to detect in the extension when the RecyclerView at the bottom of the player is redrawn."
 ) {
     dependsOn(
         sharedExtensionPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/request/BuildRequestPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/request/BuildRequestPatch.kt
@@ -14,11 +14,12 @@ import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.util.findFreeRegister
 import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
+import java.lang.ref.WeakReference
 
-private lateinit var buildRequestMethod: MutableMethod
-private var builderIndex = 0
-private var urlRegister = 0
-private var freeRegister = 0
+private lateinit var buildRequestMethod: WeakReference<MutableMethod>
+private var builderIndex = -1
+private var urlRegister = -1
+private var freeRegister = -1
 
 internal val buildRequestPatch = bytecodePatch(
     description = "buildRequestPatch",
@@ -26,19 +27,23 @@ internal val buildRequestPatch = bytecodePatch(
     dependsOn(sharedExtensionPatch)
 
     execute {
-        buildRequestMethod = BuildRequestFingerprint.method.apply {
+        buildRequestMethod = WeakReference(BuildRequestFingerprint.method.apply {
             builderIndex = indexOfNewUrlRequestBuilderInstruction(this)
             urlRegister = getInstruction<FiveRegisterInstruction>(builderIndex).registerD
             freeRegister = findFreeRegister(builderIndex, urlRegister)
 
-            if (!getInstruction(builderIndex).toString().contains("move-object v$freeRegister, p1"))
+            if (!getInstruction(builderIndex).toString().contains("move-object v$freeRegister, p1")) {
                 addInstruction(builderIndex, "move-object v$freeRegister, p1")
-        }
+            }
+        })
     }
 }
 
 internal fun hookBuildRequest(descriptor: String) {
-    buildRequestMethod.apply {
-        addInstruction(builderIndex + 1, "invoke-static { v$urlRegister, v$freeRegister }, $descriptor")
+    buildRequestMethod.get()!!.apply {
+        addInstruction(
+            builderIndex + 1,
+            "invoke-static { v$urlRegister, v$freeRegister }, $descriptor"
+        )
     }
 }

--- a/patches/src/main/resources/addresources/values/music/strings.xml
+++ b/patches/src/main/resources/addresources/values/music/strings.xml
@@ -128,6 +128,23 @@ YouTube Music 8.x — crossfade only runs on 9.x and newer"</string>
     <string name="morphe_music_hide_lyrics_share_button_title">Hide Share button</string>
     <string name="morphe_music_hide_lyrics_translate_button_title">Hide Translate button</string>
 
+    <!-- layout.hide.actionbuttons.hideActionButtonsPatch -->
+    <string name="morphe_music_action_buttons_screen_title">Action buttons</string>
+    <string name="morphe_music_action_buttons_screen_summary">Choose which action buttons appear under the player</string>
+    <string name="morphe_music_hide_action_bar_title">Hide action bar</string>
+    <string name="morphe_music_hide_like_dislike_button_title">Hide Like and Dislike button</string>
+    <string name="morphe_music_hide_comments_button_title">Hide Comments button</string>
+    <!-- 'Lyrics' should be translated using the same localized wording YouTube Music displays for the button. -->
+    <string name="morphe_music_hide_lyrics_button_title">Hide Lyrics button</string>
+    <!-- 'Share' should be translated using the same localized wording YouTube Music displays for the button. -->
+    <string name="morphe_music_hide_share_button_title">Hide Share button</string>
+    <!-- 'Save' should be translated using the same localized wording YouTube Music displays for the button. -->
+    <string name="morphe_music_hide_save_button_title">Hide Save button</string>
+    <!-- 'Download' should be translated using the same localized wording YouTube Music displays for the button. -->
+    <string name="morphe_music_hide_download_button_title">Hide Download button</string>
+    <!-- 'Start radio' should be translated using the same localized wording YouTube Music displays for the button. -->
+    <string name="morphe_music_hide_radio_button_title">Hide Start radio button</string>
+
     <!-- flyoutmenu.components.hideFlyoutMenuComponentsPatch -->
     <string name="morphe_music_hide_flyout_menu_components_screen_title">Flyout menu</string>
     <string name="morphe_music_hide_flyout_menu_components_screen_summary">Choose which components appear in the player and queue flyout menus</string>


### PR DESCRIPTION
### Description

Adds a `Music Hide action buttons` patch that hides the row under the player (Like/Dislike, Comments, Lyrics, Share, Save, Download, Radio or the entire action bar), and moves the litho tree-node / proto-parser hook infrastructure into shared factories so YouTube and YT Music share the same injection.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
