### PR TITLE
feat(YouTube Music - Hide ads): Add "Hide Music Premium promotions" setting

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/HideAdsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/HideAdsPatch.java
@@ -7,7 +7,13 @@
 
 package app.morphe.extension.music.patches;
 
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+
 import app.morphe.extension.music.settings.Settings;
+import app.morphe.extension.shared.Logger;
 
 @SuppressWarnings("unused")
 public class HideAdsPatch {
@@ -27,5 +33,34 @@ public class HideAdsPatch {
             return false;
         }
         return original;
+    }
+
+    /**
+     * Injection point.
+     */
+    public static void hidePremiumPromotionBottomSheet(View view) {
+        if (Settings.HIDE_MUSIC_PREMIUM_PROMOTIONS.get()) {
+            view.getViewTreeObserver().addOnGlobalLayoutListener(() -> {
+                try {
+                    if (!(view instanceof ViewGroup viewGroup)) {
+                        return;
+                    }
+                    if (!(viewGroup.getChildAt(0) instanceof ViewGroup mealBarLayoutRoot)) {
+                        return;
+                    }
+                    if (!(mealBarLayoutRoot.getChildAt(0) instanceof LinearLayout linearLayout)) {
+                        return;
+                    }
+                    if (!(linearLayout.getChildAt(0) instanceof ImageView imageView)) {
+                        return;
+                    }
+                    if (imageView.getVisibility() == View.VISIBLE) {
+                        view.setVisibility(View.GONE);
+                    }
+                } catch (Exception ex) {
+                    Logger.printException(() -> "hidePremiumPromotionBottomSheet failure", ex);
+                }
+            });
+        }
     }
 }

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -30,6 +30,7 @@ public class Settings extends SharedYouTubeSettings {
 
     // Ads
     public static final BooleanSetting HIDE_GET_PREMIUM_LABEL = new BooleanSetting("morphe_music_hide_get_premium_label", TRUE, true);
+    public static final BooleanSetting HIDE_MUSIC_PREMIUM_PROMOTIONS = new BooleanSetting("morphe_music_hide_music_premium_promotions", TRUE, true);
     public static final BooleanSetting HIDE_VIDEO_ADS = new BooleanSetting("morphe_music_hide_video_ads", TRUE, true);
 
     // General (Layout)

--- a/patches/src/main/kotlin/app/morphe/patches/music/ad/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/ad/Fingerprints.kt
@@ -11,10 +11,13 @@
 package app.morphe.patches.music.ad
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation.MatchAfterImmediately
 import app.morphe.patcher.OpcodesFilter
+import app.morphe.patcher.methodCall
 import app.morphe.patcher.opcode
 import app.morphe.patches.all.misc.resources.ResourceType
 import app.morphe.patches.all.misc.resources.resourceLiteral
+import app.morphe.patches.music.shared.YOUTUBE_MUSIC_MAIN_ACTIVITY_CLASS_TYPE
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 
@@ -54,13 +57,17 @@ internal object MembershipSettingsFingerprint : Fingerprint(
 )
 
 internal object FloatingLayoutFingerprint : Fingerprint(
+    definingClass = YOUTUBE_MUSIC_MAIN_ACTIVITY_CLASS_TYPE  ,
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "Landroid/view/View;",
     parameters = listOf(),
     filters = listOf(
         resourceLiteral(ResourceType.ID, "floating_layout"),
-        opcode(Opcode.INVOKE_VIRTUAL),
-        opcode(Opcode.MOVE_RESULT_OBJECT),
-        opcode(Opcode.RETURN_OBJECT)
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            name = "findViewById",
+            returnType = "Landroid/view/View;"
+        ),
+        opcode(Opcode.MOVE_RESULT_OBJECT, MatchAfterImmediately())
     )
 )

--- a/patches/src/main/kotlin/app/morphe/patches/music/ad/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/ad/Fingerprints.kt
@@ -12,6 +12,9 @@ package app.morphe.patches.music.ad
 
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.OpcodesFilter
+import app.morphe.patcher.opcode
+import app.morphe.patches.all.misc.resources.ResourceType
+import app.morphe.patches.all.misc.resources.resourceLiteral
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 
@@ -47,5 +50,17 @@ internal object MembershipSettingsFingerprint : Fingerprint(
         Opcode.MOVE_RESULT_OBJECT,
         Opcode.IF_EQZ,
         Opcode.IGET_OBJECT,
+    )
+)
+
+internal object FloatingLayoutFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "Landroid/view/View;",
+    parameters = listOf(),
+    filters = listOf(
+        resourceLiteral(ResourceType.ID, "floating_layout"),
+        opcode(Opcode.INVOKE_VIRTUAL),
+        opcode(Opcode.MOVE_RESULT_OBJECT),
+        opcode(Opcode.RETURN_OBJECT)
     )
 )

