### PR TITLE
feat: Add typed patch options

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 # Dependencies must also be addded to LicensesDialog.java
 
 [versions]
-morphe-patcher = "1.5.2"
+morphe-patcher = "1.7.0-dev.1"
 morphe-patches-library = "1.5.1-dev.2"
 # Tracking https://github.com/google/smali/issues/100.
 smali = "d92701d947"

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
@@ -19,6 +19,7 @@ import app.morphe.patcher.patch.ResourcePatch
 import app.morphe.patcher.patch.ResourcePatchBuilder
 import app.morphe.patcher.patch.ResourcePatchContext
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.folderOption
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patcher.patch.stringOption
 import app.morphe.patches.all.misc.packagename.setOrGetFallbackPackageName
@@ -116,7 +117,7 @@ internal fun baseCustomBrandingPatch(
         description = "Custom app name."
     )
 
-    val customIcon by stringOption(
+    val customIcon by folderOption(
         key = "customIcon",
         title = "Custom icon",
         description = """

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/header/BaseChangeHeaderPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/header/BaseChangeHeaderPatch.kt
@@ -14,8 +14,8 @@ import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.ResourcePatch
 import app.morphe.patcher.patch.ResourcePatchBuilder
 import app.morphe.patcher.patch.ResourcePatchContext
+import app.morphe.patcher.patch.folderOption
 import app.morphe.patcher.patch.resourcePatch
-import app.morphe.patcher.patch.stringOption
 import app.morphe.patches.shared.misc.settings.preference.BasePreferenceScreen
 import app.morphe.patches.shared.misc.settings.preference.ListPreference
 import app.morphe.util.ResourceGroup
@@ -41,7 +41,7 @@ internal fun baseChangeHeaderPatch(
         "${CUSTOM_HEADER_RESOURCE_NAME}_$variant.png"
     }.toTypedArray()
 
-    val custom by stringOption(
+    val custom by folderOption(
         key = "custom",
         title = "Custom header logo",
         description = """

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -4,8 +4,8 @@ import app.morphe.patcher.patch.BytecodePatchBuilder
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.colorOption
 import app.morphe.patcher.patch.resourcePatch
-import app.morphe.patcher.patch.stringOption
 import app.morphe.patches.shared.misc.settings.overrideThemeColors
 import app.morphe.util.childElementsSequence
 import app.morphe.util.forEachChildElement
@@ -105,7 +105,7 @@ internal fun validateColorName(colorString: String): Boolean {
 /**
  * Dark theme color options for YouTube and YT Music Theme patch.
  */
-internal val darkThemeBackgroundColorOption = stringOption(
+internal val darkThemeBackgroundColorOption = colorOption(
     key = "darkThemeBackgroundColor",
     default = "@android:color/black",
     values = mapOf(
@@ -131,7 +131,7 @@ internal val darkThemeBackgroundColorOption = stringOption(
 /**
  * Light theme color options for YouTube Theme patch.
  */
-internal val lightThemeBackgroundColorOption = stringOption(
+internal val lightThemeBackgroundColorOption = colorOption(
     key = "lightThemeBackgroundColor",
     default = "@android:color/white",
     values =  mapOf(


### PR DESCRIPTION
Adds typed patch options (folder, file, image, color) so editors dispatch on type rather than description-based heuristics. Existing `stringOption` bundles keep working unchanged.

  **Related PRs:**
  - morphe-patcher https://github.com/MorpheApp/morphe-patcher/pull/152
  - morphe-manager https://github.com/MorpheApp/morphe-manager/pull/706
  - morphe-patches https://github.com/MorpheApp/morphe-patches/pull/1971