### PR TITLE
fix(Force original audio): Not working in SABR playback

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/ForceOriginalAudioPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/ForceOriginalAudioPatch.java
@@ -1,14 +1,83 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.shared.patches;
 
+import androidx.annotation.Nullable;
+
+import java.util.Arrays;
+
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.SharedYouTubeSettings;
 
 @SuppressWarnings("unused")
 public class ForceOriginalAudioPatch {
 
-    private static final String DEFAULT_AUDIO_TRACKS_SUFFIX = ".4";
+    /**
+     * Interface to use obfuscated methods.
+     */
+    public interface AudioTrackInterface {
+        // Methods are added during patching.
+        String patch_getDisplayName();
+        String patch_getId();
+        boolean patch_getIsDefault();
+    }
 
     private static final boolean FORCE_ORIGINAL_AUDIO = SharedYouTubeSettings.FORCE_ORIGINAL_AUDIO.get();
+
+    private static final String DEFAULT_AUDIO_TRACKS_SUFFIX = ".4";
+
+    /**
+     * The available audio tracks of the current video.
+     */
+    @Nullable
+    private static AudioTrackInterface[] currentAudioTracks;
+
+    /**
+     * Injection point.
+     * Called after {@link #isDefaultAudioStream(boolean, String, String)}.
+     *
+     * @param   audioTracks Audio tracks available, sorted alphabetically.
+     * @return  Original audio track id.
+     */
+    @Nullable
+    public static String getDefaultAudioTrackId(AudioTrackInterface[] audioTracks) {
+        // No need to override when the number of audio tracks is 1 or less.
+        if (FORCE_ORIGINAL_AUDIO && audioTracks != null && audioTracks.length > 1) {
+            try {
+                Utils.verifyOnMainThread();
+
+                final boolean availableAudioTracksChanged = (currentAudioTracks == null)
+                        || !Arrays.equals(currentAudioTracks, audioTracks);
+                if (availableAudioTracksChanged) {
+                    currentAudioTracks = audioTracks;
+
+                    for (AudioTrackInterface audioTrack : audioTracks) {
+                        boolean isDefault = audioTrack.patch_getIsDefault();
+                        String audioTrackDisplayName = audioTrack.patch_getDisplayName();
+                        String audioTrackId = audioTrack.patch_getId();
+
+                        if (isDefault) {
+                            Logger.printDebug(() -> "Overriding audio track: " + audioTrackDisplayName);
+                            return audioTrackId;
+                        }
+                    }
+                }
+            } catch (Exception ex) {
+                Logger.printException(() -> "getDefaultAudioTrackId failure", ex);
+            }
+        }
+
+        return null;
+    }
 
     /**
      * Injection point.
@@ -32,17 +101,17 @@ public class ForceOriginalAudioPatch {
                     return isDefault;
                 }
 
-                Logger.printInfo(() -> "default: " + String.format("%-5s", isDefault) + " id: "
+                Logger.printDebug(() -> "default: " + String.format("%-5s", isDefault) + " id: "
                         + String.format("%-8s", audioTrackId) + " name:" + audioTrackDisplayName);
 
                 final boolean isOriginal = audioTrackId.endsWith(DEFAULT_AUDIO_TRACKS_SUFFIX);
                 if (isOriginal) {
-                    Logger.printInfo(() -> "Using audio: " + audioTrackId);
+                    Logger.printDebug(() -> "Using audio: " + audioTrackId);
                 }
 
                 return isOriginal;
             } catch (Exception ex) {
-                Logger.printInfo(() -> "isDefaultAudioStream failure", ex);
+                Logger.printException(() -> "isDefaultAudioStream failure", ex);
             }
         }
 

--- a/patches/src/main/kotlin/app/morphe/patches/shared/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/Fingerprints.kt
@@ -50,6 +50,14 @@ internal object BoldIconsFeatureFlagFingerprint : Fingerprint(
     )
 )
 
+internal object CurrentAudioVideoFormatToStringFingerprint : Fingerprint(
+    name = "toString",
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "Ljava/lang/String;",
+    parameters = listOf(),
+    strings = listOf("currentVideoFormat=")
+)
+
 internal object SpannableStringBuilderFingerprint : Fingerprint(
     returnType = "Ljava/lang/CharSequence;",
     filters = listOf(

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/audio/tracks/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/audio/tracks/Fingerprints.kt
@@ -1,8 +1,150 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.patches.shared.misc.audio.tracks
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation.MatchAfterWithin
+import app.morphe.patcher.fieldAccess
 import app.morphe.patcher.literal
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.string
+import app.morphe.patches.all.misc.resources.ResourceType
+import app.morphe.patches.all.misc.resources.resourceLiteral
+import app.morphe.patches.shared.CurrentAudioVideoFormatToStringFingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+/**
+ * YT 21.26+
+ * YTM 9.26+
+ */
+internal object AudioTrackRecordToStringFingerprint : Fingerprint(
+    name = "toString",
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "Ljava/lang/String;",
+    filters = listOf(
+        // id
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            definingClass = "this",
+            type = "Ljava/lang/String;"
+        ),
+        // displayName
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            definingClass = "this",
+            type = "Ljava/lang/String;",
+            location = MatchAfterWithin(5)
+        ),
+        // isAutoDubbed
+        fieldAccess(
+            opcode = Opcode.IGET_BOOLEAN,
+            definingClass = "this",
+            type = "Z",
+            location = MatchAfterWithin(5)
+        ),
+        // isDefault
+        fieldAccess(
+            opcode = Opcode.IGET_BOOLEAN,
+            definingClass = "this",
+            type = "Z",
+            location = MatchAfterWithin(5)
+        ),
+        string("id;displayName;isAutoDubbed;isDefault")
+    )
+)
+
+/**
+ * YT 21.26+
+ * YTM 9.26+
+ */
+private object AudioTrackItemOnClickParentFingerprint : Fingerprint(
+    parameters = listOf(),
+    returnType = "Ljava/lang/String;",
+    filters = listOf(
+        resourceLiteral(ResourceType.STRING, "audio_tracks_title"),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            smali = "Landroid/content/res/Resources;->getString(I)Ljava/lang/String;",
+            location = MatchAfterWithin(3)
+        )
+    )
+)
+
+/**
+ * YT 21.26+
+ * YTM 9.26+
+ */
+internal fun getAudioTrackItemOnClickFingerprint(
+    audioTrackRecordClass: String
+) = object : Fingerprint(
+    classFingerprint = AudioTrackItemOnClickParentFingerprint,
+    name = "onItemClick",
+    returnType = "V",
+    filters = listOf(
+        // id
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            definingClass = audioTrackRecordClass,
+            type = "Ljava/lang/String;"
+        ),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            parameters = listOf("Ljava/lang/String;"),
+            location = MatchAfterWithin(3)
+        )
+    )
+) {}
+
+/**
+ * YT 21.26+
+ * YTM 9.26+
+ */
+internal fun getCurrentAudioFormatConstructorFingerprint(
+    audioTrackRecordClass: String
+) = object : Fingerprint(
+    classFingerprint = CurrentAudioVideoFormatToStringFingerprint,
+    name = "<init>",
+    returnType = "V",
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IPUT_OBJECT,
+            definingClass = "this",
+            type = "[$audioTrackRecordClass"
+        )
+    )
+) {}
+
+/**
+ * YT 21.26+
+ * YTM 9.26+
+ */
+internal fun getSetVideoQualityListFingerprint(
+    audioVideoFormatClass: String,
+    playerControllerClass: String
+) = object : Fingerprint(
+    parameters = listOf(audioVideoFormatClass),
+    returnType = "V",
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            definingClass = audioVideoFormatClass,
+            type = "[L"
+        ),
+        resourceLiteral(ResourceType.STRING, "quality_auto"),
+    ),
+    custom = { _, classDef ->
+        classDef.fields.find { it.type == playerControllerClass } != null
+    }
+) {}
 
 internal object FormatStreamModelToStringFingerprint : Fingerprint(
     name = "toString",
@@ -15,10 +157,13 @@ internal object FormatStreamModelToStringFingerprint : Fingerprint(
     )
 )
 
