### PR TITLE
fix(YouTube - Swipe controls): Resolve memory leaks in swipe controls

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/SwipeControlsHostActivity.kt
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/SwipeControlsHostActivity.kt
@@ -86,6 +86,11 @@ class SwipeControlsHostActivity : Activity() {
         reAttachOverlays()
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        PlayerType.onChange -= this::onPlayerTypeChanged
+    }
+
     override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
         ensureInitialized()
         return if ((ev != null) && gesture.submitTouchEvent(ev)) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/controller/gesture/ClassicSwipeController.kt
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/controller/gesture/ClassicSwipeController.kt
@@ -58,6 +58,12 @@ class ClassicSwipeController(
         return arePlayerControlsVisible
     }
 
+    override fun onUp(motionEvent: MotionEvent) {
+        super.onUp(motionEvent)
+        lastOnDownEvent?.recycle()
+        lastOnDownEvent = null
+    }
+
     override fun onDown(motionEvent: MotionEvent): Boolean {
         // save the event for later
         lastOnDownEvent?.recycle()


### PR DESCRIPTION
Resolves two memory leaks in the YouTube extension's swipe controls:
1. **Activity Context Leak (`SwipeControlsHostActivity.kt`)**: 
   - **Issue**: The activity binds a listener to the global `PlayerType.onChange` event emitter on initialization, but fails to unregister it during teardown. This retains a strong reference path to destroyed Activity instances across device rotations and PiP transitions, leaking entire window contexts.
   - **Fix**: Added an `onDestroy()` override to unregister the listener from the static event emitter.
2. **Native Event Pool Leak (`ClassicSwipeController.kt`)**:
   - **Issue**: A cloned touch event (`lastOnDownEvent`) obtained via `MotionEvent.obtain()` was not recycled when gestures completed, leaking native JNI memory and causing input framework pool starvation.
   - **Fix**: Overrode `onUp()` to recycle and nullify `lastOnDownEvent` immediately when a touch gesture ends or cancels.