### PR TITLE
feat(Spoof video streams): Default client maintenance

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/spoof/SpoofVideoStreamsPatch.java
@@ -1,7 +1,6 @@
 package app.morphe.extension.music.patches.spoof;
 
 import static app.morphe.extension.music.settings.Settings.SPOOF_VIDEO_STREAMS_CLIENT_TYPE;
-import static app.morphe.extension.shared.spoof.ClientType.ANDROID_REEL_NO_AUTH;
 import static app.morphe.extension.shared.spoof.ClientType.ANDROID_MUSIC_REEL;
 import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_73;
 import static app.morphe.extension.shared.spoof.ClientType.TV;
@@ -22,7 +21,6 @@ public class SpoofVideoStreamsPatch {
                 TV,
                 ANDROID_VR_1_73,
                 VISIONOS,
-                ANDROID_REEL_NO_AUTH,
                 ANDROID_MUSIC_REEL
         );
 

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/spoof/SpoofVideoStreamsPatch.java
@@ -5,7 +5,7 @@ import static app.morphe.extension.shared.spoof.ClientType.ANDROID_MUSIC_NO_SDK;
 import static app.morphe.extension.shared.spoof.ClientType.ANDROID_MUSIC_REEL;
 import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_73;
 import static app.morphe.extension.shared.spoof.ClientType.TV;
-import static app.morphe.extension.shared.spoof.ClientType.VISIONOS;
+import static app.morphe.extension.shared.spoof.ClientType.VISIONOS_1_02;
 
 import java.util.List;
 
