### PR TITLE
feat(YouTube - Hide layout components): Add "Hide 'Search inside this video' section" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/DescriptionComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/DescriptionComponentsFilter.java
@@ -41,6 +41,16 @@ public final class DescriptionComponentsFilter extends Filter {
                 "youchat_entrypoint.e"
         );
 
+        final StringFilterGroup correctionsSection = new StringFilterGroup(
+                Settings.HIDE_CORRECTIONS_SECTION,
+                "error_corrections_section"
+        );
+
+        final StringFilterGroup courseProgressSection = new StringFilterGroup(
+                Settings.HIDE_COURSE_PROGRESS_SECTION,
+                "course_progress"
+        );
+
         featuredSection = new StringFilterGroup(
                 null,
                 "compact_infocard.e"
@@ -58,6 +68,45 @@ public final class DescriptionComponentsFilter extends Filter {
                 new ByteArrayFilterGroup(
                         Settings.HIDE_FEATURED_VIDEOS_SECTION,
                         "structured_description_video_lockup"
+                )
+        );
+
+        final StringFilterGroup howThisWasMadeSection = new StringFilterGroup(
+                Settings.HIDE_HOW_THIS_WAS_MADE_SECTION,
+                "how_this_was_made_section"
+        );
+
+        final StringFilterGroup hypePoints = new StringFilterGroup(
+                Settings.HIDE_HYPE_POINTS,
+                "hype_points_factoid"
+        );
+
+        final StringFilterGroup infoCardsSection = new StringFilterGroup(
+                Settings.HIDE_INFO_CARDS_SECTION,
+                INFOCARDS_SECTION_PATH
+        );
+
+        final StringFilterGroup lensSection = new StringFilterGroup(
+                Settings.HIDE_SEARCH_INSIDE_THIS_VIDEO_SECTION,
+                "lens_section.e"
+        );
+
+        macroMarkersCarousel = new StringFilterGroup(
+                null,
+                "macro_markers_carousel.e"
+        );
+
+        macroMarkersCarouselGroupList.addAll(
+                new ByteArrayFilterGroup(
+                        Settings.HIDE_CHAPTERS_SECTION,
+                        "chapters_horizontal_shelf",
+                        "auto-chapters",
+                        "description-chapters"
+                ),
+                new ByteArrayFilterGroup(
+                        Settings.HIDE_KEY_CONCEPTS_SECTION,
+                        "learning_concept_macro_markers_carousel_shelf",
+                        "learning-concept"
                 )
         );
 
@@ -81,9 +130,10 @@ public final class DescriptionComponentsFilter extends Filter {
                 )
         );
 
