### PR TITLE
chore(YouTube Music - Scrobbling): Replace hardcoded user agent with dynamic version

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/lastfm/LastFM.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/lastfm/LastFM.java
@@ -28,7 +28,7 @@ import app.morphe.extension.shared.requests.Requester;
 
 public class LastFM {
     private static final String BASE_URL = "https://ws.audioscrobbler.com/2.0/";
-    private static final String USER_AGENT = "Morphe/" + Utils.getAppVersionName();
+    private static final String USER_AGENT = "Morphe/" + Utils.getPatchesReleaseVersion() + " (YTMusic/" + Utils.getAppVersionName() + ")";
 
     public static final String API_KEY = "986d00852eea80eda8b2930e0abf5c46";
     public static final String SECRET = "1d802c749ccec53103400582fcaebd01";

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/lastfm/LastFM.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/lastfm/LastFM.java
@@ -23,12 +23,13 @@ import java.util.Map;
 
 import app.morphe.extension.music.patches.scrobbling.ScrobbleManager;
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.requests.Requester;
 
 public class LastFM {
     private static final String BASE_URL = "https://ws.audioscrobbler.com/2.0/";
-    private static final String USER_AGENT = "YT Music Morphe (https://github.com/MorpheApp/morphe-patches)";
-    
+    private static final String USER_AGENT = "Morphe/" + Utils.getAppVersionName();
+
     public static final String API_KEY = "986d00852eea80eda8b2930e0abf5c46";
     public static final String SECRET = "1d802c749ccec53103400582fcaebd01";
 

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/listenbrainz/ListenBrainz.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/listenbrainz/ListenBrainz.java
@@ -23,7 +23,8 @@ import app.morphe.extension.shared.requests.Requester;
 
 public class ListenBrainz {
     private static final String BASE_URL = "https://api.listenbrainz.org/";
-    private static final String USER_AGENT = "YT Music Morphe (https://github.com/MorpheApp/morphe-patches)";
+    private static final String USER_AGENT = "Morphe/" + Utils.getAppVersionName();
+    private static final String CLIENT_VERSION = Utils.getAppVersionName();
     
     public static class TokenValidation {
         public boolean valid;
@@ -152,8 +153,8 @@ public class ListenBrainz {
         if (songId != null && !songId.isBlank()) {
             info.put("origin_url", "https://music.youtube.com/watch?v=" + songId);
         }
-        info.put("submission_client", "YT Music Morphe");
-        info.put("submission_client_version", "1.0.0");
+        info.put("submission_client", "Morphe");
+        info.put("submission_client_version", CLIENT_VERSION);
         
         metadata.put("additional_info", info);
         return metadata;

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/listenbrainz/ListenBrainz.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/listenbrainz/ListenBrainz.java
@@ -23,8 +23,8 @@ import app.morphe.extension.shared.requests.Requester;
 
 public class ListenBrainz {
     private static final String BASE_URL = "https://api.listenbrainz.org/";
-    private static final String USER_AGENT = "Morphe/" + Utils.getAppVersionName();
-    private static final String CLIENT_VERSION = Utils.getAppVersionName();
+    private static final String USER_AGENT = "Morphe/" + Utils.getPatchesReleaseVersion() + " (YTMusic/" + Utils.getAppVersionName() + ")";
+    private static final String CLIENT_VERSION = Utils.getPatchesReleaseVersion();
     
     public static class TokenValidation {
         public boolean valid;


### PR DESCRIPTION
### Description

Replaces hardcoded User-Agent and submission client version strings with dynamic values derived from `Utils.getAppVersionName()` across LastFM and ListenBrainz. Renames submission client from `YT Music Morphe` to `Morphe` and extracts a `CLIENT_VERSION` constant in ListenBrainz.

### Additional context

N/A

### Test results
- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
