### PR TITLE
fix(YouTube - Swipe controls): Evaluate swipe zone before recycling MotionEvent

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/controller/gesture/core/BaseGestureController.kt
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/controller/gesture/core/BaseGestureController.kt
@@ -66,6 +66,9 @@ abstract class BaseGestureController(
         // if we force intercept events, the event is always consumed
         val consumed = detector.onTouchEvent(me) || shouldForceInterceptEvents
 
+        // evaluate swipe zone before recycling
+        val inSwipeZone = isInSwipeZone(me)
+
         // invoke the custom onUp handler
         if (me.action == MotionEvent.ACTION_UP || me.action == MotionEvent.ACTION_CANCEL) {
             onUp(me)
@@ -76,7 +79,7 @@ abstract class BaseGestureController(
 
         // do not consume dropped events
         // or events outside any swipe zone
-        return !dropped && consumed && isInSwipeZone(me)
+        return !dropped && consumed && inSwipeZone
     }
 
     /**


### PR DESCRIPTION
## Description
Fixes a use-after-recycle bug in `BaseGestureController.submitTouchEvent()` where `isInSwipeZone(me)` was called after `me.recycle()`, reading coordinates from a recycled `MotionEvent`.

## Root Cause
`me.recycle()` returns the cloned `MotionEvent` to Android's memory pool. Calling `isInSwipeZone(me)` after recycling reads $X$ and $Y$ coordinates from recycled memory, causing undefined behavior or inaccurate zone detection.

## Solution
Evaluated `isInSwipeZone(me)` prior to calling `me.recycle()` and stored the result in a local `inSwipeZone` value.