### PR TITLE
chore: Add patch availability

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 # Dependencies must also be addded to LicensesDialog.java
 
 [versions]
-morphe-patcher = "1.7.0"
+morphe-patcher = "1.8.0-dev.5" # TODO: Change to stable
 morphe-patches-library = "1.6.0-dev.2"
 # Tracking https://github.com/google/smali/issues/100.
 smali = "d92701d947"

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
@@ -14,6 +14,8 @@ import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.InstallerType
+import app.morphe.patcher.patch.PatchAvailability
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.ResourcePatch
 import app.morphe.patcher.patch.ResourcePatchBuilder
@@ -111,6 +113,14 @@ internal fun baseCustomBrandingPatch(
     description = "Adds options to change the app icon and app name. " +
             "Branding cannot be changed for mounted (root) installations."
 ) {
+
+    availability { installer, _ ->
+        when (installer) {
+            InstallerType.MOUNT -> PatchAvailability.DISABLED
+            else -> PatchAvailability.ENABLED
+        }
+    }
+
     val customName by stringOption(
         key = "customName",
         title = "App name",

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/gms/GmsCoreSupportPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/gms/GmsCoreSupportPatch.kt
@@ -18,7 +18,9 @@ import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchBuilder
 import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.InstallerType
 import app.morphe.patcher.patch.Patch
+import app.morphe.patcher.patch.PatchAvailability
 import app.morphe.patcher.patch.ResourcePatchBuilder
 import app.morphe.patcher.patch.ResourcePatchContext
 import app.morphe.patcher.patch.bytecodePatch
@@ -80,6 +82,13 @@ fun gmsCoreSupportPatch(
     description = "Allows the app to work without root by using a different package name when patched " +
             "using a GmsCore instead of Google Play Services.",
 ) {
+
+    availability { installer, _ ->
+        when (installer) {
+            InstallerType.MOUNT -> PatchAvailability.UNAVAILABLE
+            InstallerType.STANDARD, InstallerType.SHIZUKU -> PatchAvailability.REQUIRED
+        }
+    }
 
     dependsOn(
         changePackageNamePatch,


### PR DESCRIPTION
### Description

Adds a per-patch `availability { installerType, apkArchitecture -> ... }` DSL so patches declare `ENABLED` / `DISABLED` / `REQUIRED` / `UNAVAILABLE` per install target, replacing the hardcoded `GmsCore support` filter in Manager and letting third-party patches restrict themselves to root or non-root.

**Related PRs:**
- https://github.com/MorpheApp/morphe-patcher/pull/156
- https://github.com/MorpheApp/morphe-patches/pull/2155
- https://github.com/MorpheApp/morphe-manager/pull/747