### PR TITLE
fix(YouTube - Downloads): Add `;` to one of the fingerprint

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/downloads/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/downloads/Fingerprints.kt
@@ -11,7 +11,7 @@ internal object OfflineVideoEndpointFingerprint : Fingerprint(
     parameters = listOf(
         "Ljava/util/Map;",
         "L",
-        "Ljava/lang/String", // Video ID
+        "Ljava/lang/String;", // Video ID
         "L",
     ),
     filters = listOf(


### PR DESCRIPTION
### Description

<!-- ADD DETAILED DESCRIPTION HERE -->

Closes #

### Additional context

<!-- ADD ADDITIONAL CONTEXT HERE -->

N/A

### Test results

- [ ] Tested on both the **minimum** and **maximum** supported versions
- [ ] Tested on **experimental** supported versions (Optional)