--- a/patches/src/main/kotlin/app/morphe/patches/music/ad/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/ad/HideAdsPatch.kt
@@ -16,6 +16,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLa
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.patches.music.misc.extension.sharedExtensionPatch
 import app.morphe.patches.music.misc.settings.PreferenceScreen
 import app.morphe.patches.music.misc.settings.settingsPatch
@@ -36,6 +37,7 @@ val hideAdsPatch = bytecodePatch(
         sharedExtensionPatch,
         hideFullscreenAdsPatch(PreferenceScreen.ADS),
         settingsPatch,
+        resourceMappingPatch
     )
 
     compatibleWith(COMPATIBILITY_YOUTUBE_MUSIC)
@@ -91,12 +93,13 @@ val hideAdsPatch = bytecodePatch(
 
         // Hide Music Premium promotions
         FloatingLayoutFingerprint.method.apply {
-            val insertIndex = FloatingLayoutFingerprint.instructionMatches[2].index
+            val insertIndex = FloatingLayoutFingerprint.instructionMatches.last().index
             val viewRegister = getInstruction<OneRegisterInstruction>(insertIndex).registerA
 
             addInstruction(
                 insertIndex + 1,
-                "invoke-static { v$viewRegister }, $EXTENSION_CLASS->hidePremiumPromotionBottomSheet(Landroid/view/View;)V"
+                "invoke-static { v$viewRegister }, $EXTENSION_CLASS->" +
+                        "hidePremiumPromotionBottomSheet(Landroid/view/View;)V"
             )
         }
     }

--- a/patches/src/main/kotlin/app/morphe/patches/music/ad/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/ad/HideAdsPatch.kt
@@ -23,6 +23,7 @@ import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
 import app.morphe.patches.shared.ad.hideFullscreenAdsPatch
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/music/patches/HideAdsPatch;"
 
@@ -42,6 +43,7 @@ val hideAdsPatch = bytecodePatch(
     execute {
         PreferenceScreen.ADS.addPreferences(
             SwitchPreference("morphe_music_hide_get_premium_label"),
+            SwitchPreference("morphe_music_hide_music_premium_promotions"),
             SwitchPreference("morphe_music_hide_video_ads"),
         )
 
@@ -86,5 +88,16 @@ val hideAdsPatch = bytecodePatch(
                 move-result p1
             """
         )
+
+        // Hide Music Premium promotions
+        FloatingLayoutFingerprint.method.apply {
+            val insertIndex = FloatingLayoutFingerprint.instructionMatches[2].index
+            val viewRegister = getInstruction<OneRegisterInstruction>(insertIndex).registerA
+
+            addInstruction(
+                insertIndex + 1,
+                "invoke-static { v$viewRegister }, $EXTENSION_CLASS->hidePremiumPromotionBottomSheet(Landroid/view/View;)V"
+            )
+        }
     }
 }

--- a/patches/src/main/resources/addresources/values/music/strings.xml
+++ b/patches/src/main/resources/addresources/values/music/strings.xml
@@ -47,6 +47,7 @@ Second \"item\" text"</string>
 
     <!-- ad.hideAdsPatch -->
     <string name="morphe_music_hide_get_premium_label_title">Hide \'Get Music Premium\' label</string>
+    <string name="morphe_music_hide_music_premium_promotions_title">Hide Music Premium promotions</string>
     <string name="morphe_music_hide_video_ads_title">Hide video ads</string>
 
     <!-- interaction.crossfade.crossfadePatch -->


### PR DESCRIPTION
### Description

Code adapted from @inotia00 https://github.com/inotia00/revanced-patches/

Closes #1374.

### Additional context

<img width="1080" height="2242" alt="Screenshot_20260716_195208_YouTube Music" src="https://github.com/user-attachments/assets/bd97d2d3-918f-4b1d-8fbb-48ed26e1f20d" />

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
