### PR TITLE
feat(YouTube - Swipe controls): Add playback speed step preference

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -57,6 +57,7 @@ import app.morphe.extension.youtube.patches.voiceovertranslation.VoiceOverTransl
 import app.morphe.extension.youtube.sponsorblock.SponsorBlockSettings;
 import app.morphe.extension.youtube.sponsorblock.YouTubeSponsorBlockConfig;
 import app.morphe.extension.youtube.swipecontrols.SwipeControlsConfigurationProvider.SwipeOverlayStyle;
+import app.morphe.extension.youtube.swipecontrols.SwipeControlsConfigurationProvider.SwipeSpeedStep;
 import app.morphe.extension.youtube.videoplayer.PlayAllButton.PlaylistIDPrefix;
 
 public class Settings extends SharedYouTubeSettings {
@@ -491,6 +492,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final IntegerSetting SWIPE_VOLUME_SENSITIVITY = new IntegerSetting("morphe_swipe_volume_sensitivity", 1, true, parent(SWIPE_VOLUME));
     public static final IntegerSetting SWIPE_BRIGHTNESS_SENSITIVITY = new IntegerSetting("morphe_swipe_brightness_sensitivity", 1, true, parent(SWIPE_BRIGHTNESS));
     public static final IntegerSetting SWIPE_SPEED_SENSITIVITY = new IntegerSetting("morphe_swipe_speed_sensitivity", 10, true, parent(SWIPE_SPEED));
+    public static final EnumSetting<SwipeSpeedStep> SWIPE_SPEED_STEP = new EnumSetting<>("morphe_swipe_speed_step", SwipeSpeedStep.STEP_005, true, parent(SWIPE_SPEED));
     public static final IntegerSetting SWIPE_SPEED_ZONE_HEIGHT = new IntegerSetting("morphe_swipe_speed_zone_height", 30, true, parent(SWIPE_SPEED));
     public static final EnumSetting<SwipeOverlayStyle> SWIPE_OVERLAY_STYLE = new EnumSetting<>("morphe_swipe_overlay_style", SwipeOverlayStyle.HORIZONTAL,true, parentsAny(SWIPE_BRIGHTNESS, SWIPE_VOLUME, SWIPE_SPEED));
     public static final IntegerSetting SWIPE_OVERLAY_TEXT_SIZE = new IntegerSetting("morphe_swipe_text_overlay_size", 14, true, parentsAny(SWIPE_BRIGHTNESS, SWIPE_VOLUME, SWIPE_SPEED));

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -757,7 +757,7 @@ public class Settings extends SharedYouTubeSettings {
         SeekBarPreference.register(new SeekBarConfig(SWIPE_BRIGHTNESS_SENSITIVITY,
                 1, 10, 1, ""));
         SeekBarPreference.register(new SeekBarConfig(SWIPE_SPEED_SENSITIVITY,
-                1, 20, 1, ""));
+                1, 50, 1, ""));
         SeekBarPreference.register(new SeekBarConfig(SWIPE_SPEED_ZONE_HEIGHT,
                 5, 75, 1, "%"));
         SeekBarPreference.register(new SeekBarConfig(QUICK_ACTIONS_TOP_MARGIN,

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/SwipeControlsConfigurationProvider.kt
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/SwipeControlsConfigurationProvider.kt
@@ -130,6 +130,12 @@ class SwipeControlsConfigurationProvider {
             return sensitivity
         }
 
+    /**
+     * Playback speed change per tick, expressed as an integer multiplied by 100 (e.g. 5 = 0.05x).
+     */
+    val speedStepInt: Int
+        get() = Settings.SWIPE_SPEED_STEP.get().stepInt
+
     //endregion
 
     //region overlay adjustments
@@ -274,9 +280,19 @@ class SwipeControlsConfigurationProvider {
      * The current style of the overlay, determining its layout and appearance.
      */
     val overlayStyle = Settings.SWIPE_OVERLAY_STYLE.get()
+
+    /**
+     * Playback speed change per tick, expressed as an integer multiplied by 100 (e.g. 5 = 0.05x).
+     */
+    @Suppress("unused")
+    enum class SwipeSpeedStep(val stepInt: Int) {
+        STEP_005(5),
+        STEP_010(10),
+        STEP_025(25),
+    }
     //endregion
 
-    //region behaviour
+    //region behavior
     /**
      * Indicates whether the brightness level should be saved and restored when entering or exiting fullscreen mode.
      */

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/controller/gesture/core/BaseGestureController.kt
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/controller/gesture/core/BaseGestureController.kt
@@ -26,6 +26,7 @@ abstract class BaseGestureController(
         controller.config.brightnessSwipeSensitivity,
         controller.config.volumeSwipeSensitivity,
         controller.config.speedSwipeSensitivity,
+        controller.config.speedStepInt,
         controller.config.enableSpeedGestureControl,
     ) {
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/controller/gesture/core/VolumeAndBrightnessScroller.kt
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/controller/gesture/core/VolumeAndBrightnessScroller.kt
@@ -8,6 +8,7 @@ import app.morphe.extension.youtube.swipecontrols.controller.ScreenBrightnessCon
 import app.morphe.extension.youtube.swipecontrols.misc.ScrollDistanceHelper
 import app.morphe.extension.youtube.swipecontrols.misc.SwipeControlsOverlay
 import app.morphe.extension.youtube.swipecontrols.misc.applyDimension
+import kotlin.math.roundToInt
 
 /**
  * Describes a class that controls volume, brightness, and playback speed based on scrolling events.
@@ -51,6 +52,7 @@ interface VolumeAndBrightnessScroller {
  * @param brightnessDistance Unit distance for brightness scrolling, in dp; higher = more precise.
  * @param volumeSwipeSensitivity How much volume will change per swipe.
  * @param speedDistance Unit distance for speed scrolling, in dp; higher = more precise.
+ * @param speedStepInt Playback speed change per tick, expressed as an integer multiplied by 100 (e.g. 5 = 0.05x).
  * @param enableSpeedGesture Whether the playback speed swipe gesture is enabled.
  */
 class VolumeAndBrightnessScrollerImpl(
@@ -62,6 +64,7 @@ class VolumeAndBrightnessScrollerImpl(
     brightnessDistance: Int = 1,
     private val volumeSwipeSensitivity: Int,
     speedDistance: Int = 10,
+    private val speedStepInt: Int = 5,
     private val enableSpeedGesture: Boolean = false,
 ) : VolumeAndBrightnessScroller {
 
@@ -118,8 +121,10 @@ class VolumeAndBrightnessScrollerImpl(
             ),
         ) { _, _, direction ->
             if (!enableSpeedGesture) return@ScrollDistanceHelper
-            val currentSpeed = VideoInformation.getPlaybackSpeed()
-            val newSpeed = maxOf(0.25f, minOf(8.0f, currentSpeed + direction * 0.25f))
+            // Integer math (×100) avoids float drift like 1.04999 instead of 1.05.
+            val currentSpeedInt = (VideoInformation.getPlaybackSpeed() * 100).roundToInt()
+            val newSpeedInt = maxOf(25, minOf(800, currentSpeedInt + direction * speedStepInt))
+            val newSpeed = newSpeedInt / 100f
             VideoInformation.overridePlaybackSpeed(newSpeed)
             overlayController.onSpeedChanged(newSpeed)
         }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/swipecontrols/SwipeControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/swipecontrols/SwipeControlsPatch.kt
@@ -29,7 +29,7 @@ internal const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/swipecontrol
 private val swipeControlsResourcePatch = resourcePatch {
     dependsOn(
         settingsPatch,
-        versionCheckPatch,
+        versionCheckPatch
     )
 
     execute {
@@ -48,29 +48,30 @@ private val swipeControlsResourcePatch = resourcePatch {
             SwitchPreference("morphe_swipe_speed", summary = true),
             NonInteractivePreference(
                 key = "morphe_swipe_zone_width",
-                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference",
+                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference"
             ),
             NonInteractivePreference(
                 key = "morphe_swipe_speed_zone_height",
-                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference",
+                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference"
             ),
             NonInteractivePreference(
                 key = "morphe_swipe_zone_preview",
                 summaryKey = null,
-                tag = "app.morphe.extension.youtube.settings.preference.SwipeZonePreference",
+                tag = "app.morphe.extension.youtube.settings.preference.SwipeZonePreference"
             ),
             NonInteractivePreference(
                 key = "morphe_swipe_brightness_sensitivity",
-                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference",
+                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference"
             ),
             NonInteractivePreference(
                 key = "morphe_swipe_volume_sensitivity",
-                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference",
+                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference"
             ),
             NonInteractivePreference(
                 key = "morphe_swipe_speed_sensitivity",
-                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference",
+                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference"
             ),
+            ListPreference("morphe_swipe_speed_step"),
             SwitchPreference("morphe_swipe_press_to_engage", summary = true),
             SwitchPreference("morphe_swipe_haptic_feedback"),
             SwitchPreference("morphe_swipe_save_and_restore_brightness", summary = true),
@@ -78,23 +79,26 @@ private val swipeControlsResourcePatch = resourcePatch {
             ListPreference("morphe_swipe_overlay_style"),
             NonInteractivePreference(
                 key = "morphe_swipe_overlay_background_opacity",
-                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference",
+                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference"
             ),
             TextPreference("morphe_swipe_overlay_progress_brightness_color",
                 tag = "app.morphe.extension.shared.settings.preference.ColorPickerWithOpacitySliderPreference",
-                inputType = InputType.TEXT_CAP_CHARACTERS),
+                inputType = InputType.TEXT_CAP_CHARACTERS
+            ),
             TextPreference("morphe_swipe_overlay_progress_volume_color",
                 tag = "app.morphe.extension.shared.settings.preference.ColorPickerWithOpacitySliderPreference",
-                inputType = InputType.TEXT_CAP_CHARACTERS),
+                inputType = InputType.TEXT_CAP_CHARACTERS
+            ),
             TextPreference("morphe_swipe_overlay_progress_speed_color",
                 tag = "app.morphe.extension.shared.settings.preference.ColorPickerWithOpacitySliderPreference",
-                inputType = InputType.TEXT_CAP_CHARACTERS),
+                inputType = InputType.TEXT_CAP_CHARACTERS
+            ),
             NonInteractivePreference(
                 key = "morphe_swipe_text_overlay_size",
-                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference",
+                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference"
             ),
             TextPreference("morphe_swipe_overlay_timeout", inputType = InputType.NUMBER),
-            TextPreference("morphe_swipe_threshold", inputType = InputType.NUMBER),
+            TextPreference("morphe_swipe_threshold", inputType = InputType.NUMBER)
         )
 
         copyResources(
@@ -110,7 +114,7 @@ private val swipeControlsResourcePatch = resourcePatch {
                 "morphe_ic_sc_volume_low.xml",
                 "morphe_ic_sc_volume_mute.xml",
                 "morphe_ic_sc_volume_normal.xml",
-                "morphe_ic_sc_speed.xml",
+                "morphe_ic_sc_speed.xml"
             )
         )
     }
@@ -119,12 +123,12 @@ private val swipeControlsResourcePatch = resourcePatch {
 @Suppress("unused")
 val swipeControlsPatch = bytecodePatch(
     name = "Swipe controls",
-    description = "Adds options to enable and configure volume and brightness swipe controls.",
+    description = "Adds options to enable and configure volume and brightness swipe controls."
 ) {
     dependsOn(
         sharedExtensionPatch,
         playerTypeHookPatch,
-        swipeControlsResourcePatch,
+        swipeControlsResourcePatch
     )
 
     compatibleWith(COMPATIBILITY_YOUTUBE)

--- a/patches/src/main/resources/addresources/values/youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/youtube/arrays.xml
@@ -158,6 +158,16 @@
         <item>VERTICAL</item>
         <item>VERTICAL_MINIMAL</item>
     </string-array>
+    <string-array name="morphe_swipe_speed_step_entries">
+        <item>0.05x</item>
+        <item>0.10x</item>
+        <item>0.25x</item>
+    </string-array>
+    <string-array name="morphe_swipe_speed_step_entry_values">
+        <item>STEP_005</item>
+        <item>STEP_010</item>
+        <item>STEP_025</item>
+    </string-array>
 
     <!-- layout.spoofappversion.spoofAppVersionPatch -->
     <string-array name="morphe_spoof_app_version_target_entries">

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -524,6 +524,8 @@ Note: If \'Spoof video streams\' is not enabled, enabling this may cause unexpec
     <string name="morphe_swipe_speed_summary">Swipe horizontally in the upper zone of the fullscreen mode to change playback speed</string>
     <string name="morphe_swipe_speed_sensitivity_title">Speed swipe sensitivity</string>
     <string name="morphe_swipe_speed_sensitivity_summary">Higher values require more swiping per speed step</string>
+    <string name="morphe_swipe_speed_step_title">Speed step</string>
+    <string name="morphe_swipe_speed_step_summary">Amount by which the playback speed changes per tick</string>
     <string name="morphe_swipe_speed_zone_height_title">Speed zone height</string>
     <string name="morphe_swipe_speed_zone_height_summary">Height of the speed gesture zone as a percentage of the player height (5-75)</string>
     <string name="morphe_swipe_zone_label_speed">Speed</string>


### PR DESCRIPTION
### Description

Adds a new "Speed step" preference to choose how much the playback speed changes per swipe tick (0.05x / 0.10x / 0.25x, default 0.05x), and switches the internal calculation to integer math to prevent floating-point drift, and raises the maximum speed swipe sensitivity from 20 to 50.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
