### PR TITLE
fix(YouTube - Hide ads): Hide shopping links in transcripts

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AdsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AdsFilter.java
@@ -53,11 +53,11 @@ public final class AdsFilter extends Filter {
 
     public AdsFilter() {
         exceptions.addPatterns(
-                "home_video_with_context", // Don't filter anything in the home page video component.
-                "related_video_with_context", // Don't filter anything in the related video component.
-                "comment_thread", // Don't filter anything in the comments.
                 "|comment.", // Don't filter anything in the comments replies.
-                "library_recent_shelf"
+                "comment_thread", // Don't filter anything in the comments.
+                "home_video_with_context", // Don't filter anything in the home page video component.
+                "library_recent_shelf",
+                "related_video_with_context" // Don't filter anything in the related video component.
         );
 
         // Identifiers.
@@ -83,15 +83,16 @@ public final class AdsFilter extends Filter {
                 "compact_landscape_image_layout", // Tablet layout search results.
                 "composite_concurrent_carousel_layout",
                 "full_width_portrait_image_layout",
+                // full_width_square_image_button_group_layout, landscape_image_button_group_layout, text_image_button_group_layout
                 "full_width_square_image_carousel_layout",
                 "full_width_square_image_layout",
                 "hero_promo_image",
-                // text_image_button_group_layout, landscape_image_button_group_layout, full_width_square_image_button_group_layout
                 "image_button_group_layout",
                 "landscape_image_carousel_layout",
                 "landscape_image_wide_button_layout",
                 "primetime_promo",
                 "product_details",
+                "shopping_timely_shelf.", // Injection point below hides the empty space.
                 "square_image_layout",
                 "text_image_button_layout",
                 "text_image_no_button_layout", // Tablet layout search results.
@@ -100,8 +101,7 @@ public final class AdsFilter extends Filter {
                 "video_display_carousel_buttoned_short_dr_layout",
                 "video_display_full_buttoned_short_dr_layout",
                 "video_display_full_layout",
-                "watch_metadata_app_promo",
-                "shopping_timely_shelf." // Injection point below hides the empty space.
+                "watch_metadata_app_promo"
         );
 
         final var movieAds = new StringFilterGroup(
@@ -126,13 +126,14 @@ public final class AdsFilter extends Filter {
 
         final var viewProducts = new StringFilterGroup(
                 Settings.HIDE_PLAYER_POPUP_ADS,
-                "product_item",
                 "products_in_video",
+                "product_item",
                 "shopping_overlay.e" // Video player overlay shopping links.
         );
 
         final var shoppingLinks = new StringFilterGroup(
                 Settings.HIDE_SHOPPING_LINKS,
+                "shopping_description_item.e",
                 "shopping_description_shelf.e"
         );
 
@@ -151,8 +152,8 @@ public final class AdsFilter extends Filter {
 
         final var productSticker = new StringFilterGroup(
                 Settings.HIDE_PLAYER_POPUP_ADS,
-                "stickers_layer.e",
-                "product_sticker.e" // Product sticker that appears on Shorts.
+                "product_sticker.e", // Product sticker that appears on Shorts.
+                "stickers_layer.e"
         );
 
         final var selfSponsor = new StringFilterGroup(

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AdsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AdsFilter.java
@@ -50,6 +50,8 @@ public final class AdsFilter extends Filter {
 
     private final StringFilterGroup buyMovieAd;
     private final ByteArrayFilterGroup buyMovieAdBuffer;
+    private final StringFilterGroup productCard;
+    private final ByteArrayFilterGroup productCardBuffer;
 
     public AdsFilter() {
         exceptions.addPatterns(
@@ -150,6 +152,16 @@ public final class AdsFilter extends Filter {
                 "shorts_disclosures.e"
         );
 
+        productCard = new StringFilterGroup(
+                Settings.HIDE_SHOPPING_LINKS,
+                "expandable_metadata.e"
+        );
+
+        productCardBuffer = new ByteArrayFilterGroup(
+                null,
+                STORE_BANNER_DOMAIN
+        );
+
         final var productSticker = new StringFilterGroup(
                 Settings.HIDE_PLAYER_POPUP_ADS,
                 "product_sticker.e", // Product sticker that appears on Shorts.
@@ -167,6 +179,7 @@ public final class AdsFilter extends Filter {
                 merchandise,
                 movieAds,
                 paidPromotionLabel,
+                productCard,
                 productSticker,
                 selfSponsor,
                 shoppingLinks,
@@ -190,6 +203,10 @@ public final class AdsFilter extends Filter {
 
         if (matchedGroup == buyMovieAd) {
             return contentIndex == 0 && buyMovieAdBuffer.check(buffer).isFiltered();
+        }
+
+        if (matchedGroup == productCard) {
+            return productCardBuffer.check(buffer).isFiltered();
         }
 
         return !exceptions.matches(path);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -66,7 +66,6 @@ public final class LayoutComponentsFilter extends Filter {
     private final StringFilterGroup singleItemInformationPanel;
     private static final AtomicInteger singleItemInformationPanelIndex = new AtomicInteger(-1);
     private final StringFilterGroup expandableMetadata;
-    private final ByteArrayFilterGroup productCardBuffer;
     private final ByteArrayFilterGroup summaryCardBuffer;
     private final StringFilterGroup compactChannelBarInner;
     private final StringFilterGroup compactChannelBarInnerButton;
@@ -79,9 +78,7 @@ public final class LayoutComponentsFilter extends Filter {
 
     public enum ExpandableCardStyle {
         SHOW_ALL,
-        HIDE_PRODUCT_ONLY,
         HIDE_SUMMARY_ONLY,
-        HIDE_PRODUCT_AND_SUMMARY,
         HIDE_ALL
     }
 
@@ -235,11 +232,6 @@ public final class LayoutComponentsFilter extends Filter {
         expandableMetadata = new StringFilterGroup(
                 null,
                 "expandable_metadata"
-        );
-
-        productCardBuffer = new ByteArrayFilterGroup(
-                null,
-                "gstatic.com/shopping"
         );
 
         summaryCardBuffer = new ByteArrayFilterGroup(
@@ -443,15 +435,8 @@ public final class LayoutComponentsFilter extends Filter {
                 case HIDE_ALL -> {
                     return true;
                 }
-                case HIDE_PRODUCT_ONLY -> {
-                    return productCardBuffer.check(buffer).isFiltered();
-                }
                 case HIDE_SUMMARY_ONLY -> {
                     return summaryCardBuffer.check(buffer).isFiltered();
-                }
-                case HIDE_PRODUCT_AND_SUMMARY -> {
-                    return summaryCardBuffer.check(buffer).isFiltered()
-                            || productCardBuffer.check(buffer).isFiltered();
                 }
                 default -> {
                     return false;

--- a/patches/src/main/resources/addresources/values/youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/youtube/arrays.xml
@@ -230,19 +230,15 @@
         <item>@string/morphe_hide_expandable_card_entry_1</item>
         <item>@string/morphe_hide_expandable_card_entry_2</item>
         <item>@string/morphe_hide_expandable_card_entry_3</item>
-        <item>@string/morphe_hide_expandable_card_entry_4</item>
-        <item>@string/morphe_hide_expandable_card_entry_5</item>
     </string-array>
     <string-array name="morphe_hide_expandable_card_entry_values">
         <item>SHOW_ALL</item>
-        <item>HIDE_PRODUCT_ONLY</item>
         <item>HIDE_SUMMARY_ONLY</item>
-        <item>HIDE_PRODUCT_AND_SUMMARY</item>
         <item>HIDE_ALL</item>
     </string-array>
     <string-array name="morphe_hide_expandable_card_legacy_entries">
         <item>@string/morphe_hide_expandable_card_entry_1</item>
-        <item>@string/morphe_hide_expandable_card_entry_5</item>
+        <item>@string/morphe_hide_expandable_card_entry_3</item>
     </string-array>
     <string-array name="morphe_hide_expandable_card_legacy_entry_values">
         <item>SHOW_ALL</item>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -68,10 +68,8 @@ Changes include:
     <string name="morphe_hide_compact_banner_summary">Hides compact banners and spacing between some components</string>
     <string name="morphe_hide_expandable_card_title">Expandable cards under videos</string>
     <string name="morphe_hide_expandable_card_entry_1">Show all</string>
-    <string name="morphe_hide_expandable_card_entry_2">Hide product card only</string>
-    <string name="morphe_hide_expandable_card_entry_3">Hide summary card only</string>
-    <string name="morphe_hide_expandable_card_entry_4">Hide product and summary cards</string>
-    <string name="morphe_hide_expandable_card_entry_5">Hide all</string>
+    <string name="morphe_hide_expandable_card_entry_2">Hide summary card only</string>
+    <string name="morphe_hide_expandable_card_entry_3">Hide all</string>
     <string name="morphe_hide_floating_microphone_button_title">Hide floating microphone button</string>
     <string name="morphe_hide_floating_microphone_button_summary">Hides floating microphone button in the lower-right corner of search suggestions screen</string>
     <string name="morphe_hide_horizontal_shelves_title">Hide horizontal shelves</string>


### PR DESCRIPTION
### Description

Closes #2014.

### Additional context

```
07-14 02:52:17.448 23269 23368 D morphe: LithoFilterPatch: Searching ID: macro_markers_panel_item.eml-fe|a9919fd0f418016 Path: macro_markers_panel_item.eml-fe|a9919fd0f418016|CellType| BufferStrings: 1shopping_description_item.eml-fe|2c73e509fe6d6d65*❙KMap of Cyberia Desk Pad - Work and Gaming Desk Mat | LTTStore 900mm x 400mm2S❙USER_INTERFACE_THEME_DARK❙USER_INTERFACE_THEME_LIGHT❙lttstore.com2S❙USER_INTERFACE_THEME_DARK❙USER_INTERFACE_THEME_LIGHT❙https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcTOgCuaSfxKcVqPaJbLYo0yjyfH7w5-z8AKiKn-4TbomfFkok_OZj2dOJlTS3Xqq3ArrJLYTqw ❙gMap of Cyberia Desk Pad - Work and Gaming Desk Mat | LTTStore 900mm x 400mm, From Linus Tech Tips Store
``` 

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
