### PR TITLE
fix(YouTube - Hide layout components): Hide all the thumbnails when using "Hide search term thumbnails"

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -14,6 +14,7 @@ import static app.morphe.extension.shared.Utils.getFilterStrings;
 import static app.morphe.extension.youtube.shared.NavigationBar.NavigationButton;
 
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.support.v7.widget.RecyclerView;
 import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
@@ -828,8 +829,14 @@ public final class LayoutComponentsFilter extends Filter {
     /**
      * Injection point.
      */
-    public static boolean hideSearchTermThumbnails() {
-        return Settings.HIDE_SEARCH_TERM_THUMBNAILS.get();
+    public static Uri hideSearchTermThumbnails(View view, Uri uri) {
+        if (Settings.HIDE_SEARCH_TERM_THUMBNAILS.get()) {
+            if (view != null) {
+                Utils.hideViewByLayoutParams(view);
+            }
+            return null;
+        }
+        return uri;
     }
 
     /**

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -951,20 +951,24 @@ val hideLayoutComponentsPatch = bytecodePatch(
 
         CreateSearchSuggestionsFingerprint.let {
             it.method.apply {
-                val insertIndex = it.instructionMatches[2].index - 1
-                val freeRegister = findFreeRegister(insertIndex)
-                val jumpIndex = it.instructionMatches.last().index
+                val methodCalls = findInstructionIndicesReversedOrThrow {
+                    (opcode == Opcode.INVOKE_INTERFACE || opcode == Opcode.INVOKE_VIRTUAL) &&
+                            (getReference<MethodReference>()?.parameterTypes == listOf("Landroid/widget/ImageView;", "Landroid/net/Uri;"))
+                }
 
-                addInstructionsWithLabels(
-                    insertIndex,
-                    """
-                        invoke-static { }, $LAYOUT_COMPONENTS_FILTER->hideSearchTermThumbnails()Z
-                        move-result v$freeRegister
-                        
-                        if-nez v$freeRegister, :hidden
-                    """,
-                    ExternalLabel("hidden", getInstruction(jumpIndex))
-                )
+                methodCalls.forEach { insertIndex ->
+                    val invokeInstruction = getInstruction<FiveRegisterInstruction>(insertIndex)
+                    val imageViewRegister = invokeInstruction.registerD
+                    val uriRegister = invokeInstruction.registerE
+
+                    addInstructions(
+                        insertIndex,
+                        """
+                            invoke-static { v$imageViewRegister, v$uriRegister }, $LAYOUT_COMPONENTS_FILTER->hideSearchTermThumbnails(Landroid/view/View;Landroid/net/Uri;)Landroid/net/Uri;
+                            move-result-object v$uriRegister
+                        """
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
### Description

Closes #1333.

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
