### PR TITLE
feat: Add `Change installer source` universal patch

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 [versions]
 morphe-patcher = "1.7.0"
-morphe-patches-library = "1.5.1-dev.2"
+morphe-patches-library = "1.5.2-dev.6"
 # Tracking https://github.com/google/smali/issues/100.
 smali = "d92701d947"
 agp = "9.1.0"

--- a/patches/src/main/kotlin/app/morphe/patches/all/misc/installer/ChangeInstallerSource.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/all/misc/installer/ChangeInstallerSource.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2257
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.patches.all.misc.installer
+
+import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patcher.patch.stringOption
+import app.morphe.patches.all.misc.fix.changepackageinstaller.changePackageInstallerPatch
+
+@Suppress("unused")
+val changeInstallerSource = resourcePatch(
+    name = "Change installer source",
+    description = "Spoofs the installer source so the app appears to be installed from an app store.",
+    default = false
+) {
+    val packageInstallerName = stringOption(
+        key = "packageInstallerName",
+        default = "com.android.vending",
+        values = mapOf(
+            "Google Play" to "com.android.vending",
+            "Samsung Galaxy Store" to "com.sec.android.app.samsungapps",
+            "Amazon Appstore" to "com.amazon.venezia",
+            "Huawei AppGallery" to "com.huawei.appmarket",
+            "Xiaomi GetApps" to "com.xiaomi.mipicks"
+        ),
+        title = "Spoofed package installer name"
+    )
+
+    dependsOn(
+        changePackageInstallerPatch({ packageInstallerName.value!! })
+    )
+}

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/misc/fix/signature/SpoofSignaturePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/misc/fix/signature/SpoofSignaturePatch.kt
@@ -8,7 +8,7 @@
 package app.morphe.patches.reddit.misc.fix.signature
 
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.patches.all.misc.fix.changepackageinstaller.changePackageInstallerPatch
+import app.morphe.patches.all.misc.installer.changeInstallerSource
 import app.morphe.patches.reddit.misc.extension.sharedExtensionPatch
 import app.morphe.patches.reddit.shared.Constants.COMPATIBILITY_REDDIT
 
@@ -22,7 +22,7 @@ val spoofSignaturePatch = bytecodePatch(
 ) {
     compatibleWith(COMPATIBILITY_REDDIT)
 
-    dependsOn(sharedExtensionPatch, changePackageInstallerPatch())
+    dependsOn(sharedExtensionPatch, changeInstallerSource)
 
     execute {
         ApplicationFingerprint.classDef.setSuperClass(EXTENSION_CLASS)


### PR DESCRIPTION
### Description

Adds a universal patch to spoof the installer source used by any internal app code.

This can fix apps that look for an app store installation source and block side loading usage.

Patch idea was first done by [inotia00](https://github.com/inotia00/revanced-patches/commit/aef0cbb7eb2fff3783f4f22a2f613e079040cd08), but the code here was wrote from scratch using Morphe patcher features.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
