### PR TITLE
fix(YouTube - Playback speed): Update text when speed changed from native flyout menu

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlaybackSpeedDialogButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlaybackSpeedDialogButton.java
@@ -120,7 +120,7 @@ public class PlaybackSpeedDialogButton {
      * Injection point.
      */
     public static void videoSpeedChanged(float currentVideoSpeed) {
-        updateButtonAppearance();
+        Utils.runOnMainThread(PlaybackSpeedDialogButton::updateButtonAppearance);
     }
 
     /**

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/button/PlaybackSpeedButtonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/button/PlaybackSpeedButtonPatch.kt
@@ -16,6 +16,7 @@ import app.morphe.patches.youtube.video.information.userSelectedPlaybackSpeedHoo
 import app.morphe.patches.youtube.video.information.videoInformationPatch
 import app.morphe.patches.youtube.video.information.videoSpeedChangedHook
 import app.morphe.patches.youtube.video.speed.custom.customPlaybackSpeedPatch
+import app.morphe.patches.youtube.video.speed.custom.playbackRateSetHook
 import app.morphe.util.ResourceGroup
 import app.morphe.util.copyResources
 
@@ -39,7 +40,7 @@ private const val EXTENSION_BUTTON =
     "Lapp/morphe/extension/youtube/videoplayer/PlaybackSpeedDialogButton;"
 
 val playbackSpeedButtonPatch = bytecodePatch(
-    description = "Adds the option to display playback speed dialog button in the video player.",
+    description = "Adds the option to display playback speed dialog button in the video player."
 ) {
     dependsOn(
         sharedExtensionPatch,
@@ -62,5 +63,13 @@ val playbackSpeedButtonPatch = bytecodePatch(
 
         videoSpeedChangedHook(EXTENSION_BUTTON, "videoSpeedChanged")
         userSelectedPlaybackSpeedHook(EXTENSION_BUTTON, "videoSpeedChanged")
+
+        // The modern flyout menu (21.12+) bypasses the onItemClick setter hooked above.
+        // VideoInformation must run first so the button reads a fresh cached speed.
+        playbackRateSetHook(
+            "Lapp/morphe/extension/youtube/patches/VideoInformation;",
+            "videoSpeedChanged"
+        )
+        playbackRateSetHook(EXTENSION_BUTTON, "videoSpeedChanged")
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/custom/CustomPlaybackSpeedPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/custom/CustomPlaybackSpeedPatch.kt
@@ -19,6 +19,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableField
 import app.morphe.patcher.util.proxy.mutableTypes.MutableField.Companion.toMutable
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.patches.shared.misc.litho.filter.addLithoFilter
@@ -48,12 +49,16 @@ import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.immutable.ImmutableField
 import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
+import java.lang.ref.WeakReference
 
 internal const val EXTENSION_CLASS =
     "Lapp/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch;"
 
 private const val EXTENSION_FILTER =
     "Lapp/morphe/extension/youtube/patches/components/PlaybackSpeedMenuFilter;"
+
+private lateinit var playbackRateSetMethodRef: WeakReference<MutableMethod>
+private var playbackRateSetMethodInsertIndex = 0
 
 internal val customPlaybackSpeedPatch = bytecodePatch(
     description = "Adds custom playback speed options.",
@@ -84,7 +89,9 @@ internal val customPlaybackSpeedPatch = bytecodePatch(
         )
 
         // Override the min/max speeds that can be used.
-        (if (is_20_34_or_greater) SpeedLimiterFingerprint else SpeedLimiterLegacyFingerprint).method.apply {
+        val speedLimiterMethod =
+            (if (is_20_34_or_greater) SpeedLimiterFingerprint else SpeedLimiterLegacyFingerprint).method
+        speedLimiterMethod.apply {
             val limitMinIndex = indexOfFirstLiteralInstructionOrThrow(0.25f)
             // Older unsupported targets use 2.0f and not 4.0f
             val limitMaxIndex = indexOfFirstLiteralInstructionOrThrow(4.0f)
@@ -95,6 +102,7 @@ internal val customPlaybackSpeedPatch = bytecodePatch(
             replaceInstruction(limitMinIndex, "const/high16 v$limitMinRegister, 0.0f")
             replaceInstruction(limitMaxIndex, "const/high16 v$limitMaxRegister, 8.0f")
         }
+        playbackRateSetMethodRef = WeakReference(speedLimiterMethod)
 
         // Turn off client side flag that use server provided min/max speeds.
         if (is_20_34_or_greater) {
@@ -341,3 +349,13 @@ internal val customPlaybackSpeedPatch = bytecodePatch(
         // endregion
     }
 }
+
+/**
+ * Hook every playback rate change. Use over 'videoSpeedChangedHook' when observers must
+ * also react to the modern flyout menu, which bypasses the old onItemClick setter.
+ */
+fun playbackRateSetHook(targetMethodClass: String, targetMethodName: String) =
+    playbackRateSetMethodRef.get()!!.addInstruction(
+        playbackRateSetMethodInsertIndex++,
+        "invoke-static { p1 }, $targetMethodClass->$targetMethodName(F)V"
+    )


### PR DESCRIPTION
### Description

Fixes the playback speed button not updating its displayed value when the speed is changed from YouTube's native flyout menu (on 21.12+). The button now stays in sync regardless of which menu the user picks the speed from.

Closes #2054

### Test results

- [ ] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
