### PR TITLE
chore(YouTube - Seekbar): Various UI fixes

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/SeekbarThumbnailPreviewPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/SeekbarThumbnailPreviewPatch.java
@@ -246,11 +246,9 @@ public class SeekbarThumbnailPreviewPatch {
                 final int previewHeightPx = currentFrameParams.height;
 
                 int targetX = trackBallPosX - (previewWidthPx / 2);
-                final int targetY =
-                        trackBallPosY -
-                        previewHeightPx -
-                        Dim.dp(THUMBNAIL_PREVIEW_DISTANCE_DP) -
-                        Dim.dp(THUMBNAIL_PREVIEW_TIMESTAMP_HEIGHT_DP);
+                final int targetY = trackBallPosY - previewHeightPx
+                        - Dim.dp(THUMBNAIL_PREVIEW_DISTANCE_DP)
+                        - Dim.dp(THUMBNAIL_PREVIEW_TIMESTAMP_HEIGHT_DP);
 
                 final int screenWidth = Dim.getScreenWidth();
                 if (targetX < 0) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/SeekbarThumbnailPreviewPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/SeekbarThumbnailPreviewPatch.java
@@ -12,11 +12,13 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.Outline;
+import android.graphics.Point;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.GradientDrawable;
 import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewOutlineProvider;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
@@ -27,6 +29,7 @@ import android.widget.TextView;
 import java.util.Locale;
 
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.youtube.settings.Settings;
 import app.morphe.extension.youtube.shared.PlayerType;
@@ -39,12 +42,13 @@ public class SeekbarThumbnailPreviewPatch {
                                 PopupWindow thumbnailPreviewPopup) {
     }
 
-    private static final int THUMBNAIL_PREVIEW_LONG_SIDE_DP = 160;
-    private static final int THUMBNAIL_PREVIEW_DEFAULT_SHORT_SIDE_DP = THUMBNAIL_PREVIEW_LONG_SIDE_DP * 9 / 16;
-    private static final int THUMBNAIL_PREVIEW_DISTANCE_DP = 10;
-    private static final int THUMBNAIL_PREVIEW_TIMESTAMP_HEIGHT_DP = 24;
-    private static final int THUMBNAIL_PREVIEW_CORNER_RADIUS_DP = 8;
-    private static final int THUMBNAIL_PREVIEW_BORDER_WIDTH_DP = 2;
+    private static final int THUMBNAIL_PREVIEW_LONG_SIDE = 160;
+    private static final int THUMBNAIL_PREVIEW_DEFAULT_SHORT_SIDE = THUMBNAIL_PREVIEW_LONG_SIDE * 9 / 16;
+    private static final int THUMBNAIL_PREVIEW_DISTANCE_FULLSCREEN_DP = Dim.dp10;
+    private static final int THUMBNAIL_PREVIEW_DISTANCE_PORTRAIT_DP = -1 * Dim.dp20;
+    private static final int THUMBNAIL_PREVIEW_TIMESTAMP_HEIGHT_DP = Dim.dp24;
+    private static final int THUMBNAIL_PREVIEW_CORNER_RADIUS_DP = Dim.dp8;
+    private static final int THUMBNAIL_PREVIEW_BORDER_WIDTH_DP = Dim.dp2;
     private static final int THUMBNAIL_PREVIEW_BORDER_COLOR = 0xB3FFFFFF;
     private static final ColorDrawable previewPopupBackgroundDrawable = new ColorDrawable(Color.TRANSPARENT);
 
@@ -74,10 +78,10 @@ public class SeekbarThumbnailPreviewPatch {
             return views;
         }
 
-        final int longSidePx = Dim.dp(THUMBNAIL_PREVIEW_LONG_SIDE_DP);
-        final int shortSidePx = Dim.dp(THUMBNAIL_PREVIEW_DEFAULT_SHORT_SIDE_DP);
-        final int cornerRadiusPx = Dim.dp(THUMBNAIL_PREVIEW_CORNER_RADIUS_DP);
-        final int borderWidthPx = Dim.dp(THUMBNAIL_PREVIEW_BORDER_WIDTH_DP);
+        final int longSidePx = Dim.dp(THUMBNAIL_PREVIEW_LONG_SIDE);
+        final int shortSidePx = Dim.dp(THUMBNAIL_PREVIEW_DEFAULT_SHORT_SIDE);
+        final int cornerRadiusPx = THUMBNAIL_PREVIEW_CORNER_RADIUS_DP;
+        final int borderWidthPx = THUMBNAIL_PREVIEW_BORDER_WIDTH_DP;
         Context context = trackBall.getRootView().getContext();
         LinearLayout containerLayout = new LinearLayout(context);
         containerLayout.setOrientation(LinearLayout.VERTICAL);
@@ -151,7 +155,8 @@ public class SeekbarThumbnailPreviewPatch {
         if (bitmapWidth <= 0 || bitmapHeight <= 0) {
             return;
         }
-        final int longSidePx = Dim.dp(THUMBNAIL_PREVIEW_LONG_SIDE_DP);
+
+        final int longSidePx = Dim.dp(THUMBNAIL_PREVIEW_LONG_SIDE);
         final int newWidth;
         final int newHeight;
         if (bitmapWidth >= bitmapHeight) {
@@ -181,7 +186,7 @@ public class SeekbarThumbnailPreviewPatch {
     /**
      * Injection point.
      */
-    public static void updateThumbnailPreview(View container, MotionEvent containerMotionEvent, int trackBallPosX, int trackBallPosY) {
+    public static void updateThumbnailPreview(View container, MotionEvent containerMotionEvent, Point trackballPos) {
         try {
             if (!Settings.THUMBNAIL_PREVIEW.get() ||
                     !PlayerType.getCurrent().isMaximizedOrFullscreen() ||
@@ -211,11 +216,14 @@ public class SeekbarThumbnailPreviewPatch {
                 return;
             }
 
+            final int trackballPosX = trackballPos.x;
+            final int trackballPosY = trackballPos.y;
+
             if (action == MotionEvent.ACTION_MOVE) {
-                if (trackBallPosX == lastX) {
+                if (trackballPosX == lastX) {
                     return;
                 }
-                lastX = trackBallPosX;
+                lastX = trackballPosX;
 
                 View rootView = container.getRootView();
 
@@ -226,36 +234,34 @@ public class SeekbarThumbnailPreviewPatch {
                     applyBitmapAspectRatio(views.previewFrame, currentScrubbedPreviewBitmap);
                 }
 
-                if (trackBallPosX >= 0) {
+                if (trackballPosX >= 0) {
                     final int maxPixel = Dim.getScreenWidth();
                     final long totalVideoMillis = VideoInformation.getVideoLength();
 
                     if (totalVideoMillis > 0 && maxPixel > 0) {
-                        final int totalSeconds = (int) ((((long) trackBallPosX * totalVideoMillis) / maxPixel) / 1000);
+                        final int totalSeconds = (int) ((((long) trackballPosX * totalVideoMillis) / maxPixel) / 1000);
                         views.timestampPreview.setText(formatSeekTime(totalSeconds));
                     }
                 }
 
-                if (trackBallPosX == 0 && trackBallPosY == 0) {
+                if (trackballPosX == 0 && trackballPosY == 0) {
                     return;
                 }
 
-                final LinearLayout.LayoutParams currentFrameParams =
-                        (LinearLayout.LayoutParams) views.previewFrame.getLayoutParams();
-                final int previewWidthPx = currentFrameParams.width;
-                final int previewHeightPx = currentFrameParams.height;
+                ViewGroup.LayoutParams previewParams = views.previewFrame.getLayoutParams();
+                final int previewWidthPx = previewParams.width;
+                final int previewHeightPx = previewParams.height;
 
-                int targetX = trackBallPosX - (previewWidthPx / 2);
-                final int targetY = trackBallPosY - previewHeightPx
-                        - Dim.dp(THUMBNAIL_PREVIEW_DISTANCE_DP)
-                        - Dim.dp(THUMBNAIL_PREVIEW_TIMESTAMP_HEIGHT_DP);
-
-                final int screenWidth = Dim.getScreenWidth();
-                if (targetX < 0) {
-                    targetX = 0;
-                } else if (targetX + previewWidthPx > screenWidth) {
-                    targetX = screenWidth - previewWidthPx;
-                }
+                final int targetX = Utils.clamp(
+                        trackballPosX - (previewWidthPx / 2),
+                        0,
+                        Dim.getScreenWidth() - previewWidthPx
+                );
+                final int previewDistance = PlayerType.getCurrent() == PlayerType.WATCH_WHILE_FULLSCREEN
+                        ? THUMBNAIL_PREVIEW_DISTANCE_FULLSCREEN_DP
+                        : THUMBNAIL_PREVIEW_DISTANCE_PORTRAIT_DP;
+                final int targetY = trackballPosY - previewHeightPx
+                        - previewDistance - THUMBNAIL_PREVIEW_TIMESTAMP_HEIGHT_DP;
 
                 PopupWindow thumbnailPreviewPopup = views.thumbnailPreviewPopup;
                 if (!thumbnailPreviewPopup.isShowing()) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/SeekbarThumbnailPreviewPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/SeekbarThumbnailPreviewPatch.java
@@ -29,6 +29,8 @@ import java.util.Locale;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.youtube.settings.Settings;
+import app.morphe.extension.youtube.shared.PlayerType;
+import app.morphe.extension.youtube.shared.ShortsPlayerState;
 
 @SuppressWarnings("unused")
 public class SeekbarThumbnailPreviewPatch {
@@ -50,29 +52,20 @@ public class SeekbarThumbnailPreviewPatch {
     private static SeekbarViews seekbarViews;
     private static Bitmap fineScrubbingPreviewBitmap;
     private static Bitmap lastAppliedBitmap;
-    private static int fineScrubbingTimeMillis;
     private static int lastX = -1;
+    private static float touchEventInitialY = -1;
 
     /**
      * Injection point.
      */
     public static void setFineScrubbingPreviewBitmap(Bitmap bitmap) {
-        if (!Settings.THUMBNAIL_PREVIEW.get()) {
+        if (!Settings.THUMBNAIL_PREVIEW.get() ||
+                !PlayerType.getCurrent().isMaximizedOrFullscreen() ||
+                ShortsPlayerState.isOpen()) {
             return;
         }
 
         fineScrubbingPreviewBitmap = bitmap;
-    }
-
-    /**
-     * Injection point.
-     */
-    public static void setFineScrubbingTimeMillis(int newlyTimeMillis) {
-        if (!Settings.THUMBNAIL_PREVIEW.get()) {
-            return;
-        }
-
-        fineScrubbingTimeMillis = newlyTimeMillis;
     }
 
     private static SeekbarViews initializeThumbnailPreviewContainer(View trackBall) {
@@ -188,20 +181,26 @@ public class SeekbarThumbnailPreviewPatch {
     /**
      * Injection point.
      */
-    public static void updateThumbnailPreview(View trackBall, MotionEvent trackBallMotionEvent, int trackBallPosX) {
+    public static void updateThumbnailPreview(View container, MotionEvent containerMotionEvent, int trackBallPosX, int trackBallPosY) {
         try {
-            if (!Settings.THUMBNAIL_PREVIEW.get()) {
+            if (!Settings.THUMBNAIL_PREVIEW.get() ||
+                    !PlayerType.getCurrent().isMaximizedOrFullscreen() ||
+                    ShortsPlayerState.isOpen()) {
                 return;
             }
 
-            SeekbarViews views = initializeThumbnailPreviewContainer(trackBall);
+            SeekbarViews views = initializeThumbnailPreviewContainer(container);
 
-            final int action = trackBallMotionEvent.getAction();
+            final int action = containerMotionEvent.getAction();
             if (action == MotionEvent.ACTION_DOWN) {
+                touchEventInitialY = containerMotionEvent.getY();
                 return;
             }
 
-            if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
+            if (action == MotionEvent.ACTION_UP ||
+                    action == MotionEvent.ACTION_CANCEL ||
+                    (action == MotionEvent.ACTION_MOVE && (touchEventInitialY - containerMotionEvent.getY()) > Dim.dp(15))
+            ) {
                 if (views.thumbnailPreviewPopup.isShowing()) {
                     views.thumbnailPreviewPopup.dismiss();
                 }
@@ -218,7 +217,7 @@ public class SeekbarThumbnailPreviewPatch {
                 }
                 lastX = trackBallPosX;
 
-                View rootView = trackBall.getRootView();
+                View rootView = container.getRootView();
 
                 Bitmap currentScrubbedPreviewBitmap = fineScrubbingPreviewBitmap;
                 if (currentScrubbedPreviewBitmap != null && currentScrubbedPreviewBitmap != lastAppliedBitmap) {
@@ -227,19 +226,17 @@ public class SeekbarThumbnailPreviewPatch {
                     applyBitmapAspectRatio(views.previewFrame, currentScrubbedPreviewBitmap);
                 }
 
-                if (fineScrubbingTimeMillis >= 0) {
+                if (trackBallPosX >= 0) {
                     final int maxPixel = Dim.getScreenWidth();
                     final long totalVideoMillis = VideoInformation.getVideoLength();
 
                     if (totalVideoMillis > 0 && maxPixel > 0) {
-                        final int totalSeconds = (int) ((((long) fineScrubbingTimeMillis * totalVideoMillis) / maxPixel) / 1000);
+                        final int totalSeconds = (int) ((((long) trackBallPosX * totalVideoMillis) / maxPixel) / 1000);
                         views.timestampPreview.setText(formatSeekTime(totalSeconds));
                     }
                 }
 
-                final int[] locationOnScreen = new int[2];
-                trackBall.getLocationOnScreen(locationOnScreen);
-                if (locationOnScreen[0] == 0 && locationOnScreen[1] == 0) {
+                if (trackBallPosX == 0 && trackBallPosY == 0) {
                     return;
                 }
 
@@ -248,9 +245,12 @@ public class SeekbarThumbnailPreviewPatch {
                 final int previewWidthPx = currentFrameParams.width;
                 final int previewHeightPx = currentFrameParams.height;
 
-                int targetX = locationOnScreen[0] + trackBallPosX - (previewWidthPx / 2);
-                final int targetY = locationOnScreen[1] - previewHeightPx
-                        - Dim.dp(THUMBNAIL_PREVIEW_DISTANCE_DP) - Dim.dp(THUMBNAIL_PREVIEW_TIMESTAMP_HEIGHT_DP);
+                int targetX = trackBallPosX - (previewWidthPx / 2);
+                final int targetY =
+                        trackBallPosY -
+                        previewHeightPx -
+                        Dim.dp(THUMBNAIL_PREVIEW_DISTANCE_DP) -
+                        Dim.dp(THUMBNAIL_PREVIEW_TIMESTAMP_HEIGHT_DP);
 
                 final int screenWidth = Dim.getScreenWidth();
                 if (targetX < 0) {

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/Fingerprints.kt
@@ -211,7 +211,6 @@ internal object SeekbarUpdatePointFingerprint : Fingerprint (
 internal object SlideSeekbarHandlerOnTouchFingerprint : Fingerprint (
     classFingerprint = Fingerprint (
         accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
-        returnType = "V",
         filters = listOf(
             resourceLiteral(ResourceType.DIMEN, "seek_easy_horizontal_touch_offset_to_start_scrubbing")
         )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/Fingerprints.kt
@@ -20,6 +20,8 @@ import app.morphe.patcher.methodCall
 import app.morphe.patcher.newInstance
 import app.morphe.patcher.opcode
 import app.morphe.patcher.string
+import app.morphe.patches.all.misc.resources.ResourceType
+import app.morphe.patches.all.misc.resources.resourceLiteral
 import app.morphe.patches.youtube.shared.SeekbarFingerprint
 import app.morphe.patches.youtube.video.quality.VideoStreamingDataToStringFingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
@@ -172,26 +174,22 @@ internal object FormatStreamModelMaxDVRDurationFingerprint : Fingerprint(
     )
 )
 
-internal object SeekbarTrackballPosXAndTimeMillisFingerprint : Fingerprint (
+internal object SeekbarHandlerOnTouchFingerprint : Fingerprint (
     classFingerprint = SeekbarFingerprint,
-    name = "onTouchEvent",
-    filters = listOf(
-        fieldAccess(opcode = Opcode.IGET, smali = "Landroid/graphics/Point;->x:I"),
-        methodCall(
-            opcode = Opcode.INVOKE_VIRTUAL,
-            smali = "Landroid/content/res/Resources;->getDisplayMetrics()Landroid/util/DisplayMetrics;"
-        ),
-        methodCall(
-            opcode = Opcode.INVOKE_STATIC,
-            smali = "Ljava/lang/Math;->min(II)I"
-        ),
-        methodCall(
-            opcode = Opcode.INVOKE_VIRTUAL,
-            parameters = listOf("I"),
-            returnType = "V",
-            location = MatchAfterWithin(5)
+    name = "onTouchEvent"
+)
+
+internal object SlideSeekbarHandlerOnTouchFingerprint : Fingerprint (
+    classFingerprint = Fingerprint (
+        accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
+        returnType = "V",
+        filters = listOf(
+            resourceLiteral(ResourceType.DIMEN, "seek_easy_horizontal_touch_offset_to_start_scrubbing")
         )
-    )
+    ),
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "Z",
+    parameters = listOf("Landroid/view/View;", "Landroid/view/MotionEvent;")
 )
 
 internal object SeekbarFineScrubbingBitmapFingerprint : Fingerprint (

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/Fingerprints.kt
@@ -221,6 +221,29 @@ internal object SlideSeekbarHandlerOnTouchFingerprint : Fingerprint (
     parameters = listOf("Landroid/view/View;", "Landroid/view/MotionEvent;")
 )
 
+internal object SlideSeekbarGetViewControllerFingerprint : Fingerprint (
+    accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf("Landroid/view/View;", "F"),
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            definingClass = "this",
+            location = MatchAfterWithin(10) // Match close to start of method.
+        ),
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            location = MatchAfterWithin(10)
+        ),
+        literal(124587, location = MatchAfterWithin(20)),
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            location = MatchAfterWithin(10)
+        ),
+        literal(67108864)
+    )
+)
+
 internal object SeekbarFineScrubbingBitmapFingerprint : Fingerprint (
     classFingerprint = Fingerprint (
         returnType = "Landroid/graphics/Bitmap;",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/Fingerprints.kt
@@ -179,6 +179,35 @@ internal object SeekbarHandlerOnTouchFingerprint : Fingerprint (
     name = "onTouchEvent"
 )
 
+internal object SeekbarUpdatePointFingerprint : Fingerprint (
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    parameters = listOf(),
+    returnType = "V",
+    filters = listOf(
+        fieldAccess(
+            definingClass = "this",
+            type = "Landroid/graphics/Point;"
+        ),
+        methodCall( // Get seekbar point.
+            opcode = Opcode.INVOKE_INTERFACE,
+            parameters = listOf("Landroid/graphics/Point;"),
+            returnType = "V",
+            location = MatchAfterWithin(5)
+        ),
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            definingClass = "this",
+            type = "Landroid/graphics/Rect;",
+            location = MatchAfterWithin(10)
+        ),
+        fieldAccess(
+            opcode = Opcode.IGET,
+            smali = "Landroid/graphics/Rect;->left:I",
+            location = MatchAfterWithin(5)
+        )
+    )
+)
+
 internal object SlideSeekbarHandlerOnTouchFingerprint : Fingerprint (
     classFingerprint = Fingerprint (
         accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/SeekbarThumbnailPreviewPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/SeekbarThumbnailPreviewPatch.kt
@@ -8,6 +8,7 @@
 package app.morphe.patches.youtube.interaction.seekbar
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
@@ -18,7 +19,7 @@ import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
-import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/SeekbarThumbnailPreviewPatch;"
 
@@ -38,21 +39,34 @@ val seekbarThumbnailPreviewPatch = bytecodePatch(
             SwitchPreference("morphe_seekbar_thumbnail_preview")
         )
 
-        SeekbarTrackballPosXAndTimeMillisFingerprint.apply {
-            instructionMatches.last().getMethodCalled().addInstruction(
-                0,
-                "invoke-static { p1 }, $EXTENSION_CLASS->setFineScrubbingTimeMillis(I)V"
-            )
+        // To show the thumbnail during the seeking straight on seekbar.
+        SeekbarHandlerOnTouchFingerprint.method.addInstructions(
+            0,
+            """
+                new-instance v0, Landroid/graphics/Point;
+                invoke-direct {v0}, Landroid/graphics/Point;-><init>()V
+                invoke-virtual {p0, v0}, Lkri;->g(Landroid/graphics/Point;)V
+                iget v1, v0, Landroid/graphics/Point;->x:I
+                iget v2, v0, Landroid/graphics/Point;->y:I
+                invoke-static { p0, p1, v1, v2 }, $EXTENSION_CLASS->updateThumbnailPreview(Landroid/view/View;Landroid/view/MotionEvent;II)V
+            """
+        )
 
-            val posXInstructionIndex = instructionMatches.first().index
-            val posXInstructionRegister = method.getInstruction<TwoRegisterInstruction>(posXInstructionIndex).registerA
-
-            method.addInstruction(
-                posXInstructionIndex + 1,
-                "invoke-static { p0, p1, v$posXInstructionRegister }, $EXTENSION_CLASS->" +
-                        "updateThumbnailPreview(Landroid/view/View;Landroid/view/MotionEvent;I)V"
-            )
-        }
+        // To show the thumbnail during the use of slide to seek feature.
+        SlideSeekbarHandlerOnTouchFingerprint.method.addInstructions(
+            0,
+            """
+                iget-object v0, p0, Loyz;->m:Loyx;
+                iget-object v0, v0, Loyx;->a:Lown;
+                iget-object v0, v0, Lown;->a:Lkrx;
+                new-instance v1, Landroid/graphics/Point;
+                invoke-direct {v1}, Landroid/graphics/Point;-><init>()V
+                invoke-interface {v0, v1}, Lkrx;->g(Landroid/graphics/Point;)V
+                iget v2, v1, Landroid/graphics/Point;->x:I
+                iget v3, v1, Landroid/graphics/Point;->y:I
+                invoke-static { p1, p2, v2, v3 }, $EXTENSION_CLASS->updateThumbnailPreview(Landroid/view/View;Landroid/view/MotionEvent;II)V
+            """
+        )
 
         SeekbarFineScrubbingBitmapFingerprint.method.addInstruction(
             1,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/SeekbarThumbnailPreviewPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/SeekbarThumbnailPreviewPatch.kt
@@ -11,6 +11,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.playservice.is_21_12_or_greater
@@ -31,7 +32,8 @@ val seekbarThumbnailPreviewPatch = bytecodePatch(
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,
-        versionCheckPatch
+        versionCheckPatch,
+        resourceMappingPatch
     )
 
     compatibleWith(COMPATIBILITY_YOUTUBE)
@@ -59,26 +61,21 @@ val seekbarThumbnailPreviewPatch = bytecodePatch(
 
         // To show the thumbnail during the use of slide to seek feature.
         SlideSeekbarHandlerOnTouchFingerprint.method.apply {
-            val controllerInstructionMatches = SlideSeekbarGetViewControllerFingerprint.instructionMatches
-            val getViewControllerFieldRef1 = controllerInstructionMatches[0]
-                .getInstruction<ReferenceInstruction>().getReference<FieldReference>()
-            val getViewControllerFieldRef2 = controllerInstructionMatches[1]
-                .getInstruction<ReferenceInstruction>().getReference<FieldReference>()
-            val getViewControllerFieldRef3 = controllerInstructionMatches[3]
-                .getInstruction<ReferenceInstruction>().getReference<FieldReference>()
+            fun getSeekbarReference(index: Int): FieldReference = SlideSeekbarGetViewControllerFingerprint
+                .instructionMatches[index].getInstruction<ReferenceInstruction>().getReference<FieldReference>()!!
 
             addInstructions(
                 0,
                 """
-                    iget-object v0, p0, $getViewControllerFieldRef1
-                    iget-object v0, v0, $getViewControllerFieldRef2
-                    iget-object v0, v0, $getViewControllerFieldRef3
-                    new-instance v1, Landroid/graphics/Point;
-                    invoke-direct { v1 }, Landroid/graphics/Point;-><init>()V
-                    invoke-interface { v0, v1 }, $updatePointMethodRef
-                    iget v2, v1, Landroid/graphics/Point;->x:I
-                    iget v3, v1, Landroid/graphics/Point;->y:I
-                    invoke-static { p1, p2, v2, v3 }, $EXTENSION_CLASS->updateThumbnailPreview(Landroid/view/View;Landroid/view/MotionEvent;II)V
+                    iget-object v3, p0, ${getSeekbarReference(0)}
+                    iget-object v3, v3, ${getSeekbarReference(1)}
+                    iget-object v3, v3, ${getSeekbarReference(3)}
+                    new-instance v0, Landroid/graphics/Point;
+                    invoke-direct { v0 }, Landroid/graphics/Point;-><init>()V
+                    invoke-interface { v3, v0 }, $updatePointMethodRef
+                    iget v1, v0, Landroid/graphics/Point;->x:I
+                    iget v2, v0, Landroid/graphics/Point;->y:I
+                    invoke-static { p1, p2, v1, v2 }, $EXTENSION_CLASS->updateThumbnailPreview(Landroid/view/View;Landroid/view/MotionEvent;II)V
                 """
             )
         }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/SeekbarThumbnailPreviewPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/SeekbarThumbnailPreviewPatch.kt
@@ -53,29 +53,25 @@ val seekbarThumbnailPreviewPatch = bytecodePatch(
                 new-instance v0, Landroid/graphics/Point;
                 invoke-direct { v0 }, Landroid/graphics/Point;-><init>()V
                 invoke-interface { p0, v0 }, $updatePointMethodRef
-                iget v1, v0, Landroid/graphics/Point;->x:I
-                iget v2, v0, Landroid/graphics/Point;->y:I
-                invoke-static { p0, p1, v1, v2 }, $EXTENSION_CLASS->updateThumbnailPreview(Landroid/view/View;Landroid/view/MotionEvent;II)V
+                invoke-static { p0, p1, v0 }, $EXTENSION_CLASS->updateThumbnailPreview(Landroid/view/View;Landroid/view/MotionEvent;Landroid/graphics/Point;)V
             """
         )
 
         // To show the thumbnail during the use of slide to seek feature.
         SlideSeekbarHandlerOnTouchFingerprint.method.apply {
-            fun getSeekbarReference(index: Int): FieldReference = SlideSeekbarGetViewControllerFingerprint
+            fun getSeekbarReference(index: Int) = SlideSeekbarGetViewControllerFingerprint
                 .instructionMatches[index].getInstruction<ReferenceInstruction>().getReference<FieldReference>()!!
 
             addInstructions(
                 0,
                 """
-                    iget-object v3, p0, ${getSeekbarReference(0)}
-                    iget-object v3, v3, ${getSeekbarReference(1)}
-                    iget-object v3, v3, ${getSeekbarReference(3)}
-                    new-instance v0, Landroid/graphics/Point;
-                    invoke-direct { v0 }, Landroid/graphics/Point;-><init>()V
-                    invoke-interface { v3, v0 }, $updatePointMethodRef
-                    iget v1, v0, Landroid/graphics/Point;->x:I
-                    iget v2, v0, Landroid/graphics/Point;->y:I
-                    invoke-static { p1, p2, v1, v2 }, $EXTENSION_CLASS->updateThumbnailPreview(Landroid/view/View;Landroid/view/MotionEvent;II)V
+                    iget-object v0, p0, ${getSeekbarReference(0)}
+                    iget-object v0, v0, ${getSeekbarReference(1)}
+                    iget-object v0, v0, ${getSeekbarReference(3)}
+                    new-instance v1, Landroid/graphics/Point;
+                    invoke-direct { v1 }, Landroid/graphics/Point;-><init>()V
+                    invoke-interface { v0, v1 }, $updatePointMethodRef
+                    invoke-static { p1, p2, v1 }, $EXTENSION_CLASS->updateThumbnailPreview(Landroid/view/View;Landroid/view/MotionEvent;Landroid/graphics/Point;)V
                 """
             )
         }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/SeekbarThumbnailPreviewPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/SeekbarThumbnailPreviewPatch.kt
@@ -10,7 +10,6 @@ package app.morphe.patches.youtube.interaction.seekbar
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
-import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
@@ -19,7 +18,9 @@ import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
+import app.morphe.util.getReference
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/SeekbarThumbnailPreviewPatch;"
 
@@ -39,13 +40,16 @@ val seekbarThumbnailPreviewPatch = bytecodePatch(
             SwitchPreference("morphe_seekbar_thumbnail_preview")
         )
 
+        val updatePointMethodRef = SeekbarUpdatePointFingerprint.instructionMatches[1]
+            .getInstruction<ReferenceInstruction>().getReference<MethodReference>()!!
+
         // To show the thumbnail during the seeking straight on seekbar.
         SeekbarHandlerOnTouchFingerprint.method.addInstructions(
             0,
             """
                 new-instance v0, Landroid/graphics/Point;
-                invoke-direct {v0}, Landroid/graphics/Point;-><init>()V
-                invoke-virtual {p0, v0}, Lkri;->g(Landroid/graphics/Point;)V
+                invoke-direct { v0 }, Landroid/graphics/Point;-><init>()V
+                invoke-interface { p0, v0 }, $updatePointMethodRef
                 iget v1, v0, Landroid/graphics/Point;->x:I
                 iget v2, v0, Landroid/graphics/Point;->y:I
                 invoke-static { p0, p1, v1, v2 }, $EXTENSION_CLASS->updateThumbnailPreview(Landroid/view/View;Landroid/view/MotionEvent;II)V
@@ -60,8 +64,8 @@ val seekbarThumbnailPreviewPatch = bytecodePatch(
                 iget-object v0, v0, Loyx;->a:Lown;
                 iget-object v0, v0, Lown;->a:Lkrx;
                 new-instance v1, Landroid/graphics/Point;
-                invoke-direct {v1}, Landroid/graphics/Point;-><init>()V
-                invoke-interface {v0, v1}, Lkrx;->g(Landroid/graphics/Point;)V
+                invoke-direct { v1 }, Landroid/graphics/Point;-><init>()V
+                invoke-interface { v0, v1 }, $updatePointMethodRef
                 iget v2, v1, Landroid/graphics/Point;->x:I
                 iget v3, v1, Landroid/graphics/Point;->y:I
                 invoke-static { p1, p2, v2, v3 }, $EXTENSION_CLASS->updateThumbnailPreview(Landroid/view/View;Landroid/view/MotionEvent;II)V

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/SeekbarThumbnailPreviewPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/SeekbarThumbnailPreviewPatch.kt
@@ -20,6 +20,7 @@ import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import app.morphe.util.getReference
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/SeekbarThumbnailPreviewPatch;"
@@ -57,20 +58,30 @@ val seekbarThumbnailPreviewPatch = bytecodePatch(
         )
 
         // To show the thumbnail during the use of slide to seek feature.
-        SlideSeekbarHandlerOnTouchFingerprint.method.addInstructions(
-            0,
-            """
-                iget-object v0, p0, Loyz;->m:Loyx;
-                iget-object v0, v0, Loyx;->a:Lown;
-                iget-object v0, v0, Lown;->a:Lkrx;
-                new-instance v1, Landroid/graphics/Point;
-                invoke-direct { v1 }, Landroid/graphics/Point;-><init>()V
-                invoke-interface { v0, v1 }, $updatePointMethodRef
-                iget v2, v1, Landroid/graphics/Point;->x:I
-                iget v3, v1, Landroid/graphics/Point;->y:I
-                invoke-static { p1, p2, v2, v3 }, $EXTENSION_CLASS->updateThumbnailPreview(Landroid/view/View;Landroid/view/MotionEvent;II)V
-            """
-        )
+        SlideSeekbarHandlerOnTouchFingerprint.method.apply {
+            val controllerInstructionMatches = SlideSeekbarGetViewControllerFingerprint.instructionMatches
+            val getViewControllerFieldRef1 = controllerInstructionMatches[0]
+                .getInstruction<ReferenceInstruction>().getReference<FieldReference>()
+            val getViewControllerFieldRef2 = controllerInstructionMatches[1]
+                .getInstruction<ReferenceInstruction>().getReference<FieldReference>()
+            val getViewControllerFieldRef3 = controllerInstructionMatches[3]
+                .getInstruction<ReferenceInstruction>().getReference<FieldReference>()
+
+            addInstructions(
+                0,
+                """
+                    iget-object v0, p0, $getViewControllerFieldRef1
+                    iget-object v0, v0, $getViewControllerFieldRef2
+                    iget-object v0, v0, $getViewControllerFieldRef3
+                    new-instance v1, Landroid/graphics/Point;
+                    invoke-direct { v1 }, Landroid/graphics/Point;-><init>()V
+                    invoke-interface { v0, v1 }, $updatePointMethodRef
+                    iget v2, v1, Landroid/graphics/Point;->x:I
+                    iget v3, v1, Landroid/graphics/Point;->y:I
+                    invoke-static { p1, p2, v2, v3 }, $EXTENSION_CLASS->updateThumbnailPreview(Landroid/view/View;Landroid/view/MotionEvent;II)V
+                """
+            )
+        }
 
         SeekbarFineScrubbingBitmapFingerprint.method.addInstruction(
             1,


### PR DESCRIPTION
- The preview thumbnail now follows only the trackball on the seekbar, rather than the tap position of the MotionEvent.
- The preview thumbnail follows the trackball on the seekbar even during a long press on the player for seeking.
- The preview thumbnail now works only on the video player.
- The preview thumbnail now disappears when dragging upwards.