@@ -21,7 +21,7 @@ public class SpoofVideoStreamsPatch {
         List<ClientType> availableClients = List.of(
                 TV,
                 ANDROID_VR_1_73,
-                VISIONOS,
+                VISIONOS_1_02,
                 ANDROID_MUSIC_NO_SDK,
                 ANDROID_MUSIC_REEL
         );

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/spoof/SpoofVideoStreamsPatch.java
@@ -1,6 +1,7 @@
 package app.morphe.extension.music.patches.spoof;
 
 import static app.morphe.extension.music.settings.Settings.SPOOF_VIDEO_STREAMS_CLIENT_TYPE;
+import static app.morphe.extension.shared.spoof.ClientType.ANDROID_MUSIC_NO_SDK;
 import static app.morphe.extension.shared.spoof.ClientType.ANDROID_MUSIC_REEL;
 import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_73;
 import static app.morphe.extension.shared.spoof.ClientType.TV;
@@ -21,6 +22,7 @@ public class SpoofVideoStreamsPatch {
                 TV,
                 ANDROID_VR_1_73,
                 VISIONOS,
+                ANDROID_MUSIC_NO_SDK,
                 ANDROID_MUSIC_REEL
         );
 

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -127,7 +127,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting CROSSFADE_SESSION_CONTROL = new BooleanSetting("morphe_music_crossfade_session_control", TRUE, parent(CROSSFADE_ENABLED));
 
     // Miscellaneous
-    public static final EnumSetting<ClientType> SPOOF_VIDEO_STREAMS_CLIENT_TYPE = new EnumSetting<>("morphe_spoof_video_streams_client_type", ClientType.TV, true, parent(SPOOF_VIDEO_STREAMS));
+    public static final EnumSetting<ClientType> SPOOF_VIDEO_STREAMS_CLIENT_TYPE = new EnumSetting<>("morphe_spoof_video_streams_client_type", ClientType.VISIONOS_1_02, true, parent(SPOOF_VIDEO_STREAMS));
 
     // Scrobbling
     public static final BooleanSetting LISTENBRAINZ_SCROBBLING = new BooleanSetting("morphe_music_listenbrainz_enabled", FALSE, true);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
@@ -10,7 +10,6 @@ import app.morphe.extension.shared.patches.CustomBrandingPatch;
 import app.morphe.extension.shared.patches.CustomBrandingPatch.BrandingTheme;
 import app.morphe.extension.shared.patches.CustomBrandingPatch.NotificationIconTheme;
 import app.morphe.extension.shared.spoof.SpoofVideoStreamsPatch.JavaScriptClientAvailability;
-import app.morphe.extension.shared.spoof.SpoofVideoStreamsPatch.JavaScriptHashAvailability;
 import app.morphe.extension.shared.spoof.js.JavaScriptVariant;
 
 /**
@@ -37,8 +36,7 @@ public class SharedYouTubeSettings extends BaseSettings {
     public static final BooleanSetting SPOOF_VIDEO_STREAMS = new BooleanSetting("morphe_spoof_video_streams", TRUE, true, "morphe_spoof_video_streams_user_dialog_message");
     public static final BooleanSetting SPOOF_VIDEO_STREAMS_STATS_FOR_NERDS = new BooleanSetting("morphe_spoof_video_streams_stats_for_nerds", TRUE, parent(SPOOF_VIDEO_STREAMS));
     public static final EnumSetting<JavaScriptVariant> SPOOF_VIDEO_STREAMS_PLAYER_JS_VARIANT = new EnumSetting<>("morphe_spoof_video_streams_player_js_variant", JavaScriptVariant.HOUSE_BRAND, true, new JavaScriptClientAvailability());
-    public static final BooleanSetting SPOOF_VIDEO_STREAMS_DISABLE_PLAYER_JS_UPDATE = new BooleanSetting("morphe_spoof_video_streams_disable_player_js_update", FALSE, true, "morphe_spoof_video_streams_disable_player_js_update_user_dialog_message", new JavaScriptClientAvailability());
-    public static final StringSetting SPOOF_VIDEO_STREAMS_PLAYER_JS_HASH_VALUE = new StringSetting("morphe_spoof_video_streams_player_js_hash_value", "", true, new JavaScriptHashAvailability());
+    public static final StringSetting SPOOF_VIDEO_STREAMS_PLAYER_JS_HASH_VALUE = new StringSetting("morphe_spoof_video_streams_player_js_hash_value", "", true, false);
     public static final LongSetting SPOOF_VIDEO_STREAMS_PLAYER_JS_SAVED_MILLISECONDS = new LongSetting("morphe_spoof_video_streams_player_js_saved_milliseconds", -1L, false, false);
     public static final StringSetting OAUTH2_REFRESH_TOKEN = new StringSetting("morphe_oauth2_refresh_token", "", false, false);
 

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/ClientType.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/ClientType.java
@@ -49,6 +49,23 @@ public enum ClientType {
             false,
             "Android Music Reel"
     ),
+    ANDROID_MUSIC_NO_SDK(
+            21,
+            "ANDROID_MUSIC",
+            ANDROID_MUSIC_REEL.deviceMake,
+            ANDROID_MUSIC_REEL.deviceModel,
+            ANDROID_MUSIC_REEL.osName,
+            ANDROID_MUSIC_REEL.osVersion,
+            "7.12.52",
+            null,
+            "com.google.android.apps.youtube.music/7.12.52 (Linux; U; Android " + Build.VERSION.RELEASE + ") gzip",
+            IS_YOUTUBE_MUSIC,
+            IS_YOUTUBE_MUSIC,
+            false,
+            false,
+            false,
+            "Android Music No SDK"
+    ),
     /**
      * Video not playable: Kids.
      * AV1 codec available.

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/ClientType.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/ClientType.java
@@ -148,7 +148,8 @@ public enum ClientType {
      * Video not playable: None.
      * AV1 codec available.
      */
-    TV(7,
+    TV(
+            7,
             "TVHTML5",
             "Samsung",
             "SmartTV",
@@ -170,7 +171,8 @@ public enum ClientType {
      * AV1 codec available.
      * May stop working at any time.
      */
-    VISIONOS(101,
+    VISIONOS_1_03(
+            101,
             "VISIONOS",
             "Apple",
             "RealityDevice17,1",
@@ -184,7 +186,29 @@ public enum ClientType {
             true,
             true,
             false,
-            "visionOS"
+            "visionOS 1.03"
+    ),
+    /**
+     * Video not playable: Kids, Paid, Movie, Private, Age-restricted.
+     * AV1 codec not available.
+     * May stop working at any time.
+     */
+    VISIONOS_1_02(
+            VISIONOS_1_03.id,
+            VISIONOS_1_03.clientName,
+            VISIONOS_1_03.deviceMake,
+            "RealityDevice14,1",
+            VISIONOS_1_03.osName,
+            "2.6.22O785",
+            "1.02",
+            VISIONOS_1_03.clientPlatform,
+            VISIONOS_1_03.userAgent,
+            VISIONOS_1_03.canLogin,
+            VISIONOS_1_03.requireLogin,
+            VISIONOS_1_03.supportsMultiAudioTracks,
+            VISIONOS_1_03.supportsVRImmersiveMode,
+            VISIONOS_1_03.requireJS,
+            "visionOS 1.02"
     );
 
     /**

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/ClientType.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/ClientType.java
@@ -10,7 +10,6 @@
 
 package app.morphe.extension.shared.spoof;
 
-import static app.morphe.extension.shared.patches.AppCheckPatch.IS_YOUTUBE;
 import static app.morphe.extension.shared.patches.AppCheckPatch.IS_YOUTUBE_MUSIC;
 
 import android.os.Build;
@@ -25,57 +24,6 @@ import app.morphe.extension.shared.Logger;
 
 @SuppressWarnings({"ConstantLocale", "deprecation"})
 public enum ClientType {
-    /**
-     * Video not playable: None.
-     * AV1 codec available.
-     */
-    ANDROID_REEL_AUTH(
-            3,
-            "ANDROID",
-            "com.google.android.youtube",
-            Build.MANUFACTURER,
-            Build.MODEL,
-            "Android",
-            Build.VERSION.RELEASE,
-            String.valueOf(Build.VERSION.SDK_INT),
-            Build.ID,
-            // A hardcoded client version is used for YouTube Music.
-            "20.47.62",
-            null,
-            IS_YOUTUBE,
-            IS_YOUTUBE,
-            true,
-            false,
-            true,
-            true,
-            false,
-            "Android Reel auth"
-    ),
-    /**
-     * Video not playable: Paid, Movie, Private, Age-restricted.
-     * AV1 codec available.
-     */
-    ANDROID_REEL_NO_AUTH(
-            ANDROID_REEL_AUTH.id,
-            ANDROID_REEL_AUTH.clientName,
-            Objects.requireNonNull(ANDROID_REEL_AUTH.packageName),
-            ANDROID_REEL_AUTH.deviceMake,
-            ANDROID_REEL_AUTH.deviceModel,
-            ANDROID_REEL_AUTH.osName,
-            ANDROID_REEL_AUTH.osVersion,
-            Objects.requireNonNull(ANDROID_REEL_AUTH.androidSdkVersion),
-            ANDROID_REEL_AUTH.buildID,
-            ANDROID_REEL_AUTH.clientVersion,
-            ANDROID_REEL_AUTH.clientPlatform,
-            false,
-            false,
-            ANDROID_REEL_AUTH.supportsMultiAudioTracks,
-            ANDROID_REEL_AUTH.supportsOAuth2,
-            ANDROID_REEL_AUTH.supportsVRImmersiveMode,
-            ANDROID_REEL_AUTH.requireSABR,
-            ANDROID_REEL_AUTH.usePlayerEndpoint,
-            "Android Reel no auth"
-    ),
     /**
      * Video not playable: None.
      * For YouTube Music only.
@@ -373,7 +321,7 @@ public enum ClientType {
 
         Locale defaultLocale = Locale.getDefault();
         this.userAgent = String.format(Locale.ENGLISH,
-                "%s/%s (Linux; U; Android %s; %s; %s; Build/%s)",
+                "%s/%s (Linux; U; Android %s; %s; %s Build/%s)",
                 packageName,
                 clientVersion,
                 osVersion,

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
@@ -59,7 +59,7 @@ public class SpoofVideoStreamsPatch {
 
     private static final boolean SPOOF_VIDEO_STREAMS = SharedYouTubeSettings.SPOOF_VIDEO_STREAMS.get();
 
-    private static volatile ClientType preferredClient = ClientType.VISIONOS;
+    private static volatile ClientType preferredClient = ClientType.VISIONOS_1_02;
 
     private static WeakReference<Application> mainActivityRef = new WeakReference<>(null);
 

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
@@ -42,22 +42,6 @@ public class SpoofVideoStreamsPatch {
         }
     }
 
-    public static final class JavaScriptHashAvailability implements Setting.Availability {
-        @Override
-        public boolean isAvailable() {
-            return SharedYouTubeSettings.SPOOF_VIDEO_STREAMS.get() && preferredClient.requireJS &&
-                    SharedYouTubeSettings.SPOOF_VIDEO_STREAMS_DISABLE_PLAYER_JS_UPDATE.get();
-        }
-
-        @Override
-        public List<Setting<?>> getParentSettings() {
-            return List.of(
-                    SharedYouTubeSettings.SPOOF_VIDEO_STREAMS,
-                    SharedYouTubeSettings.SPOOF_VIDEO_STREAMS_DISABLE_PLAYER_JS_UPDATE
-            );
-        }
-    }
-
     /**
      * Domain used for internet connectivity verification.
      * It has an empty response body and is only used to check for a 204 response code.

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
@@ -75,7 +75,7 @@ public class SpoofVideoStreamsPatch {
 
     private static final boolean SPOOF_VIDEO_STREAMS = SharedYouTubeSettings.SPOOF_VIDEO_STREAMS.get();
 
-    private static volatile ClientType preferredClient = ClientType.ANDROID_REEL_AUTH;
+    private static volatile ClientType preferredClient = ClientType.VISIONOS;
 
     private static WeakReference<Application> mainActivityRef = new WeakReference<>(null);
 
@@ -156,35 +156,6 @@ public class SpoofVideoStreamsPatch {
         }
 
         return playerRequestBuilder;
-    }
-
-    /**
-     * Injection point.
-     * <p>
-     * Blocks /get_watch requests by returning an unreachable URI.
-     * /att/get requests are used to obtain a PoToken challenge.
-     * See: <a href="https://github.com/FreeTubeApp/FreeTube/blob/4b7208430bc1032019a35a35eb7c8a84987ddbd7/src/botGuardScript.js#L15">botGuardScript.js#L15</a>
-     * <p>
-     * Since the Spoof streaming data patch was implemented because a valid PoToken cannot be obtained,
-     * Blocking /att/get requests are not a problem.
-     */
-    public static String blockGetAttRequest(String originalUrlString) {
-        if (SPOOF_VIDEO_STREAMS) {
-            try {
-                var originalUri = Uri.parse(originalUrlString);
-                String path = originalUri.getPath();
-
-                if (path != null && path.contains("att/get")) {
-                    Logger.printDebug(() -> "Blocking 'att/get' by returning internet connection check URI");
-
-                    return INTERNET_CONNECTION_CHECK_URI_STRING;
-                }
-            } catch (Exception ex) {
-                Logger.printException(() -> "blockGetAttRequest failure", ex);
-            }
-        }
-
-        return originalUrlString;
     }
 
     /**

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/js/JavaScriptManager.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/js/JavaScriptManager.java
@@ -205,10 +205,7 @@ public final class JavaScriptManager {
             long lastSavedTime = PLAYER_JS_SAVED_MILLISECONDS.get();
 
             if (!PLAYER_JS_HASH.get().isEmpty()
-                    // If 'Disable player JavaScript update' is enabled, the 'Player JavaScript hash' will always be used.
-                    // In other words, the cache expiration is not checked, and the YouTube iframe API is not fetched either.
-                    && (SharedYouTubeSettings.SPOOF_VIDEO_STREAMS_DISABLE_PLAYER_JS_UPDATE.get()
-                    || currentTime - lastSavedTime < PLAYER_JS_CACHE_EXPIRATION_MILLISECONDS)) {
+                    && currentTime - lastSavedTime < PLAYER_JS_CACHE_EXPIRATION_MILLISECONDS) {
                 // There is a hash saved in the settings and it was saved within 3 days.
                 // Use the hash saved in the settings.
                 cachedPlayerJsHash = PLAYER_JS_HASH.get();

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/quality/PrioritizeVideoQualityPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/quality/PrioritizeVideoQualityPatch.java
@@ -16,7 +16,7 @@ import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
 public final class PrioritizeVideoQualityPatch {
-    private static final boolean PRIORITIZE_VIDEO_QUALITY = Settings.PRIORITIZE_VIDEO_QUALITY.get();
+    private static final boolean PRIORITIZE_VIDEO_QUALITY = Settings.VIDEO_QUALITY_PRIORITIZE.get();
 
     /**
      * Injection point.

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/spoof/SpoofVideoStreamsPatch.java
@@ -4,7 +4,8 @@ import static app.morphe.extension.shared.spoof.ClientType.ANDROID_CREATOR;
 import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_73;
 import static app.morphe.extension.shared.spoof.ClientType.ANDROID_VR_1_74;
 import static app.morphe.extension.shared.spoof.ClientType.TV;
-import static app.morphe.extension.shared.spoof.ClientType.VISIONOS;
+import static app.morphe.extension.shared.spoof.ClientType.VISIONOS_1_02;
+import static app.morphe.extension.shared.spoof.ClientType.VISIONOS_1_03;
 
 import java.util.List;
 
@@ -18,8 +19,9 @@ public class SpoofVideoStreamsPatch {
     public static final class SpoofClientAv1Availability implements Setting.Availability {
         @Override
         public boolean isAvailable() {
+            ClientType client = Settings.SPOOF_VIDEO_STREAMS_CLIENT_TYPE.get();
             return Settings.SPOOF_VIDEO_STREAMS_CLIENT_TYPE.isAvailable()
-                    && Settings.SPOOF_VIDEO_STREAMS_CLIENT_TYPE.get() == ANDROID_VR_1_73;
+                    && (client == ANDROID_VR_1_73 || client == VISIONOS_1_02);
         }
 
         @Override
@@ -34,21 +36,24 @@ public class SpoofVideoStreamsPatch {
     public static void setClientOrderToUse() {
         ClientType client = Settings.SPOOF_VIDEO_STREAMS_CLIENT_TYPE.get();
 
-        // Use VR 1.74 client that has AV1 if user settings allow it.
-        // AVC cannot be forced with VR 1.74 because it uses VP9 and AV1.
-        // If both settings are on, then force AVC takes priority and VR 1.73 is used.
-        if (client == ANDROID_VR_1_73 && Settings.SPOOF_VIDEO_STREAMS_AV1.get()
-                && !Settings.FORCE_AVC_CODEC.get()) {
-            client = ANDROID_VR_1_74;
+        // Use Android VR 1.74 (visonOS 1.03) client that has AV1 if user settings allow it.
+        // AVC cannot be forced with Android VR 1.74 (visonOS 1.03) because it uses VP9 and AV1.
+        // If both settings are on, then force AVC takes priority and Android VR 1.73 (visionOS 1.02) is used.
+        if (Settings.SPOOF_VIDEO_STREAMS_AV1.get() && !Settings.FORCE_AVC_CODEC.get() ) {
+            if (client == ANDROID_VR_1_73) {
+                client = ANDROID_VR_1_74;
+            } else if (client == VISIONOS_1_02) {
+                client = VISIONOS_1_03;
+            }
         }
 
         // Reels can take up to 1 minute for videos start playback.
         // Only use it if the user has selected it.
         List<ClientType> availableClients = List.of(
-                ANDROID_CREATOR,
                 TV,
                 ANDROID_VR_1_73,
-                VISIONOS
+                VISIONOS_1_02,
+                ANDROID_CREATOR
         );
 
         app.morphe.extension.shared.spoof.SpoofVideoStreamsPatch.setClientsToUse(

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -66,7 +66,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting DISABLE_HDR_VIDEO = new BooleanSetting("morphe_disable_hdr_video", FALSE);
     public static final BooleanSetting FORCE_AVC_CODEC = new BooleanSetting("morphe_force_avc_codec", FALSE, true, "morphe_force_avc_codec_user_dialog_message");
     public static final BooleanSetting HIDE_PREMIUM_VIDEO_QUALITY = new BooleanSetting("morphe_hide_premium_video_quality", TRUE, true);
-    public static final BooleanSetting PRIORITIZE_VIDEO_QUALITY = new BooleanSetting("morphe_prioritize_video_quality", TRUE, true);
+    public static final BooleanSetting VIDEO_QUALITY_PRIORITIZE = new BooleanSetting("morphe_video_quality_prioritize", TRUE, true, "morphe_video_quality_prioritize_dialog");
     public static final IntegerSetting VIDEO_QUALITY_DEFAULT_WIFI = new IntegerSetting("morphe_video_quality_default_wifi", -2);
     public static final IntegerSetting VIDEO_QUALITY_DEFAULT_MOBILE = new IntegerSetting("morphe_video_quality_default_mobile", -2);
     public static final BooleanSetting REMEMBER_VIDEO_QUALITY_LAST_SELECTED = new BooleanSetting("morphe_remember_video_quality_last_selected", FALSE);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -66,7 +66,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting DISABLE_HDR_VIDEO = new BooleanSetting("morphe_disable_hdr_video", FALSE);
     public static final BooleanSetting FORCE_AVC_CODEC = new BooleanSetting("morphe_force_avc_codec", FALSE, true, "morphe_force_avc_codec_user_dialog_message");
     public static final BooleanSetting HIDE_PREMIUM_VIDEO_QUALITY = new BooleanSetting("morphe_hide_premium_video_quality", TRUE, true);
-    public static final BooleanSetting PRIORITIZE_VIDEO_QUALITY = new BooleanSetting("morphe_prioritize_video_quality", FALSE, true);
+    public static final BooleanSetting PRIORITIZE_VIDEO_QUALITY = new BooleanSetting("morphe_prioritize_video_quality", TRUE, true);
     public static final IntegerSetting VIDEO_QUALITY_DEFAULT_WIFI = new IntegerSetting("morphe_video_quality_default_wifi", -2);
     public static final IntegerSetting VIDEO_QUALITY_DEFAULT_MOBILE = new IntegerSetting("morphe_video_quality_default_mobile", -2);
     public static final BooleanSetting REMEMBER_VIDEO_QUALITY_LAST_SELECTED = new BooleanSetting("morphe_remember_video_quality_last_selected", FALSE);
@@ -502,7 +502,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting EXTERNAL_BROWSER = new BooleanSetting("morphe_external_browser", TRUE, true);
     public static final BooleanSetting SPOOF_DEVICE_DIMENSIONS = new BooleanSetting("morphe_spoof_device_dimensions", FALSE, true,
             "morphe_spoof_device_dimensions_user_dialog_message");
-    public static final EnumSetting<ClientType> SPOOF_VIDEO_STREAMS_CLIENT_TYPE = new EnumSetting<>("morphe_spoof_video_streams_client_type", ClientType.TV, true, parent(SPOOF_VIDEO_STREAMS));
+    public static final EnumSetting<ClientType> SPOOF_VIDEO_STREAMS_CLIENT_TYPE = new EnumSetting<>("morphe_spoof_video_streams_client_type", ClientType.VISIONOS_1_02, true, parent(SPOOF_VIDEO_STREAMS));
     public static final BooleanSetting SPOOF_VIDEO_STREAMS_AV1 = new BooleanSetting("morphe_spoof_video_streams_av1", FALSE, true,
             "morphe_spoof_video_streams_av1_user_dialog_message", new SpoofClientAv1Availability());
 
@@ -746,8 +746,9 @@ public class Settings extends SharedYouTubeSettings {
             SPOOF_APP_VERSION.resetToDefault();
         }
 
-        // VR 1.74 is not selectable in the settings, and it's selected by spoof stream patch if needed.
-        if (SPOOF_VIDEO_STREAMS_CLIENT_TYPE.get() == ClientType.ANDROID_VR_1_74) {
+        // Android VR 1.74 and visionOS 1.03 are not selectable in the settings and are selected by spoof stream patch if needed.
+        ClientType client = SPOOF_VIDEO_STREAMS_CLIENT_TYPE.get();
+        if (client == ClientType.ANDROID_VR_1_74 || client == ClientType.VISIONOS_1_03) {
             SPOOF_VIDEO_STREAMS_CLIENT_TYPE.resetToDefault();
         }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/preference/ForceAVCSwitchPreference.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/preference/ForceAVCSwitchPreference.java
@@ -13,7 +13,8 @@ import android.content.Context;
 import android.preference.SwitchPreference;
 import android.util.AttributeSet;
 
-import java.util.List;import app.morphe.extension.shared.settings.SharedYouTubeSettings;
+import java.util.List;
+import app.morphe.extension.shared.settings.SharedYouTubeSettings;
 import app.morphe.extension.shared.spoof.ClientType;
 import app.morphe.extension.shared.spoof.SpoofVideoStreamsPatch;
 
@@ -26,7 +27,8 @@ public class ForceAVCSwitchPreference extends SwitchPreference {
             ClientType.ANDROID_CREATOR,
             ClientType.ANDROID_VR_1_74,
             ClientType.ANDROID_VR_1_73,
-            ClientType.VISIONOS).contains(SpoofVideoStreamsPatch.getPreferredClient());
+            ClientType.VISIONOS_1_02,
+            ClientType.VISIONOS_1_03).contains(SpoofVideoStreamsPatch.getPreferredClient());
 
     {
         if (!available) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/preference/SpoofVideoStreamsSideEffectsPreference.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/preference/SpoofVideoStreamsSideEffectsPreference.java
@@ -99,13 +99,11 @@ public class SpoofVideoStreamsSideEffectsPreference extends Preference {
                             + '\n' + str("morphe_spoof_video_streams_about_no_av1")
                             + '\n' + str("morphe_spoof_video_streams_about_720p_max")
                             + '\n' + str("morphe_spoof_video_streams_about_no_force_original_audio");
-            // VR 1.74 is not exposed in the UI and should never be reached here.
-            case ANDROID_VR_1_73, ANDROID_VR_1_74 ->
+            // Android VR 1.74 and visonOS 1.03 are not exposed in the UI and should never be reached here.
+            case ANDROID_VR_1_73, ANDROID_VR_1_74, VISIONOS_1_02, VISIONOS_1_03 ->
                     summary = str("morphe_spoof_video_streams_about_no_stable_volume");
             case TV ->
                     summary = str("morphe_spoof_video_streams_about_js");
-            case VISIONOS ->
-                    summary = str("morphe_spoof_video_streams_about_no_stable_volume");
             default -> Logger.printException(() -> "Unknown client: " + clientType);
         }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/preference/SpoofVideoStreamsSideEffectsPreference.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/preference/SpoofVideoStreamsSideEffectsPreference.java
@@ -99,8 +99,6 @@ public class SpoofVideoStreamsSideEffectsPreference extends Preference {
                             + '\n' + str("morphe_spoof_video_streams_about_no_av1")
                             + '\n' + str("morphe_spoof_video_streams_about_720p_max")
                             + '\n' + str("morphe_spoof_video_streams_about_no_force_original_audio");
-            case ANDROID_REEL_AUTH, ANDROID_REEL_NO_AUTH ->
-                    summary = str("morphe_spoof_video_streams_about_playback_failure");
             // VR 1.74 is not exposed in the UI and should never be reached here.
             case ANDROID_VR_1_73, ANDROID_VR_1_74 ->
                     summary = str("morphe_spoof_video_streams_about_no_stable_volume");

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/spoof/SpoofVideoStreamsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/spoof/SpoofVideoStreamsPatch.kt
@@ -16,7 +16,6 @@ import app.morphe.patches.shared.misc.settings.preference.ListPreference
 import app.morphe.patches.shared.misc.settings.preference.NonInteractivePreference
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
-import app.morphe.patches.shared.misc.settings.preference.TextPreference
 import app.morphe.patches.shared.misc.spoof.spoofVideoStreamsPatch
 
 val spoofVideoStreamsPatch = spoofVideoStreamsPatch(
@@ -52,12 +51,6 @@ val spoofVideoStreamsPatch = spoofVideoStreamsPatch(
                         tag = "app.morphe.extension.music.settings.preference.SpoofVideoStreamsSignInPreference",
                         selectable = true,
                     ),
-                    SwitchPreference(
-                        "morphe_spoof_video_streams_disable_player_js_update",
-                        summary = true,
-                        tag = "app.morphe.extension.shared.settings.preference.BulletPointSwitchPreference",
-                    ),
-                    TextPreference("morphe_spoof_video_streams_player_js_hash_value"),
                 )
             )
         )

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/SpoofVideoStreamsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/SpoofVideoStreamsPatch.kt
@@ -114,7 +114,6 @@ internal fun spoofVideoStreamsPatch(
 
         // region Block /initplayback requests to fall back to /get_watch requests.
 
-
         BuildInitPlaybackRequestFingerprint.let {
             it.method.apply {
                 val moveUriStringIndex = it.instructionMatches.first().index
@@ -170,18 +169,20 @@ internal fun spoofVideoStreamsPatch(
 
         // region Get replacement streams at player requests.
 
-        BuildRequestFingerprint.method.apply {
-            val newRequestBuilderIndex = BuildRequestFingerprint.instructionMatches.first().index
-            val buildRequestMethodURLRegister = getInstruction<FiveRegisterInstruction>(newRequestBuilderIndex).registerD
-            val freeRegister = findFreeRegister(newRequestBuilderIndex, buildRequestMethodURLRegister)
+        BuildRequestFingerprint.let {
+            it.method.apply {
+                val newRequestBuilderIndex = it.instructionMatches.first().index
+                val buildRequestMethodURLRegister = getInstruction<FiveRegisterInstruction>(newRequestBuilderIndex).registerD
+                val freeRegister = findFreeRegister(newRequestBuilderIndex, buildRequestMethodURLRegister)
 
-            addInstructions(
-                newRequestBuilderIndex,
-                """
-                    move-object v$freeRegister, p1
-                    invoke-static { v$buildRequestMethodURLRegister, v$freeRegister }, $EXTENSION_CLASS->fetchStreams(Ljava/lang/String;Ljava/util/Map;)V
-                """
-            )
+                addInstructions(
+                    newRequestBuilderIndex,
+                    """
+                        move-object v$freeRegister, p1
+                        invoke-static { v$buildRequestMethodURLRegister, v$freeRegister }, $EXTENSION_CLASS->fetchStreams(Ljava/lang/String;Ljava/util/Map;)V
+                    """
+                )
+            }
         }
 
         // endregion
@@ -300,26 +301,6 @@ internal fun spoofVideoStreamsPatch(
                 addInstruction(
                     videoDetailsIndex + 1,
                     "invoke-direct { p0, v$videoDetailsRegister, p1 }, $helperMethod"
-                )
-            }
-        }
-
-        // endregion
-
-        // region block getAtt request
-
-        BuildRequestFingerprint.let {
-            it.method.apply {
-                val insertIndex = indexOfNewUrlRequestBuilderInstruction(this)
-                val register = it.instructionMatches.first()
-                    .getInstruction<FiveRegisterInstruction>().registerD
-
-                addInstructions(
-                    insertIndex,
-                    """
-                        invoke-static { v$register }, $EXTENSION_CLASS->blockGetAttRequest(Ljava/lang/String;)Ljava/lang/String;
-                        move-result-object v$register
-                    """
                 )
             }
         }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/spoof/SpoofVideoStreamsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/spoof/SpoofVideoStreamsPatch.kt
@@ -4,7 +4,6 @@ import app.morphe.patches.shared.misc.settings.preference.ListPreference
 import app.morphe.patches.shared.misc.settings.preference.NonInteractivePreference
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
-import app.morphe.patches.shared.misc.settings.preference.TextPreference
 import app.morphe.patches.shared.misc.spoof.spoofVideoStreamsPatch
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.playservice.is_20_31_or_greater
@@ -69,12 +68,6 @@ val spoofVideoStreamsPatch = spoofVideoStreamsPatch(
                     ),
                     SwitchPreference("morphe_spoof_video_streams_av1", summary = true),
                     ListPreference("morphe_spoof_video_streams_player_js_variant"),
-                    SwitchPreference(
-                        "morphe_spoof_video_streams_disable_player_js_update",
-                        summary = true,
-                        tag = "app.morphe.extension.shared.settings.preference.BulletPointSwitchPreference",
-                    ),
-                    TextPreference("morphe_spoof_video_streams_player_js_hash_value"),
                     SwitchPreference("morphe_spoof_video_streams_stats_for_nerds"),
                 )
             )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/quality/PrioritizeVideoQualityPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/quality/PrioritizeVideoQualityPatch.kt
@@ -25,7 +25,7 @@ internal val prioritizeVideoQualityPatch = bytecodePatch {
 
     execute {
         settingsMenuVideoQualityGroup.add(
-            SwitchPreference("morphe_prioritize_video_quality", summary = true)
+            SwitchPreference("morphe_video_quality_prioritize", summary = true)
         )
 
         VideoStreamingDataConstructorFingerprint.let {

--- a/patches/src/main/resources/addresources/values/music/arrays.xml
+++ b/patches/src/main/resources/addresources/values/music/arrays.xml
@@ -137,7 +137,7 @@
         <item>ANDROID_MUSIC_NO_SDK</item>
         <item>ANDROID_VR_1_73</item>
         <item>TV</item>
-        <item>VISIONOS</item>
+        <item>VISIONOS_1_02</item>
     </string-array>
 
     <!-- misc.spoof.appversion.spoofAppVersionPatch -->

--- a/patches/src/main/resources/addresources/values/music/arrays.xml
+++ b/patches/src/main/resources/addresources/values/music/arrays.xml
@@ -127,12 +127,14 @@
     <!-- misc.spoof.spoofVideoStreamsPatch -->
     <string-array name="morphe_spoof_video_streams_client_type_entries">
         <item>Android Music Reel</item>
+        <item>Android Music No SDK</item>
         <item>Android VR</item>
         <item>TV</item>
         <item>visionOS</item>
     </string-array>
     <string-array name="morphe_spoof_video_streams_client_type_entry_values">
         <item>ANDROID_MUSIC_REEL</item>
+        <item>ANDROID_MUSIC_NO_SDK</item>
         <item>ANDROID_VR_1_73</item>
         <item>TV</item>
         <item>VISIONOS</item>

--- a/patches/src/main/resources/addresources/values/music/arrays.xml
+++ b/patches/src/main/resources/addresources/values/music/arrays.xml
@@ -126,14 +126,12 @@
 
     <!-- misc.spoof.spoofVideoStreamsPatch -->
     <string-array name="morphe_spoof_video_streams_client_type_entries">
-        <item>Android Reel</item>
         <item>Android Music Reel</item>
         <item>Android VR</item>
         <item>TV</item>
         <item>visionOS</item>
     </string-array>
     <string-array name="morphe_spoof_video_streams_client_type_entry_values">
-        <item>ANDROID_REEL_NO_AUTH</item>
         <item>ANDROID_MUSIC_REEL</item>
         <item>ANDROID_VR_1_73</item>
         <item>TV</item>

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -108,17 +108,6 @@ To sign in, press continue below"</string>
     <string name="morphe_oauth2_connection_failure_auth_error">Cannot sign in to VR: %s</string>
     <string name="morphe_oauth2_toast_reset">Logged out of Android VR</string>
     <string name="morphe_oauth2_toast_invalid">Invalid VR sign in token, try signing in to VR again</string>
-    <string name="morphe_spoof_video_streams_disable_player_js_update_title">Disable player JavaScript update</string>
-    <string name="morphe_spoof_video_streams_disable_player_js_update_summary">"Locks the player JavaScript to a specific version
-
-• A valid player JavaScript hash is required
-• Player JavaScript hashes are valid for approximately one month, and outdated hashes will be revoked by GVS
-• Playback fails if the hash is revoked"</string>
-    <string name="morphe_spoof_video_streams_disable_player_js_update_user_dialog_message">"You need to provide a valid player JavaScript hash.
-
-Playback will fail if the Player JavaScript hash is outdated."</string>
-    <string name="morphe_spoof_video_streams_player_js_hash_value_title">Player JavaScript hash</string>
-    <string name="morphe_spoof_video_streams_player_js_hash_value_summary">Enter a valid player JavaScript hash</string>
 
     <!-- misc.quic.disableQUICProtocolPatch -->
     <string name="morphe_disable_quic_protocol_title">Disable QUIC protocol</string>

--- a/patches/src/main/resources/addresources/values/youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/youtube/arrays.xml
@@ -116,7 +116,7 @@
         <item>ANDROID_CREATOR</item>
         <item>ANDROID_VR_1_73</item>
         <item>TV</item>
-        <item>VISIONOS</item>
+        <item>VISIONOS_1_02</item>
     </string-array>
     <string-array name="morphe_spoof_video_streams_player_js_variant_entries">
         <item>House Brand</item>

--- a/patches/src/main/resources/addresources/values/youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/youtube/arrays.xml
@@ -107,16 +107,12 @@
 
     <!-- misc.spoof.spoofVideoStreamsPatch -->
     <string-array name="morphe_spoof_video_streams_client_type_entries">
-        <item>Android Reel Auth</item>
-        <item>Android Reel No auth</item>
         <item>Android Studio</item>
         <item>Android VR</item>
         <item>TV</item>
         <item>visionOS</item>
     </string-array>
     <string-array name="morphe_spoof_video_streams_client_type_entry_values">
-        <item>ANDROID_REEL_AUTH</item>
-        <item>ANDROID_REEL_NO_AUTH</item>
         <item>ANDROID_CREATOR</item>
         <item>ANDROID_VR_1_73</item>
         <item>TV</item>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1205,8 +1205,9 @@ Limitations:
     <string name="morphe_hide_premium_video_quality_title">Hide Premium quality options</string>
 
     <!-- video.quality.prioritizeVideoQualityPatch -->
-    <string name="morphe_prioritize_video_quality_title">Prioritize video quality</string>
-    <string name="morphe_prioritize_video_quality_summary">Prioritizes the highest available video quality over codec efficiency</string>
+    <string name="morphe_video_quality_prioritize_title">Prioritize video quality</string>
+    <string name="morphe_video_quality_prioritize_summary">Prioritizes the highest available video quality over codec efficiency</string>
+    <string name="morphe_video_quality_prioritize_dialog">If this setting is turned off, then older videos can show no video quality options</string>
 
     <!-- misc.spoof.spoofVideoStreamsPatch -->
     <string name="morphe_spoof_video_streams_av1_title">Allow Android VR / visionOS AV1</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1195,7 +1195,7 @@ Limitations:
 • HDR videos will not use AVC
 • Some devices cannot force AVC"</string>
     <!-- 'Spoof video streams' should be the same translation used for 'morphe_spoof_video_streams_screen_title'. -->
-    <string name="morphe_force_avc_codec_not_available">To use this feature, set \'Spoof video streams\' to Android VR or Android Studio</string>
+    <string name="morphe_force_avc_codec_not_available">To use this feature, set \'Spoof video streams\' to \'Android VR or \'Android Studio\'</string>
 
     <!-- video.quality.advancedVideoQualityMenuPatch -->
     <string name="morphe_advanced_video_quality_menu_title">Open Advanced quality menu</string>
@@ -1209,8 +1209,8 @@ Limitations:
     <string name="morphe_prioritize_video_quality_summary">Prioritizes the highest available video quality over codec efficiency</string>
 
     <!-- misc.spoof.spoofVideoStreamsPatch -->
-    <string name="morphe_spoof_video_streams_av1_title">Allow Android VR AV1</string>
-    <string name="morphe_spoof_video_streams_av1_summary">Permits software AV1 decoding when using the Android VR client</string>
+    <string name="morphe_spoof_video_streams_av1_title">Allow Android VR / visionOS AV1</string>
+    <string name="morphe_spoof_video_streams_av1_summary">Permits software AV1 decoding when using the Android VR / visionOS client</string>
     <string name="morphe_spoof_video_streams_av1_user_dialog_message">"Enabling this setting may use software AV1 decoding.
 
 Video playback with AV1 may stutter or drop frames."</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1215,7 +1215,6 @@ Limitations:
 
 Video playback with AV1 may stutter or drop frames."</string>
     <string name="morphe_spoof_video_streams_about_title">Spoofing side effects</string>
-    <string name="morphe_spoof_video_streams_about_playback_failure">• Video may stop at 1:00, or may not be available in some regions</string>
     <string name="morphe_spoof_video_streams_about_no_audio_tracks">• Audio track menu is missing</string>
     <string name="morphe_spoof_video_streams_about_no_av1">• No AV1 video codec</string>
     <string name="morphe_spoof_video_streams_about_no_immersive_mode">• 360° VR immersive mode is not available</string>


### PR DESCRIPTION
### Removed `Android Reel` client

The `Android Reel` client now always requires a PoToken, regardless of the client version or SABR support, just like the `Android No SDK` client.

To avoid opening duplicate issues, the `Android Reel` client has been completely removed.

### Default client changed to `visionOS`

Videos that cannot be played on the `visionOS` client will attempt to be played on the `TV` client.

### `Allow Android VR AV1` renamed to `Allow Android VR / visionOS AV1`

Since #2094, ​​the `visionOS` client has been forced to use the AV1 codec.

Similar to the `Android VR` client, the AV1 codec is enabled only when `Allow Android VR / visionOS AV1` is turned on.

### The default value for `Prioritize video quality` has been changed to on.

This setting is required for some videos when `Allow Android VR / visionOS AV1` is turned off.

If `Prioritize video quality` is turned off, video quality may not be available for some videos.

### Removed `Disable player JavaScript update` and `Player JavaScript hash`

If this setting is accidentally turned on or if an old setting is imported, the `TV` client may not work.

### Restored `Android Music No SDK` client

This client has been restored as it is still working.

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
