### PR TITLE
bump(YouTube): Add experimental support for 21.28.204

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/downloads/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/downloads/Fingerprints.kt
@@ -11,7 +11,7 @@ internal object OfflineVideoEndpointFingerprint : Fingerprint(
     parameters = listOf(
         "Ljava/util/Map;",
         "L",
-        "Ljava/lang/String", // Video ID
+        "Ljava/lang/String;", // Video ID
         "L",
     ),
     filters = listOf(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/Fingerprints.kt
@@ -58,13 +58,13 @@ private object SetPivotBarVisibilityParentFingerprint : Fingerprint(
 
 internal object SetPivotBarVisibilityFingerprint : Fingerprint(
     classFingerprint = SetPivotBarVisibilityParentFingerprint,
-    accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.FINAL),
+    accessFlags = listOf(AccessFlags.FINAL),
     returnType = "V",
     parameters = listOf("Z"),
-    filters = OpcodesFilter.opcodesToFilters(
-        Opcode.CHECK_CAST,
-        Opcode.IF_EQZ,
+    filters = listOf(
+        string("FEnotifications_inbox")
     )
+   
 )
 
 internal object ShortsExperimentalPlayerFeatureFlagFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/Fingerprints.kt
@@ -58,7 +58,6 @@ private object SetPivotBarVisibilityParentFingerprint : Fingerprint(
 
 internal object SetPivotBarVisibilityFingerprint : Fingerprint(
     classFingerprint = SetPivotBarVisibilityParentFingerprint,
-    accessFlags = listOf(AccessFlags.FINAL),
     returnType = "V",
     parameters = listOf("Z"),
     filters = listOf(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
@@ -217,18 +217,25 @@ val hideShortsComponentsPatch = bytecodePatch(
         )
 
         // Set the pivotBar view.
-        SetPivotBarVisibilityFingerprint.let { result ->
-            result.method.apply {
-                val insertIndex = result.instructionMatches.last().index
-                val viewRegister = getInstruction<OneRegisterInstruction>(insertIndex - 1).registerA
-
-                addInstruction(
-                    insertIndex,
-                    "invoke-static {v$viewRegister}," +
-                            "$EXTENSION_FILTER->setPivotBar(Lcom/google/android/libraries/youtube/rendering/ui/pivotbar/PivotBar;)V",
-                )
+       // Set the pivotBar view.
+    SetPivotBarVisibilityFingerprint.let { result ->
+        result.method.apply {
+            // Safely find the exact location where the PivotBar is cast
+            val checkCastIndex = indexOfFirstInstructionOrThrow(0) {
+                it.opcode == com.android.tools.smali.dexlib2.Opcode.CHECK_CAST
             }
+            
+            // Grab the exact register holding the PivotBar
+            val viewRegister = getInstruction(checkCastIndex).registerA
+
+            // Inject our code safely, exactly one line after the cast
+            addInstruction(
+                checkCastIndex + 1,
+                "invoke-static {v$viewRegister}," +
+                        "$EXTENSION_FILTER->setPivotBar(Lcom/google/android/libraries/youtube/rendering/ui/pivotbar/PivotBar;)V",
+            )
         }
+    }
 
         // Hook to hide the pivotBar when the Shorts player is opened.
         ReelWatchFragmentInitPlaybackFingerprint.instructionMatches.last().getMethodCalled()

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
@@ -217,12 +217,11 @@ val hideShortsComponentsPatch = bytecodePatch(
         )
 
         // Set the pivotBar view.
-       // Set the pivotBar view.
     SetPivotBarVisibilityFingerprint.let { result ->
         result.method.apply {
             // Safely find the exact location where the PivotBar is cast
             val checkCastIndex = indexOfFirstInstructionOrThrow(0) {
-                it.opcode == com.android.tools.smali.dexlib2.Opcode.CHECK_CAST
+                opcode == Opcode.CHECK_CAST
             }
             
             // Grab the exact register holding the PivotBar

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
@@ -43,6 +43,7 @@ import app.morphe.util.removeFromParent
 import app.morphe.util.returnLate
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.Opcode
 
 internal val hideShortsAppShortcutOption = booleanOption(
     key = "hideShortsAppShortcut",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
@@ -217,25 +217,31 @@ val hideShortsComponentsPatch = bytecodePatch(
             highPriority = true
         )
 
-        // Set the pivotBar view.
-    SetPivotBarVisibilityFingerprint.let { result ->
-        result.method.apply {
-            // Safely find the exact location where the PivotBar is cast
-            val checkCastIndex = indexOfFirstInstructionOrThrow(0) {
-                opcode == Opcode.CHECK_CAST
-            }
-            
-            // Grab the exact register holding the PivotBar
-            val viewRegister = getInstruction(checkCastIndex).registerA
+      // Set the pivotBar view.
 
-            // Inject our code safely, exactly one line after the cast
-            addInstruction(
-                checkCastIndex + 1,
-                "invoke-static {v$viewRegister}," +
-                        "$EXTENSION_FILTER->setPivotBar(Lcom/google/android/libraries/youtube/rendering/ui/pivotbar/PivotBar;)V",
-            )
+        SetPivotBarVisibilityFingerprint.let { result ->
+
+            result.method.apply {
+
+                val insertIndex = result.instructionMatches.last().index
+
+                val viewRegister = getInstruction<OneRegisterInstruction>(insertIndex - 1).registerA
+
+
+
+                addInstruction(
+
+                    insertIndex,
+
+                    "invoke-static {v$viewRegister}," +
+
+                            "$EXTENSION_FILTER->setPivotBar(Lcom/google/android/libraries/youtube/rendering/ui/pivotbar/PivotBar;)V",
+
+                )
+
+            }
+
         }
-    }
 
         // Hook to hide the pivotBar when the Shorts player is opened.
         ReelWatchFragmentInitPlaybackFingerprint.instructionMatches.last().getMethodCalled()

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
@@ -217,30 +217,25 @@ val hideShortsComponentsPatch = bytecodePatch(
             highPriority = true
         )
 
-      // Set the pivotBar view.
-
+      
+        // Set the pivotBar view.
         SetPivotBarVisibilityFingerprint.let { result ->
-
             result.method.apply {
+                // Safely find the exact location where the PivotBar is cast
+                val checkCastIndex = indexOfFirstInstructionOrThrow(0) {
+                    opcode == Opcode.CHECK_CAST
+                }
+                
+                // Grab the exact register holding the PivotBar
+                val viewRegister = getInstruction<OneRegisterInstruction>(checkCastIndex).registerA
 
-                val insertIndex = result.instructionMatches.last().index
-
-                val viewRegister = getInstruction<OneRegisterInstruction>(insertIndex - 1).registerA
-
-
-
+                // Inject our code safely, exactly one line after the cast
                 addInstruction(
-
-                    insertIndex,
-
+                    checkCastIndex + 1,
                     "invoke-static {v$viewRegister}," +
-
                             "$EXTENSION_FILTER->setPivotBar(Lcom/google/android/libraries/youtube/rendering/ui/pivotbar/PivotBar;)V",
-
                 )
-
             }
-
         }
 
         // Hook to hide the pivotBar when the Shorts player is opened.

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/Fingerprints.kt
@@ -41,7 +41,8 @@ internal object MotionEventFingerprint : Fingerprint(
     returnType = "V",
     parameters = listOf("Landroid/view/MotionEvent;"),
     filters = listOf(
-        methodCall(name = "setTranslationY")
+        methodCall(name = "getX"),
+        methodCall(name = "getY")
     )
 )
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/LegacyPlayerControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/LegacyPlayerControlsPatch.kt
@@ -319,17 +319,13 @@ val legacyPlayerControlsPatch = bytecodePatch(
         visibilityImmediateMethodRef = WeakReference(PlayerControlsExtensionHookFingerprint.method)
 
         MotionEventFingerprint.let { result ->
-            visibilityNegatedImmediateMethodRef = WeakReference(result.method)
-            result.method.apply {
-                // Dynamically scan the method to find exactly where getX() is called
-                val getXIndex = indexOfFirstInstructionOrThrow(0) {
-                    getReference<MethodReference>()?.name == "getX"
-                }
-                
-                // Set the injection point exactly one line after getX()
-                visibilityNegatedImmediateInsertIndex = getXIndex + 1
-            }
-        }
+        visibilityNegatedImmediateMethodRef = WeakReference(result.method)
+        
+        // Bypass the Dalvik move-result trap completely.
+        // Since the hook is void and takes no parameters, we inject it 
+        // safely at the absolute beginning of the method.
+        visibilityNegatedImmediateInsertIndex = 0
+    }
 
         fun overrideExploderLayout(fingerprint: Fingerprint) {
             fingerprint.let {

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/LegacyPlayerControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/LegacyPlayerControlsPatch.kt
@@ -36,6 +36,9 @@ import app.morphe.util.findFreeRegister
 import app.morphe.util.inputStreamFromBundledResource
 import app.morphe.util.insertLiteralOverride
 import app.morphe.util.returnEarly
+import app.morphe.util.indexOfFirstInstructionOrThrow
+import app.morphe.util.getReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import org.w3c.dom.Node

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/LegacyPlayerControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/LegacyPlayerControlsPatch.kt
@@ -36,9 +36,6 @@ import app.morphe.util.findFreeRegister
 import app.morphe.util.inputStreamFromBundledResource
 import app.morphe.util.insertLiteralOverride
 import app.morphe.util.returnEarly
-import app.morphe.util.indexOfFirstInstructionOrThrow
-import app.morphe.util.getReference
-import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import org.w3c.dom.Node

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/LegacyPlayerControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playercontrols/LegacyPlayerControlsPatch.kt
@@ -315,9 +315,17 @@ val legacyPlayerControlsPatch = bytecodePatch(
         )
         visibilityImmediateMethodRef = WeakReference(PlayerControlsExtensionHookFingerprint.method)
 
-        MotionEventFingerprint.let {
-            visibilityNegatedImmediateMethodRef = WeakReference(it.method)
-            visibilityNegatedImmediateInsertIndex = it.instructionMatches.first().index + 1
+        MotionEventFingerprint.let { result ->
+            visibilityNegatedImmediateMethodRef = WeakReference(result.method)
+            result.method.apply {
+                // Dynamically scan the method to find exactly where getX() is called
+                val getXIndex = indexOfFirstInstructionOrThrow(0) {
+                    getReference<MethodReference>()?.name == "getX"
+                }
+                
+                // Set the injection point exactly one line after getX()
+                visibilityNegatedImmediateInsertIndex = getXIndex + 1
+            }
         }
 
         fun overrideExploderLayout(fingerprint: Fingerprint) {


### PR DESCRIPTION
### Description

Adds experimental support for YouTube `21.28.204`.

To make this version stable and prevent runtime crashes, the following payload injections were updated:
- **Hide Shorts:** Replaced the hardcoded instruction index with dynamic `Opcode.CHECK_CAST` scanning to safely find the `PivotBar` cast.
- **Legacy Player Controls:** Bypassed the Dalvik `move-result` verify error on the `MotionEvent` hook by injecting the void trigger at method index 0.
- **Downloads:** Fixed a malformed Dalvik type descriptor in `OfflineVideoEndpointFingerprint` by appending the missing semicolon to the String object reference.

### Additional context

Verified locally via CLI builds. Patches successfully inject and the app runs without Dalvik verification crashes.

### Test results

- [ ] Tested on **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)