### PR TITLE
feat: Add `Settings menu filter` patch

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/SettingsMenuFilterPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/SettingsMenuFilterPatch.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2029
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.music.patches;
+
+import androidx.annotation.Nullable;
+
+import app.morphe.extension.music.settings.Settings;
+import app.morphe.extension.shared.patches.BaseSettingsMenuFilter;
+
+@SuppressWarnings("unused")
+public final class SettingsMenuFilterPatch extends BaseSettingsMenuFilter {
+
+    private static final SettingsMenuFilterPatch INSTANCE = new SettingsMenuFilterPatch();
+
+    private SettingsMenuFilterPatch() {
+        super(Settings.SETTINGS_MENU_FILTER, Settings.SETTINGS_MENU_FILTER_STRINGS);
+    }
+
+    @Nullable
+    public static String[] getNeedles() {
+        return INSTANCE.needles();
+    }
+}

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/SettingsMenuFilterPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/SettingsMenuFilterPatch.java
@@ -7,8 +7,6 @@
 
 package app.morphe.extension.music.patches;
 
-import androidx.annotation.Nullable;
-
 import app.morphe.extension.music.settings.Settings;
 import app.morphe.extension.shared.patches.BaseSettingsMenuFilter;
 
@@ -18,10 +16,10 @@ public final class SettingsMenuFilterPatch extends BaseSettingsMenuFilter {
     private static final SettingsMenuFilterPatch INSTANCE = new SettingsMenuFilterPatch();
 
     private SettingsMenuFilterPatch() {
-        super(Settings.SETTINGS_MENU_FILTER, Settings.SETTINGS_MENU_FILTER_STRINGS);
+        super(Settings.SETTINGS_MENU_FILTER_STRINGS,
+                Settings.SETTINGS_MENU_FILTER_DISCOVERED);
     }
 
-    @Nullable
     public static String[] getNeedles() {
         return INSTANCE.needles();
     }

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -54,8 +54,8 @@ public class Settings extends SharedYouTubeSettings {
     public static final StringSetting CUSTOM_FILTER_STRINGS = new StringSetting("morphe_music_custom_filter_strings", "", true, parent(CUSTOM_FILTER));
 
     // Settings menu filter
-    public static final BooleanSetting SETTINGS_MENU_FILTER = new BooleanSetting("morphe_music_settings_menu_filter", FALSE);
-    public static final StringSetting SETTINGS_MENU_FILTER_STRINGS = new StringSetting("morphe_music_settings_menu_filter_strings", "", true, parent(SETTINGS_MENU_FILTER));
+    public static final StringSetting SETTINGS_MENU_FILTER_STRINGS = new StringSetting("morphe_music_settings_menu_filter_strings", "", true);
+    public static final StringSetting SETTINGS_MENU_FILTER_DISCOVERED = new StringSetting("morphe_music_settings_menu_filter_discovered", "", true);
 
     // Player
     public static final BooleanSetting MINIPLAYER_NEXT_BUTTON = new BooleanSetting("morphe_music_miniplayer_next_button", TRUE, true);

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -53,6 +53,10 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting CUSTOM_FILTER = new BooleanSetting("morphe_music_custom_filter", FALSE);
     public static final StringSetting CUSTOM_FILTER_STRINGS = new StringSetting("morphe_music_custom_filter_strings", "", true, parent(CUSTOM_FILTER));
 
+    // Settings menu filter
+    public static final BooleanSetting SETTINGS_MENU_FILTER = new BooleanSetting("morphe_music_settings_menu_filter", FALSE);
+    public static final StringSetting SETTINGS_MENU_FILTER_STRINGS = new StringSetting("morphe_music_settings_menu_filter_strings", "", true, parent(SETTINGS_MENU_FILTER));
+
     // Player
     public static final BooleanSetting MINIPLAYER_NEXT_BUTTON = new BooleanSetting("morphe_music_miniplayer_next_button", TRUE, true);
     public static final BooleanSetting MINIPLAYER_PREVIOUS_BUTTON = new BooleanSetting("morphe_music_miniplayer_previous_button", TRUE, true);
@@ -60,7 +64,6 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting CHANGE_NAVIGATION_BAR_COLOR = new BooleanSetting("morphe_music_change_navigation_bar_color", FALSE, true, parent(CHANGE_MINIPLAYER_COLOR));
     public static final BooleanSetting ENABLE_FORCED_MINIPLAYER = new BooleanSetting("morphe_music_enable_forced_miniplayer", FALSE, true);
     public static final BooleanSetting ENABLE_SWIPE_TO_DISMISS_MINIPLAYER = new BooleanSetting("morphe_music_enable_swipe_to_dismiss_miniplayer", FALSE, true);
-    public static final BooleanSetting PERMANENT_REPEAT = new BooleanSetting("morphe_music_play_permanent_repeat", FALSE, true);
     public static final BooleanSetting DISABLE_DISLIKE_REDIRECTION = new BooleanSetting("morphe_music_disable_dislike_redirection", FALSE, true);
 
     // Action buttons

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -55,7 +55,7 @@ public class Settings extends SharedYouTubeSettings {
 
     // Settings menu filter
     public static final StringSetting SETTINGS_MENU_FILTER_STRINGS = new StringSetting("morphe_music_settings_menu_filter_strings", "", true);
-    public static final StringSetting SETTINGS_MENU_FILTER_DISCOVERED = new StringSetting("morphe_music_settings_menu_filter_discovered", "", true);
+    public static final StringSetting SETTINGS_MENU_FILTER_DISCOVERED = new StringSetting("morphe_music_settings_menu_filter_discovered", "", true, false);
 
     // Player
     public static final BooleanSetting MINIPLAYER_NEXT_BUTTON = new BooleanSetting("morphe_music_miniplayer_next_button", TRUE, true);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2029
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.patches;
+
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.settings.BooleanSetting;
+import app.morphe.extension.shared.settings.StringSetting;
+
+/**
+ * Needle parsing and matching helpers called from the bytecode-injected filter.
+ */
+@SuppressWarnings("unused")
+public abstract class BaseSettingsMenuFilter {
+
+    private final BooleanSetting enabledSetting;
+    private final StringSetting entriesSetting;
+
+    protected BaseSettingsMenuFilter(BooleanSetting enabledSetting,
+                                     StringSetting entriesSetting) {
+        this.enabledSetting = enabledSetting;
+        this.entriesSetting = entriesSetting;
+    }
+
+    /**
+     * Null return short-circuits the injected filter without doing any work.
+     */
+    @Nullable
+    protected final String[] needles() {
+        if (!enabledSetting.get()) return null;
+
+        String raw = entriesSetting.get();
+        if (raw.isBlank()) return null;
+
+        List<String> result = new ArrayList<>();
+        for (String line : raw.split("\n")) {
+            String trimmed = line.trim();
+            if (!trimmed.isEmpty()) result.add(trimmed.toLowerCase(Locale.ROOT));
+        }
+        return result.isEmpty() ? null : result.toArray(new String[0]);
+    }
+
+    /** Case-insensitive exact match; user needs to type each preference name in full. */
+    public static boolean equalsAny(@Nullable CharSequence text, String[] needles) {
+        if (text == null) return false;
+        String haystack = text.toString().toLowerCase(Locale.ROOT);
+        for (String needle : needles) {
+            if (haystack.equals(needle)) return true;
+        }
+        return false;
+    }
+
+    public static void logHidden(CharSequence title) {
+        Logger.printDebug(() -> "SettingsMenuFilter hidden: " + title);
+    }
+}

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
@@ -7,11 +7,16 @@
 
 package app.morphe.extension.shared.patches;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.settings.BooleanSetting;
@@ -33,7 +38,9 @@ public abstract class BaseSettingsMenuFilter {
     }
 
     /**
-     * Null return short-circuits the injected filter without doing any work.
+     * Null return short-circuits the injected filter. Any needle that resolves to the label of
+     * the Morphe entry point (localised via {@code str()}) is silently dropped, so a user cannot
+     * accidentally hide their own way back into Morphe settings.
      */
     @Nullable
     protected final String[] needles() {
@@ -42,12 +49,32 @@ public abstract class BaseSettingsMenuFilter {
         String raw = entriesSetting.get();
         if (raw.isBlank()) return null;
 
+        Set<String> reserved = reservedNeedles();
         List<String> result = new ArrayList<>();
         for (String line : raw.split("\n")) {
-            String trimmed = line.trim();
-            if (!trimmed.isEmpty()) result.add(trimmed.toLowerCase(Locale.ROOT));
+            String trimmed = line.trim().toLowerCase(Locale.ROOT);
+            if (trimmed.isEmpty()) continue;
+            if (reserved.contains(trimmed)) {
+                Logger.printDebug(() -> "SettingsMenuFilter ignoring reserved needle: " + trimmed);
+                continue;
+            }
+            result.add(trimmed);
         }
         return result.isEmpty() ? null : result.toArray(new String[0]);
+    }
+
+    private static volatile Set<String> reservedNeedles;
+
+    private static Set<String> reservedNeedles() {
+        Set<String> cached = reservedNeedles;
+        if (cached == null) {
+            cached = new HashSet<>(Arrays.asList(
+                    str("morphe_settings_title").toLowerCase(Locale.ROOT),
+                    str("morphe_settings_submenu_title").toLowerCase(Locale.ROOT)
+            ));
+            reservedNeedles = cached;
+        }
+        return cached;
     }
 
     /** Case-insensitive exact match; user needs to type each preference name in full. */

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
@@ -9,58 +9,100 @@ package app.morphe.extension.shared.patches;
 
 import androidx.annotation.Nullable;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceUtils;
-import app.morphe.extension.shared.settings.BooleanSetting;
 import app.morphe.extension.shared.settings.StringSetting;
 
 /**
- * Needle parsing and matching helpers called from the bytecode-injected filter.
+ * Needle parsing, hierarchical discovery capture, and filter mutation helpers.
+ * Called from the bytecode-injected filter and from the picker Preference.
  */
 @SuppressWarnings("unused")
 public abstract class BaseSettingsMenuFilter {
 
-    private final BooleanSetting enabledSetting;
+    private static final int MAX_TITLE_LENGTH = 60;
+
+    @Nullable
+    private static volatile BaseSettingsMenuFilter INSTANCE;
+
+    /**
+     * Buffer for the current helper walk; endCapture() flushes it to the persisted setting
+     * so partial walks never corrupt the picker view.
+     */
+    private static final List<DiscoveredNode> currentWalk = new ArrayList<>();
+
+    /**
+     * True between beginCapture and endCapture so setTitle captures during the walk join
+     * the buffer, while post-walk assignments (async server titles) append persistently.
+     */
+    private static volatile boolean insideWalk;
+
     private final StringSetting entriesSetting;
+    private final StringSetting discoveredSetting;
 
     private volatile String cachedRaw;
     @Nullable private volatile String[] cachedNeedles;
 
-    protected BaseSettingsMenuFilter(BooleanSetting enabledSetting,
-                                     StringSetting entriesSetting) {
-        this.enabledSetting = enabledSetting;
+    protected BaseSettingsMenuFilter(StringSetting entriesSetting,
+                                     StringSetting discoveredSetting) {
         this.entriesSetting = entriesSetting;
+        this.discoveredSetting = discoveredSetting;
+        INSTANCE = this;
     }
 
     /**
-     * Null short-circuits the filter; reserved labels are dropped so the Morphe entry point stays reachable.
+     * Class.forName the known app-specific singletons so INSTANCE is populated even when
+     * the picker Preference opens before any standard-settings navigation has fired.
      */
     @Nullable
+    private static BaseSettingsMenuFilter instance() {
+        if (INSTANCE == null) {
+            String[] candidates = {
+                    "app.morphe.extension.youtube.patches.SettingsMenuFilterPatch",
+                    "app.morphe.extension.music.patches.SettingsMenuFilterPatch"
+            };
+            for (String fqn : candidates) {
+                try {
+                    Class.forName(fqn);
+                } catch (ClassNotFoundException ignored) {
+                    // Only one candidate lives in any given APK.
+                }
+            }
+        }
+        return INSTANCE;
+    }
+
+    /**
+     * Empty array means no hides; picker capture still happens so users can pick something later.
+     */
     protected final String[] needles() {
-        if (!enabledSetting.get()) return null;
-
         String raw = entriesSetting.get();
-        if (raw.isBlank()) return null;
-
         if (raw.equals(cachedRaw)) return cachedNeedles;
 
-        Set<String> reserved = reservedNeedles();
         List<String> result = new ArrayList<>();
-        for (String line : raw.split("\n")) {
-            String trimmed = line.trim().toLowerCase();
-            if (trimmed.isEmpty()) continue;
-            if (reserved.contains(trimmed)) {
-                Logger.printDebug(() -> "SettingsMenuFilter ignoring reserved needle: " + trimmed);
-                continue;
+        if (!raw.isBlank()) {
+            Set<String> reserved = reservedNeedles();
+            for (String line : raw.split("\n")) {
+                String trimmed = line.trim().toLowerCase();
+                if (trimmed.isEmpty()) continue;
+                if (reserved.contains(trimmed)) {
+                    Logger.printDebug(() -> "SettingsMenuFilter ignoring reserved needle: " + trimmed);
+                    continue;
+                }
+                result.add(trimmed);
             }
-            result.add(trimmed);
         }
-        String[] parsed = result.isEmpty() ? null : result.toArray(new String[0]);
+        String[] parsed = result.toArray(new String[0]);
         Logger.printDebug(() -> "SettingsMenuFilter active with needles=" + result);
         cachedNeedles = parsed;
         cachedRaw = raw;
@@ -96,4 +138,172 @@ public abstract class BaseSettingsMenuFilter {
     public static void logHidden(CharSequence title) {
         Logger.printDebug(() -> "SettingsMenuFilter hidden: " + title);
     }
+
+    /**
+     * Resets the walk buffer before a fresh onCreatePreferences pass so the persisted tree
+     * always reflects the most recent settings screen instead of accumulating stale nodes.
+     */
+    public static void beginCapture() {
+        if (instance() == null) return;
+        synchronized (currentWalk) {
+            currentWalk.clear();
+        }
+        insideWalk = true;
+    }
+
+    /**
+     * Adds a discovered node with its parent title so the picker can render nested rows.
+     */
+    public static void capture(@Nullable CharSequence parent, @Nullable CharSequence title) {
+        BaseSettingsMenuFilter self = instance();
+        if (self == null) return;
+
+        String cleanTitle = clean(title);
+        if (cleanTitle == null) return;
+        if (reservedNeedles().contains(cleanTitle.toLowerCase())) return;
+
+        String cleanParent = clean(parent);
+        DiscoveredNode node = new DiscoveredNode(cleanParent, cleanTitle);
+
+        if (insideWalk) {
+            synchronized (currentWalk) {
+                for (DiscoveredNode n : currentWalk) {
+                    if (n.title().equalsIgnoreCase(cleanTitle)) return;
+                }
+                currentWalk.add(node);
+            }
+        } else {
+            appendOrphan(self, node);
+        }
+    }
+
+    /**
+     * Post-walk setTitle assignments go straight to the persisted set
+     * so the picker keeps them across settings-screen re-opens.
+     */
+    private static synchronized void appendOrphan(BaseSettingsMenuFilter self, DiscoveredNode node) {
+        List<DiscoveredNode> existing = discoveredTree();
+        for (DiscoveredNode n : existing) {
+            if (n.title().equalsIgnoreCase(node.title())) return;
+        }
+        List<DiscoveredNode> updated = new ArrayList<>(existing);
+        updated.add(node);
+        self.discoveredSetting.save(serialize(updated));
+    }
+
+    /**
+     * Flushes the walk buffer to the persisted setting as JSON so the picker survives process death.
+     */
+    public static void endCapture() {
+        BaseSettingsMenuFilter self = instance();
+        if (self == null) return;
+
+        List<DiscoveredNode> snapshot;
+        synchronized (currentWalk) {
+            snapshot = new ArrayList<>(currentWalk);
+        }
+        insideWalk = false;
+        self.discoveredSetting.save(serialize(snapshot));
+    }
+
+    private static String serialize(List<DiscoveredNode> nodes) {
+        JSONArray array = new JSONArray();
+        for (DiscoveredNode node : nodes) {
+            try {
+                JSONObject entry = new JSONObject();
+                if (node.parent() != null) entry.put("parent", node.parent());
+                entry.put("title", node.title());
+                array.put(entry);
+            } catch (JSONException ignored) {
+                // put(String, String) only throws for Double NaN/Infinity, never for our strings.
+            }
+        }
+        return array.toString();
+    }
+
+    @Nullable
+    private static String clean(@Nullable CharSequence text) {
+        if (text == null) return null;
+        String value = text.toString().trim();
+        if (value.isEmpty() || value.length() > MAX_TITLE_LENGTH) return null;
+        return value;
+    }
+
+    /**
+     * Parsed hierarchical tree in traversal order for the picker to render.
+     */
+    public static List<DiscoveredNode> discoveredTree() {
+        BaseSettingsMenuFilter self = instance();
+        if (self == null) return Collections.emptyList();
+        String json = self.discoveredSetting.get();
+        if (json.isBlank()) return Collections.emptyList();
+        try {
+            JSONArray array = new JSONArray(json);
+            List<DiscoveredNode> result = new ArrayList<>(array.length());
+            for (int i = 0; i < array.length(); i++) {
+                JSONObject entry = array.getJSONObject(i);
+                String parent = entry.has("parent") ? entry.getString("parent") : null;
+                String title = entry.getString("title");
+                result.add(new DiscoveredNode(parent, title));
+            }
+            return result;
+        } catch (Exception ex) {
+            Logger.printException(() -> "SettingsMenuFilter discoveredTree parse", ex);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Lowercased snapshot of the current filter list for checkmark rendering in the picker.
+     */
+    public static Set<String> activeFilterEntries() {
+        BaseSettingsMenuFilter self = instance();
+        if (self == null) return Collections.emptySet();
+        Set<String> result = new HashSet<>();
+        for (String line : self.entriesSetting.get().split("\n")) {
+            String trimmed = line.trim().toLowerCase();
+            if (!trimmed.isEmpty()) result.add(trimmed);
+        }
+        return result;
+    }
+
+    /**
+     * Toggle picker tap: adds the title when absent, removes matching lines when present.
+     * Returns true if the title is in the filter after the operation.
+     */
+    public static boolean toggleInFilter(String title) {
+        BaseSettingsMenuFilter self = instance();
+        if (self == null) return false;
+
+        String needle = title.trim().toLowerCase();
+        String raw = self.entriesSetting.get();
+        List<String> kept = new ArrayList<>();
+        boolean removed = false;
+        for (String line : raw.split("\n")) {
+            if (line.trim().toLowerCase().equals(needle)) {
+                removed = true;
+                continue;
+            }
+            kept.add(line);
+        }
+
+        String next;
+        boolean nowSelected;
+        if (removed) {
+            next = String.join("\n", kept);
+            nowSelected = false;
+        } else {
+            next = raw.isEmpty() ? title : (raw.endsWith("\n") ? raw + title : raw + "\n" + title);
+            nowSelected = true;
+        }
+        self.entriesSetting.save(next);
+        Logger.printDebug(() -> "SettingsMenuFilter toggle '" + title + "' -> " + (nowSelected ? "added" : "removed"));
+        return nowSelected;
+    }
+
+    /**
+     * One Preference in the settings tree: null parent = top-level, matching another
+     * node's title = nested child.
+     */
+    public record DiscoveredNode(@Nullable String parent, String title) {}
 }

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
@@ -10,7 +10,6 @@ package app.morphe.extension.shared.patches;
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -64,12 +63,19 @@ public abstract class BaseSettingsMenuFilter {
      * Resolved per call so the host app locale wins over the Morphe language override.
      */
     private static Set<String> reservedNeedles() {
-        return new HashSet<>(Arrays.asList(
-                ResourceUtils.getString("morphe_settings_title").toLowerCase(Locale.ROOT),
-                ResourceUtils.getString("morphe_settings_submenu_title").toLowerCase(Locale.ROOT)
-        ));
+        Set<String> result = new HashSet<>();
+        addLoweredIfPresent(result, ResourceUtils.getString("morphe_settings_title"));
+        addLoweredIfPresent(result, ResourceUtils.getString("morphe_settings_submenu_title"));
+        return result;
     }
 
+    private static void addLoweredIfPresent(Set<String> target, @Nullable String value) {
+        if (value != null) target.add(value.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Exact match keeps a needle from over-hiding unrelated titles that share substrings with it.
+     */
     public static boolean equalsAny(@Nullable CharSequence text, String[] needles) {
         if (text == null) return false;
         String haystack = text.toString().toLowerCase(Locale.ROOT);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
@@ -12,7 +12,6 @@ import androidx.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 
 import app.morphe.extension.shared.Logger;
@@ -53,7 +52,7 @@ public abstract class BaseSettingsMenuFilter {
         Set<String> reserved = reservedNeedles();
         List<String> result = new ArrayList<>();
         for (String line : raw.split("\n")) {
-            String trimmed = line.trim().toLowerCase(Locale.ROOT);
+            String trimmed = line.trim().toLowerCase();
             if (trimmed.isEmpty()) continue;
             if (reserved.contains(trimmed)) {
                 Logger.printDebug(() -> "SettingsMenuFilter ignoring reserved needle: " + trimmed);
@@ -78,7 +77,7 @@ public abstract class BaseSettingsMenuFilter {
     }
 
     private static void addLoweredIfPresent(Set<String> target, @Nullable String value) {
-        if (value != null) target.add(value.toLowerCase(Locale.ROOT));
+        if (value != null) target.add(value.toLowerCase());
     }
 
     /**
@@ -86,7 +85,7 @@ public abstract class BaseSettingsMenuFilter {
      */
     public static boolean equalsAny(@Nullable CharSequence text, String[] needles) {
         if (text == null) return false;
-        String haystack = text.toString().toLowerCase(Locale.ROOT);
+        String haystack = text.toString().toLowerCase();
         for (String needle : needles) {
             if (haystack.equals(needle)) return true;
         }

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
@@ -7,8 +7,6 @@
 
 package app.morphe.extension.shared.patches;
 
-import static app.morphe.extension.shared.StringRef.str;
-
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
@@ -19,6 +17,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.settings.BooleanSetting;
 import app.morphe.extension.shared.settings.StringSetting;
 
@@ -38,9 +37,7 @@ public abstract class BaseSettingsMenuFilter {
     }
 
     /**
-     * Null return short-circuits the injected filter. Any needle that resolves to the label of
-     * the Morphe entry point (localised via {@code str()}) is silently dropped, so a user cannot
-     * accidentally hide their own way back into Morphe settings.
+     * Null short-circuits the filter; reserved labels are dropped so the Morphe entry point stays reachable.
      */
     @Nullable
     protected final String[] needles() {
@@ -63,21 +60,16 @@ public abstract class BaseSettingsMenuFilter {
         return result.isEmpty() ? null : result.toArray(new String[0]);
     }
 
-    private static volatile Set<String> reservedNeedles;
-
+    /**
+     * Resolved per call so the host app locale wins over the Morphe language override.
+     */
     private static Set<String> reservedNeedles() {
-        Set<String> cached = reservedNeedles;
-        if (cached == null) {
-            cached = new HashSet<>(Arrays.asList(
-                    str("morphe_settings_title").toLowerCase(Locale.ROOT),
-                    str("morphe_settings_submenu_title").toLowerCase(Locale.ROOT)
-            ));
-            reservedNeedles = cached;
-        }
-        return cached;
+        return new HashSet<>(Arrays.asList(
+                ResourceUtils.getString("morphe_settings_title").toLowerCase(Locale.ROOT),
+                ResourceUtils.getString("morphe_settings_submenu_title").toLowerCase(Locale.ROOT)
+        ));
     }
 
-    /** Case-insensitive exact match; user needs to type each preference name in full. */
     public static boolean equalsAny(@Nullable CharSequence text, String[] needles) {
         if (text == null) return false;
         String haystack = text.toString().toLowerCase(Locale.ROOT);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
@@ -61,6 +61,7 @@ public abstract class BaseSettingsMenuFilter {
             result.add(trimmed);
         }
         String[] parsed = result.isEmpty() ? null : result.toArray(new String[0]);
+        Logger.printDebug(() -> "SettingsMenuFilter active with needles=" + result);
         cachedNeedles = parsed;
         cachedRaw = raw;
         return parsed;

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.WeakHashMap;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceUtils;
@@ -46,6 +47,12 @@ public abstract class BaseSettingsMenuFilter {
      * the buffer, while post-walk assignments (async server titles) append persistently.
      */
     private static volatile boolean insideWalk;
+
+    /**
+     * Scopes setTitle capture to Preferences the helper has actually visited; weak keys
+     * let stale fragment-scoped entries GC naturally between opens.
+     */
+    private static final WeakHashMap<Object, Boolean> walkedPrefs = new WeakHashMap<>();
 
     private final StringSetting entriesSetting;
     private final StringSetting discoveredSetting;
@@ -148,7 +155,33 @@ public abstract class BaseSettingsMenuFilter {
         synchronized (currentWalk) {
             currentWalk.clear();
         }
+        synchronized (walkedPrefs) {
+            walkedPrefs.clear();
+        }
         insideWalk = true;
+    }
+
+    /**
+     * Called from the helper walk for every visited Preference so the setTitle hook can
+     * limit its capture to Preferences that actually belong to the standard settings tree.
+     */
+    public static void markWalked(Object preference) {
+        if (preference == null) return;
+        synchronized (walkedPrefs) {
+            walkedPrefs.put(preference, Boolean.TRUE);
+        }
+    }
+
+    /**
+     * setTitle capture entry point: only accepts titles for Preferences the walk has seen,
+     * which filters out unrelated Preference UI (account drawer, dialogs) from the picker.
+     */
+    public static void scopedCapture(Object preference, @Nullable CharSequence title) {
+        boolean known;
+        synchronized (walkedPrefs) {
+            known = walkedPrefs.containsKey(preference);
+        }
+        if (known) capture(null, title);
     }
 
     /**
@@ -265,6 +298,17 @@ public abstract class BaseSettingsMenuFilter {
             if (!trimmed.isEmpty()) result.add(trimmed);
         }
         return result;
+    }
+
+    /**
+     * Picker reset entry point: wipes the filter list in one shot so the user does not have
+     * to untap every row individually after selecting too much.
+     */
+    public static void clearFilter() {
+        BaseSettingsMenuFilter self = instance();
+        if (self == null) return;
+        self.entriesSetting.save("");
+        Logger.printDebug(() -> "SettingsMenuFilter cleared");
     }
 
     /**

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/BaseSettingsMenuFilter.java
@@ -29,6 +29,9 @@ public abstract class BaseSettingsMenuFilter {
     private final BooleanSetting enabledSetting;
     private final StringSetting entriesSetting;
 
+    private volatile String cachedRaw;
+    @Nullable private volatile String[] cachedNeedles;
+
     protected BaseSettingsMenuFilter(BooleanSetting enabledSetting,
                                      StringSetting entriesSetting) {
         this.enabledSetting = enabledSetting;
@@ -45,6 +48,8 @@ public abstract class BaseSettingsMenuFilter {
         String raw = entriesSetting.get();
         if (raw.isBlank()) return null;
 
+        if (raw.equals(cachedRaw)) return cachedNeedles;
+
         Set<String> reserved = reservedNeedles();
         List<String> result = new ArrayList<>();
         for (String line : raw.split("\n")) {
@@ -56,7 +61,10 @@ public abstract class BaseSettingsMenuFilter {
             }
             result.add(trimmed);
         }
-        return result.isEmpty() ? null : result.toArray(new String[0]);
+        String[] parsed = result.isEmpty() ? null : result.toArray(new String[0]);
+        cachedNeedles = parsed;
+        cachedRaw = raw;
+        return parsed;
     }
 
     /**

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/SettingsMenuFilterPickerPreference.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/SettingsMenuFilterPickerPreference.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Set;
 
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.settings.preference.AbstractPreferenceFragment;
 import app.morphe.extension.shared.ui.CustomDialog;
 
 /**
@@ -90,6 +91,7 @@ public class SettingsMenuFilterPickerPreference extends Preference {
 
         Set<String> selectedLower = new HashSet<>(BaseSettingsMenuFilter.activeFilterEntries());
         HierarchyAdapter[] adapterRef = {null};
+        boolean[] changesMade = {false};
 
         if (rows.isEmpty()) {
             TextView hint = new TextView(context);
@@ -116,6 +118,7 @@ public class SettingsMenuFilterPickerPreference extends Preference {
                 if (nowSelected) selectedLower.add(key);
                 else selectedLower.remove(key);
                 adapter.notifyDataSetChanged();
+                changesMade[0] = true;
             });
 
             LinearLayout.LayoutParams listViewParams = new LinearLayout.LayoutParams(
@@ -131,10 +134,13 @@ public class SettingsMenuFilterPickerPreference extends Preference {
                 null,
                 null,
                 null,
-                () -> {},
+                () -> {
+                    if (changesMade[0]) AbstractPreferenceFragment.showRestartDialog(context);
+                },
                 null,
                 str("morphe_settings_reset"),
                 () -> {
+                    if (!selectedLower.isEmpty()) changesMade[0] = true;
                     BaseSettingsMenuFilter.clearFilter();
                     selectedLower.clear();
                     if (adapterRef[0] != null) adapterRef[0].notifyDataSetChanged();

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/SettingsMenuFilterPickerPreference.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/SettingsMenuFilterPickerPreference.java
@@ -42,7 +42,6 @@ import java.util.List;
 import java.util.Set;
 
 import app.morphe.extension.shared.Utils;
-import app.morphe.extension.shared.settings.preference.AbstractPreferenceFragment;
 import app.morphe.extension.shared.ui.CustomDialog;
 
 /**
@@ -89,7 +88,8 @@ public class SettingsMenuFilterPickerPreference extends Preference {
         LinearLayout content = new LinearLayout(context);
         content.setOrientation(LinearLayout.VERTICAL);
 
-        boolean[] changesMade = {false};
+        Set<String> selectedLower = new HashSet<>(BaseSettingsMenuFilter.activeFilterEntries());
+        HierarchyAdapter[] adapterRef = {null};
 
         if (rows.isEmpty()) {
             TextView hint = new TextView(context);
@@ -101,12 +101,11 @@ public class SettingsMenuFilterPickerPreference extends Preference {
                     LinearLayout.LayoutParams.MATCH_PARENT,
                     LinearLayout.LayoutParams.WRAP_CONTENT));
         } else {
-            Set<String> selectedLower = new HashSet<>(BaseSettingsMenuFilter.activeFilterEntries());
-
             ListView listView = new ListView(context);
             listView.setId(android.R.id.list);
 
             HierarchyAdapter adapter = new HierarchyAdapter(context, rows, selectedLower);
+            adapterRef[0] = adapter;
             listView.setAdapter(adapter);
 
             listView.setOnItemClickListener((parent, view, position, id) -> {
@@ -117,7 +116,6 @@ public class SettingsMenuFilterPickerPreference extends Preference {
                 if (nowSelected) selectedLower.add(key);
                 else selectedLower.remove(key);
                 adapter.notifyDataSetChanged();
-                changesMade[0] = true;
             });
 
             LinearLayout.LayoutParams listViewParams = new LinearLayout.LayoutParams(
@@ -133,13 +131,15 @@ public class SettingsMenuFilterPickerPreference extends Preference {
                 null,
                 null,
                 null,
+                () -> {},
+                null,
+                str("morphe_settings_reset"),
                 () -> {
-                    if (changesMade[0]) AbstractPreferenceFragment.showRestartDialog(context);
+                    BaseSettingsMenuFilter.clearFilter();
+                    selectedLower.clear();
+                    if (adapterRef[0] != null) adapterRef[0].notifyDataSetChanged();
                 },
-                null,
-                null,
-                null,
-                true
+                false
         );
 
         LinearLayout mainLayout = dialogPair.second;

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/SettingsMenuFilterPickerPreference.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/SettingsMenuFilterPickerPreference.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2029
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.patches;
+
+import static app.morphe.extension.shared.StringRef.str;
+import static app.morphe.extension.shared.settings.preference.CustomDialogListPreference.DRAWABLE_CHECKMARK;
+import static app.morphe.extension.shared.settings.preference.CustomDialogListPreference.DRAWABLE_CHECKMARK_BOLD;
+import static app.morphe.extension.shared.settings.preference.CustomDialogListPreference.ID_MORPHE_CHECK_ICON;
+import static app.morphe.extension.shared.settings.preference.CustomDialogListPreference.ID_MORPHE_CHECK_ICON_PLACEHOLDER;
+import static app.morphe.extension.shared.settings.preference.CustomDialogListPreference.ID_MORPHE_ITEM_TEXT;
+import static app.morphe.extension.shared.settings.preference.CustomDialogListPreference.LAYOUT_MORPHE_CUSTOM_LIST_ITEM_CHECKED;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.graphics.Typeface;
+import android.preference.Preference;
+import android.util.AttributeSet;
+import android.util.Pair;
+import android.util.TypedValue;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.settings.preference.AbstractPreferenceFragment;
+import app.morphe.extension.shared.ui.CustomDialog;
+
+/**
+ * Selecting a category grays and locks its children because the filter hides descendants
+ * recursively, keeping the picker state consistent with what actually gets hidden.
+ */
+@SuppressWarnings({"unused", "deprecation"})
+public class SettingsMenuFilterPickerPreference extends Preference {
+
+    public SettingsMenuFilterPickerPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init();
+    }
+
+    public SettingsMenuFilterPickerPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    public SettingsMenuFilterPickerPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public SettingsMenuFilterPickerPreference(Context context) {
+        super(context);
+        init();
+    }
+
+    private void init() {
+        setSelectable(true);
+        setPersistent(false);
+    }
+
+    @Override
+    protected void onClick() {
+        showPickerDialog();
+    }
+
+    private void showPickerDialog() {
+        Context context = getContext();
+        List<Row> rows = buildRows(BaseSettingsMenuFilter.discoveredTree());
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+
+        boolean[] changesMade = {false};
+
+        if (rows.isEmpty()) {
+            TextView hint = new TextView(context);
+            hint.setText(str("morphe_settings_menu_filter_picker_empty"));
+            hint.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14);
+            hint.setTextColor(Utils.getAppForegroundColor());
+            hint.setPadding(0, 24, 0, 24);
+            content.addView(hint, new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT));
+        } else {
+            Set<String> selectedLower = new HashSet<>(BaseSettingsMenuFilter.activeFilterEntries());
+
+            ListView listView = new ListView(context);
+            listView.setId(android.R.id.list);
+
+            HierarchyAdapter adapter = new HierarchyAdapter(context, rows, selectedLower);
+            listView.setAdapter(adapter);
+
+            listView.setOnItemClickListener((parent, view, position, id) -> {
+                Row row = adapter.getItem(position);
+                if (row == null || isLockedByParent(row, selectedLower)) return;
+                boolean nowSelected = BaseSettingsMenuFilter.toggleInFilter(row.title());
+                String key = row.title().toLowerCase();
+                if (nowSelected) selectedLower.add(key);
+                else selectedLower.remove(key);
+                adapter.notifyDataSetChanged();
+                changesMade[0] = true;
+            });
+
+            LinearLayout.LayoutParams listViewParams = new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    0,
+                    1.0f);
+            content.addView(listView, listViewParams);
+        }
+
+        Pair<Dialog, LinearLayout> dialogPair = CustomDialog.create(
+                context,
+                getTitle() != null ? getTitle().toString() : "",
+                null,
+                null,
+                null,
+                () -> {
+                    if (changesMade[0]) AbstractPreferenceFragment.showRestartDialog(context);
+                },
+                null,
+                null,
+                null,
+                true
+        );
+
+        LinearLayout mainLayout = dialogPair.second;
+        mainLayout.addView(content, mainLayout.getChildCount() - 1,
+                new LinearLayout.LayoutParams(
+                        LinearLayout.LayoutParams.MATCH_PARENT,
+                        LinearLayout.LayoutParams.MATCH_PARENT,
+                        1.0f));
+
+        dialogPair.first.show();
+    }
+
+    private static List<Row> buildRows(List<BaseSettingsMenuFilter.DiscoveredNode> tree) {
+        LinkedHashSet<String> rootOrder = new LinkedHashSet<>();
+        LinkedHashMap<String, LinkedHashSet<String>> childrenByParent = new LinkedHashMap<>();
+
+        for (BaseSettingsMenuFilter.DiscoveredNode node : tree) {
+            if (node.parent() == null) {
+                rootOrder.add(node.title());
+            } else {
+                childrenByParent
+                        .computeIfAbsent(node.parent(), k -> new LinkedHashSet<>())
+                        .add(node.title());
+            }
+        }
+
+        List<Row> rows = new ArrayList<>();
+        for (String root : rootOrder) {
+            LinkedHashSet<String> children = childrenByParent.get(root);
+            if (children != null && !children.isEmpty()) {
+                rows.add(new Row(RowType.CATEGORY, root, null));
+                for (String child : children) {
+                    rows.add(new Row(RowType.CHILD, child, root));
+                }
+            } else {
+                rows.add(new Row(RowType.LEAF, root, null));
+            }
+        }
+        return rows;
+    }
+
+    /**
+     * Locked children inherit selection from their parent category and cannot be toggled
+     * independently while the category is selected.
+     */
+    private static boolean isLockedByParent(Row row, Set<String> selectedLower) {
+        return row.type() == RowType.CHILD
+                && row.parentTitle() != null
+                && selectedLower.contains(row.parentTitle().toLowerCase());
+    }
+
+    private enum RowType { CATEGORY, LEAF, CHILD }
+
+    private record Row(RowType type, String title, @Nullable String parentTitle) {}
+
+    private static final class HierarchyAdapter extends BaseAdapter {
+        private static final int CHILD_INDENT_DP = 24;
+        private static final float DISABLED_ALPHA = 0.5f;
+
+        private final Context context;
+        private final List<Row> rows;
+        private final Set<String> selectedLower;
+        private final int checkDrawable;
+        private final int childIndentPx;
+        private final int foregroundColor;
+
+        HierarchyAdapter(Context context, List<Row> rows, Set<String> selectedLower) {
+            this.context = context;
+            this.rows = rows;
+            this.selectedLower = selectedLower;
+            this.checkDrawable = Utils.appIsUsingBoldIcons() ? DRAWABLE_CHECKMARK_BOLD : DRAWABLE_CHECKMARK;
+            this.childIndentPx = (int) (CHILD_INDENT_DP * context.getResources().getDisplayMetrics().density);
+            this.foregroundColor = Utils.getAppForegroundColor();
+        }
+
+        @Override public int getCount() { return rows.size(); }
+        @Override public Row getItem(int position) { return rows.get(position); }
+        @Override public long getItemId(int position) { return position; }
+
+        @Override
+        public boolean isEnabled(int position) {
+            return !isLockedByParent(rows.get(position), selectedLower);
+        }
+
+        @NonNull
+        @Override
+        public View getView(int position, View convertView, @NonNull ViewGroup parent) {
+            View view = convertView;
+            Holder holder;
+            if (view == null) {
+                view = LayoutInflater.from(context)
+                        .inflate(LAYOUT_MORPHE_CUSTOM_LIST_ITEM_CHECKED, parent, false);
+                holder = new Holder();
+                holder.placeholder = view.findViewById(ID_MORPHE_CHECK_ICON_PLACEHOLDER);
+                holder.itemText = view.findViewById(ID_MORPHE_ITEM_TEXT);
+                holder.checkIcon = view.findViewById(ID_MORPHE_CHECK_ICON);
+                holder.checkIcon.setImageResource(checkDrawable);
+                holder.defaultPaddingLeft = holder.itemText.getPaddingLeft();
+                view.setTag(holder);
+            } else {
+                holder = (Holder) view.getTag();
+            }
+
+            Row row = rows.get(position);
+            holder.itemText.setText(row.title());
+            holder.itemText.setTextColor(foregroundColor);
+            holder.itemText.setTypeface(null, row.type() == RowType.CATEGORY ? Typeface.BOLD : Typeface.NORMAL);
+            holder.itemText.setPadding(
+                    row.type() == RowType.CHILD ? holder.defaultPaddingLeft + childIndentPx : holder.defaultPaddingLeft,
+                    holder.itemText.getPaddingTop(),
+                    holder.itemText.getPaddingRight(),
+                    holder.itemText.getPaddingBottom());
+
+            boolean parentSelected = isLockedByParent(row, selectedLower);
+            boolean visualChecked = parentSelected || selectedLower.contains(row.title().toLowerCase());
+
+            holder.checkIcon.setVisibility(visualChecked ? View.VISIBLE : View.GONE);
+            holder.checkIcon.setColorFilter(foregroundColor);
+            holder.placeholder.setVisibility(visualChecked ? View.GONE : View.VISIBLE);
+
+            float alpha = parentSelected ? DISABLED_ALPHA : 1.0f;
+            holder.itemText.setAlpha(alpha);
+            holder.checkIcon.setAlpha(alpha);
+
+            return view;
+        }
+
+        private static final class Holder {
+            ImageView checkIcon;
+            View placeholder;
+            TextView itemText;
+            int defaultPaddingLeft;
+        }
+    }
+}

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/SettingsMenuFilterPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/SettingsMenuFilterPatch.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2029
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.youtube.patches;
+
+import androidx.annotation.Nullable;
+
+import app.morphe.extension.shared.patches.BaseSettingsMenuFilter;
+import app.morphe.extension.youtube.settings.Settings;
+
+@SuppressWarnings("unused")
+public final class SettingsMenuFilterPatch extends BaseSettingsMenuFilter {
+
+    private static final SettingsMenuFilterPatch INSTANCE = new SettingsMenuFilterPatch();
+
+    private SettingsMenuFilterPatch() {
+        super(Settings.SETTINGS_MENU_FILTER, Settings.SETTINGS_MENU_FILTER_STRINGS);
+    }
+
+    @Nullable
+    public static String[] getNeedles() {
+        return INSTANCE.needles();
+    }
+}

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/SettingsMenuFilterPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/SettingsMenuFilterPatch.java
@@ -7,8 +7,6 @@
 
 package app.morphe.extension.youtube.patches;
 
-import androidx.annotation.Nullable;
-
 import app.morphe.extension.shared.patches.BaseSettingsMenuFilter;
 import app.morphe.extension.youtube.settings.Settings;
 
@@ -18,10 +16,10 @@ public final class SettingsMenuFilterPatch extends BaseSettingsMenuFilter {
     private static final SettingsMenuFilterPatch INSTANCE = new SettingsMenuFilterPatch();
 
     private SettingsMenuFilterPatch() {
-        super(Settings.SETTINGS_MENU_FILTER, Settings.SETTINGS_MENU_FILTER_STRINGS);
+        super(Settings.SETTINGS_MENU_FILTER_STRINGS,
+                Settings.SETTINGS_MENU_FILTER_DISCOVERED);
     }
 
-    @Nullable
     public static String[] getNeedles() {
         return INSTANCE.needles();
     }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -396,6 +396,10 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting CUSTOM_FILTER = new BooleanSetting("morphe_custom_filter", FALSE);
     public static final StringSetting CUSTOM_FILTER_STRINGS = new StringSetting("morphe_custom_filter_strings", "", true, parent(CUSTOM_FILTER));
 
+    // Settings menu filter
+    public static final BooleanSetting SETTINGS_MENU_FILTER = new BooleanSetting("morphe_settings_menu_filter", FALSE);
+    public static final StringSetting SETTINGS_MENU_FILTER_STRINGS = new StringSetting("morphe_settings_menu_filter_strings", "", true, parent(SETTINGS_MENU_FILTER));
+
     // Navigation buttons
     public static final BooleanSetting HIDE_NAVIGATION_BAR = new BooleanSetting("morphe_hide_navigation_bar", FALSE, true, "morphe_hide_navigation_bar_user_dialog_message");
     public static final BooleanSetting HIDE_HOME_BUTTON = new BooleanSetting("morphe_hide_home_button", FALSE, true, parentNot(HIDE_NAVIGATION_BAR));

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -397,8 +397,8 @@ public class Settings extends SharedYouTubeSettings {
     public static final StringSetting CUSTOM_FILTER_STRINGS = new StringSetting("morphe_custom_filter_strings", "", true, parent(CUSTOM_FILTER));
 
     // Settings menu filter
-    public static final BooleanSetting SETTINGS_MENU_FILTER = new BooleanSetting("morphe_settings_menu_filter", FALSE);
-    public static final StringSetting SETTINGS_MENU_FILTER_STRINGS = new StringSetting("morphe_settings_menu_filter_strings", "", true, parent(SETTINGS_MENU_FILTER));
+    public static final StringSetting SETTINGS_MENU_FILTER_STRINGS = new StringSetting("morphe_settings_menu_filter_strings", "", true);
+    public static final StringSetting SETTINGS_MENU_FILTER_DISCOVERED = new StringSetting("morphe_settings_menu_filter_discovered", "", true);
 
     // Navigation buttons
     public static final BooleanSetting HIDE_NAVIGATION_BAR = new BooleanSetting("morphe_hide_navigation_bar", FALSE, true, "morphe_hide_navigation_bar_user_dialog_message");

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -398,7 +398,7 @@ public class Settings extends SharedYouTubeSettings {
 
     // Settings menu filter
     public static final StringSetting SETTINGS_MENU_FILTER_STRINGS = new StringSetting("morphe_settings_menu_filter_strings", "", true);
-    public static final StringSetting SETTINGS_MENU_FILTER_DISCOVERED = new StringSetting("morphe_settings_menu_filter_discovered", "", true);
+    public static final StringSetting SETTINGS_MENU_FILTER_DISCOVERED = new StringSetting("morphe_settings_menu_filter_discovered", "", true, false);
 
     // Navigation buttons
     public static final BooleanSetting HIDE_NAVIGATION_BAR = new BooleanSetting("morphe_hide_navigation_bar", FALSE, true, "morphe_hide_navigation_bar_user_dialog_message");

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/hide/settingsmenu/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/hide/settingsmenu/Fingerprints.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2029
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.patches.music.layout.hide.settingsmenu
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.fieldAccess
+import com.android.tools.smali.dexlib2.Opcode
+
+private const val SETTINGS_HEADERS_FRAGMENT_CLASS =
+    "Lcom/google/android/apps/youtube/music/settings/fragment/SettingsHeadersFragment;"
+
+/**
+ * YT Music top-level Settings fragment. onCreatePreferences reassigns p0 to the peer object at
+ * entry, so the captured iget-object recovers the original fragment from `peer.fragment` at exit.
+ */
+internal object SettingsHeadersOnCreatePreferencesFingerprint : Fingerprint(
+    definingClass = SETTINGS_HEADERS_FRAGMENT_CLASS,
+    name = "onCreatePreferences",
+    returnType = "V",
+    parameters = listOf("Landroid/os/Bundle;", "Ljava/lang/String;"),
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            type = SETTINGS_HEADERS_FRAGMENT_CLASS
+        )
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/hide/settingsmenu/HideSettingsMenuFilterPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/hide/settingsmenu/HideSettingsMenuFilterPatch.kt
@@ -13,12 +13,9 @@ import app.morphe.patches.music.misc.extension.sharedExtensionPatch
 import app.morphe.patches.music.misc.settings.PreferenceScreen
 import app.morphe.patches.music.misc.settings.settingsPatch
 import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
-import app.morphe.patches.shared.misc.settings.preference.InputType
-import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
-import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference.Sorting
-import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
-import app.morphe.patches.shared.misc.settings.preference.TextPreference
+import app.morphe.patches.shared.misc.settings.preference.NonInteractivePreference
 import app.morphe.patches.shared.misc.settingsmenu.HIDE_MATCHING_METHOD
+import app.morphe.patches.shared.misc.settingsmenu.SETTINGS_MENU_FILTER_CLASS
 import app.morphe.patches.shared.misc.settingsmenu.injectHideMatchingHelper
 import app.morphe.patches.shared.misc.settingsmenu.injectSettingsMenuFilterHook
 import app.morphe.util.getReference
@@ -44,23 +41,12 @@ val hideSettingsMenuFilterPatch = bytecodePatch(
 
     execute {
         PreferenceScreen.GENERAL.addPreferences(
-            PreferenceScreenPreference(
-                key = "morphe_music_settings_menu_filter_screen",
+            NonInteractivePreference(
+                key = "morphe_music_settings_menu_filter",
                 titleKey = "morphe_settings_menu_filter_screen_title",
                 summaryKey = "morphe_settings_menu_filter_screen_summary",
-                sorting = Sorting.UNSORTED,
-                preferences = setOf(
-                    SwitchPreference(
-                        key = "morphe_music_settings_menu_filter",
-                        titleKey = "morphe_settings_menu_filter_title"
-                    ),
-                    TextPreference(
-                        key = "morphe_music_settings_menu_filter_strings",
-                        titleKey = "morphe_settings_menu_filter_strings_title",
-                        summaryKey = "morphe_settings_menu_filter_strings_summary",
-                        inputType = InputType.TEXT_MULTI_LINE
-                    )
-                )
+                tag = "app.morphe.extension.shared.patches.SettingsMenuFilterPickerPreference",
+                selectable = true
             )
         )
 
@@ -87,7 +73,12 @@ val hideSettingsMenuFilterPatch = bytecodePatch(
                         move-result-object v1
                         if-eqz v1, :ignore
 
-                        invoke-virtual { v0, v1 }, $HIDE_MATCHING_METHOD
+                        invoke-static { }, $SETTINGS_MENU_FILTER_CLASS->beginCapture()V
+
+                        const/4 v2, 0x0
+                        invoke-virtual { v0, v1, v2 }, $HIDE_MATCHING_METHOD
+
+                        invoke-static { }, $SETTINGS_MENU_FILTER_CLASS->endCapture()V
 
                         :ignore
                         nop

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/hide/settingsmenu/HideSettingsMenuFilterPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/hide/settingsmenu/HideSettingsMenuFilterPatch.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2029
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.patches.music.layout.hide.settingsmenu
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.music.misc.extension.sharedExtensionPatch
+import app.morphe.patches.music.misc.settings.PreferenceScreen
+import app.morphe.patches.music.misc.settings.settingsPatch
+import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
+import app.morphe.patches.shared.misc.settings.preference.InputType
+import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
+import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference.Sorting
+import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import app.morphe.patches.shared.misc.settings.preference.TextPreference
+import app.morphe.patches.shared.misc.settingsmenu.HIDE_MATCHING_METHOD
+import app.morphe.patches.shared.misc.settingsmenu.injectHideMatchingHelper
+import app.morphe.patches.shared.misc.settingsmenu.injectSettingsMenuFilterHook
+import app.morphe.util.getReference
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+
+private const val EXTENSION_CLASS =
+    "Lapp/morphe/extension/music/patches/SettingsMenuFilterPatch;"
+
+private const val SETTINGS_HEADERS_FRAGMENT_CLASS =
+    "Lcom/google/android/apps/youtube/music/settings/fragment/SettingsHeadersFragment;"
+
+@Suppress("unused")
+val hideSettingsMenuFilterPatch = bytecodePatch(
+    name = "Settings menu filter",
+    description = "Adds an option to hide items on the standard YouTube Music settings screen by their visible name."
+) {
+    dependsOn(
+        settingsPatch,
+        sharedExtensionPatch
+    )
+
+    compatibleWith(COMPATIBILITY_YOUTUBE_MUSIC)
+
+    execute {
+        PreferenceScreen.GENERAL.addPreferences(
+            PreferenceScreenPreference(
+                key = "morphe_music_settings_menu_filter_screen",
+                titleKey = "morphe_settings_menu_filter_screen_title",
+                summaryKey = "morphe_settings_menu_filter_screen_summary",
+                sorting = Sorting.UNSORTED,
+                preferences = setOf(
+                    SwitchPreference(
+                        key = "morphe_music_settings_menu_filter",
+                        titleKey = "morphe_settings_menu_filter_title"
+                    ),
+                    TextPreference(
+                        key = "morphe_music_settings_menu_filter_strings",
+                        titleKey = "morphe_settings_menu_filter_strings_title",
+                        summaryKey = "morphe_settings_menu_filter_strings_summary",
+                        inputType = InputType.TEXT_MULTI_LINE
+                    )
+                )
+            )
+        )
+
+        injectSettingsMenuFilterHook(EXTENSION_CLASS)
+        injectHideMatchingHelper()
+
+        // p0 is reassigned to the peer at method entry, so recover the fragment via peer.fragment.
+        SettingsHeadersOnCreatePreferencesFingerprint.let {
+            val fragmentField = it.instructionMatches.first()
+                .instruction.getReference<FieldReference>()!!
+
+            it.method.apply {
+                val insertIndex = implementation!!.instructions.size - 1
+
+                addInstructionsWithLabels(
+                    insertIndex,
+                    """
+                        iget-object v0, p0, $fragmentField
+                        invoke-virtual { v0 }, $SETTINGS_HEADERS_FRAGMENT_CLASS->getPreferenceScreen()Landroidx/preference/PreferenceScreen;
+                        move-result-object v0
+                        if-eqz v0, :ignore
+
+                        invoke-static { }, $EXTENSION_CLASS->getNeedles()[Ljava/lang/String;
+                        move-result-object v1
+                        if-eqz v1, :ignore
+
+                        invoke-virtual { v0, v1 }, $HIDE_MATCHING_METHOD
+
+                        :ignore
+                        nop
+                    """
+                )
+            }
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/settingsmenu/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/settingsmenu/Fingerprints.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2029
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.patches.shared.misc.settingsmenu
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.fieldAccess
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+/**
+ * Preference.setTitle(CharSequence). setSummary shares the parameter type but is not final.
+ */
+internal object PreferenceSetTitleFingerprint : Fingerprint(
+    definingClass = "Landroidx/preference/Preference;",
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    parameters = listOf("Ljava/lang/CharSequence;"),
+    returnType = "V",
+)
+
+/**
+ * Preference.setVisible(boolean). Only (Z)V setter that stores + notifies via a listener field.
+ */
+internal object PreferenceSetVisibleFingerprint : Fingerprint(
+    definingClass = "Landroidx/preference/Preference;",
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    parameters = listOf("Z"),
+    returnType = "V",
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IPUT_BOOLEAN,
+            definingClass = "this"
+        ),
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            definingClass = "this"
+        )
+    )
+)
+
+/**
+ * PreferenceGroup.getPreference(int). The captured iget yields the backing list field ref.
+ */
+internal object PreferenceGroupGetPreferenceFingerprint : Fingerprint(
+    definingClass = "Landroidx/preference/PreferenceGroup;",
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    parameters = listOf("I"),
+    returnType = "Landroidx/preference/Preference;",
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            definingClass = "this",
+            type = "Ljava/util/List;"
+        )
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/settingsmenu/HideMatchingHelper.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/settingsmenu/HideMatchingHelper.kt
@@ -44,8 +44,7 @@ internal fun BytecodePatchContext.injectSettingsMenuFilterHook(extensionClass: S
         addInstructionsWithLabels(
             0,
             """
-                const/4 v0, 0x0
-                invoke-static { v0, p1 }, $SETTINGS_MENU_FILTER_CLASS->capture(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)V
+                invoke-static { p0, p1 }, $SETTINGS_MENU_FILTER_CLASS->scopedCapture(Ljava/lang/Object;Ljava/lang/CharSequence;)V
 
                 invoke-static { }, $extensionClass->getNeedles()[Ljava/lang/String;
                 move-result-object v0
@@ -152,6 +151,8 @@ internal fun BytecodePatchContext.injectHideMatchingHelper() {
                     invoke-interface { v0, v6 }, Ljava/util/List;->get(I)Ljava/lang/Object;
                     move-result-object v2
                     check-cast v2, $PREFERENCE_CLASS
+
+                    invoke-static { v2 }, $SETTINGS_MENU_FILTER_CLASS->markWalked(Ljava/lang/Object;)V
 
                     # Pass 1: pick title for capture + recursion parent context.
                     const/4 v8, 0x0

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/settingsmenu/HideMatchingHelper.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/settingsmenu/HideMatchingHelper.kt
@@ -36,6 +36,9 @@ internal const val HIDE_MATCHING_METHOD =
  */
 internal fun BytecodePatchContext.injectSettingsMenuFilterHook(extensionClass: String) {
     val setVisible = PreferenceSetVisibleFingerprint.method
+    val visibleField = PreferenceSetVisibleFingerprint.let {
+        it.instructionMatches.first().instruction.getReference<FieldReference>()!!
+    }
 
     PreferenceSetTitleFingerprint.method.apply {
         val firstInstruction = implementation!!.instructions.first()
@@ -49,6 +52,9 @@ internal fun BytecodePatchContext.injectSettingsMenuFilterHook(extensionClass: S
 
                 invoke-static { p1, v0 }, $LOGGER_CLASS->equalsAny(Ljava/lang/CharSequence;[Ljava/lang/String;)Z
                 move-result v0
+                if-eqz v0, :original
+
+                iget-boolean v0, p0, $visibleField
                 if-eqz v0, :original
 
                 invoke-static { p1 }, $LOGGER_CLASS->logHidden(Ljava/lang/CharSequence;)V
@@ -74,7 +80,7 @@ internal fun BytecodePatchContext.injectHideMatchingHelper() {
         it.instructionMatches.last().instruction.getReference<FieldReference>()!!
     }
     val setVisible = PreferenceSetVisibleFingerprint.method
-    // Read mVisible so an empty container (all children invisible) can hide its header too.
+    // mVisible: guards against duplicate work + drives the self-hide-when-all-children-invisible rule.
     val visibleField = PreferenceSetVisibleFingerprint.let {
         it.instructionMatches.first().instruction.getReference<FieldReference>()!!
     }
@@ -137,23 +143,26 @@ internal fun BytecodePatchContext.injectHideMatchingHelper() {
 
                     $fieldChecks
 
-                    goto :after_hide
+                    goto :recurse
 
                     :match
+                    # Log + hide only if this pref is currently visible; either way, fall through
+                    # to :recurse so nested groups still get processed.
+                    iget-boolean v4, v2, $visibleField
+                    if-eqz v4, :recurse
                     invoke-static { v3 }, $LOGGER_CLASS->logHidden(Ljava/lang/CharSequence;)V
-                    const/4 v3, 0x0
-                    invoke-virtual { v2, v3 }, $setVisible
-                    add-int/lit8 v5, v5, 0x1
-                    goto :next
+                    const/4 v4, 0x0
+                    invoke-virtual { v2, v4 }, $setVisible
 
-                    :after_hide
-                    # Recurse into nested groups.
+                    :recurse
                     instance-of v4, v2, $PREFERENCE_GROUP_CLASS
-                    if-eqz v4, :next
+                    if-eqz v4, :count
                     check-cast v2, $PREFERENCE_GROUP_CLASS
                     invoke-virtual { v2, p1 }, $HIDE_MATCHING_METHOD
 
-                    # If the recursion left the group invisible (all its children hidden), count it.
+                    :count
+                    # Single counting point: pref counts as hidden if it ended up invisible,
+                    # whether we hid it, recursion hid it, or the app had it invisible already.
                     iget-boolean v4, v2, $visibleField
                     if-nez v4, :next
                     add-int/lit8 v5, v5, 0x1

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/settingsmenu/HideMatchingHelper.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/settingsmenu/HideMatchingHelper.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2029
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.patches.shared.misc.settingsmenu
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
+import app.morphe.patcher.util.smali.ExternalLabel
+import app.morphe.util.getReference
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
+
+private const val PREFERENCE_GROUP_CLASS = "Landroidx/preference/PreferenceGroup;"
+private const val PREFERENCE_CLASS = "Landroidx/preference/Preference;"
+private const val LOGGER_CLASS = "Lapp/morphe/extension/shared/patches/BaseSettingsMenuFilter;"
+
+/**
+ * Smali descriptor of the helper method injected by [injectHideMatchingHelper].
+ */
+internal const val HIDE_MATCHING_METHOD =
+    "$PREFERENCE_GROUP_CLASS->patch_hideMatching([Ljava/lang/String;)V"
+
+/**
+ * Hooks Preference.setTitle to catch async title assignments that arrive after onCreatePreferences.
+ * Must be paired with [injectHideMatchingHelper] because R8 sometimes inlines setTitle
+ * into the Preference constructor for XML-inflated titles, skipping the setter entirely.
+ */
+internal fun BytecodePatchContext.injectSettingsMenuFilterHook(extensionClass: String) {
+    val setVisible = PreferenceSetVisibleFingerprint.method
+
+    PreferenceSetTitleFingerprint.method.apply {
+        val firstInstruction = implementation!!.instructions.first()
+
+        addInstructionsWithLabels(
+            0,
+            """
+                invoke-static { }, $extensionClass->getNeedles()[Ljava/lang/String;
+                move-result-object v0
+                if-eqz v0, :original
+
+                invoke-static { p1, v0 }, $LOGGER_CLASS->equalsAny(Ljava/lang/CharSequence;[Ljava/lang/String;)Z
+                move-result v0
+                if-eqz v0, :original
+
+                invoke-static { p1 }, $LOGGER_CLASS->logHidden(Ljava/lang/CharSequence;)V
+
+                const/4 v0, 0x0
+                invoke-virtual { p0, v0 }, $setVisible
+            """,
+            ExternalLabel("original", firstInstruction)
+        )
+    }
+}
+
+/**
+ * Injects a helper on PreferenceGroup that recursively walks the backing list, reads CharSequence
+ * fields directly, calls setVisible(false) on matches, and self-hides when every child ends up
+ * invisible (so an empty category header disappears too). Field reads (not getters) are required
+ * because R8 can inline setTitle into the Preference constructor for XML-inflated titles. Private
+ * CharSequence fields are widened to public first: a subclass method cannot access private parent
+ * fields, and our helper lives on PreferenceGroup.
+ */
+internal fun BytecodePatchContext.injectHideMatchingHelper() {
+    val listField = PreferenceGroupGetPreferenceFingerprint.let {
+        it.instructionMatches.last().instruction.getReference<FieldReference>()!!
+    }
+    val setVisible = PreferenceSetVisibleFingerprint.method
+    // Read mVisible so an empty container (all children invisible) can hide its header too.
+    val visibleField = PreferenceSetVisibleFingerprint.let {
+        it.instructionMatches.first().instruction.getReference<FieldReference>()!!
+    }
+
+    val preferenceClass = mutableClassDefByOrNull(PREFERENCE_CLASS)
+        ?: throw PatchException("Class not found in target: $PREFERENCE_CLASS")
+    val textFields = preferenceClass.fields.filter { it.type == "Ljava/lang/CharSequence;" }
+    if (textFields.isEmpty()) {
+        throw PatchException("No CharSequence fields on $PREFERENCE_CLASS - obfuscation changed")
+    }
+    textFields.forEach { field ->
+        if (AccessFlags.PRIVATE.isSet(field.accessFlags)) {
+            val flags = (field.accessFlags and AccessFlags.PRIVATE.value.inv()) or AccessFlags.PUBLIC.value
+            field.setAccessFlags(flags)
+        }
+    }
+
+    val fieldChecks = textFields.joinToString("\n") { field ->
+        """
+            iget-object v3, v2, $PREFERENCE_CLASS->${field.name}:${field.type}
+            invoke-static { v3, p1 }, $LOGGER_CLASS->equalsAny(Ljava/lang/CharSequence;[Ljava/lang/String;)Z
+            move-result v4
+            if-nez v4, :match
+        """.trimIndent()
+    }
+
+    PreferenceGroupGetPreferenceFingerprint.classDef.apply {
+        val helper = ImmutableMethod(
+            type,
+            "patch_hideMatching",
+            listOf(ImmutableMethodParameter("[Ljava/lang/String;", null, null)),
+            "V",
+            AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+            null,
+            null,
+            MutableMethodImplementation(10),
+        ).toMutable().apply {
+            addInstructionsWithLabels(
+                0,
+                """
+                    if-eqz p1, :done
+                    array-length v0, p1
+                    if-eqz v0, :done
+
+                    iget-object v0, p0, $listField
+                    invoke-interface { v0 }, Ljava/util/List;->size()I
+                    move-result v1
+
+                    if-eqz v1, :done
+
+                    const/4 v5, 0x0
+                    add-int/lit8 v6, v1, -0x1
+
+                    :outer
+                    if-ltz v6, :after_loop
+
+                    invoke-interface { v0, v6 }, Ljava/util/List;->get(I)Ljava/lang/Object;
+                    move-result-object v2
+                    check-cast v2, $PREFERENCE_CLASS
+
+                    $fieldChecks
+
+                    goto :after_hide
+
+                    :match
+                    invoke-static { v3 }, $LOGGER_CLASS->logHidden(Ljava/lang/CharSequence;)V
+                    const/4 v3, 0x0
+                    invoke-virtual { v2, v3 }, $setVisible
+                    add-int/lit8 v5, v5, 0x1
+                    goto :next
+
+                    :after_hide
+                    # Recurse into nested groups.
+                    instance-of v4, v2, $PREFERENCE_GROUP_CLASS
+                    if-eqz v4, :next
+                    check-cast v2, $PREFERENCE_GROUP_CLASS
+                    invoke-virtual { v2, p1 }, $HIDE_MATCHING_METHOD
+
+                    # If the recursion left the group invisible (all its children hidden), count it.
+                    iget-boolean v4, v2, $visibleField
+                    if-nez v4, :next
+                    add-int/lit8 v5, v5, 0x1
+
+                    :next
+                    add-int/lit8 v6, v6, -0x1
+                    goto :outer
+
+                    :after_loop
+                    # All direct children invisible? Hide self so an empty category header disappears.
+                    if-ne v5, v1, :done
+                    const/4 v3, 0x0
+                    invoke-virtual { p0, v3 }, $setVisible
+
+                    :done
+                    return-void
+                """
+            )
+        }
+        methods.add(helper)
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/settingsmenu/HideMatchingHelper.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/settingsmenu/HideMatchingHelper.kt
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2026 Morphe.
  * https://github.com/MorpheApp/morphe-patches/pull/2029
  *
@@ -21,18 +21,16 @@ import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
 
 private const val PREFERENCE_GROUP_CLASS = "Landroidx/preference/PreferenceGroup;"
 private const val PREFERENCE_CLASS = "Landroidx/preference/Preference;"
-private const val LOGGER_CLASS = "Lapp/morphe/extension/shared/patches/BaseSettingsMenuFilter;"
+internal const val SETTINGS_MENU_FILTER_CLASS = "Lapp/morphe/extension/shared/patches/BaseSettingsMenuFilter;"
 
 /**
  * Smali descriptor of the helper method injected by [injectHideMatchingHelper].
  */
 internal const val HIDE_MATCHING_METHOD =
-    "$PREFERENCE_GROUP_CLASS->patch_hideMatching([Ljava/lang/String;)V"
+    "$PREFERENCE_GROUP_CLASS->patch_hideMatching([Ljava/lang/String;Ljava/lang/CharSequence;)V"
 
 /**
- * Hooks Preference.setTitle to catch async title assignments that arrive after onCreatePreferences.
- * Must be paired with [injectHideMatchingHelper] because R8 sometimes inlines setTitle
- * into the Preference constructor for XML-inflated titles, skipping the setter entirely.
+ * Catches async title assignments that skip the tree walk.
  */
 internal fun BytecodePatchContext.injectSettingsMenuFilterHook(extensionClass: String) {
     val setVisible = PreferenceSetVisibleFingerprint.method
@@ -46,18 +44,21 @@ internal fun BytecodePatchContext.injectSettingsMenuFilterHook(extensionClass: S
         addInstructionsWithLabels(
             0,
             """
+                const/4 v0, 0x0
+                invoke-static { v0, p1 }, $SETTINGS_MENU_FILTER_CLASS->capture(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)V
+
                 invoke-static { }, $extensionClass->getNeedles()[Ljava/lang/String;
                 move-result-object v0
                 if-eqz v0, :original
 
-                invoke-static { p1, v0 }, $LOGGER_CLASS->equalsAny(Ljava/lang/CharSequence;[Ljava/lang/String;)Z
+                invoke-static { p1, v0 }, $SETTINGS_MENU_FILTER_CLASS->equalsAny(Ljava/lang/CharSequence;[Ljava/lang/String;)Z
                 move-result v0
                 if-eqz v0, :original
 
                 iget-boolean v0, p0, $visibleField
                 if-eqz v0, :original
 
-                invoke-static { p1 }, $LOGGER_CLASS->logHidden(Ljava/lang/CharSequence;)V
+                invoke-static { p1 }, $SETTINGS_MENU_FILTER_CLASS->logHidden(Ljava/lang/CharSequence;)V
 
                 const/4 v0, 0x0
                 invoke-virtual { p0, v0 }, $setVisible
@@ -68,12 +69,9 @@ internal fun BytecodePatchContext.injectSettingsMenuFilterHook(extensionClass: S
 }
 
 /**
- * Injects a helper on PreferenceGroup that recursively walks the backing list, reads CharSequence
- * fields directly, calls setVisible(false) on matches, and self-hides when every child ends up
- * invisible (so an empty category header disappears too). Field reads (not getters) are required
- * because R8 can inline setTitle into the Preference constructor for XML-inflated titles. Private
- * CharSequence fields are widened to public first: a subclass method cannot access private parent
- * fields, and our helper lives on PreferenceGroup.
+ * Field reads are required because R8 inlines setTitle into the constructor
+ * for XML-inflated titles, and private CharSequence fields are widened first because a
+ * subclass method on PreferenceGroup cannot access them otherwise.
  */
 internal fun BytecodePatchContext.injectHideMatchingHelper() {
     val listField = PreferenceGroupGetPreferenceFingerprint.let {
@@ -98,10 +96,22 @@ internal fun BytecodePatchContext.injectHideMatchingHelper() {
         }
     }
 
-    val fieldChecks = textFields.joinToString("\n") { field ->
+    // Pick title = first non-null CharSequence field on this Preference.
+    // R8 can reorder fields so we cannot rely on mTitle being declared first.
+    val titlePickPass = textFields.mapIndexed { i, field ->
         """
             iget-object v3, v2, $PREFERENCE_CLASS->${field.name}:${field.type}
-            invoke-static { v3, p1 }, $LOGGER_CLASS->equalsAny(Ljava/lang/CharSequence;[Ljava/lang/String;)Z
+            if-eqz v3, :skip_title_$i
+            move-object v8, v3
+            goto :title_picked
+            :skip_title_$i
+        """.trimIndent()
+    }.joinToString("\n")
+
+    val hideFieldChecks = textFields.joinToString("\n") { field ->
+        """
+            iget-object v3, v2, $PREFERENCE_CLASS->${field.name}:${field.type}
+            invoke-static { v3, p1 }, $SETTINGS_MENU_FILTER_CLASS->equalsAny(Ljava/lang/CharSequence;[Ljava/lang/String;)Z
             move-result v4
             if-nez v4, :match
         """.trimIndent()
@@ -111,67 +121,83 @@ internal fun BytecodePatchContext.injectHideMatchingHelper() {
         val helper = ImmutableMethod(
             type,
             "patch_hideMatching",
-            listOf(ImmutableMethodParameter("[Ljava/lang/String;", null, null)),
+            listOf(
+                ImmutableMethodParameter("[Ljava/lang/String;", null, null),
+                ImmutableMethodParameter("Ljava/lang/CharSequence;", null, null)
+            ),
             "V",
             AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
             null,
             null,
-            MutableMethodImplementation(10),
+            MutableMethodImplementation(12),
         ).toMutable().apply {
             addInstructionsWithLabels(
                 0,
                 """
                     if-eqz p1, :done
-                    array-length v0, p1
-                    if-eqz v0, :done
-
                     iget-object v0, p0, $listField
                     invoke-interface { v0 }, Ljava/util/List;->size()I
                     move-result v1
 
                     if-eqz v1, :done
 
+                    array-length v7, p1
+
                     const/4 v5, 0x0
-                    add-int/lit8 v6, v1, -0x1
+                    const/4 v6, 0x0
 
                     :outer
-                    if-ltz v6, :after_loop
+                    if-ge v6, v1, :after_loop
 
                     invoke-interface { v0, v6 }, Ljava/util/List;->get(I)Ljava/lang/Object;
                     move-result-object v2
                     check-cast v2, $PREFERENCE_CLASS
 
-                    $fieldChecks
+                    # Pass 1: pick title for capture + recursion parent context.
+                    const/4 v8, 0x0
+                    $titlePickPass
+
+                    :title_picked
+                    if-eqz v8, :hide_pass
+                    invoke-static { p2, v8 }, $SETTINGS_MENU_FILTER_CLASS->capture(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)V
+
+                    :hide_pass
+                    # Pass 2: hide only when needles are present.
+                    if-eqz v7, :recurse
+
+                    $hideFieldChecks
 
                     goto :recurse
 
                     :match
-                    # Log + hide only if this pref is currently visible; either way, fall through
-                    # to :recurse so nested groups still get processed.
+                    # Log + hide only if this pref is currently visible; goto :recurse so nested
+                    # groups still get processed for capture and their own hide pass.
                     iget-boolean v4, v2, $visibleField
                     if-eqz v4, :recurse
-                    invoke-static { v3 }, $LOGGER_CLASS->logHidden(Ljava/lang/CharSequence;)V
+                    invoke-static { v3 }, $SETTINGS_MENU_FILTER_CLASS->logHidden(Ljava/lang/CharSequence;)V
                     const/4 v4, 0x0
                     invoke-virtual { v2, v4 }, $setVisible
+                    goto :recurse
 
                     :recurse
                     instance-of v4, v2, $PREFERENCE_GROUP_CLASS
                     if-eqz v4, :count
                     check-cast v2, $PREFERENCE_GROUP_CLASS
-                    invoke-virtual { v2, p1 }, $HIDE_MATCHING_METHOD
+                    invoke-virtual { v2, p1, v8 }, $HIDE_MATCHING_METHOD
 
                     :count
-                    # Single counting point: pref counts as hidden if it ended up invisible,
-                    # whether we hid it, recursion hid it, or the app had it invisible already.
+                    # Counting + self-hide are meaningful only when we are actually hiding.
+                    if-eqz v7, :next
                     iget-boolean v4, v2, $visibleField
                     if-nez v4, :next
                     add-int/lit8 v5, v5, 0x1
 
                     :next
-                    add-int/lit8 v6, v6, -0x1
+                    add-int/lit8 v6, v6, 0x1
                     goto :outer
 
                     :after_loop
+                    if-eqz v7, :done
                     # All direct children invisible? Hide self so an empty category header disappears.
                     if-ne v5, v1, :done
                     const/4 v3, 0x0

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/settingsmenu/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/settingsmenu/Fingerprints.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2029
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.patches.youtube.layout.hide.settingsmenu
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.opcode
+import app.morphe.patcher.string
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+/**
+ * Synthetic Runnable from YT settings intent handling, fired after the PreferenceScreen builds.
+ */
+internal object PreferenceScreenSyntheticFingerprint : Fingerprint(
+    name = "run",
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    parameters = listOf(),
+    returnType = "V",
+    filters = listOf(
+        string(":android:show_fragment_args"),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            parameters = listOf(),
+            returnType = "Landroidx/preference/PreferenceScreen;"
+        ),
+        opcode(Opcode.RETURN_VOID)
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/settingsmenu/HideSettingsMenuFilterPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/settingsmenu/HideSettingsMenuFilterPatch.kt
@@ -9,12 +9,9 @@ package app.morphe.patches.youtube.layout.hide.settingsmenu
 
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.patches.shared.misc.settings.preference.InputType
-import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
-import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference.Sorting
-import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
-import app.morphe.patches.shared.misc.settings.preference.TextPreference
+import app.morphe.patches.shared.misc.settings.preference.NonInteractivePreference
 import app.morphe.patches.shared.misc.settingsmenu.HIDE_MATCHING_METHOD
+import app.morphe.patches.shared.misc.settingsmenu.SETTINGS_MENU_FILTER_CLASS
 import app.morphe.patches.shared.misc.settingsmenu.injectHideMatchingHelper
 import app.morphe.patches.shared.misc.settingsmenu.injectSettingsMenuFilterHook
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
@@ -43,16 +40,12 @@ val hideSettingsMenuFilterPatch = bytecodePatch(
 
     execute {
         PreferenceScreen.GENERAL.addPreferences(
-            PreferenceScreenPreference(
-                key = "morphe_settings_menu_filter_screen",
-                sorting = Sorting.UNSORTED,
-                preferences = setOf(
-                    SwitchPreference("morphe_settings_menu_filter"),
-                    TextPreference(
-                        "morphe_settings_menu_filter_strings",
-                        inputType = InputType.TEXT_MULTI_LINE
-                    )
-                )
+            NonInteractivePreference(
+                key = "morphe_settings_menu_filter",
+                titleKey = "morphe_settings_menu_filter_screen_title",
+                summaryKey = "morphe_settings_menu_filter_screen_summary",
+                tag = "app.morphe.extension.shared.patches.SettingsMenuFilterPickerPreference",
+                selectable = true
             )
         )
 
@@ -70,6 +63,7 @@ val hideSettingsMenuFilterPatch = bytecodePatch(
 
                 val insertIndex = it.instructionMatches.last().index
                 val screenRegister = findFreeRegister(insertIndex, fragmentRegister)
+                val nullRegister = findFreeRegister(insertIndex, fragmentRegister, screenRegister)
 
                 addInstructionsAtControlFlowLabel(
                     insertIndex,
@@ -82,7 +76,12 @@ val hideSettingsMenuFilterPatch = bytecodePatch(
                         move-result-object v$fragmentRegister
                         if-eqz v$fragmentRegister, :ignore
 
-                        invoke-virtual { v$screenRegister, v$fragmentRegister }, $HIDE_MATCHING_METHOD
+                        invoke-static { }, $SETTINGS_MENU_FILTER_CLASS->beginCapture()V
+
+                        const/4 v$nullRegister, 0x0
+                        invoke-virtual { v$screenRegister, v$fragmentRegister, v$nullRegister }, $HIDE_MATCHING_METHOD
+
+                        invoke-static { }, $SETTINGS_MENU_FILTER_CLASS->endCapture()V
 
                         :ignore
                         nop

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/settingsmenu/HideSettingsMenuFilterPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/settingsmenu/HideSettingsMenuFilterPatch.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2029
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.patches.youtube.layout.hide.settingsmenu
+
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.misc.settings.preference.InputType
+import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
+import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference.Sorting
+import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import app.morphe.patches.shared.misc.settings.preference.TextPreference
+import app.morphe.patches.shared.misc.settingsmenu.HIDE_MATCHING_METHOD
+import app.morphe.patches.shared.misc.settingsmenu.injectHideMatchingHelper
+import app.morphe.patches.shared.misc.settingsmenu.injectSettingsMenuFilterHook
+import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
+import app.morphe.patches.youtube.misc.settings.PreferenceScreen
+import app.morphe.patches.youtube.misc.settings.settingsPatch
+import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
+import app.morphe.util.addInstructionsAtControlFlowLabel
+import app.morphe.util.findFreeRegister
+import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+
+private const val EXTENSION_CLASS =
+    "Lapp/morphe/extension/youtube/patches/SettingsMenuFilterPatch;"
+
+@Suppress("unused")
+val hideSettingsMenuFilterPatch = bytecodePatch(
+    name = "Settings menu filter",
+    description = "Adds an option to hide items on the standard YouTube settings screen by their visible name."
+) {
+    dependsOn(
+        settingsPatch,
+        sharedExtensionPatch
+    )
+
+    compatibleWith(COMPATIBILITY_YOUTUBE)
+
+    execute {
+        PreferenceScreen.GENERAL.addPreferences(
+            PreferenceScreenPreference(
+                key = "morphe_settings_menu_filter_screen",
+                sorting = Sorting.UNSORTED,
+                preferences = setOf(
+                    SwitchPreference("morphe_settings_menu_filter"),
+                    TextPreference(
+                        "morphe_settings_menu_filter_strings",
+                        inputType = InputType.TEXT_MULTI_LINE
+                    )
+                )
+            )
+        )
+
+        injectSettingsMenuFilterHook(EXTENSION_CLASS)
+        injectHideMatchingHelper()
+
+        // Reuse the method's own getPreferenceScreen call; fragmentRegister is dead after it.
+        PreferenceScreenSyntheticFingerprint.let {
+            it.method.apply {
+                val getPreferenceScreenIndex = it.instructionMatches[1].index
+                val fragmentRegister =
+                    getInstruction<FiveRegisterInstruction>(getPreferenceScreenIndex).registerC
+                val getPreferenceScreenReference =
+                    getInstruction<ReferenceInstruction>(getPreferenceScreenIndex).reference
+
+                val insertIndex = it.instructionMatches.last().index
+                val screenRegister = findFreeRegister(insertIndex, fragmentRegister)
+
+                addInstructionsAtControlFlowLabel(
+                    insertIndex,
+                    """
+                        invoke-virtual { v$fragmentRegister }, $getPreferenceScreenReference
+                        move-result-object v$screenRegister
+                        if-eqz v$screenRegister, :ignore
+
+                        invoke-static { }, $EXTENSION_CLASS->getNeedles()[Ljava/lang/String;
+                        move-result-object v$fragmentRegister
+                        if-eqz v$fragmentRegister, :ignore
+
+                        invoke-virtual { v$screenRegister, v$fragmentRegister }, $HIDE_MATCHING_METHOD
+
+                        :ignore
+                        nop
+                    """
+                )
+            }
+        }
+    }
+}

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -182,6 +182,12 @@ However, enabling this will also log some user data such as your IP address."</s
     <string name="morphe_custom_filter_strings_summary">List of component path builder strings to filter, separated by new lines</string>
     <string name="morphe_custom_filter_toast_invalid_syntax">Invalid custom filter: %s</string>
 
+    <!-- Settings menu filter -->
+    <string name="morphe_settings_menu_filter_screen_title">Settings menu filter</string>
+    <string name="morphe_settings_menu_filter_screen_summary">Hide items on the standard app settings screen by their visible name</string>
+    <string name="morphe_settings_menu_filter_title">Enable settings menu filter</string>
+    <string name="morphe_settings_menu_filter_strings_title">Items to hide</string>
+    <string name="morphe_settings_menu_filter_strings_summary">One item per line. Matching is case-insensitive and requires the exact title</string>
 
     <!-- misc.spoof.appversion.spoofAppVersionPatch -->
     <string name="morphe_spoof_app_version_title">Spoof app version</string>

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -185,11 +185,7 @@ However, enabling this will also log some user data such as your IP address."</s
     <!-- Settings menu filter -->
     <string name="morphe_settings_menu_filter_screen_title">Settings menu filter</string>
     <string name="morphe_settings_menu_filter_screen_summary">Hide items on the standard app settings screen by their visible name</string>
-    <string name="morphe_settings_menu_filter_title">Enable settings menu filter</string>
-    <string name="morphe_settings_menu_filter_strings_title">Items to hide</string>
-    <string name="morphe_settings_menu_filter_strings_summary">"• One item per line
-• Matching is case-insensitive and requires the exact title
-• Typing a category name hides the whole section along with every item under it"</string>
+    <string name="morphe_settings_menu_filter_picker_empty">Open the standard app settings screen once to populate the list</string>
 
     <!-- misc.spoof.appversion.spoofAppVersionPatch -->
     <string name="morphe_spoof_app_version_title">Spoof app version</string>

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -187,7 +187,9 @@ However, enabling this will also log some user data such as your IP address."</s
     <string name="morphe_settings_menu_filter_screen_summary">Hide items on the standard app settings screen by their visible name</string>
     <string name="morphe_settings_menu_filter_title">Enable settings menu filter</string>
     <string name="morphe_settings_menu_filter_strings_title">Items to hide</string>
-    <string name="morphe_settings_menu_filter_strings_summary">One item per line. Matching is case-insensitive and requires the exact title</string>
+    <string name="morphe_settings_menu_filter_strings_summary">"• One item per line
+• Matching is case-insensitive and requires the exact title
+• Typing a category name hides the whole section along with every item under it"</string>
 
     <!-- misc.spoof.appversion.spoofAppVersionPatch -->
     <string name="morphe_spoof_app_version_title">Spoof app version</string>


### PR DESCRIPTION
### Description

 Adds a `Settings menu filter` for YouTube and YT Music.

Opens a picker with the items collected from the standard app settings screen, tap to hide or unhide. Selecting a category hides the whole section along with every item under it in one shot.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
___
![Screenshot_2026-07-15-00-56-08-628_com.google.android.youtube.test.jpg](https://github.com/user-attachments/assets/8426b36d-89d8-4416-ae26-824af11fdf76)

