### PR TITLE
feat(YouTube - Hide layout components): Add "Hide video thumbnail" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -297,6 +297,11 @@ public final class LayoutComponentsFilter extends Filter {
                 "endorsement_header_footer.e"
         );
 
+        final var videoThumbnail = new StringFilterGroup(
+                Settings.HIDE_VIDEO_THUMBNAIL,
+                "video_lockup_thumbnail.e"
+        );
+
         final var videoTitle = new StringFilterGroup(
                 Settings.HIDE_VIDEO_TITLE,
                 "player_overlay_video_heading.e"
@@ -379,6 +384,7 @@ public final class LayoutComponentsFilter extends Filter {
                 subscriptionsChipBar,
                 surveys,
                 timedReactions,
+                videoThumbnail,
                 videoLabels,
                 videoTitle,
                 videoRecommendationLabels,

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -129,6 +129,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_SURVEYS = new BooleanSetting("morphe_hide_surveys", TRUE);
     public static final BooleanSetting HIDE_TICKET_SHELF = new BooleanSetting("morphe_hide_ticket_shelf", FALSE);
     public static final BooleanSetting HIDE_UPLOAD_TIME = new BooleanSetting("morphe_hide_upload_time", FALSE);
+    public static final BooleanSetting HIDE_VIDEO_THUMBNAIL = new BooleanSetting("morphe_hide_video_thumbnail", FALSE);
     public static final BooleanSetting HIDE_VIDEO_RECOMMENDATION_LABELS = new BooleanSetting("morphe_hide_video_recommendation_labels", TRUE);
     public static final BooleanSetting HIDE_VIEW_COUNT = new BooleanSetting("morphe_hide_view_count", FALSE);
     public static final BooleanSetting HIDE_WEB_SEARCH_RESULTS = new BooleanSetting("morphe_hide_web_search_results", TRUE);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -361,6 +361,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
                 summary = true,
                 tag = "app.morphe.extension.shared.settings.preference.BulletPointSwitchPreference"
             ),
+            SwitchPreference("morphe_hide_video_thumbnail"),
             SwitchPreference("morphe_hide_video_recommendation_labels", summary = true),
             SwitchPreference(
                 "morphe_hide_view_count",

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -104,6 +104,7 @@ Changes include:
     <string name="morphe_hide_upload_time_summary">"Limitations:
 • Shorts shelves, channel pages, and search results may still show upload times
 • Does not work with automotive layout"</string>
+    <string name="morphe_hide_video_thumbnail_title">Hide video thumbnail</string>
     <!-- 'People also watched' and 'You might also like' should be translated using the same localized wording YouTube displays for the label. -->
     <string name="morphe_hide_video_recommendation_labels_title">Hide video recommendation labels</string>
     <string name="morphe_hide_video_recommendation_labels_summary">Hides \'People also watched\' and \'You might also like\' labels in search results</string>


### PR DESCRIPTION
### Description

Partially closes #1542.

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