-        final StringFilterGroup correctionsSection = new StringFilterGroup(
-                Settings.HIDE_CORRECTIONS_SECTION,
-                "error_corrections_section"
+        shortsHowThisWasMadeSection = new StringFilterGroup(
+                Settings.HIDE_HOW_THIS_WAS_MADE_SECTION,
+                "shelf_header.e",
+                "cell_video_attribute.e"
         );
 
         final StringFilterGroup transcriptSection = new StringFilterGroup(
@@ -91,54 +141,9 @@ public final class DescriptionComponentsFilter extends Filter {
                 "transcript_section"
         );
 
-        final StringFilterGroup howThisWasMadeSection = new StringFilterGroup(
-                Settings.HIDE_HOW_THIS_WAS_MADE_SECTION,
-                "how_this_was_made_section"
-        );
-
-        final StringFilterGroup courseProgressSection = new StringFilterGroup(
-                Settings.HIDE_COURSE_PROGRESS_SECTION,
-                "course_progress"
-        );
-
-        final StringFilterGroup hypePoints = new StringFilterGroup(
-                Settings.HIDE_HYPE_POINTS,
-                "hype_points_factoid"
-        );
-
-        final StringFilterGroup infoCardsSection = new StringFilterGroup(
-                Settings.HIDE_INFO_CARDS_SECTION,
-                INFOCARDS_SECTION_PATH
-        );
-
         subscribeButton = new StringFilterGroup(
                 Settings.HIDE_SUBSCRIBE_BUTTON,
                 "subscribe_button"
-        );
-
-        macroMarkersCarousel = new StringFilterGroup(
-                null,
-                "macro_markers_carousel.e"
-        );
-
-        macroMarkersCarouselGroupList.addAll(
-                new ByteArrayFilterGroup(
-                        Settings.HIDE_CHAPTERS_SECTION,
-                        "chapters_horizontal_shelf",
-                        "auto-chapters",
-                        "description-chapters"
-                ),
-                new ByteArrayFilterGroup(
-                        Settings.HIDE_KEY_CONCEPTS_SECTION,
-                        "learning_concept_macro_markers_carousel_shelf",
-                        "learning-concept"
-                )
-        );
-
-        shortsHowThisWasMadeSection = new StringFilterGroup(
-                Settings.HIDE_HOW_THIS_WAS_MADE_SECTION,
-                "shelf_header.e",
-                "cell_video_attribute.e"
         );
 
         videoDetails = new StringFilterGroup(
@@ -160,6 +165,7 @@ public final class DescriptionComponentsFilter extends Filter {
                 howThisWasMadeSection,
                 hypePoints,
                 infoCardsSection,
+                lensSection,
                 macroMarkersCarousel,
                 playlistSection,
                 shortsHowThisWasMadeSection,

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -329,6 +329,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_KEY_CONCEPTS_SECTION = new BooleanSetting("morphe_hide_key_concepts_section", FALSE);
     public static final BooleanSetting HIDE_MUSIC_SECTION = new BooleanSetting("morphe_hide_music_section", FALSE);
     public static final BooleanSetting HIDE_QUIZZES_SECTION = new BooleanSetting("morphe_hide_quizzes_section", FALSE);
+    public static final BooleanSetting HIDE_SEARCH_INSIDE_THIS_VIDEO_SECTION = new BooleanSetting("morphe_hide_search_inside_this_video_section", FALSE);
     public static final BooleanSetting HIDE_TRANSCRIPT_SECTION = new BooleanSetting("morphe_hide_transcript_section", FALSE);
     public static final BooleanSetting HIDE_VIDEO_DETAILS_SECTION = new BooleanSetting("morphe_hide_video_details_section", FALSE);
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -59,7 +59,6 @@ import app.morphe.util.getReference
 import app.morphe.util.indexOfFirstInstructionOrThrow
 import app.morphe.util.indexOfFirstInstructionReversedOrThrow
 import app.morphe.util.injectHideViewCall
-import app.morphe.util.insertLiteralOverride
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
@@ -136,6 +135,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
                     SwitchPreference("morphe_hide_key_concepts_section"),
                     SwitchPreference("morphe_hide_music_section"),
                     SwitchPreference("morphe_hide_quizzes_section"),
+                    SwitchPreference("morphe_hide_search_inside_this_video_section"),
                     SwitchPreference("morphe_hide_subscribe_button"),
                     SwitchPreference("morphe_hide_transcript_section"),
                     SwitchPreference("morphe_hide_video_details_section")

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -169,6 +169,7 @@ Changes include:
     <string name="morphe_hide_key_concepts_section_title">Hide \'Key concepts\' section</string>
     <string name="morphe_hide_music_section_title">Hide Music section</string>
     <string name="morphe_hide_quizzes_section_title">Hide Quizzes section</string>
+    <string name="morphe_hide_search_inside_this_video_section_title">Hide \'Search inside this video\' section</string>
     <string name="morphe_hide_subscribe_button_title">Hide Subscribe button</string>
     <string name="morphe_hide_transcript_section_title">Hide Transcript section</string>
     <string name="morphe_hide_video_details_section_title">Hide \'Video details\' section</string>


### PR DESCRIPTION
### Description

Closes #1677.

### Additional context

```
07-19 17:54:23.449 11949 11949 D morphe: LithoFilterPatch: Searching ID: lens_section.eml-fe|75051497aadac5a0 Path: lens_section.eml-fe|75051497aadac5a0|CellType|ContainerType| BufferStrings: button.eml-fe|bc5ee1cef0ea6f26*❙,yt_outline_experimental_google_lens_black_24❙Google Lens"❙"Lens unavailable. Try again later.*❙2Rotate your device to portrait to use this feature*❙theme|10de10758b1ecf0d❙333?❙dismiss❙$KEN_BURNS_ANIMATION_TYPE_UNSPECIFIED❙capabilities|66b80408845d91d92❙theme|10de10758b1ecf0d❙capabilities|66b80408845d91d9❙theme|10de10758b1ecf0d❙capabilities|66b80408845d91d9❙
``` 

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
