### PR TITLE
fix(YouTube - Playback speed): "Use normal speed for music" does not work when default playback speed is "Auto"

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
@@ -5,6 +5,8 @@ import android.icu.text.NumberFormat;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.protobuf.MessageLite;
+
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.Objects;
@@ -14,6 +16,7 @@ import java.util.regex.Pattern;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.patches.components.ContextInterface;
+import app.morphe.extension.youtube.innertube.AvailablePlaybackSpeedsOuterClass.AvailablePlaybackSpeeds;
 import app.morphe.extension.youtube.patches.voiceovertranslation.VoiceOverTranslationPatch;
 import app.morphe.extension.youtube.shared.Event;
 import app.morphe.extension.youtube.shared.ShortsPlayerState;
@@ -302,6 +305,30 @@ public final class VideoInformation {
             // An exception occurs when the playback speed dialog is opened by an overlay button while 'Restore old playback speed menu' is off.
             // Update the formatted string value to avoid the exception.
             playbackSpeedFormattedString = formatSpeedStringX(currentVideoSpeed);
+        }
+    }
+
+    /**
+     * Injection point.
+     */
+    public static void videoSpeedChanged(MessageLite[] availablePlaybackSpeeds, int newIndex) {
+        if (availablePlaybackSpeeds != null && newIndex > -1) {
+            MessageLite messageLite = availablePlaybackSpeeds[newIndex];
+            if (messageLite != null) {
+                try {
+                    var availablePlaybackSpeed = AvailablePlaybackSpeeds.parseFrom(messageLite.toByteArray());
+                    float currentVideoSpeed = availablePlaybackSpeed.getValue();
+
+                    if (currentVideoSpeed > 0) {
+                        VideoInformation.videoSpeedChanged(currentVideoSpeed);
+
+                        // Rest of the implementation added by patch.
+                        // PlaybackSpeedDialogButton.videoSpeedChanged(newlyLoadedPlaybackSpeed);
+                    }
+                } catch (Exception ex) {
+                    Logger.printException(() -> "videoSpeedChanged failed", ex);
+                }
+            }
         }
     }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/RememberPlaybackSpeedPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/RememberPlaybackSpeedPatch.java
@@ -95,9 +95,6 @@ public final class RememberPlaybackSpeedPatch {
             VideoInformation.setPlaybackSpeedMenu(menu);
 
             float defaultSpeed = Settings.PLAYBACK_SPEED_DEFAULT.get();
-            if (defaultSpeed < 0) {
-                return;
-            }
             if (DISABLE_PLAYBACK_SPEED_MUSIC && defaultSpeed != 1.0f) {
                 String videoId = VideoInformation.getVideoId();
                 GetMixPlaylistRequest request = GetMixPlaylistRequest.getRequestForVideoId(videoId);
@@ -108,7 +105,9 @@ public final class RememberPlaybackSpeedPatch {
                 }
             }
 
-            VideoInformation.changePlaybackSpeed(defaultSpeed);
+            if (defaultSpeed > 0) {
+                VideoInformation.changePlaybackSpeed(defaultSpeed);
+            }
         }
     }
 

--- a/extensions/youtube/src/main/proto/app/morphe/extension/youtube/innertube/availablePlaybackSpeeds.proto
+++ b/extensions/youtube/src/main/proto/app/morphe/extension/youtube/innertube/availablePlaybackSpeeds.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package app.morphe.extension.youtube.innertube;
+
+option optimize_for = LITE_RUNTIME;
+option java_package = "app.morphe.extension.youtube.innertube";
+
+message AvailablePlaybackSpeeds {
+    float value = 2;
+}

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/information/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/information/Fingerprints.kt
@@ -245,6 +245,20 @@ internal object SetPlaybackSpeedFormattedStringFingerprint : Fingerprint(
     )
 )
 
+internal object SetPlaybackSpeedProtoMessageFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS,
+    name = "videoSpeedChanged",
+    parameters = listOf("[Lcom/google/protobuf/MessageLite;", "I"),
+    filters = listOf(
+        methodCall(
+            opcode = Opcode.INVOKE_STATIC,
+            definingClass = EXTENSION_CLASS,
+            name = "videoSpeedChanged",
+            parameters = listOf("F")
+        )
+    )
+)
+
 // Class name is un-obfuscated in targets before 21.01
 internal object VideoQualityFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/information/VideoInformationPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/information/VideoInformationPatch.kt
