### PR TITLE
fix: Mirror in RTL locales and restyle to match the manager

### DIFF
--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutDialogStyle.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutDialogStyle.java
@@ -300,6 +300,35 @@ final class AboutDialogStyle {
                         transform: scaleX(-1);
                     }
 
+                    /* Bundled license text. Kept selectable, since users do copy legal notices. */
+                    .license-body {
+                        padding: 16px;
+                        -webkit-user-select: text;
+                        user-select: text;
+                    }
+                    .license-body h2 {
+                        font-size: 13px;
+                        font-weight: 600;
+                        color: {accent};
+                        word-break: break-all;
+                        border-bottom: 1px solid rgba(128, 128, 128, 0.20);
+                        padding-bottom: 6px;
+                        margin-top: 24px;
+                    }
+                    .license-body h2:first-of-type {
+                        margin-top: 0;
+                    }
+                    .license-body pre {
+                        margin: 0;
+                        font-family: monospace;
+                        font-size: 13px;
+                        line-height: 1.6;
+                        white-space: pre;
+                    }
+                    .license-body a {
+                        color: {accent};
+                    }
+
                     /* Credits contributor initial. */
                     .avatar {
                         width: 30px;

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutDialogStyle.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutDialogStyle.java
@@ -50,27 +50,12 @@ final class AboutDialogStyle {
             "M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 "
                     + "240v480q0 33-23.5 56.5T720-80H240Zm280-520v-200H240v640h480v-440H520ZM240-800v200-200 640-640Z";
     private static final String PATH_CHEVRON = "M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z";
-
-    // Brand marks, 24px viewBox.
-    private static final String PATH_GITHUB =
-            "M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338"
-                    + ".724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 "
-                    + "1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 "
-                    + "0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 "
-                    + "1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 "
-                    + "3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 "
-                    + "22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12";
-    private static final String PATH_REDDIT =
-            "M12 0C5.373 0 0 5.373 0 12c0 3.314 1.343 6.314 3.515 8.485l-2.286 2.286C.775 23.225 1.097 24 1.738 24H12c6.627 0 12-5.373 "
-                    + "12-12S18.627 0 12 0Zm4.388 3.199c1.104 0 1.999.895 1.999 1.999 0 1.105-.895 2-1.999 2-.946 0-1.739-.657-1.947-1.539v"
-                    + ".002c-1.147.162-2.032 1.15-2.032 2.341v.007c1.776.067 3.4.567 4.686 1.363.473-.363 1.064-.58 1.707-.58 1.547 0 2.802 "
-                    + "1.254 2.802 2.802 0 1.117-.655 2.081-1.601 2.531-.088 3.256-3.637 5.876-7.997 5.876-4.361 0-7.905-2.617-7.998-5.87-.954"
-                    + "-.447-1.614-1.415-1.614-2.538 0-1.548 1.255-2.802 2.803-2.802.645 0 1.239.218 1.712.585 1.275-.79 2.881-1.291 4.64-1.365v"
-                    + "-.01c0-1.663 1.263-3.034 2.88-3.207.188-.911.993-1.595 1.959-1.595Zm-8.085 8.376c-.784 0-1.459.78-1.506 1.797-.047 1.016"
-                    + ".64 1.429 1.426 1.429.786 0 1.371-.369 1.418-1.385.047-1.017-.553-1.841-1.338-1.841Zm7.406 0c-.786 0-1.385.824-1.338 "
-                    + "1.841.047 1.017.634 1.385 1.418 1.385.785 0 1.473-.413 1.426-1.429-.046-1.017-.721-1.797-1.506-1.797Zm-3.703 4.013c-.974 "
-                    + "0-1.907.048-2.77.135-.147.015-.241.168-.183.305.483 1.154 1.622 1.964 2.953 1.964 1.33 0 2.47-.81 2.953-1.964.057-.137"
-                    + "-.037-.29-.184-.305-.863-.087-1.795-.135-2.769-.135Z";
+    private static final String PATH_CODE =
+            "M320-240 80-480l240-240 57 57-184 184 183 183-56 56Zm320 0-57-57 184-184-183-183 56-56 240 240-240 240Z";
+    private static final String PATH_FORUM =
+            "M280-240q-17 0-28.5-11.5T240-280v-80h520v-360h80q17 0 28.5 11.5T880-680v600L720-240H280ZM80-280v-560q0-17 "
+                    + "11.5-28.5T120-880h520q17 0 28.5 11.5T680-840v360q0 17-11.5 28.5T640-440H240L80-280Zm520-240v-280H160v280h440Zm-440 "
+                    + "0v-280 280Z";
 
     /**
      * Wraps text in Unicode isolate marks so a left to right token such as a version name keeps its
@@ -93,10 +78,6 @@ final class AboutDialogStyle {
         return "<svg viewBox='0 -960 960 960'><path d='" + path + "'/></svg>";
     }
 
-    private static String brandIcon(String path) {
-        return "<svg viewBox='0 0 24 24'><path d='" + path + "'/></svg>";
-    }
-
     /**
      * @return An icon for a link, matched on the URL because link names arrive localized.
      */
@@ -104,8 +85,8 @@ final class AboutDialogStyle {
         if (url == null) return materialIcon(PATH_PUBLIC);
 
         String lower = url.toLowerCase(Locale.US);
-        if (lower.contains("github.com")) return brandIcon(PATH_GITHUB);
-        if (lower.contains("reddit.com")) return brandIcon(PATH_REDDIT);
+        if (lower.contains("github.com")) return materialIcon(PATH_CODE);
+        if (lower.contains("reddit.com")) return materialIcon(PATH_FORUM);
         if (lower.contains("crowdin") || lower.contains("translate")) return materialIcon(PATH_TRANSLATE);
         if (lower.contains("donat")) return materialIcon(PATH_FAVORITE);
         if (lower.startsWith("https://license")) return materialIcon(PATH_DESCRIPTION);

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutDialogStyle.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutDialogStyle.java
@@ -99,6 +99,25 @@ final class AboutDialogStyle {
     }
 
     /**
+     * @return The text with the characters that would otherwise be read as markup escaped.
+     */
+    static String escapeHtml(String text) {
+        return text
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;");
+    }
+
+    /**
+     * @return The escaped text with any urls in it turned into links, so the addresses named inside
+     *         a license can be opened.
+     */
+    static String linkifyHtml(String text) {
+        return escapeHtml(text)
+                .replaceAll("(https?://[^\\s<>\"]+)", "<a href='$1'>$1</a>");
+    }
+
+    /**
      * @return A heading for the group of rows that follows it.
      */
     static String sectionTitle(String text) {

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutDialogStyle.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutDialogStyle.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2221
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
 package app.morphe.extension.shared.settings.preference.about;
 
 import java.util.Locale;

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutDialogStyle.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutDialogStyle.java
@@ -1,0 +1,321 @@
+package app.morphe.extension.shared.settings.preference.about;
+
+import java.util.Locale;
+
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.settings.BaseSettings;
+
+/**
+ * HTML scaffolding shared by the About and Credits dialogs, styled to match Morphe.
+ * <p>
+ * Both dialogs render into a WebView, so the look has to be rebuilt in CSS. Holding the
+ * stylesheet, the icon set and the document direction in one place keeps them consistent.
+ */
+final class AboutDialogStyle {
+
+    private AboutDialogStyle() {
+    }
+
+    /**
+     * Morphe logo gradient.
+     */
+    private static final String MORPHE_BLUE = "#1E5AA8";
+    private static final String MORPHE_TEAL = "#00AFAE";
+
+    // Material Symbols outlined, 24dp. The same icons Morphe shows for these entries.
+    private static final String PATH_PUBLIC =
+            "M480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 "
+                    + "31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm-40-82v-78q-33 "
+                    + "0-56.5-23.5T360-320v-40L168-552q-3 18-5.5 36t-2.5 36q0 121 79.5 212T440-162Zm276-102q20-22 "
+                    + "36-47.5t26.5-53q10.5-27.5 16-56.5t5.5-59q0-98-54.5-179T600-776v16q0 33-23.5 56.5T520-680h-80v80q0 "
+                    + "17-11.5 28.5T400-560h-80v80h240q17 0 28.5 11.5T600-440v120h40q26 0 47 15.5t29 40.5Z";
+    private static final String PATH_FAVORITE =
+            "m480-120-58-52q-101-91-167-157T150-447.5Q111-500 95.5-544T80-634q0-94 63-157t157-63q52 0 99 22t81 62q34-40 "
+                    + "81-62t99-22q94 0 157 63t63 157q0 46-15.5 90T810-447.5Q771-395 705-329T538-172l-58 52Zm0-108q96-86 "
+                    + "158-147.5t98-107q36-45.5 50-81t14-70.5q0-60-40-100t-100-40q-47 0-87 26.5T518-680h-76q-15-41-55-67.5T300-774q-60 "
+                    + "0-100 40t-40 100q0 35 14 70.5t50 81q36 45.5 98 107T480-228Zm0-273Z";
+    private static final String PATH_TRANSLATE =
+            "m476-80 182-480h84L924-80h-84l-43-122H603L560-80h-84ZM160-200l-56-56 202-202q-35-35-63.5-80T190-640h84q20 39 "
+                    + "40 68t48 58q33-33 68.5-92.5T484-720H40v-80h280v-80h80v80h280v80H564q-21 72-63 148t-83 116l96 98-30 "
+                    + "82-122-125-202 201Zm468-72h144l-72-204-72 204Z";
+    private static final String PATH_GROUP =
+            "M40-160v-112q0-34 17.5-62.5T104-378q62-31 126-46.5T360-440q66 0 130 15.5T616-378q29 15 46.5 43.5T680-272v112H40Zm720 "
+                    + "0v-120q0-44-24.5-84.5T666-434q51 6 96 20.5t84 35.5q36 20 55 44.5t19 53.5v120H760ZM360-480q-66 "
+                    + "0-113-47t-47-113q0-66 47-113t113-47q66 0 113 47t47 113q0 66-47 113t-113 47Zm400-160q0 66-47 "
+                    + "113t-113 47q-11 0-28-2.5t-28-5.5q27-32 41.5-71t14.5-81q0-42-14.5-81T544-792q14-5 28-6.5t28-1.5q66 "
+                    + "0 113 47t47 113ZM120-240h480v-32q0-11-5.5-20T580-306q-54-27-109-40.5T360-360q-56 0-111 13.5T140-306q-9 "
+                    + "5-14.5 14t-5.5 20v32Zm240-320q33 0 56.5-23.5T440-640q0-33-23.5-56.5T360-720q-33 0-56.5 23.5T280-640q0 "
+                    + "33 23.5 56.5T360-560Zm0 320Zm0-400Z";
+    private static final String PATH_DESCRIPTION =
+            "M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 "
+                    + "240v480q0 33-23.5 56.5T720-80H240Zm280-520v-200H240v640h480v-440H520ZM240-800v200-200 640-640Z";
+    private static final String PATH_CHEVRON = "M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z";
+
+    // Brand marks, 24px viewBox.
+    private static final String PATH_GITHUB =
+            "M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338"
+                    + ".724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 "
+                    + "1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 "
+                    + "0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 "
+                    + "1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 "
+                    + "3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 "
+                    + "22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12";
+    private static final String PATH_REDDIT =
+            "M12 0C5.373 0 0 5.373 0 12c0 3.314 1.343 6.314 3.515 8.485l-2.286 2.286C.775 23.225 1.097 24 1.738 24H12c6.627 0 12-5.373 "
+                    + "12-12S18.627 0 12 0Zm4.388 3.199c1.104 0 1.999.895 1.999 1.999 0 1.105-.895 2-1.999 2-.946 0-1.739-.657-1.947-1.539v"
+                    + ".002c-1.147.162-2.032 1.15-2.032 2.341v.007c1.776.067 3.4.567 4.686 1.363.473-.363 1.064-.58 1.707-.58 1.547 0 2.802 "
+                    + "1.254 2.802 2.802 0 1.117-.655 2.081-1.601 2.531-.088 3.256-3.637 5.876-7.997 5.876-4.361 0-7.905-2.617-7.998-5.87-.954"
+                    + "-.447-1.614-1.415-1.614-2.538 0-1.548 1.255-2.802 2.803-2.802.645 0 1.239.218 1.712.585 1.275-.79 2.881-1.291 4.64-1.365v"
+                    + "-.01c0-1.663 1.263-3.034 2.88-3.207.188-.911.993-1.595 1.959-1.595Zm-8.085 8.376c-.784 0-1.459.78-1.506 1.797-.047 1.016"
+                    + ".64 1.429 1.426 1.429.786 0 1.371-.369 1.418-1.385.047-1.017-.553-1.841-1.338-1.841Zm7.406 0c-.786 0-1.385.824-1.338 "
+                    + "1.841.047 1.017.634 1.385 1.418 1.385.785 0 1.473-.413 1.426-1.429-.046-1.017-.721-1.797-1.506-1.797Zm-3.703 4.013c-.974 "
+                    + "0-1.907.048-2.77.135-.147.015-.241.168-.183.305.483 1.154 1.622 1.964 2.953 1.964 1.33 0 2.47-.81 2.953-1.964.057-.137"
+                    + "-.037-.29-.184-.305-.863-.087-1.795-.135-2.769-.135Z";
+
+    /**
+     * Wraps text in Unicode isolate marks so a left to right token such as a version name keeps its
+     * internal order when placed inside right to left text. Without this the bidi algorithm splits
+     * {@code 1.37.0-dev.4} at the hyphen and renders it as {@code dev.4-1.37.0}.
+     */
+    static String isolateLtr(String text) {
+        return '\u2066' + text + '\u2069';
+    }
+
+    /**
+     * @return The accent used for icons and highlights, picked from the logo gradient so it stays
+     *         legible against the current dialog background.
+     */
+    private static String accentColor() {
+        return Utils.isDarkModeEnabled() ? MORPHE_TEAL : MORPHE_BLUE;
+    }
+
+    private static String materialIcon(String path) {
+        return "<svg viewBox='0 -960 960 960'><path d='" + path + "'/></svg>";
+    }
+
+    private static String brandIcon(String path) {
+        return "<svg viewBox='0 0 24 24'><path d='" + path + "'/></svg>";
+    }
+
+    /**
+     * @return An icon for a link, matched on the URL because link names arrive localized.
+     */
+    static String linkIcon(String url) {
+        if (url == null) return materialIcon(PATH_PUBLIC);
+
+        String lower = url.toLowerCase(Locale.US);
+        if (lower.contains("github.com")) return brandIcon(PATH_GITHUB);
+        if (lower.contains("reddit.com")) return brandIcon(PATH_REDDIT);
+        if (lower.contains("crowdin") || lower.contains("translate")) return materialIcon(PATH_TRANSLATE);
+        if (lower.contains("donat")) return materialIcon(PATH_FAVORITE);
+        if (lower.startsWith("https://license")) return materialIcon(PATH_DESCRIPTION);
+        if (lower.contains("credits")) return materialIcon(PATH_GROUP);
+        return materialIcon(PATH_PUBLIC);
+    }
+
+    static String chevron() {
+        return "<span class=\"item-chevron\">" + materialIcon(PATH_CHEVRON) + "</span>";
+    }
+
+    /**
+     * @return A heading for the group of rows that follows it.
+     */
+    static String sectionTitle(String text) {
+        return "<div class=\"section-title\">" + text + "</div>";
+    }
+
+    /**
+     * @return Everything up to and including the opening body tag, with the document direction and
+     *         theme colors already applied. The direction follows the Morphe language override
+     *         rather than the device locale, since that is what the dialog strings are resolved to.
+     */
+    static String documentStart() {
+        return DOCUMENT_START
+                .replace("{dir}", Utils.isRightToLeftLocale(
+                        BaseSettings.MORPHE_LANGUAGE.get().getLocale()) ? "rtl" : "ltr")
+                .replace("{bg}", Utils.getColorHexString(Utils.getDialogBackgroundColor()))
+                .replace("{fg}", Utils.getColorHexString(Utils.getAppForegroundColor()))
+                .replace("{accent}", accentColor())
+                .replace("{blue}", MORPHE_BLUE)
+                .replace("{teal}", MORPHE_TEAL);
+    }
+
+    static final String DOCUMENT_END = "</body></html>";
+
+    /**
+     * Surfaces are drawn with neutral gray overlays rather than tints of the foreground color, so a
+     * single stylesheet reads correctly against both the light and the AMOLED dialog backgrounds.
+     */
+    private static final String DOCUMENT_START = """
+            <html dir="{dir}">
+            <head>
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <style>
+                    * {
+                        margin: 0;
+                        padding: 0;
+                        box-sizing: border-box;
+                    }
+                    body {
+                        background: {bg};
+                        color: {fg};
+                        font-family: Roboto, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+                        -webkit-tap-highlight-color: transparent;
+                        -webkit-touch-callout: none;
+                        -webkit-user-select: none;
+                        user-select: none;
+                    }
+
+                    /* Header. The About dialog fills it with the logo, the Credits dialog with a title. */
+                    .dialog-header {
+                        padding: 24px 20px 4px;
+                        text-align: center;
+                    }
+                    .app-logo {
+                        width: 96px;
+                        height: 96px;
+                        margin: 0 auto 14px;
+                        border-radius: 24px;
+                        background: linear-gradient(135deg, {blue} 0%, {teal} 100%);
+                        padding: 8px;
+                    }
+                    .app-logo-inner {
+                        width: 100%;
+                        height: 100%;
+                        border-radius: 18px;
+                        background: #EEEEEE;
+                        overflow: hidden;
+                    }
+                    .app-logo img {
+                        width: 100%;
+                        height: 100%;
+                        object-fit: contain;
+                    }
+                    .app-name {
+                        font-size: 22px;
+                        font-weight: 700;
+                    }
+                    .dialog-title {
+                        font-size: 18px;
+                        font-weight: 700;
+                    }
+
+                    /* Version status and dev build notes. */
+                    .info-card {
+                        margin-top: 14px;
+                        padding: 12px 14px;
+                        border-radius: 14px;
+                        text-align: center;
+                        background: rgba(128, 128, 128, 0.10);
+                        border: 1px solid rgba(128, 128, 128, 0.16);
+                    }
+                    .info-card h3 {
+                        font-size: 13px;
+                        font-weight: 600;
+                        color: {accent};
+                        margin-bottom: 3px;
+                    }
+                    .info-card p {
+                        font-size: 12px;
+                        opacity: 0.7;
+                        line-height: 1.45;
+                    }
+
+                    /* A heading followed by the card holding that section's rows. */
+                    .section {
+                        padding: 20px 16px 16px;
+                    }
+                    .section + .section {
+                        padding-top: 4px;
+                    }
+                    .section-title {
+                        font-size: 15px;
+                        font-weight: 700;
+                        margin-bottom: 12px;
+                        text-align: center;
+                    }
+
+                    .settings-group {
+                        border-radius: 18px;
+                        background: rgba(128, 128, 128, 0.10);
+                        border: 1px solid rgba(128, 128, 128, 0.16);
+                        overflow: hidden;
+                    }
+                    .settings-item {
+                        position: relative;
+                        display: flex;
+                        align-items: center;
+                        gap: 12px;
+                        padding: 14px 16px;
+                        text-decoration: none;
+                        color: inherit;
+                    }
+                    .settings-item:active {
+                        background: rgba(128, 128, 128, 0.12);
+                    }
+                    /* Drawn as a pseudo element rather than a border, so it stays inset from the card edges. */
+                    .settings-item + .settings-item::before {
+                        content: '';
+                        position: absolute;
+                        top: 0;
+                        left: 16px;
+                        right: 16px;
+                        height: 1px;
+                        background: rgba(128, 128, 128, 0.20);
+                    }
+                    .item-icon {
+                        display: flex;
+                        flex-shrink: 0;
+                    }
+                    .item-icon svg {
+                        width: 22px;
+                        height: 22px;
+                        fill: {accent};
+                    }
+                    .item-text {
+                        flex: 1;
+                        min-width: 0;
+                    }
+                    .item-title {
+                        font-size: 15px;
+                        font-weight: 500;
+                    }
+                    .item-subtitle {
+                        font-size: 12px;
+                        opacity: 0.6;
+                        margin-top: 2px;
+                    }
+                    .item-chevron {
+                        display: flex;
+                        flex-shrink: 0;
+                        opacity: 0.55;
+                    }
+                    .item-chevron svg {
+                        width: 20px;
+                        height: 20px;
+                        fill: {accent};
+                    }
+                    /* Material ships no mirrored chevron, so flip it for right to left layouts. */
+                    html[dir="rtl"] .item-chevron svg {
+                        transform: scaleX(-1);
+                    }
+
+                    /* Credits contributor initial. */
+                    .avatar {
+                        width: 30px;
+                        height: 30px;
+                        border-radius: 50%;
+                        background: linear-gradient(135deg, {blue} 0%, {teal} 100%);
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        font-size: 13px;
+                        font-weight: 700;
+                        color: #FFFFFF;
+                        flex-shrink: 0;
+                    }
+                </style>
+            </head>
+            <body>
+            """;
+}

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutWebViewDialog.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutWebViewDialog.java
@@ -10,6 +10,7 @@ import android.view.Gravity;
 import android.view.View;
 import android.view.Window;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
@@ -27,6 +28,14 @@ class AboutWebViewDialog extends Dialog {
     public AboutWebViewDialog(@NonNull Context context, @NonNull String htmlContent) {
         super(context);
         this.htmlContent = htmlContent;
+    }
+
+    /**
+     * @return The client driving the page. Override to handle navigation that stays inside the app;
+     *         the default sends every link to an external browser.
+     */
+    protected WebViewClient createWebViewClient() {
+        return new AboutLinksWebClient(getContext(), this);
     }
 
     // JS required to hide any broken images. No remote JavaScript is ever loaded.
@@ -52,7 +61,7 @@ class AboutWebViewDialog extends Dialog {
         webView.setVerticalScrollBarEnabled(false); // Disable the vertical scrollbar.
         webView.setOverScrollMode(View.OVER_SCROLL_NEVER);
         webView.getSettings().setJavaScriptEnabled(true);
-        webView.setWebViewClient(new AboutLinksWebClient(getContext(), this));
+        webView.setWebViewClient(createWebViewClient());
         webView.loadDataWithBaseURL(null, htmlContent, "text/html", "utf-8", null);
 
         // Add WebView to layout.

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutWebViewDialog.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutWebViewDialog.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.shared.settings.preference.about;
 
 import android.annotation.SuppressLint;

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/LicenseTextDialog.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/LicenseTextDialog.java
@@ -1,0 +1,109 @@
+package app.morphe.extension.shared.settings.preference.about;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.graphics.Insets;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowInsets;
+import android.webkit.WebView;
+
+import java.util.List;
+
+import app.morphe.extension.shared.Utils;
+
+/**
+ * Shows the notices of a single bundled dependency.
+ */
+@SuppressWarnings({"deprecation", "RedundantSuppression"})
+class LicenseTextDialog extends Dialog {
+
+    private final List<LicenseContent> content;
+
+    LicenseTextDialog(Context context, List<LicenseContent> content) {
+        super(context, android.R.style.Theme_DeviceDefault_NoActionBar);
+        this.content = content;
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        requestWindowFeature(Window.FEATURE_NO_TITLE);
+
+        // The window fills the screen, so its own background and the navigation bar are painted the
+        // same color the page is, rather than whatever the device theme happens to be.
+        Window window = getWindow();
+        if (window != null) {
+            window.setBackgroundDrawable(new ColorDrawable(Utils.getDialogBackgroundColor()));
+            window.setNavigationBarColor(Utils.getDialogBackgroundColor());
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                window.setNavigationBarContrastEnforced(true);
+            }
+        }
+
+        WebView webView = new WebView(getContext());
+        webView.setLayoutParams(new ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT));
+        webView.getSettings().setJavaScriptEnabled(false);
+        webView.getSettings().setUseWideViewPort(true);
+        webView.getSettings().setLoadWithOverviewMode(true);
+        webView.getSettings().setSupportZoom(true);
+        webView.getSettings().setBuiltInZoomControls(true);
+        webView.getSettings().setDisplayZoomControls(false);
+        // A WebView paints white until the page is parsed, which flashes as the dialog opens.
+        webView.setBackgroundColor(Utils.getDialogBackgroundColor());
+        webView.setWebViewClient(new AboutLinksWebClient(getContext(), this));
+
+        webView.loadDataWithBaseURL(null, buildHtml(), "text/html", "UTF-8", null);
+
+        setContentView(webView);
+        applyInsetsToContentView();
+    }
+
+    /**
+     * Applies window insets to the content root view.
+     */
+    private void applyInsetsToContentView() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return;
+
+        Window window = getWindow();
+        if (window == null) return;
+
+        ViewGroup rootView = (ViewGroup) window.getDecorView()
+                .findViewById(android.R.id.content)
+                .getParent();
+
+        rootView.setOnApplyWindowInsetsListener((v, insets) -> {
+            Insets statusInsets = insets.getInsets(WindowInsets.Type.statusBars());
+            Insets navInsets = insets.getInsets(WindowInsets.Type.navigationBars());
+            Insets cutoutInsets = insets.getInsets(WindowInsets.Type.displayCutout());
+
+            v.setPadding(
+                    cutoutInsets.left,
+                    statusInsets.top,
+                    cutoutInsets.right,
+                    navInsets.bottom
+            );
+            return insets;
+        });
+    }
+
+    private String buildHtml() {
+        StringBuilder html = new StringBuilder(AboutDialogStyle.documentStart());
+
+        // The notices are pre-formatted English whose alignment only holds left to right, so they
+        // stay unmirrored even when the surrounding app language reads the other way.
+        html.append("<div class=\"license-body\" dir=\"ltr\">");
+        for (LicenseContent item : content) {
+            html.append("<h2>").append(AboutDialogStyle.escapeHtml(item.title())).append("</h2>");
+            html.append("<pre>").append(AboutDialogStyle.linkifyHtml(item.content())).append("</pre>");
+        }
+        html.append("</div>").append(AboutDialogStyle.DOCUMENT_END);
+
+        return html.toString();
+    }
+}

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/LicenseTextDialog.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/LicenseTextDialog.java
@@ -1,3 +1,10 @@
+/*
+ * A reminder to anyone using any code from this software project:
+ *
+ * Refer to GPLv3 Section 5(d) regarding the preservation of
+ * interactive notices such as in-app notices or in-app credits.
+ */
+
 package app.morphe.extension.shared.settings.preference.about;
 
 import android.app.Dialog;

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/LicensesDialog.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/LicensesDialog.java
@@ -1,5 +1,7 @@
 package app.morphe.extension.shared.settings.preference.about;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.app.Dialog;
 import android.content.Context;
 import android.graphics.Insets;
@@ -9,12 +11,9 @@ import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowInsets;
 import android.webkit.WebView;
-import android.widget.ArrayAdapter;
-import android.widget.ListView;
 
 import androidx.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -42,8 +41,13 @@ public class LicensesDialog extends Dialog {
         }
     }
 
-    @Nullable
-    private WebView webView;
+    /**
+     * Dummy url opening a bundled license by its index in {@link #dependencies}, so the list rows
+     * can be ordinary links and reuse the shared row styling.
+     */
+    private static final String LICENSE_ROUTE_PREFIX = "https://license/";
+
+    private boolean showingLicense;
 
     public LicensesDialog(Context context) {
         super(context, android.R.style.Theme_DeviceDefault_NoActionBar);
@@ -68,8 +72,7 @@ public class LicensesDialog extends Dialog {
 
     @Override
     public void onBackPressed() {
-        if (webView != null) {
-            webView = null;
+        if (showingLicense) {
             showList();
         } else {
             super.onBackPressed();
@@ -77,38 +80,33 @@ public class LicensesDialog extends Dialog {
     }
 
     private void showList() {
-        List<String> names = new ArrayList<>(dependencies.size());
-        for (License dep : dependencies) {
-            names.add(dep.name);
-        }
-
-        ListView listView = new ListView(getContext());
-        listView.setLayoutParams(new ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT));
-        listView.setAdapter(new ArrayAdapter<>(getContext(),
-                android.R.layout.simple_list_item_1, names));
-        listView.setOnItemClickListener((parent, view, position, id) ->
-                showDetail(dependencies.get(position)));
-        setContentView(listView);
-        applyInsetsToContentView();
+        showingLicense = false;
+        showPage(buildListHtml(), false);
     }
 
     private void showDetail(License dep) {
-        webView = new WebView(getContext());
+        showingLicense = true;
+        showPage(buildLicenseHtml(dep.staticContent()), true);
+    }
+
+    /**
+     * @param legalText Whether the page holds pre-formatted license text, which needs the wide
+     *                  viewport and the zoom controls the row list has no use for.
+     */
+    private void showPage(String html, boolean legalText) {
+        WebView webView = new WebView(getContext());
         webView.setLayoutParams(new ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT));
         webView.getSettings().setJavaScriptEnabled(false);
-        webView.getSettings().setUseWideViewPort(true);
-        webView.getSettings().setLoadWithOverviewMode(true);
-        webView.getSettings().setSupportZoom(true);
-        webView.getSettings().setBuiltInZoomControls(true);
+        webView.getSettings().setUseWideViewPort(legalText);
+        webView.getSettings().setLoadWithOverviewMode(legalText);
+        webView.getSettings().setSupportZoom(legalText);
+        webView.getSettings().setBuiltInZoomControls(legalText);
         webView.getSettings().setDisplayZoomControls(false);
-        webView.setWebViewClient(new AboutLinksWebClient(getContext(), this));
+        webView.setWebViewClient(new LicensesWebClient(getContext(), this));
 
-        webView.loadDataWithBaseURL(null, buildHtml(dep.staticContent),
-                "text/html", "UTF-8", null);
+        webView.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null);
 
         setContentView(webView);
         applyInsetsToContentView();
@@ -142,33 +140,95 @@ public class LicensesDialog extends Dialog {
         });
     }
 
-    private String buildHtml(List<LicenseContent> items) {
-        StringBuilder body = new StringBuilder();
-        for (LicenseContent item : items) {
-            body.append("<h2>").append(htmlEscape(item.title())).append("</h2>");
-            body.append("<pre>").append(htmlEscape(item.content())).append("</pre>");
-        }
+    private String buildListHtml() {
+        StringBuilder html = new StringBuilder(AboutDialogStyle.documentStart());
 
-        return "<!DOCTYPE html><html><head><meta charset='UTF-8'>" +
-                "<meta name='viewport' content='width=device-width'>" +
-                "<style>" +
-                "  html, body { margin: 0; padding: 0; background: #1C1B1F; color: #E6E1E5;" +
-                "               font-family: monospace; font-size: 13px; line-height: 1.6; }" +
-                "  body { padding: 16px; box-sizing: border-box; }" +
-                "  h2 { color: #D0BCFF; font-family: sans-serif; font-size: 13px; word-break: break-all;" +
-                "       border-bottom: 1px solid #49454F; padding-bottom: 6px; margin-top: 24px; }" +
-                "  h2:first-of-type { margin-top: 0; }" +
-                "  pre { white-space: pre; word-break: normal; overflow-wrap: normal; margin: 0; }" +
-                "  a { color: #80BCFF; }" +
-                "</style></head><body>" + body + "</body></html>";
+        html.append("<div class=\"dialog-header\"><div class=\"dialog-title\">")
+                .append(str("morphe_settings_about_links_licenses"))
+                .append("</div></div>");
+
+        html.append("<div class=\"section\"><div class=\"settings-group\">");
+        for (int index = 0; index < dependencies.size(); index++) {
+            html.append("<a href=\"").append(LICENSE_ROUTE_PREFIX).append(index).append("\" class=\"settings-item\">")
+                    .append("<span class=\"item-icon\">")
+                    .append(AboutDialogStyle.linkIcon(LICENSE_ROUTE_PREFIX))
+                    .append("</span>")
+                    .append("<div class=\"item-text\"><div class=\"item-title\">")
+                    .append(htmlEscape(dependencies.get(index).name()))
+                    .append("</div></div>")
+                    .append(AboutDialogStyle.chevron())
+                    .append("</a>");
+        }
+        html.append("</div></div>").append(AboutDialogStyle.DOCUMENT_END);
+
+        return html.toString();
+    }
+
+    private String buildLicenseHtml(List<LicenseContent> items) {
+        StringBuilder html = new StringBuilder(AboutDialogStyle.documentStart());
+
+        // The notices are pre-formatted English whose alignment only holds left to right, so they
+        // stay unmirrored even when the surrounding app language reads the other way.
+        html.append("<div class=\"license-body\" dir=\"ltr\">");
+        for (LicenseContent item : items) {
+            html.append("<h2>").append(htmlEscape(item.title())).append("</h2>");
+            html.append("<pre>").append(linkifyHtml(item.content())).append("</pre>");
+        }
+        html.append("</div>").append(AboutDialogStyle.DOCUMENT_END);
+
+        return html.toString();
     }
 
     private static String htmlEscape(String text) {
         return text
                 .replace("&", "&amp;")
                 .replace("<", "&lt;")
-                .replace(">", "&gt;")
+                .replace(">", "&gt;");
+    }
+
+    /**
+     * Escapes the text and turns any urls in it into links, so the addresses named inside a license
+     * can be opened.
+     */
+    private static String linkifyHtml(String text) {
+        return htmlEscape(text)
                 .replaceAll("(https?://[^\\s<>\"]+)", "<a href='$1'>$1</a>");
+    }
+
+    @Nullable
+    private static License licenseForRoute(String url) {
+        try {
+            final int index = Integer.parseInt(url.substring(LICENSE_ROUTE_PREFIX.length()));
+            if (index >= 0 && index < dependencies.size()) {
+                return dependencies.get(index);
+            }
+        } catch (NumberFormatException ex) {
+            // Not one of the list rows, so it is handled as an ordinary link.
+        }
+        return null;
+    }
+
+    /**
+     * Opens the list rows in place, and leaves every other link to the shared handling that sends it
+     * to a browser.
+     */
+    private class LicensesWebClient extends AboutLinksWebClient {
+
+        LicensesWebClient(Context context, Dialog dialog) {
+            super(context, dialog);
+        }
+
+        @Override
+        public boolean shouldOverrideUrlLoading(WebView view, String url) {
+            if (url != null && url.startsWith(LICENSE_ROUTE_PREFIX)) {
+                License license = licenseForRoute(url);
+                if (license != null) {
+                    showDetail(license);
+                    return true;
+                }
+            }
+            return super.shouldOverrideUrlLoading(view, url);
+        }
     }
 }
 

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/LicensesDialog.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/LicensesDialog.java
@@ -5,6 +5,7 @@ import static app.morphe.extension.shared.StringRef.str;
 import android.app.Dialog;
 import android.content.Context;
 import android.graphics.Insets;
+import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.ViewGroup;
@@ -58,10 +59,12 @@ public class LicensesDialog extends Dialog {
         super.onCreate(savedInstanceState);
         requestWindowFeature(Window.FEATURE_NO_TITLE);
 
-        // Apply the background color to the navigation bar.
+        // The window fills the screen, so its own background and the navigation bar are painted the
+        // same color the pages are, rather than whatever the device theme happens to be.
         Window window = getWindow();
         if (window != null) {
-            window.setNavigationBarColor(Utils.getAppBackgroundColor());
+            window.setBackgroundDrawable(new ColorDrawable(Utils.getDialogBackgroundColor()));
+            window.setNavigationBarColor(Utils.getDialogBackgroundColor());
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 window.setNavigationBarContrastEnforced(true);
             }
@@ -104,6 +107,8 @@ public class LicensesDialog extends Dialog {
         webView.getSettings().setSupportZoom(legalText);
         webView.getSettings().setBuiltInZoomControls(legalText);
         webView.getSettings().setDisplayZoomControls(false);
+        // A WebView paints white until the page is parsed, which flashes on every navigation here.
+        webView.setBackgroundColor(Utils.getDialogBackgroundColor());
         webView.setWebViewClient(new LicensesWebClient(getContext(), this));
 
         webView.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null);

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/LicensesDialog.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/LicensesDialog.java
@@ -4,24 +4,20 @@ import static app.morphe.extension.shared.StringRef.str;
 
 import android.app.Dialog;
 import android.content.Context;
-import android.graphics.Insets;
-import android.graphics.drawable.ColorDrawable;
-import android.os.Build;
-import android.os.Bundle;
-import android.view.ViewGroup;
-import android.view.Window;
-import android.view.WindowInsets;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.List;
 
-import app.morphe.extension.shared.Utils;
-
-@SuppressWarnings({"deprecation", "RedundantSuppression"})
-public class LicensesDialog extends Dialog {
+/**
+ * Lists the software bundled with the patches. Picking one opens its notices in
+ * {@link LicenseTextDialog}, which is full screen because the texts run to hundreds of lines.
+ */
+class LicensesDialog extends AboutWebViewDialog {
 
     // Licenses for all software bundled with Morphe MPP Patches.
     private static final List<License> dependencies = List.of(
@@ -36,116 +32,28 @@ public class LicensesDialog extends Dialog {
             new License("Protocol Buffers", LicenseContent.PROTOCOL_BUFFERS)
     );
 
-    private record License(String name, List<LicenseContent> staticContent) {
-        public License(String name, LicenseContent staticContent) {
+    record License(String name, List<LicenseContent> staticContent) {
+        License(String name, LicenseContent staticContent) {
             this(name, Collections.singletonList(staticContent));
         }
     }
 
     /**
-     * Dummy url opening a bundled license by its index in {@link #dependencies}, so the list rows
-     * can be ordinary links and reuse the shared row styling.
+     * Dummy url opening a bundled license by its index in {@link #dependencies}, so the rows can be
+     * ordinary links and reuse the shared row styling.
      */
     private static final String LICENSE_ROUTE_PREFIX = "https://license/";
 
-    private boolean showingLicense;
-
-    public LicensesDialog(Context context) {
-        super(context, android.R.style.Theme_DeviceDefault_NoActionBar);
+    LicensesDialog(@NonNull Context context) {
+        super(context, buildListHtml());
     }
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        requestWindowFeature(Window.FEATURE_NO_TITLE);
-
-        // The window fills the screen, so its own background and the navigation bar are painted the
-        // same color the pages are, rather than whatever the device theme happens to be.
-        Window window = getWindow();
-        if (window != null) {
-            window.setBackgroundDrawable(new ColorDrawable(Utils.getDialogBackgroundColor()));
-            window.setNavigationBarColor(Utils.getDialogBackgroundColor());
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                window.setNavigationBarContrastEnforced(true);
-            }
-        }
-
-        showList();
+    protected WebViewClient createWebViewClient() {
+        return new LicensesWebClient(getContext(), this);
     }
 
-    @Override
-    public void onBackPressed() {
-        if (showingLicense) {
-            showList();
-        } else {
-            super.onBackPressed();
-        }
-    }
-
-    private void showList() {
-        showingLicense = false;
-        showPage(buildListHtml(), false);
-    }
-
-    private void showDetail(License dep) {
-        showingLicense = true;
-        showPage(buildLicenseHtml(dep.staticContent()), true);
-    }
-
-    /**
-     * @param legalText Whether the page holds pre-formatted license text, which needs the wide
-     *                  viewport and the zoom controls the row list has no use for.
-     */
-    private void showPage(String html, boolean legalText) {
-        WebView webView = new WebView(getContext());
-        webView.setLayoutParams(new ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT));
-        webView.getSettings().setJavaScriptEnabled(false);
-        webView.getSettings().setUseWideViewPort(legalText);
-        webView.getSettings().setLoadWithOverviewMode(legalText);
-        webView.getSettings().setSupportZoom(legalText);
-        webView.getSettings().setBuiltInZoomControls(legalText);
-        webView.getSettings().setDisplayZoomControls(false);
-        // A WebView paints white until the page is parsed, which flashes on every navigation here.
-        webView.setBackgroundColor(Utils.getDialogBackgroundColor());
-        webView.setWebViewClient(new LicensesWebClient(getContext(), this));
-
-        webView.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null);
-
-        setContentView(webView);
-        applyInsetsToContentView();
-    }
-
-    /**
-     * Applies window insets to the content root view.
-     */
-    private void applyInsetsToContentView() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return;
-
-        Window window = getWindow();
-        if (window == null) return;
-
-        ViewGroup rootView = (ViewGroup) window.getDecorView()
-                .findViewById(android.R.id.content)
-                .getParent();
-
-        rootView.setOnApplyWindowInsetsListener((v, insets) -> {
-            Insets statusInsets = insets.getInsets(WindowInsets.Type.statusBars());
-            Insets navInsets = insets.getInsets(WindowInsets.Type.navigationBars());
-            Insets cutoutInsets = insets.getInsets(WindowInsets.Type.displayCutout());
-
-            v.setPadding(
-                    cutoutInsets.left,
-                    statusInsets.top,
-                    cutoutInsets.right,
-                    navInsets.bottom
-            );
-            return insets;
-        });
-    }
-
-    private String buildListHtml() {
+    private static String buildListHtml() {
         StringBuilder html = new StringBuilder(AboutDialogStyle.documentStart());
 
         html.append("<div class=\"dialog-header\"><div class=\"dialog-title\">")
@@ -159,7 +67,7 @@ public class LicensesDialog extends Dialog {
                     .append(AboutDialogStyle.linkIcon(LICENSE_ROUTE_PREFIX))
                     .append("</span>")
                     .append("<div class=\"item-text\"><div class=\"item-title\">")
-                    .append(htmlEscape(dependencies.get(index).name()))
+                    .append(AboutDialogStyle.escapeHtml(dependencies.get(index).name()))
                     .append("</div></div>")
                     .append(AboutDialogStyle.chevron())
                     .append("</a>");
@@ -167,37 +75,6 @@ public class LicensesDialog extends Dialog {
         html.append("</div></div>").append(AboutDialogStyle.DOCUMENT_END);
 
         return html.toString();
-    }
-
-    private String buildLicenseHtml(List<LicenseContent> items) {
-        StringBuilder html = new StringBuilder(AboutDialogStyle.documentStart());
-
-        // The notices are pre-formatted English whose alignment only holds left to right, so they
-        // stay unmirrored even when the surrounding app language reads the other way.
-        html.append("<div class=\"license-body\" dir=\"ltr\">");
-        for (LicenseContent item : items) {
-            html.append("<h2>").append(htmlEscape(item.title())).append("</h2>");
-            html.append("<pre>").append(linkifyHtml(item.content())).append("</pre>");
-        }
-        html.append("</div>").append(AboutDialogStyle.DOCUMENT_END);
-
-        return html.toString();
-    }
-
-    private static String htmlEscape(String text) {
-        return text
-                .replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;");
-    }
-
-    /**
-     * Escapes the text and turns any urls in it into links, so the addresses named inside a license
-     * can be opened.
-     */
-    private static String linkifyHtml(String text) {
-        return htmlEscape(text)
-                .replaceAll("(https?://[^\\s<>\"]+)", "<a href='$1'>$1</a>");
     }
 
     @Nullable
@@ -208,16 +85,16 @@ public class LicensesDialog extends Dialog {
                 return dependencies.get(index);
             }
         } catch (NumberFormatException ex) {
-            // Not one of the list rows, so it is handled as an ordinary link.
+            // Not one of the rows, so it is handled as an ordinary link.
         }
         return null;
     }
 
     /**
-     * Opens the list rows in place, and leaves every other link to the shared handling that sends it
-     * to a browser.
+     * Opens the rows in a license dialog on top of this one, and leaves every other link to the
+     * shared handling that sends it to a browser.
      */
-    private class LicensesWebClient extends AboutLinksWebClient {
+    private static class LicensesWebClient extends AboutLinksWebClient {
 
         LicensesWebClient(Context context, Dialog dialog) {
             super(context, dialog);
@@ -228,7 +105,7 @@ public class LicensesDialog extends Dialog {
             if (url != null && url.startsWith(LICENSE_ROUTE_PREFIX)) {
                 License license = licenseForRoute(url);
                 if (license != null) {
-                    showDetail(license);
+                    new LicenseTextDialog(context, license.staticContent()).show();
                     return true;
                 }
             }

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/MorpheAboutPreference.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/MorpheAboutPreference.java
@@ -101,57 +101,6 @@ public class MorpheAboutPreference extends Preference {
         MorpheCreditsDialog.showVancedAsPastContributor = includeVanced;
     }
 
-    /**
-     * Returns an SVG icon string based on the link URL pattern.
-     * Matching by URL avoids issues with localized link names.
-     */
-    private static String getLinkIcon(String url) {
-        // Globe - website / generic
-        final String iconGlobe =
-                "<svg viewBox='0 0 16 16'><circle cx='8' cy='8' r='6'/>" +
-                        "<ellipse cx='8' cy='8' rx='2.8' ry='6'/>" +
-                        "<line x1='2' y1='8' x2='14' y2='8'/></svg>";
-        // Heart - donate
-        final String iconHeart =
-                "<svg viewBox='0 0 16 16'><path d='M8 13s-5-3.5-5-7a3 3 0 0 1 5-2.24A3 3 0 0 1 13 6c0 3.5-5 7-5 7z'/></svg>";
-        // Bubble + A - translations
-        final String iconTranslate =
-                "<svg viewBox='0 0 16 16'>" +
-                        "<path d='M2 2.5A1.5 1.5 0 0 1 3.5 1h9A1.5 1.5 0 0 1 14 2.5v6A1.5 1.5 0 0 1 12.5 10H9l-3 3v-3H3.5A1.5 1.5 0 0 1 2 8.5v-6z'/>" +
-                        "<path d='M5.5 7.5L7.5 3l2 4.5M6.2 6h2.6' stroke-width='1.3'/>" +
-                        "</svg>";
-        // Person - credits
-        final String iconPerson =
-                "<svg viewBox='0 0 16 16'><circle cx='8' cy='5' r='2.5'/>" +
-                        "<path d='M3 13c0-2.76 2.24-5 5-5s5 2.24 5 5'/></svg>";
-        // GitHub mark
-        final String iconGitHub =
-                "<svg viewBox='0 0 16 16'><path d='M8 1a7 7 0 0 0-2.21 13.64c.35.06.48-.15.48-.34v-1.2C4.07 13.54 3.67 12 3.67 12c-.32-.81-.78-1.02-.78-1.02-.63-.43.05-.42.05-.42.7.05 1.07.72 1.07.72.62 1.06 1.63.75 2.03.58.06-.45.24-.75.44-.92C5 10.79 3.37 10.17 3.37 7.5c0-.75.27-1.36.71-1.84-.07-.18-.31-.87.07-1.82 0 0 .58-.18 1.9.71A6.6 6.6 0 0 1 8 4.18c.59 0 1.18.08 1.73.23 1.31-.89 1.9-.71 1.9-.71.38.95.14 1.64.07 1.82.44.48.71 1.09.71 1.84 0 2.68-1.63 3.28-3.19 3.45.25.22.47.65.47 1.31v1.95c0 .19.13.4.48.34A7 7 0 0 0 8 1z'/></svg>";
-        // Reddit - alien head
-        final String iconReddit =
-                "<svg viewBox='0 0 16 16'>" +
-                        "<path d='M3 10.5C3 7.46 5.24 5 8 5s5 2.46 5 5.5'/>" +
-                        "<path d='M3 10.5c0 1.93 2.24 3.5 5 3.5s5-1.57 5-3.5'/>" +
-                        "<circle cx='5.8' cy='9.5' r='.9' fill='currentColor' stroke='none'/>" +
-                        "<circle cx='10.2' cy='9.5' r='.9' fill='currentColor' stroke='none'/>" +
-                        "<path d='M6 11.8c.5.7 3.5.7 4 0'/>" +
-                        "<path d='M8 5c.3-1.5 1.5-2 3-1.5'/>" +
-                        "<circle cx='11.5' cy='3.8' r='.9' fill='currentColor' stroke='none'/>" +
-                        "</svg>";
-        // External link - fallback
-        final String iconExternal =
-                "<svg viewBox='0 0 16 16'><path d='M6 3H3v10h10v-3M9 2h5v5M14 2l-6 6'/></svg>";
-
-        if (url == null) return iconExternal;
-        String u = url.toLowerCase(Locale.US);
-        if (u.contains("github.com")) return iconGitHub;
-        if (u.contains("reddit.com")) return iconReddit;
-        if (u.contains("crowdin") || u.contains("translate")) return iconTranslate;
-        if (u.contains("donate") || u.contains("donat")) return iconHeart;
-        if (u.equals("https://credits/")) return iconPerson;
-        return iconGlobe;
-    }
-
     // Dummy url
     static final String CREDITS_LINK_PLACEHOLDER_URL = "https://morphe.software/credits/";
 
@@ -160,7 +109,7 @@ public class MorpheAboutPreference extends Preference {
     private static String useNonBreakingHyphens(String text) {
         // Replace any dashes with non-breaking dashes, so the English text 'pre-release'
         // and the dev release number does not break and cover two lines.
-        return text.replace("-", "&#8209;"); // #8209 = non breaking hyphen.
+        return text.replace("-", "&#8209;"); // #8209 = non-breaking hyphen.
     }
 
     /**
@@ -173,205 +122,42 @@ public class MorpheAboutPreference extends Preference {
     }
 
     private String createDialogHtml(List<WebLink> aboutLinks, @Nullable String currentVersion) {
-        final boolean isNetworkConnected = Utils.isNetworkConnected();
+        StringBuilder html = new StringBuilder(AboutDialogStyle.documentStart());
 
-        // Get theme colors.
-        String foregroundColorHex = Utils.getColorHexString(Utils.getAppForegroundColor());
-        String backgroundColorHex = Utils.getColorHexString(Utils.getDialogBackgroundColor());
+        html.append("<div class=\"dialog-header\">");
 
-        // Morphe brand colors from logo.
-        String morpheBlue = "#1E5AA8";
-        String morpheTeal = "#00AFAE";
-
-        StringBuilder html = new StringBuilder(String.format("""
-                         <html>
-                         <head>
-                             <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                         </head>
-                         <body>
-                         <style>
-                             * {
-                                 margin: 0;
-                                 padding: 0;
-                                 box-sizing: border-box;
-                             }
-                             body {
-                                 background: %s;
-                                 color: %s;
-                                 font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-                                 padding: 0;
-                             }
-                             /* Header */
-                             .about-header {
-                                 padding: 28px 20px 20px;
-                                 text-align: center;
-                                 border-bottom: 1px solid rgba(128, 128, 128, 0.12);
-                             }
-                             .logo-container {
-                                 margin: 0 auto 14px;
-                                 width: 72px;
-                                 height: 72px;
-                                 border-radius: 18px;
-                                 background: linear-gradient(135deg, %s 0%%, %s 100%%);
-                                 padding: 2px;
-                                 display: inline-block;
-                             }
-                             .logo-inner {
-                                 width: 100%%;
-                                 height: 100%%;
-                                 border-radius: 16px;
-                                 background: #EEEEEE;
-                                 display: flex;
-                                 align-items: center;
-                                 justify-content: center;
-                                 overflow: hidden;
-                             }
-                             img {
-                                 width: 100%%;
-                                 height: 100%%;
-                                 object-fit: contain;
-                             }
-                             .app-name {
-                                 font-size: 18px;
-                                 font-weight: 600;
-                                 color: %s;
-                                 margin-bottom: 10px;
-                             }
-                             /* Info card - version + dev-note, centered, no icon */
-                             .info-card {
-                                 text-align: center;
-                                 margin-bottom: 8px;
-                                 padding: 10px 14px;
-                                 border-radius: 10px;
-                                 background: rgba(30, 90, 168, 0.06);
-                                 border: 1px solid rgba(30, 90, 168, 0.15);
-                             }
-                             .info-card:last-child {
-                                 margin-bottom: 0;
-                             }
-                             .info-card h3 {
-                                 font-size: 13px;
-                                 font-weight: 600;
-                                 color: %s;
-                                 margin-bottom: 2px;
-                             }
-                             .info-card p {
-                                 margin: 0;
-                                 font-size: 12px;
-                                 color: %s;
-                                 opacity: 0.75;
-                                 line-height: 1.4;
-                             }
-                             /* Links */
-                             .links-section {
-                                 padding: 16px;
-                             }
-                             .section-label {
-                                 font-size: 11px;
-                                 font-weight: 600;
-                                 color: %s;
-                                 opacity: 0.5;
-                                 text-transform: uppercase;
-                                 letter-spacing: 0.07em;
-                                 margin-bottom: 8px;
-                                 padding: 0 4px;
-                             }
-                             .link-button {
-                                 display: flex;
-                                 align-items: center;
-                                 gap: 10px;
-                                 text-decoration: none;
-                                 color: %s;
-                                 background: linear-gradient(135deg, rgba(30, 90, 168, 0.07) 0%%, rgba(0, 175, 174, 0.07) 100%%);
-                                 border: 1px solid rgba(30, 90, 168, 0.2);
-                                 border-radius: 12px;
-                                 padding: 11px 14px;
-                                 margin-bottom: 6px;
-                                 font-size: 14px;
-                                 font-weight: 500;
-                                 -webkit-tap-highlight-color: transparent;
-                                 -webkit-touch-callout: none;
-                                 -webkit-user-select: none;
-                                 user-select: none;
-                             }
-                             .link-button:last-child {
-                                 margin-bottom: 0;
-                             }
-                             .link-button:active {
-                                 background: linear-gradient(135deg, rgba(30, 90, 168, 0.14) 0%%, rgba(0, 175, 174, 0.14) 100%%);
-                                 border-color: rgba(30, 90, 168, 0.35);
-                             }
-                             .link-icon {
-                                 width: 28px;
-                                 height: 28px;
-                                 border-radius: 8px;
-                                 background: linear-gradient(135deg, rgba(30, 90, 168, 0.15) 0%%, rgba(0, 175, 174, 0.15) 100%%);
-                                 display: flex;
-                                 align-items: center;
-                                 justify-content: center;
-                                 flex-shrink: 0;
-                                 font-size: 15px;
-                             }
-                             .link-icon svg {
-                                 width: 16px;
-                                 height: 16px;
-                                 fill: none;
-                                 stroke: %s;
-                                 stroke-width: 1.6;
-                                 stroke-linecap: round;
-                                 stroke-linejoin: round;
-                             }
-                             .link-label {
-                                 flex: 1;
-                             }
-                             .link-chevron {
-                                 font-size: 24px;
-                                 opacity: 0.3;
-                                 line-height: 1;
-                             }
-                         </style>
-                        """, backgroundColorHex, foregroundColorHex,
-                morpheBlue, morpheTeal,
-                foregroundColorHex,
-                morpheBlue, foregroundColorHex,
-                foregroundColorHex, foregroundColorHex, foregroundColorHex
-        ));
-
-        // Header section.
-        html.append("<div class=\"about-header\">");
-
-        // Logo with Morphe gradient border.
-        if (isNetworkConnected) {
+        // The logo is fetched over the network, so the container is skipped entirely when offline.
+        if (Utils.isNetworkConnected()) {
             html.append(String.format("""
-                    <div class="logo-container">
-                        <div class="logo-inner">
+                    <div class="app-logo">
+                        <div class="app-logo-inner">
                             <img src="%s" onerror="this.parentElement.parentElement.style.display='none';" />
                         </div>
                     </div>
                     """, AboutRoutes.aboutLogoUrl));
         }
 
-        // App name.
         html.append("<div class=\"app-name\">Morphe</div>");
 
         String appPatchesVersion = Utils.getPatchesReleaseVersion();
+        final boolean isUpToDate = currentVersion == null || appPatchesVersion.equalsIgnoreCase(currentVersion);
 
-        // Version info card.
-        boolean isUpToDate = currentVersion == null || appPatchesVersion.equalsIgnoreCase(currentVersion);
-        String versionTitle = isUpToDate
-                ? getString("morphe_settings_about_links_dev_header_up_to_date")
-                : getString("morphe_settings_about_links_dev_header_update_available");
+        // Version status card.
         html.append(String.format("""
-                <div class="info-card">
-                    <h3>%s</h3>
-                    <p>%s</p>
-                </div>
-                """,
-                useNonBreakingHyphens(versionTitle),
+                        <div class="info-card">
+                            <h3>%s</h3>
+                            <p>%s</p>
+                        </div>
+                        """,
                 useNonBreakingHyphens(isUpToDate
-                        ? getString("morphe_settings_about_links_body_version_current", appPatchesVersion)
-                        : getString("morphe_settings_about_links_body_version_outdated", appPatchesVersion, currentVersion)
-                )
+                        ? getString("morphe_settings_about_links_dev_header_up_to_date")
+                        : getString("morphe_settings_about_links_dev_header_update_available")),
+                useNonBreakingHyphens(isUpToDate
+                        ? getString("morphe_settings_about_links_body_version_current",
+                                AboutDialogStyle.isolateLtr(appPatchesVersion))
+                        : getString("morphe_settings_about_links_body_version_outdated",
+                                AboutDialogStyle.isolateLtr(appPatchesVersion),
+                                AboutDialogStyle.isolateLtr(currentVersion)))
         ));
 
         // Dev note card.
@@ -381,34 +167,32 @@ public class MorpheAboutPreference extends Preference {
                                 <h3>%s</h3>
                                 <p>%s</p>
                             </div>
-                            """, useNonBreakingHyphens(getString("morphe_settings_about_links_dev_header")),
+                            """,
+                    useNonBreakingHyphens(getString("morphe_settings_about_links_dev_header")),
                     getString("morphe_settings_about_links_dev_body")
             ));
         }
 
-        html.append("</div>"); // end .about-header
+        html.append("</div>"); // end .dialog-header
 
         // Links section.
-        html.append(String.format("""
-                <div class="links-section">
-                    <div class="section-label">%s</div>
-                """, getString("morphe_settings_about_links_header")));
+        html.append("<div class=\"section\">")
+                .append(AboutDialogStyle.sectionTitle(getString("morphe_settings_about_links_header")))
+                .append("<div class=\"settings-group\">");
 
-        // Link buttons with per-URL SVG icons.
         for (WebLink link : aboutLinks) {
-            String icon = getLinkIcon(link.url);
-            html.append("<a href=\"").append(link.url).append("\" class=\"link-button\">")
-                    .append("<span class=\"link-icon\">").append(icon).append("</span>")
-                    .append("<span class=\"link-label\">").append(link.name).append("</span>")
-                    .append("<span class=\"link-chevron\">&#x203A;</span>")
+            html.append("<a href=\"").append(link.url).append("\" class=\"settings-item\">")
+                    .append("<span class=\"item-icon\">")
+                    .append(AboutDialogStyle.linkIcon(link.url))
+                    .append("</span>")
+                    .append("<div class=\"item-text\"><div class=\"item-title\">")
+                    .append(link.name)
+                    .append("</div></div>")
+                    .append(AboutDialogStyle.chevron())
                     .append("</a>");
         }
 
-        html.append("""
-                </div>
-                </body>
-                </html>
-                """);
+        html.append("</div></div>").append(AboutDialogStyle.DOCUMENT_END);
 
         return html.toString();
     }

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/MorpheCreditsDialog.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/MorpheCreditsDialog.java
@@ -2,26 +2,13 @@ package app.morphe.extension.shared.settings.preference.about;
 
 import static app.morphe.extension.shared.StringRef.str;
 
-import android.annotation.SuppressLint;
-import android.app.Dialog;
 import android.content.Context;
-import android.graphics.drawable.ShapeDrawable;
-import android.graphics.drawable.shapes.RoundRectShape;
-import android.os.Bundle;
-import android.view.Gravity;
-import android.view.View;
-import android.view.Window;
-import android.webkit.WebView;
-import android.widget.LinearLayout;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import app.morphe.extension.shared.Utils;
-import app.morphe.extension.shared.ui.Dim;
-
-class MorpheCreditsDialog extends Dialog {
+class MorpheCreditsDialog extends AboutWebViewDialog {
 
     private static final List<MorpheAboutPreference.WebLink> WORKS_LINKS_CURRENT = List.of(
             new MorpheAboutPreference.WebLink("Morphe",
@@ -61,7 +48,7 @@ class MorpheCreditsDialog extends Dialog {
         return prior;
     }
 
-    private String createDialogHtml() {
+    private static String createDialogHtml() {
         StringBuilder html = new StringBuilder(AboutDialogStyle.documentStart());
 
         html.append("<div class=\"dialog-header\"><div class=\"dialog-title\">")
@@ -113,48 +100,7 @@ class MorpheCreditsDialog extends Dialog {
         html.append("</div></div>");
     }
 
-    private final String htmlContent;
-
-    public MorpheCreditsDialog(Context context) {
-        super(context);
-        this.htmlContent = createDialogHtml();
-    }
-
-    // JS required to hide any broken images. No remote JavaScript is ever loaded.
-    @SuppressLint("SetJavaScriptEnabled")
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        requestWindowFeature(Window.FEATURE_NO_TITLE); // Remove default title bar.
-
-        // Create main layout.
-        LinearLayout mainLayout = new LinearLayout(getContext());
-        mainLayout.setOrientation(LinearLayout.VERTICAL);
-
-        mainLayout.setPadding(Dim.dp10, Dim.dp10, Dim.dp10, Dim.dp10);
-        // Set rounded rectangle background.
-        ShapeDrawable mainBackground = new ShapeDrawable(new RoundRectShape(
-                Dim.roundedCorners(28), null, null));
-        mainBackground.getPaint().setColor(Utils.getDialogBackgroundColor());
-        mainLayout.setBackground(mainBackground);
-
-        // Create WebView.
-        WebView webView = new WebView(getContext());
-        webView.setVerticalScrollBarEnabled(false); // Disable the vertical scrollbar.
-        webView.setOverScrollMode(View.OVER_SCROLL_NEVER);
-        webView.getSettings().setJavaScriptEnabled(true);
-        webView.setWebViewClient(new AboutLinksWebClient(getContext(), this));
-        webView.loadDataWithBaseURL(null, htmlContent, "text/html", "utf-8", null);
-
-        // Add WebView to layout.
-        mainLayout.addView(webView);
-
-        setContentView(mainLayout);
-
-        // Set dialog window attributes.
-        Window window = getWindow();
-        if (window != null) {
-            Utils.setDialogWindowParameters(window, Gravity.CENTER, 0, 90, false);
-        }
+    MorpheCreditsDialog(Context context) {
+        super(context, createDialogHtml());
     }
 }

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/MorpheCreditsDialog.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/MorpheCreditsDialog.java
@@ -1,3 +1,10 @@
+/*
+ * A reminder to anyone using any code from this software project:
+ *
+ * Refer to GPLv3 Section 5(d) regarding the preservation of
+ * interactive notices such as in-app notices or in-app credits.
+ */
+
 package app.morphe.extension.shared.settings.preference.about;
 
 import static app.morphe.extension.shared.StringRef.str;

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/MorpheCreditsDialog.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/MorpheCreditsDialog.java
@@ -62,215 +62,55 @@ class MorpheCreditsDialog extends Dialog {
     }
 
     private String createDialogHtml() {
-        // Get theme colors.
-        String foregroundColorHex = Utils.getColorHexString(Utils.getAppForegroundColor());
-        String backgroundColorHex = Utils.getColorHexString(Utils.getDialogBackgroundColor());
+        StringBuilder html = new StringBuilder(AboutDialogStyle.documentStart());
 
-        // Morphe brand colors from logo.
-        String morpheBlue = "#1E5AA8";
-        String morpheTeal = "#00AFAE";
+        html.append("<div class=\"dialog-header\"><div class=\"dialog-title\">")
+                .append(str("morphe_settings_about_links_credits"))
+                .append("</div></div>");
 
-        StringBuilder html = new StringBuilder(String.format("""
-                         <html>
-                         <head>
-                             <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                         </head>
-                         <body>
-                         <style>
-                             * {
-                                 margin: 0;
-                                 padding: 0;
-                                 box-sizing: border-box;
-                             }
-                             body {
-                                 background: %s;
-                                 color: %s;
-                                 font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-                                 padding: 0;
-                             }
-                             /* Header */
-                             .credits-header {
-                                 padding: 22px 20px 16px;
-                                 text-align: center;
-                                 border-bottom: 1px solid rgba(128, 128, 128, 0.12);
-                             }
-                             .credits-title {
-                                 font-size: 17px;
-                                 font-weight: 600;
-                                 color: %s;
-                             }
-                             /* Sections */
-                             .credits-section {
-                                 padding: 14px 16px;
-                             }
-                             .credits-section + .credits-section {
-                                 border-top: 1px solid rgba(128, 128, 128, 0.12);
-                             }
-                             .section-label {
-                                 font-size: 11px;
-                                 font-weight: 600;
-                                 color: %s;
-                                 opacity: 0.5;
-                                 text-transform: uppercase;
-                                 letter-spacing: 0.07em;
-                                 margin-bottom: 8px;
-                                 padding: 0 4px;
-                             }
-                             /* Contributor rows - same style as About */
-                             .link-button {
-                                 display: flex;
-                                 align-items: center;
-                                 gap: 10px;
-                                 text-decoration: none;
-                                 color: %s;
-                                 background: linear-gradient(135deg, rgba(30, 90, 168, 0.07) 0%%, rgba(0, 175, 174, 0.07) 100%%);
-                                 border: 1px solid rgba(30, 90, 168, 0.2);
-                                 border-radius: 12px;
-                                 padding: 11px 14px;
-                                 margin-bottom: 6px;
-                                 font-size: 14px;
-                                 font-weight: 500;
-                                 -webkit-tap-highlight-color: transparent;
-                                 -webkit-touch-callout: none;
-                                 -webkit-user-select: none;
-                                 user-select: none;
-                             }
-                             .link-button:last-child {
-                                 margin-bottom: 0;
-                             }
-                             .link-button:active {
-                                 background: linear-gradient(135deg, rgba(30, 90, 168, 0.14) 0%%, rgba(0, 175, 174, 0.14) 100%%);
-                                 border-color: rgba(30, 90, 168, 0.35);
-                             }
-                             .avatar {
-                                 width: 28px;
-                                 height: 28px;
-                                 border-radius: 50%%;
-                                 background: linear-gradient(135deg, %s 0%%, %s 100%%);
-                                 display: flex;
-                                 align-items: center;
-                                 justify-content: center;
-                                 font-size: 12px;
-                                 font-weight: 700;
-                                 color: #ffffff;
-                                 flex-shrink: 0;
-                             }
-                             .contributor-info {
-                                 flex: 1;
-                             }
-                             .contributor-name {
-                                 font-size: 14px;
-                                 font-weight: 500;
-                                 color: %s;
-                             }
-                             .contributor-role {
-                                 font-size: 11px;
-                                 color: %s;
-                                 opacity: 0.5;
-                                 margin-top: 1px;
-                             }
-                             .link-chevron {
-                                 font-size: 24px;
-                                 color: %s;
-                                 opacity: 0.3;
-                                 line-height: 1;
-                             }
-                             .link-icon {
-                                 width: 28px;
-                                 height: 28px;
-                                 border-radius: 8px;
-                                 background: linear-gradient(135deg, rgba(30, 90, 168, 0.12) 0%%, rgba(0, 175, 174, 0.12) 100%%);
-                                 display: flex;
-                                 align-items: center;
-                                 justify-content: center;
-                                 flex-shrink: 0;
-                             }
-                             .link-icon svg {
-                                 width: 16px;
-                                 height: 16px;
-                                 fill: none;
-                                 stroke: %s;
-                                 stroke-width: 1.6;
-                                 stroke-linecap: round;
-                                 stroke-linejoin: round;
-                             }
-                         </style>
-                        """,
-                backgroundColorHex, foregroundColorHex,
-                foregroundColorHex, foregroundColorHex,
-                foregroundColorHex, morpheBlue, morpheTeal,
-                foregroundColorHex, foregroundColorHex, foregroundColorHex,
-                foregroundColorHex
-        ));
-
-        // Header.
-        html.append(String.format("""
-                        <div class="credits-header">
-                            <div class="credits-title">%s</div>
-                        </div>
-                        """,
-                str("morphe_settings_about_links_credits")
-        ));
-
-        // Current contributors section.
-        html.append(String.format("""
-                <div class="credits-section">
-                    <div class="section-label">%s</div>
-                """, str("morphe_settings_about_contributors_current")));
-        for (MorpheAboutPreference.WebLink link : WORKS_LINKS_CURRENT) {
-            String initial = link.name.substring(0, 1).toUpperCase(Locale.getDefault());
-            html.append("<a href=\"").append(link.url).append("\" class=\"link-button\">")
-                    .append("<div class=\"avatar\">").append(initial).append("</div>")
-                    .append("<div class=\"contributor-info\">")
-                    .append("<div class=\"contributor-name\">").append(link.name).append("</div>")
-                    .append("<div class=\"contributor-role\">").append(link.subText).append("</div>")
-                    .append("</div>")
-                    .append("<span class=\"link-chevron\">&#x203A;</span>")
-                    .append("</a>");
-        }
-        html.append("</div>");
-
-        // Prior contributors section.
-        html.append(String.format("""
-                <div class="credits-section">
-                    <div class="section-label">%s</div>
-                """, str("morphe_settings_about_contributors_prior")));
-        for (MorpheAboutPreference.WebLink link : getWorksLinksPrior()) {
-            String initial = link.name.substring(0, 1).toUpperCase(Locale.getDefault());
-            html.append("<a href=\"").append(link.url).append("\" class=\"link-button\">")
-                    .append("<div class=\"avatar\">").append(initial).append("</div>")
-                    .append("<div class=\"contributor-info\">")
-                    .append("<div class=\"contributor-name\">").append(link.name).append("</div>");
-            if (link.subText != null) {
-                html.append("<div class=\"contributor-role\">").append(link.subText).append("</div>");
-            }
-            html.append("</div>")
-                    .append("<span class=\"link-chevron\">&#x203A;</span>")
-                    .append("</a>");
-        }
-        html.append("</div>");
+        appendContributors(html, str("morphe_settings_about_contributors_current"), WORKS_LINKS_CURRENT);
+        appendContributors(html, str("morphe_settings_about_contributors_prior"), getWorksLinksPrior());
 
         // In-app user-facing attribution of licenses and notices (Apache 2.0 criteria).
-        html.append("<div class=\"credits-section\">");
-        html.append("<a href=\"").append(ABOUT_LICENSE.url).append("\" class=\"link-button\">")
-                .append("<span class=\"link-icon\">")
-                .append("<svg viewBox='0 0 16 16'><path d='M4 1h6l3 3v10a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1z'/><path d='M10 1v3h3'/><line x1='5' y1='7' x2='11' y2='7'/><line x1='5' y1='10' x2='11' y2='10'/><line x1='5' y1='13' x2='8' y2='13'/></svg>")
+        html.append("<div class=\"section\"><div class=\"settings-group\">")
+                .append("<a href=\"").append(ABOUT_LICENSE.url).append("\" class=\"settings-item\">")
+                .append("<span class=\"item-icon\">")
+                .append(AboutDialogStyle.linkIcon(ABOUT_LICENSE.url))
                 .append("</span>")
-                .append("<div class=\"contributor-info\">")
-                .append("<div class=\"contributor-name\">")
+                .append("<div class=\"item-text\"><div class=\"item-title\">")
                 .append(str("morphe_settings_about_links_licenses"))
-                .append("</div>");
-        html.append("</div>")
-                .append("<span class=\"link-chevron\">&#x203A;</span>")
-                .append("</a>");
-        html.append("</div>");
+                .append("</div></div>")
+                .append(AboutDialogStyle.chevron())
+                .append("</a>")
+                .append("</div></div>");
 
-        html.append("""
-                </body>
-                </html>
-            """);
+        html.append(AboutDialogStyle.DOCUMENT_END);
 
         return html.toString();
+    }
+
+    private static void appendContributors(StringBuilder html, String title,
+                                           List<MorpheAboutPreference.WebLink> links) {
+        html.append("<div class=\"section\">")
+                .append(AboutDialogStyle.sectionTitle(title))
+                .append("<div class=\"settings-group\">");
+
+        for (MorpheAboutPreference.WebLink link : links) {
+            String initial = link.name.substring(0, 1).toUpperCase(Locale.getDefault());
+            html.append("<a href=\"").append(link.url).append("\" class=\"settings-item\">")
+                    .append("<span class=\"avatar\">").append(initial).append("</span>")
+                    .append("<div class=\"item-text\"><div class=\"item-title\">")
+                    .append(link.name)
+                    .append("</div>");
+            if (link.subText != null) {
+                html.append("<div class=\"item-subtitle\">").append(link.subText).append("</div>");
+            }
+            html.append("</div>")
+                    .append(AboutDialogStyle.chevron())
+                    .append("</a>");
+        }
+
+        html.append("</div></div>");
     }
 
     private final String htmlContent;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 [versions]
 morphe-patcher = "1.7.0"
-morphe-patches-library = "1.5.1-dev.2"
+morphe-patches-library = "1.5.2-dev.10"
 # Tracking https://github.com/google/smali/issues/100.
 smali = "d92701d947"
 agp = "9.1.0"


### PR DESCRIPTION
### Description

Fixes the `About` and `Credits` dialogs rendering left to right in RTL locales, where the row chevrons pointed the wrong way and pre-release version numbers were reordered by the bidi algorithm. Both dialogs now share a single stylesheet that follows the `Morphe` app's look, with Material Symbols and brand marks replacing the hand-drawn SVG icons.
___
![Screenshot_2026-07-30-20-01-28-853_com.google.android.apps.youtube.music.test-edit.jpg](https://github.com/user-attachments/assets/cc492a6f-3b87-4eee-9231-96b9ff09cc3d)

