### PR TITLE
feat(YouTube - Hide layout components): Add "Hide 'Get Premium' button" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AdsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AdsFilter.java
@@ -72,6 +72,16 @@ public final class AdsFilter extends Filter {
 
         // Paths.
 
+        buyMovieAd = new StringFilterGroup(
+                Settings.HIDE_MOVIES_SECTION,
+                "video_lockup_with_attachment.e"
+        );
+
+        buyMovieAdBuffer = new ByteArrayFilterGroup(
+                null,
+                "FEstorefront"
+        );
+
         final var generalAds = new StringFilterGroup(
                 Settings.HIDE_GENERAL_ADS,
                 "_ad_with",
@@ -106,6 +116,12 @@ public final class AdsFilter extends Filter {
                 "watch_metadata_app_promo"
         );
 
+        final var merchandise = new StringFilterGroup(
+                Settings.HIDE_MERCHANDISE_BANNERS,
+                "product_carousel",
+                "shopping_carousel.e" // Channel profile shopping shelf.
+        );
+
         final var movieAds = new StringFilterGroup(
                 Settings.HIDE_MOVIES_SECTION,
                 "browsy_bar",
@@ -116,37 +132,8 @@ public final class AdsFilter extends Filter {
                 "offer_module_root"
         );
 
-        buyMovieAd = new StringFilterGroup(
-                Settings.HIDE_MOVIES_SECTION,
-                "video_lockup_with_attachment.e"
-        );
-
-        buyMovieAdBuffer = new ByteArrayFilterGroup(
-                null,
-                "FEstorefront"
-        );
-
-        final var viewProducts = new StringFilterGroup(
-                Settings.HIDE_PLAYER_POPUP_ADS,
-                "product_item",
-                "products_in_video",
-                "shopping_overlay.e" // Video player overlay shopping links.
-        );
-
-        final var shoppingLinks = new StringFilterGroup(
-                Settings.HIDE_SHOPPING_LINKS,
-                "shopping_description_item.e",
-                "shopping_description_shelf.e"
-        );
-
-        final var merchandise = new StringFilterGroup(
-                Settings.HIDE_MERCHANDISE_BANNERS,
-                "product_carousel",
-                "shopping_carousel.e" // Channel profile shopping shelf.
-        );
-
         final var paidPromotionLabel = new StringFilterGroup(
-                Settings.HIDE_PAID_PROMOTION_LABEL,
+                Settings.HIDE_PAID_PROMOTION_LABELS,
                 "paid_content_overlay",
                 "reel_player_disclosure.e",
                 "shorts_disclosures.e"
@@ -173,14 +160,27 @@ public final class AdsFilter extends Filter {
                 "cta_shelf_card"
         );
 
+        final var shoppingLinks = new StringFilterGroup(
+                Settings.HIDE_SHOPPING_LINKS,
+                "shopping_description_item.e",
+                "shopping_description_shelf.e"
+        );
+
         shortsPaidPromotionLabel = new StringFilterGroup(
-                Settings.HIDE_PAID_PROMOTION_LABEL,
+                Settings.HIDE_PAID_PROMOTION_LABELS,
                 "reel_carousel.e"
         );
 
         shortsPaidPromotionLabelBuffer = new ByteArrayFilterGroup(
                 null,
                 "/youtube?p=ppp" // https://support.google.com/youtube?p=ppp
+        );
+
+        final var viewProducts = new StringFilterGroup(
+                Settings.HIDE_PLAYER_POPUP_ADS,
+                "product_item",
+                "products_in_video",
+                "shopping_overlay.e" // Video player overlay shopping links.
         );
 
         addPathCallbacks(
@@ -286,7 +286,7 @@ public final class AdsFilter extends Filter {
      * Injection point.
      */
     public static void hideMiniplayerPaidPromotionLabelView(View view) {
-        Utils.hideViewBy0dpUnderCondition(Settings.HIDE_PAID_PROMOTION_LABEL, view);
+        Utils.hideViewBy0dpUnderCondition(Settings.HIDE_PAID_PROMOTION_LABELS, view);
     }
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -73,6 +73,8 @@ public final class LayoutComponentsFilter extends Filter {
     private final StringFilterGroup chipBar;
     private final StringFilterGroup channelProfile;
     private final StringFilterGroupList channelProfileGroupList = new StringFilterGroupList();
+    private final StringFilterGroup getPremiumButton;
+    private final ByteArrayFilterGroup getPremiumButtonBuffer;
     private final StringFilterGroup videoLabels;
     private final ByteArrayFilterGroupList videoLabelsGroupList = new ByteArrayFilterGroupList();
 
@@ -248,6 +250,16 @@ public final class LayoutComponentsFilter extends Filter {
                 "mixed_content_shelf"
         );
 
+        getPremiumButton = new StringFilterGroup(
+                Settings.HIDE_GET_PREMIUM_BUTTON,
+                "|button.e"
+        );
+
+        getPremiumButtonBuffer = new ByteArrayFilterGroup(
+                null,
+                "SPunlimited"
+        );
+
         final var imageShelf = new StringFilterGroup(
                 Settings.HIDE_IMAGE_SHELF,
                 "image_shelf"
@@ -371,6 +383,7 @@ public final class LayoutComponentsFilter extends Filter {
                 emergencyBox,
                 expandableMetadata,
                 forYouShelf,
+                getPremiumButton,
                 imageShelf,
                 infoPanel,
                 medicalPanel,
@@ -450,10 +463,6 @@ public final class LayoutComponentsFilter extends Filter {
             }
         }
 
-        if (matchedGroup == videoLabels) {
-            return videoLabelsGroupList.check(buffer).isFiltered();
-        }
-
         if (matchedGroup == channelProfile) {
             return channelProfileGroupList.check(accessibility).isFiltered();
         }
@@ -472,6 +481,14 @@ public final class LayoutComponentsFilter extends Filter {
         if (matchedGroup == chipBar) {
             return contentIndex == 0 && NavigationBar.NavigationButton.getSelectedNavigationButton()
                     == NavigationBar.NavigationButton.LIBRARY;
+        }
+
+        if (matchedGroup == getPremiumButton) {
+            return path.startsWith("page_header.e") && getPremiumButtonBuffer.check(buffer).isFiltered();
+        }
+
+        if (matchedGroup == videoLabels) {
+            return videoLabelsGroupList.check(buffer).isFiltered();
         }
 
         return true;

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -90,7 +90,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_END_SCREEN_STORE_BANNER = new BooleanSetting("morphe_hide_end_screen_store_banner", TRUE, true);
     public static final BooleanSetting HIDE_GENERAL_ADS = new BooleanSetting("morphe_hide_general_ads", TRUE);
     public static final BooleanSetting HIDE_MERCHANDISE_BANNERS = new BooleanSetting("morphe_hide_merchandise_banners", TRUE);
-    public static final BooleanSetting HIDE_PAID_PROMOTION_LABEL = new BooleanSetting("morphe_hide_paid_promotion_label", TRUE, true);
+    public static final BooleanSetting HIDE_PAID_PROMOTION_LABELS = new BooleanSetting("morphe_hide_paid_promotion_labels", TRUE, true);
     public static final BooleanSetting HIDE_PLAYER_POPUP_ADS = new BooleanSetting("morphe_hide_player_popup_ads", TRUE);
     public static final BooleanSetting HIDE_SELF_SPONSOR = new BooleanSetting("morphe_hide_self_sponsor_ads", TRUE);
     public static final BooleanSetting HIDE_SHOPPING_LINKS = new BooleanSetting("morphe_hide_shopping_links", TRUE);
@@ -114,6 +114,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_FILTER_BAR_IN_RELATED_VIDEOS = new BooleanSetting("morphe_hide_filter_bar_in_related_videos", FALSE, true);
     public static final BooleanSetting HIDE_FILTER_BAR_IN_SEARCH = new BooleanSetting("morphe_hide_filter_bar_in_search", FALSE, true);
     public static final BooleanSetting HIDE_FLOATING_MICROPHONE_BUTTON = new BooleanSetting("morphe_hide_floating_microphone_button", TRUE, true);
+    public static final BooleanSetting HIDE_GET_PREMIUM_BUTTON = new BooleanSetting("morphe_hide_get_premium_button", FALSE);
     public static final BooleanSetting HIDE_HORIZONTAL_SHELVES = new BooleanSetting("morphe_hide_horizontal_shelves", TRUE);
     public static final BooleanSetting HIDE_HYPED_LABEL = new BooleanSetting("morphe_hide_hyped_label", FALSE);
     public static final BooleanSetting HIDE_IMAGE_SHELF = new BooleanSetting("morphe_hide_image_shelf", TRUE);
@@ -633,12 +634,13 @@ public class Settings extends SharedYouTubeSettings {
     private static final BooleanSetting DEPRECATED_DISABLE_SIGNIN_TO_TV_POPUP = new BooleanSetting("morphe_disable_signin_to_tv_popup", FALSE);
     private static final BooleanSetting DEPRECATED_HIDE_COMMENTS_EMOJI_AND_TIMESTAMP_BUTTONS = new BooleanSetting("morphe_hide_comments_emoji_and_timestamp_buttons", FALSE);
     private static final BooleanSetting DEPRECATED_HIDE_COMMENTS_PROMPTS = new BooleanSetting("morphe_hide_comments_prompts", FALSE);
+    private static final BooleanSetting DEPRECATED_HIDE_DOODLES = new BooleanSetting("morphe_hide_doodles", FALSE);
     private static final BooleanSetting DEPRECATED_HIDE_ENDSCREEN_CARDS = new BooleanSetting("morphe_hide_endscreen_cards", FALSE);
     private static final BooleanSetting DEPRECATED_HIDE_FILTER_BAR_FEED_IN_FEED = new BooleanSetting("morphe_hide_filter_bar_feed_in_feed", FALSE, true);
     private static final BooleanSetting DEPRECATED_HIDE_FILTER_BAR_FEED_IN_HISTORY = new BooleanSetting("morphe_hide_filter_bar_feed_in_history", FALSE);
     private static final BooleanSetting DEPRECATED_HIDE_FILTER_BAR_FEED_IN_RELATED_VIDEOS = new BooleanSetting("morphe_hide_filter_bar_feed_in_related_videos", FALSE, true);
     private static final BooleanSetting DEPRECATED_HIDE_FILTER_BAR_FEED_IN_SEARCH = new BooleanSetting("morphe_hide_filter_bar_feed_in_search", FALSE, true);
-    private static final BooleanSetting DEPRECATED_HIDE_DOODLES = new BooleanSetting("morphe_hide_doodles", FALSE);
+    private static final BooleanSetting DEPRECATED_HIDE_PAID_PROMOTION_LABEL = new BooleanSetting("morphe_hide_paid_promotion_label", TRUE, true);
     private static final BooleanSetting DEPRECATED_OVERRIDE_YOUTUBE_MUSIC_BUTTON = new BooleanSetting("morphe_override_youtube_music_button", FALSE, true);
     private static final BooleanSetting DEPRECATED_RELOAD_VIDEO = new BooleanSetting("morphe_reload_video", FALSE);
     private static final BooleanSetting DEPRECATED_SANITIZE_COMMENTS_CATEGORY_BAR = new BooleanSetting("morphe_sanitize_comments_category_bar", FALSE);
@@ -699,12 +701,13 @@ public class Settings extends SharedYouTubeSettings {
         migrateOldSettingToNew(DEPRECATED_DISABLE_SIGNIN_TO_TV_POPUP, DISABLE_SIGN_IN_TO_TV_POPUP);
         migrateOldSettingToNew(DEPRECATED_HIDE_COMMENTS_EMOJI_AND_TIMESTAMP_BUTTONS, HIDE_COMMENTS_EMOJI_BUTTON);
         migrateOldSettingToNew(DEPRECATED_HIDE_COMMENTS_PROMPTS, HIDE_COMMENTS_CONTEXTS);
+        migrateOldSettingToNew(DEPRECATED_HIDE_DOODLES, HIDE_YOUTUBE_DOODLES);
         migrateOldSettingToNew(DEPRECATED_HIDE_ENDSCREEN_CARDS, HIDE_END_SCREEN_CARDS);
         migrateOldSettingToNew(DEPRECATED_HIDE_FILTER_BAR_FEED_IN_FEED, HIDE_FILTER_BAR_IN_FEED);
         migrateOldSettingToNew(DEPRECATED_HIDE_FILTER_BAR_FEED_IN_HISTORY, HIDE_FILTER_BAR_IN_HISTORY);
         migrateOldSettingToNew(DEPRECATED_HIDE_FILTER_BAR_FEED_IN_RELATED_VIDEOS, HIDE_FILTER_BAR_IN_RELATED_VIDEOS);
         migrateOldSettingToNew(DEPRECATED_HIDE_FILTER_BAR_FEED_IN_SEARCH, HIDE_FILTER_BAR_IN_SEARCH);
-        migrateOldSettingToNew(DEPRECATED_HIDE_DOODLES, HIDE_YOUTUBE_DOODLES);
+        migrateOldSettingToNew(DEPRECATED_HIDE_PAID_PROMOTION_LABEL, HIDE_PAID_PROMOTION_LABELS);
         migrateOldSettingToNew(DEPRECATED_OVERRIDE_YOUTUBE_MUSIC_BUTTON, OVERRIDE_YOUTUBE_MUSIC_BUTTONS);
         migrateOldSettingToNew(DEPRECATED_RELOAD_VIDEO, RELOAD_VIDEO_BUTTON);
         migrateOldSettingToNew(DEPRECATED_SANITIZE_COMMENTS_CATEGORY_BAR, HIDE_COMMENTS_FILTER_BAR_OPTIONS);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/ad/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/ad/HideAdsPatch.kt
@@ -62,7 +62,7 @@ private val hideAdsResourcePatch = resourcePatch {
             SwitchPreference("morphe_hide_end_screen_store_banner"),
             SwitchPreference("morphe_hide_general_ads"),
             SwitchPreference("morphe_hide_merchandise_banners"),
-            SwitchPreference("morphe_hide_paid_promotion_label"),
+            SwitchPreference("morphe_hide_paid_promotion_labels"),
             SwitchPreference("morphe_hide_player_popup_ads"),
             SwitchPreference("morphe_hide_self_sponsor_ads"),
             SwitchPreference("morphe_hide_shopping_links"),

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -380,6 +380,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
                 )
             ),
             SwitchPreference("morphe_hide_floating_microphone_button", summary = true),
+            SwitchPreference("morphe_hide_get_premium_button"),
             SwitchPreference("morphe_hide_horizontal_shelves", summary = true),
             SwitchPreference("morphe_hide_hyped_label"),
             SwitchPreference("morphe_hide_image_shelf", summary = true),

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -72,6 +72,7 @@ Changes include:
     <string name="morphe_hide_expandable_card_entry_3">Hide all</string>
     <string name="morphe_hide_floating_microphone_button_title">Hide floating microphone button</string>
     <string name="morphe_hide_floating_microphone_button_summary">Hides floating microphone button in the lower-right corner of search suggestions screen</string>
+    <string name="morphe_hide_get_premium_button_title">Hide \'Get Premium\' button</string>
     <string name="morphe_hide_horizontal_shelves_title">Hide horizontal shelves</string>
     <string name="morphe_hide_horizontal_shelves_summary">Hides horizontal shelves such as Breaking news, Community posts you may like, Continue watching, Explore more channels, Explore more topics, For You, Latest videos, Most relevant, Posts from Creator\'s Community, Shopping, and Watch it again</string>
     <string name="morphe_hide_hyped_label_title">Hide Hyped label</string>
@@ -327,7 +328,7 @@ Tap here to open AiSlopList.com and see downloads for other platforms"</string>
     <string name="morphe_hide_general_ads_title">Hide general ads</string>
     <string name="morphe_hide_merchandise_banners_title">Hide merchandise banners</string>
     <!-- 'Includes paid promotion' should be translated using the same localized wording YouTube displays for the label. -->
-    <string name="morphe_hide_paid_promotion_label_title">Hide \'Includes paid promotion\' label</string>
+    <string name="morphe_hide_paid_promotion_labels_title">Hide paid promotion labels</string>
     <string name="morphe_hide_player_popup_ads_title">Hide player popup ads</string>
     <string name="morphe_hide_self_sponsor_ads_title">Hide self sponsored cards</string>
     <string name="morphe_hide_shopping_links_title">Hide shopping links</string>


### PR DESCRIPTION
### Description

Closes #2231.

<img width="1080" height="654" alt="Screenshot_20260731_171732_YouTube" src="https://github.com/user-attachments/assets/9a30951f-6705-4590-ab2f-426de124508e" />


### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
