### PR TITLE
chore(YouTube Music - Third-party lyrics): Use the "Show" naming convention for the button settings and fix auto-translation

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/lyrics/ui/LyricsPanelView.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/lyrics/ui/LyricsPanelView.java
@@ -173,7 +173,7 @@ public final class LyricsPanelView extends FrameLayout implements LyricsManager.
         buttonRow.setGravity(Gravity.CENTER);
         buttonRow.setVisibility(GONE);
 
-        if (Settings.LYRICS_COPY_BUTTON.get()) {
+        if (!Settings.LYRICS_HIDE_COPY_BUTTON.get()) {
             TextView copyView = new TextView(context);
             applyButtonStyle(copyView, COPY_ICON);
             copyView.setText(str("morphe_music_lyrics_copy"));
@@ -183,7 +183,7 @@ public final class LyricsPanelView extends FrameLayout implements LyricsManager.
                     LinearLayout.LayoutParams.WRAP_CONTENT));
         }
 
-        if (Settings.LYRICS_TRANSLATE_BUTTON.get()) {
+        if (!Settings.LYRICS_HIDE_TRANSLATE_BUTTON.get()) {
             translateView = new TextView(context);
             applyButtonStyle(translateView, APP_TRANSLATE_ICON);
             translateView.setOnClickListener(view -> onTranslateClicked());

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/lyrics/ui/LyricsPanelView.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/lyrics/ui/LyricsPanelView.java
@@ -37,7 +37,6 @@ import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import app.morphe.extension.music.patches.lyrics.Lyrics;
 import app.morphe.extension.music.patches.lyrics.LyricsLine;
@@ -448,6 +447,12 @@ public final class LyricsPanelView extends FrameLayout implements LyricsManager.
 
     private void onTranslateClicked() {
         try {
+            // The saved translation state outlives the button, so a track change can
+            // auto translate when there is no button to drive the translation from.
+            if (translateView == null) {
+                return;
+            }
+
             Lyrics current = lyrics;
             TrackInfo track = LyricsManager.getInstance().getCurrentTrack();
             if (current == null || track == null) {
@@ -462,7 +467,7 @@ public final class LyricsPanelView extends FrameLayout implements LyricsManager.
             }
 
             Settings.LYRICS_TRANSLATE.save(true);
-            Objects.requireNonNull(translateView).setEnabled(false);
+            translateView.setEnabled(false);
             translateView.setText(str("morphe_music_lyrics_translating"));
 
             LyricsTranslator.translate(track, current, lines -> {

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/lyrics/ui/LyricsPanelView.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/lyrics/ui/LyricsPanelView.java
@@ -172,7 +172,7 @@ public final class LyricsPanelView extends FrameLayout implements LyricsManager.
         buttonRow.setGravity(Gravity.CENTER);
         buttonRow.setVisibility(GONE);
 
-        if (!Settings.LYRICS_HIDE_COPY_BUTTON.get()) {
+        if (Settings.LYRICS_SHOW_COPY_BUTTON.get()) {
             TextView copyView = new TextView(context);
             applyButtonStyle(copyView, COPY_ICON);
             copyView.setText(str("morphe_music_lyrics_copy"));
@@ -182,7 +182,7 @@ public final class LyricsPanelView extends FrameLayout implements LyricsManager.
                     LinearLayout.LayoutParams.WRAP_CONTENT));
         }
 
-        if (!Settings.LYRICS_HIDE_TRANSLATE_BUTTON.get()) {
+        if (Settings.LYRICS_SHOW_TRANSLATE_BUTTON.get()) {
             translateView = new TextView(context);
             applyButtonStyle(translateView, APP_TRANSLATE_ICON);
             translateView.setOnClickListener(view -> onTranslateClicked());

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -173,8 +173,8 @@ public class Settings extends SharedYouTubeSettings {
     public static final EnumSetting<LyricsSource> LYRICS_SOURCE = new EnumSetting<>("morphe_music_lyrics_source", LyricsSource.LRCLIB_THEN_KUGOU, true, parent(LYRICS_ENABLED));
     public static final BooleanSetting LYRICS_TRANSLATE = new BooleanSetting("morphe_music_lyrics_translate", FALSE, true, parent(LYRICS_ENABLED));
     public static final BooleanSetting LYRICS_TAP_TO_SEEK = new BooleanSetting("morphe_music_lyrics_tap_to_seek", TRUE, true, parent(LYRICS_ENABLED));
-    public static final BooleanSetting LYRICS_HIDE_COPY_BUTTON = new BooleanSetting("morphe_music_lyrics_hide_copy_button", FALSE, true, parent(LYRICS_ENABLED));
-    public static final BooleanSetting LYRICS_HIDE_TRANSLATE_BUTTON = new BooleanSetting("morphe_music_lyrics_hide_translate_button", FALSE, true, parent(LYRICS_ENABLED));
+    public static final BooleanSetting LYRICS_SHOW_COPY_BUTTON = new BooleanSetting("morphe_music_lyrics_show_copy_button", TRUE, true, parent(LYRICS_ENABLED));
+    public static final BooleanSetting LYRICS_SHOW_TRANSLATE_BUTTON = new BooleanSetting("morphe_music_lyrics_show_translate_button", TRUE, true, parent(LYRICS_ENABLED));
     public static final IntegerSetting LYRICS_TEXT_SIZE = new IntegerSetting("morphe_music_lyrics_text_size", 24, true, parent(LYRICS_ENABLED));
     public static final IntegerSetting LYRICS_OFFSET_MS = new IntegerSetting("morphe_music_lyrics_offset_ms", 0, true, parent(LYRICS_ENABLED));
 

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -173,8 +173,8 @@ public class Settings extends SharedYouTubeSettings {
     public static final EnumSetting<LyricsSource> LYRICS_SOURCE = new EnumSetting<>("morphe_music_lyrics_source", LyricsSource.LRCLIB_THEN_KUGOU, true, parent(LYRICS_ENABLED));
     public static final BooleanSetting LYRICS_TRANSLATE = new BooleanSetting("morphe_music_lyrics_translate", FALSE, true, parent(LYRICS_ENABLED));
     public static final BooleanSetting LYRICS_TAP_TO_SEEK = new BooleanSetting("morphe_music_lyrics_tap_to_seek", TRUE, true, parent(LYRICS_ENABLED));
-    public static final BooleanSetting LYRICS_COPY_BUTTON = new BooleanSetting("morphe_music_lyrics_copy_button", TRUE, true, parent(LYRICS_ENABLED));
-    public static final BooleanSetting LYRICS_TRANSLATE_BUTTON = new BooleanSetting("morphe_music_lyrics_translate_button", TRUE, true, parent(LYRICS_ENABLED));
+    public static final BooleanSetting LYRICS_HIDE_COPY_BUTTON = new BooleanSetting("morphe_music_lyrics_hide_copy_button", FALSE, true, parent(LYRICS_ENABLED));
+    public static final BooleanSetting LYRICS_HIDE_TRANSLATE_BUTTON = new BooleanSetting("morphe_music_lyrics_hide_translate_button", FALSE, true, parent(LYRICS_ENABLED));
     public static final IntegerSetting LYRICS_TEXT_SIZE = new IntegerSetting("morphe_music_lyrics_text_size", 24, true, parent(LYRICS_ENABLED));
     public static final IntegerSetting LYRICS_OFFSET_MS = new IntegerSetting("morphe_music_lyrics_offset_ms", 0, true, parent(LYRICS_ENABLED));
 

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/lyrics/LyricsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/lyrics/LyricsPatch.kt
@@ -61,8 +61,8 @@ val lyricsPatch = bytecodePatch(
             SwitchPreference("morphe_music_lyrics_enabled", summary = true),
             ListPreference("morphe_music_lyrics_source"),
             SwitchPreference("morphe_music_lyrics_tap_to_seek", summary = true),
-            SwitchPreference("morphe_music_lyrics_hide_copy_button"),
-            SwitchPreference("morphe_music_lyrics_hide_translate_button"),
+            SwitchPreference("morphe_music_lyrics_show_copy_button"),
+            SwitchPreference("morphe_music_lyrics_show_translate_button"),
             NonInteractivePreference(
                 key = "morphe_music_lyrics_text_size",
                 summaryKey = "morphe_music_lyrics_text_size_summary",

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/lyrics/LyricsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/lyrics/LyricsPatch.kt
@@ -61,8 +61,8 @@ val lyricsPatch = bytecodePatch(
             SwitchPreference("morphe_music_lyrics_enabled", summary = true),
             ListPreference("morphe_music_lyrics_source"),
             SwitchPreference("morphe_music_lyrics_tap_to_seek", summary = true),
-            SwitchPreference("morphe_music_lyrics_copy_button"),
-            SwitchPreference("morphe_music_lyrics_translate_button"),
+            SwitchPreference("morphe_music_lyrics_hide_copy_button"),
+            SwitchPreference("morphe_music_lyrics_hide_translate_button"),
             NonInteractivePreference(
                 key = "morphe_music_lyrics_text_size",
                 summaryKey = "morphe_music_lyrics_text_size_summary",

--- a/patches/src/main/resources/addresources/values/music/strings.xml
+++ b/patches/src/main/resources/addresources/values/music/strings.xml
@@ -344,8 +344,8 @@ To ensure scrobbling is synced during background playback, ensure that YouTube M
     <string name="morphe_music_lyrics_source_entry_kugou" translatable="false">KuGou</string>
     <string name="morphe_music_lyrics_tap_to_seek_title">Tap a line to seek</string>
     <string name="morphe_music_lyrics_tap_to_seek_summary">Tapping a line jumps to that moment in the song</string>
-    <string name="morphe_music_lyrics_hide_copy_button_title">Hide Copy button</string>
-    <string name="morphe_music_lyrics_hide_translate_button_title">Hide Translate button</string>
+    <string name="morphe_music_lyrics_show_copy_button_title">Show Copy button</string>
+    <string name="morphe_music_lyrics_show_translate_button_title">Show Translate button</string>
     <string name="morphe_music_lyrics_text_size_title">Text size</string>
     <string name="morphe_music_lyrics_text_size_summary">Size of the lyrics text</string>
     <string name="morphe_music_lyrics_offset_ms_title">Timing offset</string>

--- a/patches/src/main/resources/addresources/values/music/strings.xml
+++ b/patches/src/main/resources/addresources/values/music/strings.xml
@@ -344,8 +344,8 @@ To ensure scrobbling is synced during background playback, ensure that YouTube M
     <string name="morphe_music_lyrics_source_entry_kugou" translatable="false">KuGou</string>
     <string name="morphe_music_lyrics_tap_to_seek_title">Tap a line to seek</string>
     <string name="morphe_music_lyrics_tap_to_seek_summary">Tapping a line jumps to that moment in the song</string>
-    <string name="morphe_music_lyrics_copy_button_title">Show copy lyrics button</string>
-    <string name="morphe_music_lyrics_translate_button_title">Show translate lyrics button</string>
+    <string name="morphe_music_lyrics_hide_copy_button_title">Hide Copy button</string>
+    <string name="morphe_music_lyrics_hide_translate_button_title">Hide Translate button</string>
     <string name="morphe_music_lyrics_text_size_title">Text size</string>
     <string name="morphe_music_lyrics_text_size_summary">Size of the lyrics text</string>
     <string name="morphe_music_lyrics_offset_ms_title">Timing offset</string>


### PR DESCRIPTION
### Description

Makes the state of the `Third-party lyrics` button settings explicit in their keys. Setting titles describe the state the toggle turns on, so both keep their "Show ..." wording and stay enabled by default; only the keys and the title phrasing change.

| Before | After |
| --- | --- |
| `morphe_music_lyrics_copy_button` — "Show copy lyrics button" | `morphe_music_lyrics_show_copy_button` — "Show Copy button" |
| `morphe_music_lyrics_translate_button` — "Show translate lyrics button" | `morphe_music_lyrics_show_translate_button` — "Show Translate button" |

Both default to on, so there is no behaviour change.

It also fixes a null dereference on the auto-translate path, reported by Copilot during review. `LYRICS_TRANSLATE` is persisted, so a track change could call `onTranslateClicked()` with the Translate button hidden and `translateView` null. `Objects.requireNonNull` then threw, and because the method catches `Exception` this never crashed — it silently stopped translating while leaving the setting saved as on. The guard now returns before the state is saved, matching how `updateTranslateLabel()` already null-checks the same field.

The setting is deliberately not forced off when the button is hidden, so hiding and later unhiding the button resumes translation as the user left it.

This part is not caused by the rename — the previous `morphe_music_lyrics_translate_button` switch could hide the button too, so the same path was already reachable.

Closes #

### Additional context

The two renamed keys lose their existing translations until the next Crowdin sync. `AddResourcesPatch` skips translated strings whose key is missing from the default locale, so both settings fall back to English in the meantime. The wording is unchanged in meaning, so the translations should carry over cleanly once Crowdin picks up the new keys.

No settings migration is included, as the old keys only ever shipped in the `v1.39.0-dev.2` and `v1.39.0-dev.3` prereleases. The polarity is unchanged, so `migrateOldSettingToNew` would work here if one is wanted.

### Test results

- [ ] Tested on both the **minimum** and **maximum** supported versions
- [ ] Tested on **experimental** supported versions (Optional)