@@ -23,6 +23,7 @@ import app.morphe.patcher.util.proxy.mutableTypes.MutableField.Companion.toMutab
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
 import app.morphe.patcher.util.smali.toInstructions
+import app.morphe.patches.shared.misc.fix.proto.fixProtoLibraryPatch
 import app.morphe.patches.shared.misc.textcomponent.hookSpannableString
 import app.morphe.patches.shared.misc.textcomponent.textComponentPatch
 import app.morphe.patches.shared.misc.videoinformation.PlayerControllerSetTimeReferenceFingerprint
@@ -96,6 +97,10 @@ private var formattedSpeedStringValueRegister = -1
 private lateinit var setPlaybackSpeedMethodRef : WeakReference<MutableMethod>
 private var setPlaybackSpeedMethodIndex = -1
 
+private lateinit var setPlaybackSpeedProtoMessageMethodRef : WeakReference<MutableMethod>
+private var setPlaybackSpeedProtoMessageMethodIndex = -1
+private var setPlaybackSpeedProtoMessageMethodRegister = -1
+
 internal lateinit var playerStatusMethodRef : WeakReference<MutableMethod>
 
 val videoInformationPatch = bytecodePatch(
@@ -106,6 +111,7 @@ val videoInformationPatch = bytecodePatch(
         videoIdPatch,
         playerResponseMethodHookPatch,
         conversionContextPatch,
+        fixProtoLibraryPatch,
         textComponentPatch,
         versionCheckPatch,
     )
@@ -226,6 +232,20 @@ val videoInformationPatch = bytecodePatch(
             }
         }
 
+        SetPlaybackSpeedProtoMessageFingerprint.let {
+            it.method.apply {
+                val index = it.instructionMatches.first().index
+
+                setPlaybackSpeedProtoMessageMethodRef = WeakReference(this)
+                setPlaybackSpeedProtoMessageMethodIndex = index
+                setPlaybackSpeedProtoMessageMethodRegister =
+                    getInstruction<FiveRegisterInstruction>(index).registerC
+
+                // Prevent duplicate hooking.
+                replaceInstruction(index, "nop")
+            }
+        }
+
         val setPlaybackSpeedMethodReference = with(PlaybackSpeedOnItemClickFingerprint) {
             val index = instructionMatches.first().index
 
@@ -319,6 +339,11 @@ val videoInformationPatch = bytecodePatch(
                     }
                 )
             }
+
+            it.method.addInstruction(
+                0,
+                "invoke-static/range { p1 .. p2 }, ${setPlaybackSpeedProtoMessageMethodRef.get()!!}"
+            )
         }
 
         // endregion.
@@ -668,11 +693,18 @@ fun videoTimeHook(targetMethodClass: String, targetMethodName: String) =
 /**
  * Hook when the video speed is changed for any reason _except when the user manually selects a new speed_.
  */
-fun videoSpeedChangedHook(targetMethodClass: String, targetMethodName: String) =
+fun videoSpeedChangedHook(targetMethodClass: String, targetMethodName: String) {
     setPlaybackSpeedMethodRef.get()!!.addInstruction(
         setPlaybackSpeedMethodIndex++,
         "invoke-static { p1 }, $targetMethodClass->$targetMethodName(F)V"
     )
+
+    setPlaybackSpeedProtoMessageMethodRef.get()!!.addInstruction(
+        setPlaybackSpeedProtoMessageMethodIndex++,
+        "invoke-static { v$setPlaybackSpeedProtoMessageMethodRegister }, $targetMethodClass->$targetMethodName(F)V"
+    )
+}
+
 
 /**
  * Hook the video speed selected by the user.

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/information/VideoInformationPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/information/VideoInformationPatch.kt
@@ -705,7 +705,6 @@ fun videoSpeedChangedHook(targetMethodClass: String, targetMethodName: String) {
     )
 }
 
-
 /**
  * Hook the video speed selected by the user.
  */


### PR DESCRIPTION
### Description

Closes #2161.

### Additional context

Part of @0xrxL's code from #1957 was used to write this PR.

### Build artifact

https://github.com/MorpheApp/morphe-patches/actions/runs/29999075886/artifacts/8560266999

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
