### PR TITLE
feat(YouTube Music): Add `Disable dislike redirection` patch

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/DisableDislikeRedirectionPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/DisableDislikeRedirectionPatch.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.music.patches;
+
+import app.morphe.extension.music.settings.Settings;
+
+@SuppressWarnings("unused")
+public class DisableDislikeRedirectionPatch {
+
+    /**
+     * Injection point.
+     */
+    public static boolean disableDislikeRedirection() {
+        return Settings.DISABLE_DISLIKE_REDIRECTION.get();
+    }
+}

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -64,6 +64,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting ENABLE_FORCED_MINIPLAYER = new BooleanSetting("morphe_music_enable_forced_miniplayer", FALSE, true);
     public static final BooleanSetting ENABLE_SWIPE_TO_DISMISS_MINIPLAYER = new BooleanSetting("morphe_music_enable_swipe_to_dismiss_miniplayer", FALSE, true);
     public static final BooleanSetting PERMANENT_REPEAT = new BooleanSetting("morphe_music_play_permanent_repeat", FALSE, true);
+    public static final BooleanSetting DISABLE_DISLIKE_REDIRECTION = new BooleanSetting("morphe_music_disable_dislike_redirection", FALSE, true);
 
     // Flyout menu
     public static final BooleanSetting HIDE_FLYOUT_MENU_3_COLUMN_COMPONENT = new BooleanSetting("morphe_music_hide_flyout_menu_3_column_component", FALSE);

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/dislikeredirection/DisableDislikeRedirectionPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/dislikeredirection/DisableDislikeRedirectionPatch.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.patches.music.interaction.dislikeredirection
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import app.morphe.patcher.util.smali.ExternalLabel
+import app.morphe.patches.music.misc.extension.sharedExtensionPatch
+import app.morphe.patches.music.misc.settings.PreferenceScreen
+import app.morphe.patches.music.misc.settings.settingsPatch
+import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
+import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import app.morphe.util.getReference
+import app.morphe.util.indexOfFirstInstructionOrThrow
+import app.morphe.util.indexOfFirstInstructionReversedOrThrow
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+
+private const val EXTENSION_CLASS =
+    "Lapp/morphe/extension/music/patches/DisableDislikeRedirectionPatch;"
+
+@Suppress("unused")
+val disableDislikeRedirectionPatch = bytecodePatch(
+    name = "Disable dislike redirection",
+    description = "Adds an option to prevent skipping to the next track when the dislike " +
+            "button is pressed."
+) {
+    dependsOn(
+        sharedExtensionPatch,
+        settingsPatch,
+    )
+
+    compatibleWith(COMPATIBILITY_YOUTUBE_MUSIC)
+
+    execute {
+        PreferenceScreen.PLAYER.addPreferences(
+            SwitchPreference("morphe_music_disable_dislike_redirection", summary = true),
+        )
+
+        // The notification and player handlers share the same onClick dispatch interface method,
+        // extract its reference here to locate the twin call inside the player handler below.
+        val onClickReference = NotificationLikeButtonOnClickListenerFingerprint.method.let { method ->
+            val mapIndex = indexOfMapInstruction(method)
+            val onClickIndex = method.indexOfFirstInstructionOrThrow(mapIndex) {
+                val reference = getReference<MethodReference>()
+                opcode == Opcode.INVOKE_INTERFACE &&
+                        reference?.returnType == "V" &&
+                        reference.parameterTypes.size == 1
+            }
+            val reference = method.getInstruction<ReferenceInstruction>(onClickIndex)
+                .reference.toString()
+
+            method.injectRedirectionGuard(onClickIndex)
+            reference
+        }
+
+        DislikeButtonOnClickListenerFingerprint.method.apply {
+            val onClickIndex = indexOfFirstInstructionOrThrow {
+                getReference<MethodReference>()?.toString() == onClickReference
+            }
+            injectRedirectionGuard(onClickIndex)
+        }
+    }
+}
+
+// Register from the existing IF_EQZ is reused for move-result; both branches
+// reassign it before the next read, so the clobber is safe.
+private fun MutableMethod.injectRedirectionGuard(onClickIndex: Int) {
+    val targetIndex = indexOfFirstInstructionReversedOrThrow(onClickIndex, Opcode.IF_EQZ)
+    val insertRegister = getInstruction<OneRegisterInstruction>(targetIndex).registerA
+
+    addInstructionsWithLabels(
+        targetIndex + 1,
+        """
+            invoke-static { }, $EXTENSION_CLASS->disableDislikeRedirection()Z
+            move-result v$insertRegister
+            if-nez v$insertRegister, :disable
+        """,
+        ExternalLabel("disable", getInstruction(onClickIndex + 1))
+    )
+}

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/dislikeredirection/DisableDislikeRedirectionPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/dislikeredirection/DisableDislikeRedirectionPatch.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/1962
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
@@ -43,29 +43,25 @@ val disableDislikeRedirectionPatch = bytecodePatch(
 
     execute {
         PreferenceScreen.PLAYER.addPreferences(
-            SwitchPreference("morphe_music_disable_dislike_redirection", summary = true),
+            SwitchPreference("morphe_music_disable_dislike_redirection", summary = true)
         )
 
         // The notification and player handlers share the same onClick dispatch interface method,
         // extract its reference here to locate the twin call inside the player handler below.
-        val onClickReference = NotificationLikeButtonOnClickListenerFingerprint.method.let { method ->
-            val mapIndex = indexOfMapInstruction(method)
-            val onClickIndex = method.indexOfFirstInstructionOrThrow(mapIndex) {
-                val reference = getReference<MethodReference>()
-                opcode == Opcode.INVOKE_INTERFACE &&
-                        reference?.returnType == "V" &&
-                        reference.parameterTypes.size == 1
-            }
-            val reference = method.getInstruction<ReferenceInstruction>(onClickIndex)
-                .reference.toString()
+        val onClickReference = NotificationLikeButtonOnClickListenerFingerprint.let {
+            it.method.let { method ->
+                val onClickIndex = it.instructionMatches.last().index
+                val reference = method.getInstruction<ReferenceInstruction>(onClickIndex)
+                    .reference
 
-            method.injectRedirectionGuard(onClickIndex)
-            reference
+                method.injectRedirectionGuard(onClickIndex)
+                reference
+            }
         }
 
         DislikeButtonOnClickListenerFingerprint.method.apply {
             val onClickIndex = indexOfFirstInstructionOrThrow {
-                getReference<MethodReference>()?.toString() == onClickReference
+                getReference<MethodReference>() == onClickReference
             }
             injectRedirectionGuard(onClickIndex)
         }

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/dislikeredirection/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/dislikeredirection/Fingerprints.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.patches.music.interaction.dislikeredirection
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.util.getReference
+import app.morphe.util.indexOfFirstInstruction
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.Method
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+
+// String is a substring so both `NotificationLikeButtonController` (pre-8.x) and
+// `DefaultNotificationLikeButtonController` (8.x+) match.
+internal object NotificationLikeButtonControllerFingerprint : Fingerprint(
+    returnType = "V",
+    parameters = listOf(),
+    strings = listOf("NotificationLikeButtonController"),
+    custom = { method, _ ->
+        method.name == "<clinit>"
+    }
+)
+
+internal object NotificationLikeButtonOnClickListenerFingerprint : Fingerprint(
+    classFingerprint = NotificationLikeButtonControllerFingerprint,
+    accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf("L"),
+    custom = { method, _ ->
+        indexOfMapInstruction(method) >= 0
+    }
+)
+
+internal fun indexOfMapInstruction(method: Method) =
+    method.indexOfFirstInstruction {
+        val reference = getReference<MethodReference>()
+        opcode == Opcode.INVOKE_VIRTUAL &&
+                reference?.parameterTypes?.size == 3 &&
+                reference.parameterTypes[2].toString() == "Ljava/util/Map;"
+    }
+
+// Field names are obfuscated in 9.x.
+// Class shape is stable: 7 fields, 5 methods, 3 of which are `V(L, Ljava/util/Map;)` interface impls
+// and only one dispatches the next-track onClick (invoke-interface V(L)).
+internal object DislikeButtonOnClickListenerFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf("L", "Ljava/util/Map;"),
+    custom = custom@{ method, classDef ->
+        if (classDef.fields.count() != 7) return@custom false
+        if (classDef.methods.count() != 5) return@custom false
+
+        val interfaceMethodCount = classDef.methods.count { m ->
+            AccessFlags.PUBLIC.isSet(m.accessFlags) &&
+                    AccessFlags.FINAL.isSet(m.accessFlags) &&
+                    m.returnType == "V" &&
+                    m.parameterTypes.size == 2 &&
+                    m.parameterTypes.last().toString() == "Ljava/util/Map;"
+        }
+        if (interfaceMethodCount != 3) return@custom false
+
+        val instructions = method.implementation?.instructions ?: return@custom false
+        if (instructions.count() < 50) return@custom false
+
+        method.indexOfFirstInstruction {
+            val reference = getReference<MethodReference>()
+            opcode == Opcode.INVOKE_INTERFACE &&
+                    reference?.returnType == "V" &&
+                    reference.parameterTypes.size == 1
+        } >= 0
+    }
+)

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/dislikeredirection/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/dislikeredirection/Fingerprints.kt
@@ -8,6 +8,7 @@
 package app.morphe.patches.music.interaction.dislikeredirection
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.anyInstruction
 import app.morphe.patcher.methodCall
 import app.morphe.patcher.string
 import com.android.tools.smali.dexlib2.AccessFlags
@@ -21,7 +22,12 @@ internal object NotificationLikeButtonOnClickListenerFingerprint : Fingerprint(
         returnType = "V",
         parameters = listOf(),
         filters = listOf(
-            string("com/google/android/apps/youtube/music/player/notification/DefaultNotificationLikeButtonController")
+            anyInstruction(
+                // 7.29
+                string("com/google/android/apps/youtube/music/player/notification/NotificationLikeButtonController"),
+                // 8.x+
+                string("com/google/android/apps/youtube/music/player/notification/DefaultNotificationLikeButtonController")
+            )
         )
     ),
     accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.FINAL),

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/dislikeredirection/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/dislikeredirection/Fingerprints.kt
@@ -8,41 +8,37 @@
 package app.morphe.patches.music.interaction.dislikeredirection
 
 import app.morphe.patcher.Fingerprint
-import app.morphe.util.getReference
-import app.morphe.util.indexOfFirstInstruction
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.string
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.Method
-import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 // String is a substring so both `NotificationLikeButtonController` (pre-8.x) and
 // `DefaultNotificationLikeButtonController` (8.x+) match.
-internal object NotificationLikeButtonControllerFingerprint : Fingerprint(
-    returnType = "V",
-    parameters = listOf(),
-    strings = listOf("NotificationLikeButtonController"),
-    custom = { method, _ ->
-        method.name == "<clinit>"
-    }
-)
-
 internal object NotificationLikeButtonOnClickListenerFingerprint : Fingerprint(
-    classFingerprint = NotificationLikeButtonControllerFingerprint,
+    classFingerprint = Fingerprint(
+        name = "<clinit>",
+        returnType = "V",
+        parameters = listOf(),
+        filters = listOf(
+            string("com/google/android/apps/youtube/music/player/notification/DefaultNotificationLikeButtonController")
+        )
+    ),
     accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.FINAL),
     returnType = "V",
     parameters = listOf("L"),
-    custom = { method, _ ->
-        indexOfMapInstruction(method) >= 0
-    }
+    filters = listOf(
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            parameters = listOf("L", "L", "Ljava/util/Map;")
+        ),
+        methodCall(
+            opcode = Opcode.INVOKE_INTERFACE,
+            returnType = "V",
+            parameters = listOf("L")
+        )
+    )
 )
