### PR TITLE
bump(YouTube): Add experimental support for `21.29.363`

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ToolBarPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ToolBarPatch.java
@@ -10,6 +10,8 @@ package app.morphe.extension.youtube.patches;
 import android.view.View;
 import android.widget.ImageView;
 
+import androidx.annotation.Nullable;
+
 import app.morphe.extension.shared.Logger;
 
 @SuppressWarnings("unused")
@@ -18,7 +20,7 @@ public class ToolBarPatch {
     /**
      * Injection point.
      */
-    public static void hookToolBar(Enum<?> iconEnum, ImageView imageView) {
+    public static void hookToolBar(@Nullable Enum<?> iconEnum, ImageView imageView) {
         if (iconEnum != null && imageView.getParent() instanceof View parentView) {
             String enumName = iconEnum.name();
             Logger.printDebug(() -> "enum: " + enumName);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/Fingerprints.kt
@@ -48,7 +48,7 @@ internal object MiniplayerModernFeatureFingerprint : Fingerprint(
 internal object MiniplayerModernConstructorFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
     filters = listOf(
-        literal(MINIPLAYER_MODERN_TYPE_1_FEATURE_KEY)
+        literal(MINIPLAYER_DRAG_DROP_FEATURE_KEY)
     )
 )
 
@@ -265,7 +265,8 @@ internal object MiniplayerSetIconsFingerprint : Fingerprint(
         accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
         returnType = "Landroid/graphics/drawable/Drawable;",
         filters = listOf(
-            resourceLiteral(ResourceType.DRAWABLE, "floatybar_progress_circle_autonav")
+            resourceLiteral(ResourceType.DIMEN, "shadow_icon_offset_x"),
+            resourceLiteral(ResourceType.DIMEN, "shadow_icon_offset_y")
         )
     ),
     returnType = "V",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/MiniplayerPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/MiniplayerPatch.kt
@@ -29,6 +29,8 @@ import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.playservice.is_20_31_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_20_37_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_21_17_or_greater
+import app.morphe.patches.youtube.misc.playservice.is_21_29_or_greater
+import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
@@ -51,11 +53,13 @@ internal const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/Mini
 @Suppress("unused")
 val miniplayerPatch = bytecodePatch(
     name = "Miniplayer",
-    description = "Adds options to change the in-app minimized player."
+    description = "Adds options to change the in-app minimized player. " +
+            "Patching 21.28.206 and lower has more miniplayer types to choose from."
 ) {
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,
+        versionCheckPatch
     )
 
     compatibleWith(COMPATIBILITY_YOUTUBE)
@@ -63,16 +67,18 @@ val miniplayerPatch = bytecodePatch(
     execute {
         val preferences = mutableSetOf<BasePreference>()
 
-        preferences +=
-            if (is_20_37_or_greater) {
-                ListPreference("morphe_miniplayer_type")
-            } else {
-                ListPreference(
-                    key = "morphe_miniplayer_type",
-                    entriesKey = "morphe_miniplayer_type_legacy_20_03_entries",
-                    entryValuesKey = "morphe_miniplayer_type_legacy_20_03_entry_values"
-                )
-            }
+        if (is_20_37_or_greater) {
+            // 21.29 removed all modern miniplayers except modern 3
+//            if (!is_21_29_or_greater) {
+                preferences += ListPreference("morphe_miniplayer_type")
+//            }
+        } else {
+            preferences += ListPreference(
+                key = "morphe_miniplayer_type",
+                entriesKey = "morphe_miniplayer_type_legacy_20_03_entries",
+                entryValuesKey = "morphe_miniplayer_type_legacy_20_03_entry_values"
+            )
+        }
 
         preferences += SwitchPreference("morphe_miniplayer_disable_resuming", summary = true)
         preferences += SwitchPreference("morphe_miniplayer_disable_drag_and_drop", summary = true)
@@ -80,10 +86,12 @@ val miniplayerPatch = bytecodePatch(
         preferences += SwitchPreference("morphe_miniplayer_disable_rounded_corners")
         preferences += SwitchPreference("morphe_miniplayer_hide_overlay_buttons")
         preferences += TextPreference("morphe_miniplayer_width_dip", inputType = InputType.NUMBER)
-        preferences += NonInteractivePreference(
-            key = "morphe_miniplayer_opacity",
-            tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference",
-        )
+        if (!is_21_29_or_greater) {
+            preferences += NonInteractivePreference(
+                key = "morphe_miniplayer_opacity",
+                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference",
+            )
+        }
         preferences += SwitchPreference("morphe_miniplayer_disable_horizontal_drag_playback", summary = true)
         preferences += SwitchPreference("morphe_miniplayer_disable_horizontal_reposition", summary = true)
 
@@ -115,13 +123,6 @@ val miniplayerPatch = bytecodePatch(
             insertMiniplayerBooleanOverride(index, "getLegacyTabletMiniplayerOverride")
         }
 
-        /**
-         * Adds an override to force modern miniplayer to be used or not used.
-         */
-        fun MutableMethod.insertModernMiniplayerOverride(index: Int) {
-            insertMiniplayerBooleanOverride(index, "getModernMiniplayerOverride")
-        }
-
         fun Fingerprint.insertMiniplayerFeatureFlagBooleanOverride(
             literal: Long,
             extensionMethod: String,
@@ -147,21 +148,6 @@ val miniplayerPatch = bytecodePatch(
                     """
                 )
             }
-        }
-
-        /**
-         * Adds an override to specify which modern miniplayer is used.
-         */
-        fun MutableMethod.insertModernMiniplayerTypeOverride(iPutIndex: Int) {
-            val register = getInstruction<TwoRegisterInstruction>(iPutIndex).registerA
-
-            addInstructionsAtControlFlowLabel(
-                iPutIndex,
-                """
-                    invoke-static { v$register }, $EXTENSION_CLASS->getModernMiniplayerOverrideType(I)I
-                    move-result v$register
-                """
-            )
         }
 
         // region Disable resuming miniplayer (Continue watching)
@@ -213,16 +199,27 @@ val miniplayerPatch = bytecodePatch(
 
         // region Enable modern miniplayer.
 
-        MiniplayerModernConstructorFingerprint.classDef.methods.forEach {
-            it.apply {
-                if (AccessFlags.CONSTRUCTOR.isSet(accessFlags)) {
-                    val iPutIndex = indexOfFirstInstructionOrThrow {
-                        this.opcode == Opcode.IPUT && this.getReference<FieldReference>()?.type == "I"
-                    }
+        if (!is_21_29_or_greater) {
+            MiniplayerModernConstructorFingerprint.classDef.methods.forEach {
+                it.apply {
+                    if (AccessFlags.CONSTRUCTOR.isSet(accessFlags)) {
+                        val iPutIndex = indexOfFirstInstructionOrThrow {
+                            opcode == Opcode.IPUT && getReference<FieldReference>()?.type == "I"
+                        }
 
-                    insertModernMiniplayerTypeOverride(iPutIndex)
-                } else {
-                    findReturnIndicesReversed().forEach { index -> insertModernMiniplayerOverride(index) }
+                        val register = getInstruction<TwoRegisterInstruction>(iPutIndex).registerA
+                        addInstructionsAtControlFlowLabel(
+                            iPutIndex,
+                            """
+                                invoke-static { v$register }, $EXTENSION_CLASS->getModernMiniplayerOverrideType(I)I
+                                move-result v$register
+                            """
+                        )
+                    } else {
+                        findReturnIndicesReversed().forEach { index ->
+                            insertMiniplayerBooleanOverride(index, "getModernMiniplayerOverride")
+                        }
+                    }
                 }
             }
         }
@@ -232,21 +229,24 @@ val miniplayerPatch = bytecodePatch(
             "getMiniplayerDragAndDrop",
         )
 
-
-        MiniplayerModernConstructorFingerprint.insertMiniplayerFeatureFlagBooleanOverride(
-            MINIPLAYER_MODERN_FEATURE_LEGACY_KEY,
-            "getModernMiniplayerOverride",
-        )
+        if (!is_21_29_or_greater) {
+            MiniplayerModernConstructorFingerprint.insertMiniplayerFeatureFlagBooleanOverride(
+                MINIPLAYER_MODERN_FEATURE_LEGACY_KEY,
+                "getModernMiniplayerOverride",
+            )
+        }
 
         MiniplayerModernFeatureFingerprint.insertMiniplayerFeatureFlagBooleanOverride(
             MINIPLAYER_MODERN_FEATURE_KEY,
             "getModernFeatureFlagsActiveOverride",
         )
 
-        MiniplayerModernConstructorFingerprint.insertMiniplayerFeatureFlagBooleanOverride(
-            MINIPLAYER_DOUBLE_TAP_FEATURE_KEY,
-            "getMiniplayerDoubleTapAction",
-        )
+        if (!is_21_29_or_greater) {
+            MiniplayerModernConstructorFingerprint.insertMiniplayerFeatureFlagBooleanOverride(
+                MINIPLAYER_DOUBLE_TAP_FEATURE_KEY,
+                "getMiniplayerDoubleTapAction",
+            )
+        }
 
         MiniplayerModernConstructorFingerprint.method.apply {
             val literalIndex = indexOfFirstLiteralInstructionOrThrow(
@@ -380,12 +380,15 @@ val miniplayerPatch = bytecodePatch(
 
         // region Add hooks to hide modern miniplayer buttons.
 
-        listOf(
+        val fingerprints = mutableListOf(
             MiniplayerModernExpandButtonFingerprint to "hideMiniplayerExpandClose",
             MiniplayerModernCloseButtonFingerprint to "hideMiniplayerExpandClose",
             MiniplayerModernActionButtonFingerprint to "hideMiniplayerActionButton",
-            MiniplayerModernOverlayViewFingerprint to "adjustMiniplayerOpacity"
-        ).forEach { (fingerprint, methodName) ->
+        )
+        if (!is_21_29_or_greater) {
+            fingerprints += MiniplayerModernOverlayViewFingerprint to "adjustMiniplayerOpacity"
+        }
+        fingerprints.forEach { (fingerprint, methodName) ->
             fingerprint.method.apply {
                 val index = fingerprint.instructionMatches.last().index
                 val register = getInstruction<OneRegisterInstruction>(index).registerA

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/MiniplayerPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/MiniplayerPatch.kt
@@ -337,7 +337,7 @@ val miniplayerPatch = bytecodePatch(
 
         // region fix minimal miniplayer using the wrong pause/play bold icons.
 
-        if (is_20_31_or_greater) {
+        if (is_20_31_or_greater && !is_21_29_or_greater) {
             if (is_21_17_or_greater) {
                 // 21.17+ removed the code to set the non-bold miniplayer pause/play icon,
                 // and removed the non bold yt_fill_pause_white_36 icons.

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/buttons/PlayerOverlayButtonsHookPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/buttons/PlayerOverlayButtonsHookPatch.kt
@@ -14,6 +14,8 @@ import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.patches.youtube.layout.miniplayer.EXTENSION_CLASS
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
+import app.morphe.patches.youtube.misc.playservice.is_21_29_or_greater
+import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import java.lang.ref.WeakReference
 
@@ -32,6 +34,7 @@ internal val playerOverlayButtonsHookPatch = bytecodePatch {
     dependsOn(
         sharedExtensionPatch,
         resourceMappingPatch, // Used by fingerprints.
+        versionCheckPatch
     )
 
     execute {
@@ -45,10 +48,12 @@ internal val playerOverlayButtonsHookPatch = bytecodePatch {
                 // Fix the fullscreen button tint when the minimal miniplayer type is selected.
                 // The minimal type forces a theme where ytOverlayButtonPrimary resolves to gray
                 // instead of white, making the fullscreen button appear gray instead of white.
-                addInstruction(
-                    index + 1,
-                    "invoke-static { v$exploderButtonInsertRegister }, $EXTENSION_CLASS->fixMinimalMiniplayerFullscreenButtonTint(Landroid/view/View;)V"
-                )
+                if (!is_21_29_or_greater) {
+                    addInstruction(
+                        index + 1,
+                        "invoke-static { v$exploderButtonInsertRegister }, $EXTENSION_CLASS->fixMinimalMiniplayerFullscreenButtonTint(Landroid/view/View;)V"
+                    )
+                }
             }
         }
     }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playservice/VersionCheckPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playservice/VersionCheckPatch.kt
@@ -83,6 +83,8 @@ var is_21_26_or_greater : Boolean by Delegates.notNull()
     private set
 var is_21_28_or_greater : Boolean by Delegates.notNull()
     private set
+var is_21_29_or_greater : Boolean by Delegates.notNull()
+    private set
 
 val versionCheckPatch = bytecodePatch {
     execute {
@@ -129,5 +131,6 @@ val versionCheckPatch = bytecodePatch {
         is_21_25_or_greater = isEqualsOrGreaterThan("21.25.000")
         is_21_26_or_greater = isEqualsOrGreaterThan("21.26.000")
         is_21_28_or_greater = isEqualsOrGreaterThan("21.28.000")
+        is_21_29_or_greater = isEqualsOrGreaterThan("21.29.000")
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/shared/Constants.kt
@@ -18,6 +18,11 @@ internal object Constants {
         ),
         targets = listOf(
             AppTarget(
+                version = "21.29.363",
+                minSdk = 29,
+                isExperimental = true
+            ),
+            AppTarget(
                 version = "21.28.204",
                 minSdk = 29,
                 isExperimental = true

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/shared/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/shared/Fingerprints.kt
@@ -158,14 +158,16 @@ internal object ToolBarButtonFingerprint : Fingerprint(
     filters = listOf(
         resourceLiteral(ResourceType.ID, "menu_item_view"),
         methodCall(smali = "Landroid/view/MenuItem;->setShowAsAction(I)V"),
-        fieldAccess(
-            type = "I",
-            opcode = Opcode.IGET
+        methodCall(
+            opcode = Opcode.INVOKE_STATIC,
+            returnType = "L",
+            parameters = listOf("I")
         ),
-        opcode(Opcode.SGET_OBJECT),
+        opcode(Opcode.MOVE_RESULT_OBJECT, MatchAfterImmediately()),
         methodCall(
             opcode = Opcode.INVOKE_INTERFACE,
-            returnType = "I"
+            returnType = "I",
+            parameters = listOf("L")
         ),
         opcode(Opcode.MOVE_RESULT, MatchAfterImmediately()),
         fieldAccess(


### PR DESCRIPTION
### Description

In 21.29 YouTube has removed all modern miniplayers except the default modern 4, including the 'minimal' miniplayer type.

Previously the miniplayer type was an int field and used in ~ 60 different places to give the different behavior of each player. 21.29 removes that field and all code using it. It seems infeasible to restore the old miniplayers with so much code removed.

Patch 21.28 or lower if you want a different miniplayer type (rip Modern 1 and minimal).


### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