+/**
+ * ~ YT 21.25
+ * ~ YTM 9.25
+ */
 internal object SelectAudioStreamFingerprint : Fingerprint(
     filters = listOf(
-        // YT 21.25 and older.
-        // 21.26+ usage appears to be partially replaced with flag 45673827L
+        // Replaced with 45673827L?
         literal(45666189L)
     )
 )

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/audio/tracks/ForceOriginalAudioPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/audio/tracks/ForceOriginalAudioPatch.kt
@@ -1,24 +1,47 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.patches.shared.misc.audio.tracks
 
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.BytecodePatchBuilder
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableField.Companion.toMutable
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
+import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.patches.shared.misc.settings.preference.BasePreferenceScreen
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.util.addInstructionsAtControlFlowLabel
 import app.morphe.util.cloneMutable
 import app.morphe.util.findMethodFromToString
+import app.morphe.util.getReference
 import app.morphe.util.indexOfFirstInstructionReversedOrThrow
 import app.morphe.util.insertLiteralOverride
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.immutable.ImmutableField
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
 
 private const val EXTENSION_CLASS =
     "Lapp/morphe/extension/shared/patches/ForceOriginalAudioPatch;"
+private const val EXTENSION_AUDIO_TRACK_INTERFACE =
+    $$"Lapp/morphe/extension/shared/patches/ForceOriginalAudioPatch$AudioTrackInterface;"
 
 /**
  * Patch shared with YouTube and YT Music.
@@ -35,6 +58,8 @@ internal fun forceOriginalAudioPatch(
 
     block()
 
+    dependsOn(resourceMappingPatch)
+
     execute {
         preferenceScreen.addPreferences(
             SwitchPreference(
@@ -43,15 +68,6 @@ internal fun forceOriginalAudioPatch(
                 summary = true
             )
         )
-
-        // Disable feature flag that ignores the default track flag
-        // and instead overrides to the user region language.
-        if (fixUseLocalizedAudioTrackFlag()) {
-            SelectAudioStreamFingerprint.method.insertLiteralOverride(
-                SelectAudioStreamFingerprint.instructionMatches.first().index,
-                "$EXTENSION_CLASS->ignoreDefaultAudioStream(Z)Z"
-            )
-        }
 
         FormatStreamModelToStringFingerprint.let {
             val isDefaultAudioTrackMethod = it.originalMethod.findMethodFromToString("isDefaultAudioTrack=")
@@ -119,6 +135,133 @@ internal fun forceOriginalAudioPatch(
                             move-result-object v$free2
                             iput-object v$free2, p0, $type->$helperFieldName:Ljava/lang/Boolean;
                             return v$free1
+                        """
+                    )
+                }
+            }
+        }
+
+        // Disable feature flag that ignores the default track flag
+        // and instead overrides to the user region language.
+        if (fixUseLocalizedAudioTrackFlag()) {
+            SelectAudioStreamFingerprint.method.insertLiteralOverride(
+                SelectAudioStreamFingerprint.instructionMatches.first().index,
+                "$EXTENSION_CLASS->ignoreDefaultAudioStream(Z)Z"
+            )
+        } else {
+            // If there is no feature flag, the SABR protocol parameter (proto buffer) must be overridden:
+            // https://github.com/LuanRT/googlevideo/commit/173a2b0717c19c922e5fb53b170640a9c9d58819
+            //
+            // Since mapping the proto field and finding the appropriate hooking point is very difficult,
+            // 'Default audio track' patches has been implemented (like 'Default video quality' patches).
+            val audioTrackRecordClass = with(AudioTrackRecordToStringFingerprint) {
+                val definingClass = classDef.type
+                mapOf(
+                    0 to "patch_getId",
+                    1 to "patch_getDisplayName",
+                    3 to "patch_getIsDefault"
+                ).forEach { (matchIndex, methodName) ->
+                    val fieldInstruction = instructionMatches[matchIndex].instruction
+                    val fieldOpcode = fieldInstruction.opcode.name
+                    val fieldReference = fieldInstruction.getReference<FieldReference>()!!
+                    val fieldReturnType = fieldReference.type
+                    val operation = if (fieldReturnType == "Z") {
+                        "return v0"
+                    } else {
+                        "return-object v0"
+                    }
+
+                    val helperMethod = ImmutableMethod(
+                        definingClass,
+                        methodName,
+                        listOf(),
+                        fieldReturnType,
+                        AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+                        null,
+                        null,
+                        MutableMethodImplementation(2),
+                    ).toMutable().apply {
+                        addInstructions(
+                            0,
+                            """
+                                $fieldOpcode v0, p0, $fieldReference
+                                $operation
+                            """
+                        )
+                    }
+
+                    classDef.methods.add(helperMethod)
+                }
+
+                classDef.interfaces.add(EXTENSION_AUDIO_TRACK_INTERFACE)
+                definingClass
+            }
+
+            val setAudioTrackMethod =
+                getAudioTrackItemOnClickFingerprint(audioTrackRecordClass)
+                    .instructionMatches.last().instruction.getReference<MethodReference>()!!
+
+            val playerControllerClass = setAudioTrackMethod.definingClass
+
+            val audioTrackRecordArrayField =
+                getCurrentAudioFormatConstructorFingerprint(audioTrackRecordClass)
+                    .instructionMatches.last().instruction.getReference<FieldReference>()!!
+
+            getSetVideoQualityListFingerprint(
+                audioVideoFormatClass = audioTrackRecordArrayField.definingClass,
+                playerControllerClass = playerControllerClass
+            ).let {
+                it.method.apply {
+                    val helperMethod = ImmutableMethod(
+                        definingClass,
+                        "patch_setAudioTrack",
+                        listOf(
+                            ImmutableMethodParameter(
+                                "Ljava/lang/String;",
+                                null,
+                                null
+                            )
+                        ),
+                        "V",
+                        AccessFlags.PRIVATE.value or AccessFlags.FINAL.value,
+                        null,
+                        null,
+                        MutableMethodImplementation(3),
+                    ).toMutable().apply {
+                        val playerControllerType = it.classDef.fields.single { field ->
+                            field.type == playerControllerClass
+                        }
+                        addInstructionsWithLabels(
+                            0,
+                            """
+                                # Check if the audio track id is null.
+                                if-eqz p1, :ignore
+                                iget-object v0, p0, $playerControllerType
+                                
+                                # Check if the player controller class is null.
+                                if-eqz v0, :ignore
+                                invoke-virtual { v0, p1 }, $setAudioTrackMethod
+                                
+                                :ignore
+                                return-void
+                            """
+                        )
+                    }
+
+                    it.classDef.methods.add(helperMethod)
+
+                    val index = it.instructionMatches.first().index
+                    val instruction = getInstruction<TwoRegisterInstruction>(index)
+                    val freeRegister = instruction.registerA
+                    val audioVideoFormatRegister = instruction.registerB
+
+                    addInstructionsAtControlFlowLabel(
+                        index,
+                        """
+                            iget-object v$freeRegister, v$audioVideoFormatRegister, $audioTrackRecordArrayField
+                            invoke-static { v$freeRegister }, $EXTENSION_CLASS->getDefaultAudioTrackId([${EXTENSION_AUDIO_TRACK_INTERFACE})Ljava/lang/String;
+                            move-result-object v$freeRegister
+                            invoke-direct { p0, v$freeRegister }, $helperMethod
                         """
                     )
                 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/quality/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/quality/Fingerprints.kt
@@ -20,6 +20,7 @@ import app.morphe.patcher.opcode
 import app.morphe.patcher.string
 import app.morphe.patches.all.misc.resources.ResourceType
 import app.morphe.patches.all.misc.resources.resourceLiteral
+import app.morphe.patches.shared.CurrentAudioVideoFormatToStringFingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 
@@ -30,13 +31,20 @@ internal object NewAdvancedQualityMenuStyleFlyout : Fingerprint(
     )
 )
 
-internal object CurrentVideoFormatToStringFingerprint : Fingerprint(
-    name = "toString",
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
-    returnType = "Ljava/lang/String;",
-    parameters = listOf(),
-    strings = listOf("currentVideoFormat=")
-)
+internal fun getCurrentVideoFormatConstructorFingerprint(
+    videoQualityArray: String
+) = object : Fingerprint(
+    classFingerprint = CurrentAudioVideoFormatToStringFingerprint,
+    name = "<init>",
+    returnType = "V",
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IPUT_OBJECT,
+            definingClass = "this",
+            type = videoQualityArray
+        )
+    )
+) {}
 
 internal object DefaultOverflowOverlayOnClickFingerprint : Fingerprint(
     definingClass = "Lcom/google/android/libraries/youtube/player/features/overlay/overflow/ui/DefaultOverflowOverlay;",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/quality/HidePremiumVideoQualityPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/quality/HidePremiumVideoQualityPatch.kt
@@ -1,9 +1,7 @@
 package app.morphe.patches.youtube.video.quality
 
-import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
-import app.morphe.patcher.fieldAccess
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
@@ -11,8 +9,6 @@ import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.video.information.EXTENSION_VIDEO_QUALITY_INTERFACE
 import app.morphe.patches.youtube.video.information.videoInformationPatch
 import app.morphe.util.getReference
-import com.android.tools.smali.dexlib2.AccessFlags
-import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 
@@ -44,18 +40,7 @@ internal val hidePremiumVideoQualityPatch = bytecodePatch {
             """
         )
 
-        Fingerprint(
-            classFingerprint = CurrentVideoFormatToStringFingerprint,
-            accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
-            returnType = "V",
-            filters = listOf(
-                fieldAccess(
-                    opcode = Opcode.IPUT_OBJECT,
-                    definingClass = "this",
-                    type = videoQualityArray
-                )
-            )
-        ).let {
+        getCurrentVideoFormatConstructorFingerprint(videoQualityArray).let {
             it.method.apply {
                 val index = it.instructionMatches.last().index
                 val register = getInstruction<TwoRegisterInstruction>(index).registerA


### PR DESCRIPTION
### Description

Closes #2105.

### Additional context

The feature flag (**45666189L**) was removed in YouTube 21.26+ (YouTube Music 9.26+):

https://github.com/MorpheApp/morphe-patches/blob/e12088c89942f5d637a824ce81643a28b86fb851/patches/src/main/kotlin/app/morphe/patches/shared/misc/audio/tracks/Fingerprints.kt#L18-L24

Since the SABR protocol relies heavily on the server, the audio track's proto parameters must be overridden:

https://github.com/LuanRT/googlevideo/commit/173a2b0717c19c922e5fb53b170640a9c9d58819

Mapping the proto field and finding appropriate hooking points is very difficult.

Therefore, I partially implemented a `Default audio track` patch (similar to the `Default video quality` patch).

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