-
-internal fun indexOfMapInstruction(method: Method) =
-    method.indexOfFirstInstruction {
-        val reference = getReference<MethodReference>()
-        opcode == Opcode.INVOKE_VIRTUAL &&
-                reference?.parameterTypes?.size == 3 &&
-                reference.parameterTypes[2].toString() == "Ljava/util/Map;"
-    }
 
 // Field names are obfuscated in 9.x.
 // Class shape is stable: 7 fields, 5 methods, 3 of which are `V(L, Ljava/util/Map;)` interface impls
@@ -51,6 +47,13 @@ internal object DislikeButtonOnClickListenerFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "V",
     parameters = listOf("L", "Ljava/util/Map;"),
+    filters = listOf(
+        methodCall(
+            opcode = Opcode.INVOKE_INTERFACE,
+            returnType = "V",
+            parameters = listOf("L")
+        )
+    ),
     custom = custom@{ method, classDef ->
         if (classDef.fields.count() != 7) return@custom false
         if (classDef.methods.count() != 5) return@custom false
@@ -65,13 +68,6 @@ internal object DislikeButtonOnClickListenerFingerprint : Fingerprint(
         if (interfaceMethodCount != 3) return@custom false
 
         val instructions = method.implementation?.instructions ?: return@custom false
-        if (instructions.count() < 50) return@custom false
-
-        method.indexOfFirstInstruction {
-            val reference = getReference<MethodReference>()
-            opcode == Opcode.INVOKE_INTERFACE &&
-                    reference?.returnType == "V" &&
-                    reference.parameterTypes.size == 1
-        } >= 0
+        return@custom instructions.count() >= 50
     }
 )

--- a/patches/src/main/resources/addresources/values/music/strings.xml
+++ b/patches/src/main/resources/addresources/values/music/strings.xml
@@ -117,6 +117,10 @@ YouTube Music 8.x — crossfade only runs on 9.x and newer"</string>
     <!-- interaction.permanentrepeat.permanentRepeatPatch -->
     <string name="morphe_music_play_permanent_repeat_title">Enable permanent repeat</string>
 
+    <!-- interaction.dislikeredirection.disableDislikeRedirectionPatch -->
+    <string name="morphe_music_disable_dislike_redirection_title">Disable dislike redirection</string>
+    <string name="morphe_music_disable_dislike_redirection_summary">Prevents skipping to the next track when the dislike button is pressed</string>
+
     <!-- layout.buttons.hideButtonsPatch -->
     <string name="morphe_music_hide_cast_button_title">Hide Cast button</string>
     <string name="morphe_music_hide_history_button_title">Hide History button</string>


### PR DESCRIPTION
### Description

Adds an option to prevent skipping to the next track when the dislike button is pressed, the dislike is still registered, but playback stays on the current song.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
