### PR TITLE
feat(YouTube - Disable sign in to TV popup): Add "Disable 'Connect your devices' popup" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableSignInToTVPopupPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableSignInToTVPopupPatch.java
@@ -11,4 +11,11 @@ public class DisableSignInToTVPopupPatch {
     public static boolean disableSignInToTVPopup() {
         return Settings.DISABLE_SIGN_IN_TO_TV_POPUP.get();
     }
+
+    /**
+     * Injection point.
+     */
+    public static boolean disableConnectYourDevicesPopup() {
+        return Settings.DISABLE_CONNECT_YOUR_DEVICES_POPUP.get();
+    }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableSignInToTVPopupPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableSignInToTVPopupPatch.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.youtube.patches;
 
 import app.morphe.extension.youtube.settings.Settings;

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -415,6 +415,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final EnumSetting<SplashScreenAnimationStyle> SPLASH_SCREEN_ANIMATION_STYLE = new EnumSetting<>("morphe_splash_screen_animation_style", SplashScreenAnimationStyle.FPS_60_ONE_SECOND, true);
     public static final EnumSetting<HeaderLogo> HEADER_LOGO = new EnumSetting<>("morphe_header_logo", HeaderLogo.DEFAULT, true);
     public static final BooleanSetting DISABLE_SIGN_IN_TO_TV_POPUP = new BooleanSetting("morphe_disable_sign_in_to_tv_popup", FALSE);
+    public static final BooleanSetting DISABLE_CONNECT_YOUR_DEVICES_POPUP = new BooleanSetting("morphe_disable_connect_your_devices_popup", FALSE);
     public static final BooleanSetting OPEN_SYSTEM_SHARE_SHEET = new BooleanSetting("morphe_open_system_share_sheet", FALSE);
     public static final BooleanSetting OVERRIDE_YOUTUBE_MUSIC_BUTTONS = new BooleanSetting("morphe_override_youtube_music_buttons", FALSE, true);
     public static final StringSetting MORPHE_MUSIC_PACKAGE_NAME = new StringSetting("morphe_music_package_name", "app.morphe.android.apps.youtube.music", true, parent(OVERRIDE_YOUTUBE_MUSIC_BUTTONS));

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/signintotvpopup/DisableSignInToTVPopupPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/signintotvpopup/DisableSignInToTVPopupPatch.kt
@@ -27,7 +27,8 @@ private const val EXTENSION_CLASS =
 
 val disableSignInToTVPopupPatch = bytecodePatch(
     name = "Disable sign in to TV popup",
-    description = "Adds an option to disable the popup asking to sign into a TV on the same local network.",
+    description = "Adds options to disable the popups asking to sign into or connect to a TV " +
+        "on the same local network.",
 ) {
     dependsOn(
         settingsPatch,
@@ -39,7 +40,8 @@ val disableSignInToTVPopupPatch = bytecodePatch(
 
     execute {
         PreferenceScreen.MISC.addPreferences(
-            SwitchPreference("morphe_disable_sign_in_to_tv_popup")
+            SwitchPreference("morphe_disable_sign_in_to_tv_popup"),
+            SwitchPreference("morphe_disable_connect_your_devices_popup")
         )
 
         SignInToTVPopupFingerprint.let {
@@ -66,6 +68,22 @@ val disableSignInToTVPopupPatch = bytecodePatch(
                     """
                 )
             }
+        }
+
+        HandoffPromoCommandResolverFingerprint.method.apply {
+            val free = findFreeRegister(0)
+
+            addInstructionsWithLabels(
+                0,
+                """
+                    invoke-static { }, $EXTENSION_CLASS->disableConnectYourDevicesPopup()Z
+                    move-result v$free
+                    if-eqz v$free, :allow_connect_popup
+                    return-void
+                    :allow_connect_popup
+                    nop
+                """
+            )
         }
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/signintotvpopup/DisableSignInToTVPopupPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/signintotvpopup/DisableSignInToTVPopupPatch.kt
@@ -70,20 +70,16 @@ val disableSignInToTVPopupPatch = bytecodePatch(
             }
         }
 
-        HandoffPromoCommandResolverFingerprint.method.apply {
-            val free = findFreeRegister(0)
-
-            addInstructionsWithLabels(
-                0,
-                """
-                    invoke-static { }, $EXTENSION_CLASS->disableConnectYourDevicesPopup()Z
-                    move-result v$free
-                    if-eqz v$free, :allow_connect_popup
-                    return-void
-                    :allow_connect_popup
-                    nop
-                """
-            )
-        }
+        HandoffPromoCommandResolverFingerprint.method.addInstructionsWithLabels(
+            0,
+            """
+                invoke-static { }, $EXTENSION_CLASS->disableConnectYourDevicesPopup()Z
+                move-result v0
+                if-eqz v0, :allow_connect_popup
+                return-void
+                :allow_connect_popup
+                nop
+            """
+        )
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/signintotvpopup/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/signintotvpopup/Fingerprints.kt
@@ -37,8 +37,8 @@ internal object HandoffPromoCommandResolverFingerprint : Fingerprint(
     returnType = "V",
     parameters = listOf("L", "Ljava/util/Map;"),
     strings = listOf(
-        "com/google/android/apps/youtube/app/mdx/handoff/HandoffPromoCommandResolver",
-        "generateMealbarPromoRendererWithSubstitutedPlaceholders"
+        "Unsupported RunCase: ",
+        "Unspecified PlaceholderType."
     )
 )
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/signintotvpopup/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/signintotvpopup/Fingerprints.kt
@@ -32,6 +32,16 @@ internal object SignInToTVPopupFingerprint : Fingerprint(
     )
 )
 
+internal object HandoffPromoCommandResolverFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf("L", "Ljava/util/Map;"),
+    strings = listOf(
+        "com/google/android/apps/youtube/app/mdx/handoff/HandoffPromoCommandResolver",
+        "generateMealbarPromoRendererWithSubstitutedPlaceholders"
+    )
+)
+
 internal object SignInToTVPopupDismissFingerprint : Fingerprint(
     classFingerprint = SignInToTVPopupFingerprint,
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -363,6 +363,7 @@ Tap here to open AiSlopList.com and see downloads for other platforms"</string>
 
     <!-- layout.hide.signintotv.disableSignInToTVPopupPatch -->
     <string name="morphe_disable_sign_in_to_tv_popup_title">Disable \'Sign in to TV\' popup</string>
+    <string name="morphe_disable_connect_your_devices_popup_title">Disable \'Connect your devices\' popup</string>
 
     <!-- interaction.doubletap.disableDoubleTapActionsPatch -->
     <string name="morphe_disable_chapter_skip_double_tap_title">Disable double-tap chapter skip</string>


### PR DESCRIPTION
### Description

Adds a setting to hide the "Connect your devices" popup that YouTube shows when a TV on the same local network is signed in to your account.

![Screenshot_2026-08-04-15-40-40-911_com.google.android.youtube.test-edit.jpg](https://github.com/user-attachments/assets/1b890012-d039-442f-adb0-c2cd149ca89d)

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
