### PR TITLE
feat(YouTube - Add to queue): Add "Add feed flyout queue menu item" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AddToQueuePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AddToQueuePatch.java
@@ -53,6 +53,7 @@ public final class AddToQueuePatch {
             initializeNewDivider(flyoutPanel, currentInjectIndex);
         }
     }
+
     @SuppressWarnings({"UnusedReturnValue", "SameParameterValue"})
     private static int initializeNewButton(Object flyoutPanel, Drawable icon, String text,
                                            View.OnClickListener clickListener, int index) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AddToQueuePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AddToQueuePatch.java
@@ -8,8 +8,21 @@
 package app.morphe.extension.youtube.patches;
 
 import android.app.Activity;
+import android.app.Dialog;
+import android.content.Context;
+import android.graphics.PorterDuff;
+import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
 import android.util.Pair;
+import android.view.Gravity;
 import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.PopupWindow;
+import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 
@@ -17,7 +30,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.youtube.patches.utils.FlyoutUtils;
 import app.morphe.extension.youtube.patches.utils.PlaylistPatch;
 import app.morphe.extension.youtube.settings.Settings;
@@ -26,11 +41,173 @@ import app.morphe.extension.youtube.settings.Settings;
 public final class AddToQueuePatch {
 
     private static final String queueButtonName = "QUEUE_PLAY_NEXT";
+    private static final Drawable queueButtonDrawable =
+            ResourceUtils.getDrawable("quantum_ic_playlist_add_white_24");
     private static final String shareButtonName = "SHARE_ARROW";
 
+    private static final int BLACK_COLOR = ResourceUtils.getColor("yt_black1");
+    private static final int GREY_COLOR = ResourceUtils.getColor("yt_grey1");
+    private static final int WHITE_COLOR = ResourceUtils.getColor("yt_white1");
+
     private static final List<Pair<String, Integer>> visibleFlyoutButtons = new ArrayList<>();
+
     private static String currentButtonName = "";
     private static int currentButtonIndex;
+
+    public static void injectFlyoutElements(Object popupView) {
+        int currentInjectIndex = initializeNewButton(
+                popupView,
+                queueButtonDrawable,
+                "Add to queue (Morphe)",
+                v -> {
+                    flyoutButtonClickLogic(queueButtonName);
+                },
+                0
+        );
+        initializeNewDivider(popupView, currentInjectIndex + 1);
+    }
+    @SuppressWarnings({"UnusedReturnValue", "SameParameterValue"})
+    private static int initializeNewButton(
+            Object popupView,
+            Drawable icon,
+            String text,
+            View.OnClickListener clickListener,
+            int index
+    ) {
+        return initializeNewElement(
+                popupView,
+                icon,
+                text,
+                clickListener,
+                index,
+                false
+        );
+    }
+    @SuppressWarnings({"UnusedReturnValue", "SameParameterValue"})
+    private static int initializeNewDivider(
+            Object popupView,
+            int index
+    ) {
+        return initializeNewElement(
+                popupView,
+                null,
+                null,
+                null,
+                index,
+                true
+        );
+    }
+    private static int initializeNewElement(
+            Object popupView,
+            Drawable icon,
+            String text,
+            View.OnClickListener clickListener,
+            int index,
+            boolean isDivider
+    ) {
+        try {
+            if (popupView == null) {
+                return -1;
+            }
+
+            PopupWindow popupWindow = null;
+            FrameLayout frameLayout = null;
+
+            if (popupView instanceof PopupWindow checkedPopupWindow) {
+                popupWindow = checkedPopupWindow;
+                if (checkedPopupWindow.getContentView() instanceof FrameLayout checkFrame) {
+                    frameLayout = checkFrame;
+                }
+            } else if (popupView instanceof Dialog checkedDialog) {
+                Window window = checkedDialog.getWindow();
+                if (window != null && window.getDecorView() instanceof ViewGroup decorView) {
+                    if (decorView.getChildAt(0) instanceof FrameLayout checkFrame) {
+                        frameLayout = checkFrame;
+                    }
+                }
+            }
+
+            if (frameLayout == null ||
+                    !(frameLayout.getChildAt(0) instanceof ViewGroup viewGroup)) {
+                return -1;
+            }
+
+            if (!(viewGroup.getChildAt(0) instanceof LinearLayout menuContainer)) {
+                return -1;
+            }
+
+            Context context = Utils.getContext();
+            if (context == null) {
+                return -1;
+            }
+
+            float density = Dim.getMetrics().density;
+            int density1 = (int) (1 * density);
+            int density4 = (int) (4 * density);
+            int density12 = (int) (12 * density);
+            int density16 = (int) (16 * density);
+            int density24 = (int) (24 * density);
+
+            if (!isDivider) {
+                final LinearLayout customButton = new LinearLayout(context);
+                customButton.setOrientation(LinearLayout.HORIZONTAL);
+                customButton.setGravity(Gravity.CENTER_VERTICAL);
+                customButton.setPadding(density16, density12, density16, density12);
+                customButton.setClickable(true);
+                customButton.setBackgroundColor(
+                        Utils.isDarkModeEnabled()
+                                ? BLACK_COLOR
+                                : WHITE_COLOR
+                );
+
+                final LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(density24, density24);
+                layoutParams.rightMargin = density16;
+
+                if (icon != null) {
+                    final ImageView iconView = new ImageView(context);
+                    iconView.setLayoutParams(layoutParams);
+
+                    final Drawable mutableIcon = icon.mutate();
+                    mutableIcon.setTint(Utils.isDarkModeEnabled() ? WHITE_COLOR : BLACK_COLOR);
+                    mutableIcon.setTintMode(PorterDuff.Mode.SRC_IN);
+                    iconView.setImageDrawable(mutableIcon);
+
+                    customButton.addView(iconView);
+                }
+
+                final TextView textView = new TextView(context);
+                textView.setText(text);
+                textView.setTextSize(16);
+                textView.setTypeface(null, Typeface.BOLD);
+
+                customButton.addView(textView);
+                customButton.setOnClickListener(clickListener);
+
+                menuContainer.addView(customButton, index);
+            } else {
+                final View divider = new View(context);
+                final LinearLayout.LayoutParams dividerParams = new LinearLayout.LayoutParams(
+                        LinearLayout.LayoutParams.MATCH_PARENT,
+                        density1
+                );
+                dividerParams.setMargins(density16, density4, density16, density4);
+                divider.setLayoutParams(dividerParams);
+                divider.setBackgroundColor(GREY_COLOR);
+
+                menuContainer.addView(divider, index);
+            }
+
+            if (popupWindow != null) {
+                popupWindow.update();
+            }
+
+            return index;
+        } catch (Exception ex) {
+            Logger.printException(() -> "injectButton failure", ex);
+        }
+
+        return -1;
+    }
 
     /**
      * Injection point.

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AddToQueuePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AddToQueuePatch.java
@@ -24,7 +24,7 @@ public final class AddToQueuePatch {
 
     public static final String queueButtonName = "QUEUE_PLAY_NEXT";
     public static final Drawable queueButtonDrawable = ResourceUtils
-            .getDrawable("quantum_ic_playlist_add_white_24");
+            .getDrawable("yt_outline_experimental_queue_vd_theme_24");
 
     /**
      * Injection point.

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AddToQueuePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AddToQueuePatch.java
@@ -7,6 +7,8 @@
 
 package app.morphe.extension.youtube.patches;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
@@ -30,8 +32,8 @@ import app.morphe.extension.youtube.settings.Settings;
 public final class AddToQueuePatch {
 
     private static final String queueButtonName = "QUEUE_PLAY_NEXT";
-    private static final Drawable queueButtonDrawable =
-            ResourceUtils.getDrawable("quantum_ic_playlist_add_white_24");
+    private static final Drawable queueButtonDrawable = ResourceUtils
+            .getDrawable("quantum_ic_playlist_add_white_24");
     private static final String shareButtonName = "SHARE_ARROW";
 
     private static final List<Pair<String, Integer>> visibleFlyoutButtons = new ArrayList<>();
@@ -43,10 +45,8 @@ public final class AddToQueuePatch {
         int currentInjectIndex = initializeNewButton(
                 flyoutPanel,
                 queueButtonDrawable,
-                "Add to queue (Morphe)",
-                v -> {
-                    flyoutButtonClickLogic(queueButtonName);
-                },
+                str("morphe_queue_flyout_title"),
+                v -> flyoutButtonClickLogic(queueButtonName),
                 0
         );
         if (currentInjectIndex > 0) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AddToQueuePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AddToQueuePatch.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.ui.Dim;
@@ -54,9 +55,9 @@ public final class AddToQueuePatch {
     private static String currentButtonName = "";
     private static int currentButtonIndex;
 
-    public static void injectFlyoutElements(Object popupView) {
+    public static void injectFlyoutElements(Object flyoutPanel) {
         int currentInjectIndex = initializeNewButton(
-                popupView,
+                flyoutPanel,
                 queueButtonDrawable,
                 "Add to queue (Morphe)",
                 v -> {
@@ -64,18 +65,20 @@ public final class AddToQueuePatch {
                 },
                 0
         );
-        initializeNewDivider(popupView, currentInjectIndex + 1);
+        if (currentInjectIndex > 0) {
+            initializeNewDivider(flyoutPanel, currentInjectIndex);
+        }
     }
     @SuppressWarnings({"UnusedReturnValue", "SameParameterValue"})
     private static int initializeNewButton(
-            Object popupView,
+            Object flyoutPanel,
             Drawable icon,
             String text,
             View.OnClickListener clickListener,
             int index
     ) {
         return initializeNewElement(
-                popupView,
+                flyoutPanel,
                 icon,
                 text,
                 clickListener,
@@ -85,11 +88,11 @@ public final class AddToQueuePatch {
     }
     @SuppressWarnings({"UnusedReturnValue", "SameParameterValue"})
     private static int initializeNewDivider(
-            Object popupView,
+            Object flyoutPanel,
             int index
     ) {
         return initializeNewElement(
-                popupView,
+                flyoutPanel,
                 null,
                 null,
                 null,
@@ -98,7 +101,7 @@ public final class AddToQueuePatch {
         );
     }
     private static int initializeNewElement(
-            Object popupView,
+            Object flyoutPanel,
             Drawable icon,
             String text,
             View.OnClickListener clickListener,
@@ -106,33 +109,45 @@ public final class AddToQueuePatch {
             boolean isDivider
     ) {
         try {
-            if (popupView == null) {
+            if (flyoutPanel == null) {
                 return -1;
             }
 
             PopupWindow popupWindow = null;
-            FrameLayout frameLayout = null;
+            LinearLayout menuContainer = null;
+            int fixedIndex = index;
 
-            if (popupView instanceof PopupWindow checkedPopupWindow) {
+            if (flyoutPanel instanceof PopupWindow checkedPopupWindow) {
                 popupWindow = checkedPopupWindow;
-                if (checkedPopupWindow.getContentView() instanceof FrameLayout checkFrame) {
-                    frameLayout = checkFrame;
+                if (checkedPopupWindow.getContentView() instanceof FrameLayout frameLayout) {
+                    if (frameLayout.getChildAt(0) instanceof ViewGroup viewGroup &&
+                            viewGroup.getChildAt(0) instanceof LinearLayout checkedMenuContainer) {
+                        menuContainer = checkedMenuContainer;
+                    }
                 }
-            } else if (popupView instanceof Dialog checkedDialog) {
+            } else if (flyoutPanel instanceof Dialog checkedDialog) {
                 Window window = checkedDialog.getWindow();
-                if (window != null && window.getDecorView() instanceof ViewGroup decorView) {
-                    if (decorView.getChildAt(0) instanceof FrameLayout checkFrame) {
-                        frameLayout = checkFrame;
+                if (window != null) {
+                    View decorView = window.getDecorView();
+                    int containerId = ResourceUtils.getIdentifier(ResourceType.ID, "container");
+                    if (containerId != 0) {
+                        View container = decorView.findViewById(containerId);
+                        if (container instanceof FrameLayout frameLayout) {
+                            if (frameLayout.getChildAt(0) instanceof ViewGroup coordinator &&
+                                    coordinator.getChildAt(1) instanceof ViewGroup nestedFrame) {
+                                View menuRoot = nestedFrame.getChildAt(0);
+                                if (menuRoot instanceof ViewGroup group &&
+                                        group.getChildAt(0) instanceof LinearLayout linearLayout) {
+                                    menuContainer = linearLayout;
+                                    fixedIndex += 1;
+                                }
+                            }
+                        }
                     }
                 }
             }
 
-            if (frameLayout == null ||
-                    !(frameLayout.getChildAt(0) instanceof ViewGroup viewGroup)) {
-                return -1;
-            }
-
-            if (!(viewGroup.getChildAt(0) instanceof LinearLayout menuContainer)) {
+            if (menuContainer == null) {
                 return -1;
             }
 
@@ -183,7 +198,7 @@ public final class AddToQueuePatch {
                 customButton.addView(textView);
                 customButton.setOnClickListener(clickListener);
 
-                menuContainer.addView(customButton, index);
+                menuContainer.addView(customButton, fixedIndex);
             } else {
                 final View divider = new View(context);
                 final LinearLayout.LayoutParams dividerParams = new LinearLayout.LayoutParams(
@@ -194,14 +209,14 @@ public final class AddToQueuePatch {
                 divider.setLayoutParams(dividerParams);
                 divider.setBackgroundColor(GREY_COLOR);
 
-                menuContainer.addView(divider, index);
+                menuContainer.addView(divider, fixedIndex);
             }
 
             if (popupWindow != null) {
                 popupWindow.update();
             }
 
-            return index;
+            return fixedIndex;
         } catch (Exception ex) {
             Logger.printException(() -> "injectButton failure", ex);
         }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AddToQueuePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AddToQueuePatch.java
@@ -116,6 +116,7 @@ public final class AddToQueuePatch {
             PopupWindow popupWindow = null;
             LinearLayout menuContainer = null;
             int fixedIndex = index;
+            final boolean newLayout;
 
             if (flyoutPanel instanceof PopupWindow checkedPopupWindow) {
                 popupWindow = checkedPopupWindow;
@@ -125,26 +126,31 @@ public final class AddToQueuePatch {
                         menuContainer = checkedMenuContainer;
                     }
                 }
-            } else if (flyoutPanel instanceof Dialog checkedDialog) {
-                Window window = checkedDialog.getWindow();
-                if (window != null) {
-                    View decorView = window.getDecorView();
-                    int containerId = ResourceUtils.getIdentifier(ResourceType.ID, "container");
-                    if (containerId != 0) {
-                        View container = decorView.findViewById(containerId);
-                        if (container instanceof FrameLayout frameLayout) {
-                            if (frameLayout.getChildAt(0) instanceof ViewGroup coordinator &&
-                                    coordinator.getChildAt(1) instanceof ViewGroup nestedFrame) {
-                                View menuRoot = nestedFrame.getChildAt(0);
-                                if (menuRoot instanceof ViewGroup group &&
-                                        group.getChildAt(0) instanceof LinearLayout linearLayout) {
-                                    menuContainer = linearLayout;
-                                    fixedIndex += 1;
+                newLayout = true;
+            } else {
+                if (flyoutPanel instanceof Dialog checkedDialog) {
+                    Window window = checkedDialog.getWindow();
+                    if (window != null) {
+                        View decorView = window.getDecorView();
+                        int containerId = ResourceUtils.getIdentifier(ResourceType.ID, "container");
+                        if (containerId != 0) {
+                            View container = decorView.findViewById(containerId);
+                            if (container instanceof FrameLayout frameLayout) {
+                                if (frameLayout.getChildAt(0) instanceof ViewGroup coordinator &&
+                                        coordinator.getChildAt(1) instanceof ViewGroup nestedFrame) {
+                                    View menuRoot = nestedFrame.getChildAt(0);
+                                    if (menuRoot instanceof ViewGroup group &&
+                                            group.getChildAt(0) instanceof LinearLayout linearLayout) {
+                                        menuContainer = linearLayout;
+                                        // Skip an index to inject the button after the bottom sheet handle.
+                                        fixedIndex += 1;
+                                    }
                                 }
                             }
                         }
                     }
                 }
+                newLayout = false;
             }
 
             if (menuContainer == null) {
@@ -214,6 +220,12 @@ public final class AddToQueuePatch {
 
             if (popupWindow != null) {
                 popupWindow.update();
+            }
+
+            // For new layout only:
+            // Skip an index to inject the next element after the current button.
+            if (newLayout) {
+                fixedIndex++;
             }
 
             return fixedIndex;

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AddToQueuePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AddToQueuePatch.java
@@ -7,19 +7,10 @@
 
 package app.morphe.extension.youtube.patches;
 
-import static app.morphe.extension.shared.StringRef.str;
-
 import android.app.Activity;
-import android.content.Context;
 import android.graphics.drawable.Drawable;
-import android.util.Pair;
-import android.view.View;
-import android.widget.PopupWindow;
 
 import androidx.annotation.Nullable;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceUtils;
@@ -31,105 +22,9 @@ import app.morphe.extension.youtube.settings.Settings;
 @SuppressWarnings("unused")
 public final class AddToQueuePatch {
 
-    private static final String queueButtonName = "QUEUE_PLAY_NEXT";
-    private static final Drawable queueButtonDrawable = ResourceUtils
+    public static final String queueButtonName = "QUEUE_PLAY_NEXT";
+    public static final Drawable queueButtonDrawable = ResourceUtils
             .getDrawable("quantum_ic_playlist_add_white_24");
-    private static final String shareButtonName = "SHARE_ARROW";
-
-    private static final List<Pair<String, Integer>> visibleFlyoutButtons = new ArrayList<>();
-
-    private static String currentButtonName = "";
-    private static int currentButtonIndex;
-
-    public static void injectFlyoutElements(Object flyoutPanel) {
-        int currentInjectIndex = initializeNewButton(
-                flyoutPanel,
-                queueButtonDrawable,
-                str("morphe_queue_flyout_title"),
-                v -> flyoutButtonClickLogic(queueButtonName),
-                0
-        );
-        if (currentInjectIndex > 0) {
-            initializeNewDivider(flyoutPanel, currentInjectIndex);
-        }
-    }
-
-    @SuppressWarnings({"UnusedReturnValue", "SameParameterValue"})
-    private static int initializeNewButton(Object flyoutPanel, Drawable icon, String text,
-                                           View.OnClickListener clickListener, int index) {
-        return initializeNewElement(flyoutPanel, icon, text, clickListener, index, false);
-    }
-
-    @SuppressWarnings({"UnusedReturnValue", "SameParameterValue"})
-    private static int initializeNewDivider(Object flyoutPanel, int index) {
-        return initializeNewElement(flyoutPanel, null, null, null, index, true);
-    }
-
-    private static int initializeNewElement(Object flyoutPanel, Drawable icon, String text,
-                                            View.OnClickListener clickListener, int index,
-                                            boolean isDivider) {
-        try {
-            FlyoutUtils.FlyoutMenuInfo menuInfo = FlyoutUtils.getFlyoutMenuInfo(flyoutPanel, index);
-            if (menuInfo == null) {
-                return -1;
-            }
-
-            Context context = Utils.getActivity();
-            if (context == null) {
-                return -1;
-            }
-
-            View view = isDivider
-                    ? FlyoutUtils.createFlyoutDivider(context)
-                    : FlyoutUtils.createFlyoutButton(context, icon, text, clickListener);
-
-            int fixedIndex = menuInfo.adjustedIndex();
-            menuInfo.menuContainer().addView(view, fixedIndex);
-
-            PopupWindow popupWindow = menuInfo.popupWindow();
-            if (popupWindow != null) {
-                popupWindow.update();
-            }
-
-            // For new layout only:
-            // Skip an index to inject the next element after the current button.
-            if (menuInfo.isPopupWindow()) {
-                fixedIndex++;
-            }
-
-            return fixedIndex;
-        } catch (Exception ex) {
-            Logger.printException(() -> "initializeNewElement failure", ex);
-        }
-
-        return -1;
-    }
-
-    /**
-     * Injection point.
-     */
-    public static void setCurrentButtonInfo(@Nullable Enum<?> buttonEnum, @Nullable Object buttonInfo) {
-        if (buttonEnum == null) {
-            return;
-        }
-
-        if (buttonInfo instanceof CharSequence charSequence && charSequence.toString().isEmpty()) {
-            return;
-        }
-
-        if (buttonInfo instanceof View view && view.getVisibility() == View.GONE) {
-            return;
-        }
-
-        if (currentButtonIndex == 0 && !visibleFlyoutButtons.isEmpty()) {
-            visibleFlyoutButtons.clear();
-        }
-
-        currentButtonName = buttonEnum.name();
-        currentButtonIndex++;
-
-        visibleFlyoutButtons.add(new Pair<>(currentButtonName, currentButtonIndex));
-    }
 
     /**
      * Injection point.
@@ -144,12 +39,11 @@ public final class AddToQueuePatch {
             return original;
         }
 
-        return getNewRunnable(original, currentButtonName);
+        return getNewRunnable(original, FlyoutUtils.getCurrentButtonName());
     }
 
     /**
      * Injection point.
-     * -
      * 21.04 and older.
      */
     public static boolean replaceOnItemClick(Object object) {
@@ -172,9 +66,9 @@ public final class AddToQueuePatch {
         }
 
         try {
-            if (!visibleFlyoutButtons.isEmpty()) {
+            if (!FlyoutUtils.getVisibleFlyoutButtons().isEmpty()) {
                 if (buttonIndex >= 0) {
-                    return flyoutButtonClickLogic(visibleFlyoutButtons.get(buttonIndex).first);
+                    return flyoutButtonClickLogic(FlyoutUtils.getVisibleFlyoutButtons().get(buttonIndex).first);
                 } else if (!buttonName.isEmpty()) {
                     return flyoutButtonClickLogic(buttonName);
                 }
@@ -188,7 +82,7 @@ public final class AddToQueuePatch {
     private static Runnable getNewRunnable(@Nullable Runnable original, String buttonName) {
         return () -> {
             // Reset index logic goes here if needed between UI clicks
-            currentButtonIndex = 0;
+            FlyoutUtils.resetCurrentButtonIndex();
 
             if (flyoutButtonClickLogic(buttonName)) {
                 return;
@@ -200,7 +94,7 @@ public final class AddToQueuePatch {
         };
     }
 
-    private static boolean flyoutButtonClickLogic(String buttonName) {
+    public static boolean flyoutButtonClickLogic(String buttonName) {
         if (buttonName.equals(queueButtonName)) {
             Logger.printDebug(() -> "Opening custom queue flyout with videoId: " + FlyoutUtils.getFlyoutVideoId());
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AddToQueuePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AddToQueuePatch.java
@@ -8,21 +8,11 @@
 package app.morphe.extension.youtube.patches;
 
 import android.app.Activity;
-import android.app.Dialog;
 import android.content.Context;
-import android.graphics.PorterDuff;
-import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.util.Pair;
-import android.view.Gravity;
 import android.view.View;
-import android.view.ViewGroup;
-import android.view.Window;
-import android.widget.FrameLayout;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.PopupWindow;
-import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 
@@ -30,10 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import app.morphe.extension.shared.Logger;
-import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
-import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.youtube.patches.utils.FlyoutUtils;
 import app.morphe.extension.youtube.patches.utils.PlaylistPatch;
 import app.morphe.extension.youtube.settings.Settings;
@@ -45,10 +33,6 @@ public final class AddToQueuePatch {
     private static final Drawable queueButtonDrawable =
             ResourceUtils.getDrawable("quantum_ic_playlist_add_white_24");
     private static final String shareButtonName = "SHARE_ARROW";
-
-    private static final int BLACK_COLOR = ResourceUtils.getColor("yt_black1");
-    private static final int GREY_COLOR = ResourceUtils.getColor("yt_grey1");
-    private static final int WHITE_COLOR = ResourceUtils.getColor("yt_white1");
 
     private static final List<Pair<String, Integer>> visibleFlyoutButtons = new ArrayList<>();
 
@@ -70,167 +54,51 @@ public final class AddToQueuePatch {
         }
     }
     @SuppressWarnings({"UnusedReturnValue", "SameParameterValue"})
-    private static int initializeNewButton(
-            Object flyoutPanel,
-            Drawable icon,
-            String text,
-            View.OnClickListener clickListener,
-            int index
-    ) {
-        return initializeNewElement(
-                flyoutPanel,
-                icon,
-                text,
-                clickListener,
-                index,
-                false
-        );
+    private static int initializeNewButton(Object flyoutPanel, Drawable icon, String text,
+                                           View.OnClickListener clickListener, int index) {
+        return initializeNewElement(flyoutPanel, icon, text, clickListener, index, false);
     }
+
     @SuppressWarnings({"UnusedReturnValue", "SameParameterValue"})
-    private static int initializeNewDivider(
-            Object flyoutPanel,
-            int index
-    ) {
-        return initializeNewElement(
-                flyoutPanel,
-                null,
-                null,
-                null,
-                index,
-                true
-        );
+    private static int initializeNewDivider(Object flyoutPanel, int index) {
+        return initializeNewElement(flyoutPanel, null, null, null, index, true);
     }
-    private static int initializeNewElement(
-            Object flyoutPanel,
-            Drawable icon,
-            String text,
-            View.OnClickListener clickListener,
-            int index,
-            boolean isDivider
-    ) {
+
+    private static int initializeNewElement(Object flyoutPanel, Drawable icon, String text,
+                                            View.OnClickListener clickListener, int index,
+                                            boolean isDivider) {
         try {
-            if (flyoutPanel == null) {
+            FlyoutUtils.FlyoutMenuInfo menuInfo = FlyoutUtils.getFlyoutMenuInfo(flyoutPanel, index);
+            if (menuInfo == null) {
                 return -1;
             }
 
-            PopupWindow popupWindow = null;
-            LinearLayout menuContainer = null;
-            int fixedIndex = index;
-            final boolean newLayout;
-
-            if (flyoutPanel instanceof PopupWindow checkedPopupWindow) {
-                popupWindow = checkedPopupWindow;
-                if (checkedPopupWindow.getContentView() instanceof FrameLayout frameLayout) {
-                    if (frameLayout.getChildAt(0) instanceof ViewGroup viewGroup &&
-                            viewGroup.getChildAt(0) instanceof LinearLayout checkedMenuContainer) {
-                        menuContainer = checkedMenuContainer;
-                    }
-                }
-                newLayout = true;
-            } else {
-                if (flyoutPanel instanceof Dialog checkedDialog) {
-                    Window window = checkedDialog.getWindow();
-                    if (window != null) {
-                        View decorView = window.getDecorView();
-                        int containerId = ResourceUtils.getIdentifier(ResourceType.ID, "container");
-                        if (containerId != 0) {
-                            View container = decorView.findViewById(containerId);
-                            if (container instanceof FrameLayout frameLayout) {
-                                if (frameLayout.getChildAt(0) instanceof ViewGroup coordinator &&
-                                        coordinator.getChildAt(1) instanceof ViewGroup nestedFrame) {
-                                    View menuRoot = nestedFrame.getChildAt(0);
-                                    if (menuRoot instanceof ViewGroup group &&
-                                            group.getChildAt(0) instanceof LinearLayout linearLayout) {
-                                        menuContainer = linearLayout;
-                                        // Skip an index to inject the button after the bottom sheet handle.
-                                        fixedIndex += 1;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                newLayout = false;
-            }
-
-            if (menuContainer == null) {
-                return -1;
-            }
-
-            Context context = Utils.getContext();
+            Context context = Utils.getActivity();
             if (context == null) {
                 return -1;
             }
 
-            float density = Dim.getMetrics().density;
-            int density1 = (int) (1 * density);
-            int density4 = (int) (4 * density);
-            int density12 = (int) (12 * density);
-            int density16 = (int) (16 * density);
-            int density24 = (int) (24 * density);
+            View view = isDivider
+                    ? FlyoutUtils.createFlyoutDivider(context)
+                    : FlyoutUtils.createFlyoutButton(context, icon, text, clickListener);
 
-            if (!isDivider) {
-                final LinearLayout customButton = new LinearLayout(context);
-                customButton.setOrientation(LinearLayout.HORIZONTAL);
-                customButton.setGravity(Gravity.CENTER_VERTICAL);
-                customButton.setPadding(density16, density12, density16, density12);
-                customButton.setClickable(true);
-                customButton.setBackgroundColor(
-                        Utils.isDarkModeEnabled()
-                                ? BLACK_COLOR
-                                : WHITE_COLOR
-                );
+            int fixedIndex = menuInfo.adjustedIndex();
+            menuInfo.menuContainer().addView(view, fixedIndex);
 
-                final LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(density24, density24);
-                layoutParams.rightMargin = density16;
-
-                if (icon != null) {
-                    final ImageView iconView = new ImageView(context);
-                    iconView.setLayoutParams(layoutParams);
-
-                    final Drawable mutableIcon = icon.mutate();
-                    mutableIcon.setTint(Utils.isDarkModeEnabled() ? WHITE_COLOR : BLACK_COLOR);
-                    mutableIcon.setTintMode(PorterDuff.Mode.SRC_IN);
-                    iconView.setImageDrawable(mutableIcon);
-
-                    customButton.addView(iconView);
-                }
-
-                final TextView textView = new TextView(context);
-                textView.setText(text);
-                textView.setTextSize(16);
-                textView.setTypeface(null, Typeface.BOLD);
-
-                customButton.addView(textView);
-                customButton.setOnClickListener(clickListener);
-
-                menuContainer.addView(customButton, fixedIndex);
-            } else {
-                final View divider = new View(context);
-                final LinearLayout.LayoutParams dividerParams = new LinearLayout.LayoutParams(
-                        LinearLayout.LayoutParams.MATCH_PARENT,
-                        density1
-                );
-                dividerParams.setMargins(density16, density4, density16, density4);
-                divider.setLayoutParams(dividerParams);
-                divider.setBackgroundColor(GREY_COLOR);
-
-                menuContainer.addView(divider, fixedIndex);
-            }
-
+            PopupWindow popupWindow = menuInfo.popupWindow();
             if (popupWindow != null) {
                 popupWindow.update();
             }
 
             // For new layout only:
             // Skip an index to inject the next element after the current button.
-            if (newLayout) {
+            if (menuInfo.isPopupWindow()) {
                 fixedIndex++;
             }
 
             return fixedIndex;
         } catch (Exception ex) {
-            Logger.printException(() -> "injectButton failure", ex);
+            Logger.printException(() -> "initializeNewElement failure", ex);
         }
 
         return -1;

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
@@ -10,12 +10,23 @@ package app.morphe.extension.youtube.patches.utils;
 import static app.morphe.extension.youtube.patches.AddToQueuePatch.injectFlyoutElements;
 
 import android.app.Dialog;
+import android.content.Context;
+import android.graphics.PorterDuff;
+import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Base64;
+import android.view.Gravity;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.view.Window;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.PopupWindow;
+import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import com.facebook.litho.ComponentHost;
@@ -30,8 +41,11 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.ResourceType;
+import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.patches.components.BufferAsciiStrings;
+import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.youtube.patches.VideoInformation;
 import app.morphe.extension.youtube.settings.Settings;
 import app.morphe.extension.youtube.shared.EngagementPanel;
@@ -83,6 +97,14 @@ public final class FlyoutUtils {
     private static final Pattern TITLE_CLEANUP_PATTERN = Pattern.compile("[^a-zA-Z0-9\\s]");
     private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
     private static final Pattern COMMENT_ID_CLEANUP_PATTERN = Pattern.compile("[^A-Za-z0-9_.-]");
+
+    public static final int BLACK_COLOR = ResourceUtils.getColor("yt_black1");
+    public static final int GREY_COLOR = ResourceUtils.getColor("yt_grey1");
+    public static final int WHITE_COLOR = ResourceUtils.getColor("yt_white1");
+
+    public record FlyoutMenuInfo(LinearLayout menuContainer, int adjustedIndex,
+                                 boolean isPopupWindow, @Nullable PopupWindow popupWindow) {
+    }
 
     private static WeakReference<View> senderViewRef = new WeakReference<>(null);
 
@@ -167,6 +189,103 @@ public final class FlyoutUtils {
                 }
             }
         });
+    }
+
+    @Nullable
+    public static FlyoutMenuInfo getFlyoutMenuInfo(Object flyoutPanel, int initialIndex) {
+        LinearLayout menuContainer = null;
+        PopupWindow popupWindow = null;
+        boolean isPopupWindow = false;
+        int adjustedIndex = initialIndex;
+
+        if (flyoutPanel instanceof PopupWindow checkedPopupWindow) {
+            popupWindow = checkedPopupWindow;
+            if (checkedPopupWindow.getContentView() instanceof FrameLayout frameLayout) {
+                if (frameLayout.getChildAt(0) instanceof ViewGroup viewGroup &&
+                        viewGroup.getChildAt(0) instanceof LinearLayout checkedMenuContainer) {
+                    menuContainer = checkedMenuContainer;
+                }
+            }
+            isPopupWindow = true;
+        } else if (flyoutPanel instanceof Dialog checkedDialog) {
+            Window window = checkedDialog.getWindow();
+            if (window != null) {
+                View decorView = window.getDecorView();
+                final int containerId = ResourceUtils.getIdentifier(ResourceType.ID, "container");
+                if (containerId != 0) {
+                    View container = decorView.findViewById(containerId);
+                    if (container instanceof FrameLayout frameLayout) {
+                        if (frameLayout.getChildAt(0) instanceof ViewGroup coordinator &&
+                                coordinator.getChildAt(1) instanceof ViewGroup nestedFrame) {
+                            View menuRoot = nestedFrame.getChildAt(0);
+                            if (menuRoot instanceof ViewGroup group &&
+                                    group.getChildAt(0) instanceof LinearLayout linearLayout) {
+                                menuContainer = linearLayout;
+                                // Skip an index to inject the button after the bottom sheet handle.
+                                adjustedIndex += 1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (menuContainer == null) {
+            return null;
+        }
+
+        return new FlyoutMenuInfo(menuContainer, adjustedIndex, isPopupWindow, popupWindow);
+    }
+
+    public static View createFlyoutButton(Context context, @Nullable Drawable icon,
+                                          String text, View.OnClickListener clickListener) {
+        LinearLayout customButton = new LinearLayout(context);
+        customButton.setOrientation(LinearLayout.HORIZONTAL);
+        customButton.setGravity(Gravity.CENTER_VERTICAL);
+        customButton.setPadding(Dim.dp16, Dim.dp12, Dim.dp16, Dim.dp12);
+        customButton.setClickable(true);
+        customButton.setBackgroundColor(Utils.isDarkModeEnabled()
+                ? BLACK_COLOR
+                : WHITE_COLOR
+        );
+
+        LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(Dim.dp24, Dim.dp24);
+        layoutParams.rightMargin = Dim.dp16;
+
+        if (icon != null) {
+            ImageView iconView = new ImageView(context);
+            iconView.setLayoutParams(layoutParams);
+
+            Drawable mutableIcon = icon.mutate();
+            mutableIcon.setTint(Utils.isDarkModeEnabled() ? WHITE_COLOR : BLACK_COLOR);
+            mutableIcon.setTintMode(PorterDuff.Mode.SRC_IN);
+            iconView.setImageDrawable(mutableIcon);
+
+            customButton.addView(iconView);
+        }
+
+        TextView textView = new TextView(context);
+        textView.setText(text);
+        textView.setTextSize(16);
+        textView.setTypeface(null, Typeface.BOLD);
+
+        customButton.addView(textView);
+        customButton.setOnClickListener(clickListener);
+
+        return customButton;
+    }
+
+    public static View createFlyoutDivider(Context context) {
+        final View divider = new View(context);
+        final LinearLayout.LayoutParams dividerParams = new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                Dim.dp1
+        );
+        dividerParams.setMargins(Dim.dp16, Dim.dp4, Dim.dp16, Dim.dp4);
+        divider.setLayoutParams(dividerParams);
+        divider.setBackgroundColor(GREY_COLOR);
+
+        return divider;
     }
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
@@ -7,6 +7,8 @@
 
 package app.morphe.extension.youtube.patches.utils;
 
+import static app.morphe.extension.youtube.patches.AddToQueuePatch.injectFlyoutElements;
+
 import android.app.Dialog;
 import android.os.Handler;
 import android.os.Looper;
@@ -103,6 +105,7 @@ public final class FlyoutUtils {
         }
         flyoutDialog = dialog;
         runFlyoutPanelVisibilityHandler(dialog);
+        injectFlyoutElements(dialog);
     }
 
     public static void dismissBottomSheetFlyout() {
@@ -120,6 +123,8 @@ public final class FlyoutUtils {
         }
         flyoutPopupWindow = popupWindow;
         runFlyoutPanelVisibilityHandler(popupWindow);
+
+        injectFlyoutElements(popupWindow);
     }
 
     public static void dismissPopupWindowFlyout() {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
@@ -139,7 +139,8 @@ public final class FlyoutUtils {
         flyoutDialog = dialog;
         runFlyoutPanelVisibilityHandler(dialog);
 
-        if (Settings.QUEUE_ADD_FLYOUT_MENU.get()) {
+        if (Settings.QUEUE_ADD_FLYOUT_MENU.get()
+                && (!flyoutVideoId.isEmpty() || !flyoutPlaylistId.isEmpty())) {
             dialog.setOnShowListener(dialogInterface -> {
                 addFlyoutElements(dialog);
             });

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
@@ -15,6 +15,8 @@ import android.os.Looper;
 import android.util.Base64;
 import android.view.View;
 import android.view.ViewParent;
+import android.view.Window;
+import android.widget.FrameLayout;
 import android.widget.PopupWindow;
 
 import androidx.annotation.Nullable;
@@ -30,6 +32,8 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.ResourceType;
+import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.patches.components.BufferAsciiStrings;
 import app.morphe.extension.youtube.patches.VideoInformation;
@@ -105,7 +109,9 @@ public final class FlyoutUtils {
         }
         flyoutDialog = dialog;
         runFlyoutPanelVisibilityHandler(dialog);
-        injectFlyoutElements(dialog);
+        dialog.setOnShowListener(dialogInterface -> {
+            injectFlyoutElements(dialog);
+        });
     }
 
     public static void dismissBottomSheetFlyout() {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
@@ -58,24 +58,15 @@ import app.morphe.extension.youtube.shared.ShortsPlayerState;
 public final class FlyoutUtils {
 
     public interface ProtocolBufferFieldInterface {
-
         byte[] patch_getBuffer();
     }
-    public interface FlyoutMenuVideoIdInterface {
 
+    public interface FlyoutMenuVideoIdInterface {
         String patch_getVideoId();
     }
-    public static byte[] getAsciiBytes(String string) {
-        return string.getBytes(StandardCharsets.US_ASCII);
-    }
-    public static String getFlyoutVideoId() {
-        return flyoutVideoId;
-    }
-    public static String getFlyoutPlaylistId() {
-        return flyoutPlaylistId;
-    }
-    public static String getFlyoutCommentId() {
-        return flyoutCommentId;
+
+    public record FlyoutMenuInfo(LinearLayout menuContainer, int adjustedIndex,
+                                 boolean isPopupWindow, @Nullable PopupWindow popupWindow) {
     }
 
     public static final int CHANNEL_ID_LENGTH = 24;
@@ -104,10 +95,6 @@ public final class FlyoutUtils {
     public static final int GREY_COLOR = ResourceUtils.getColor("yt_grey1");
     public static final int WHITE_COLOR = ResourceUtils.getColor("yt_white1");
 
-    public record FlyoutMenuInfo(LinearLayout menuContainer, int adjustedIndex,
-                                 boolean isPopupWindow, @Nullable PopupWindow popupWindow) {
-    }
-
     private static final List<Pair<String, Integer>> visibleFlyoutButtons = new ArrayList<>();
 
     private static String currentButtonName = "";
@@ -124,6 +111,22 @@ public final class FlyoutUtils {
             "comment-item-section",
             "shorts-comments-panel"
     );
+
+    public static byte[] getAsciiBytes(String string) {
+        return string.getBytes(StandardCharsets.US_ASCII);
+    }
+
+    public static String getFlyoutVideoId() {
+        return flyoutVideoId;
+    }
+
+    public static String getFlyoutPlaylistId() {
+        return flyoutPlaylistId;
+    }
+
+    public static String getFlyoutCommentId() {
+        return flyoutCommentId;
+    }
 
     /**
      * Injection point.
@@ -672,14 +675,17 @@ public final class FlyoutUtils {
     public static int byteIndexOf(byte[] haystack, byte[] needle) {
         return byteIndexOf(haystack, needle, 0);
     }
+
     public static int byteIndexOf(byte[] haystack, byte[] needle, int startIndex) {
         if (needle == null) return -1;
         final List<Integer> indices = byteIndexesOf(haystack, List.of(needle), startIndex);
         return indices.isEmpty() ? -1 : indices.get(0);
     }
+
     public static List<Integer> byteIndexesOf(byte[] haystack, List<byte[]> needles) {
         return byteIndexesOf(haystack, needles, 0);
     }
+
     public static List<Integer> byteIndexesOf(byte[] haystack, List<byte[]> needles, int startIndex) {
         final List<Integer> indices = new ArrayList<>();
         if (haystack == null || needles == null) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
@@ -15,8 +15,6 @@ import android.os.Looper;
 import android.util.Base64;
 import android.view.View;
 import android.view.ViewParent;
-import android.view.Window;
-import android.widget.FrameLayout;
 import android.widget.PopupWindow;
 
 import androidx.annotation.Nullable;
@@ -32,8 +30,6 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import app.morphe.extension.shared.Logger;
-import app.morphe.extension.shared.ResourceType;
-import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.patches.components.BufferAsciiStrings;
 import app.morphe.extension.youtube.patches.VideoInformation;

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
@@ -7,7 +7,7 @@
 
 package app.morphe.extension.youtube.patches.utils;
 
-import static app.morphe.extension.youtube.patches.AddToQueuePatch.injectFlyoutElements;
+import static app.morphe.extension.shared.StringRef.str;
 
 import android.app.Dialog;
 import android.content.Context;
@@ -17,6 +17,7 @@ import android.graphics.drawable.Drawable;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Base64;
+import android.util.Pair;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -46,6 +47,7 @@ import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.patches.components.BufferAsciiStrings;
 import app.morphe.extension.shared.ui.Dim;
+import app.morphe.extension.youtube.patches.AddToQueuePatch;
 import app.morphe.extension.youtube.patches.VideoInformation;
 import app.morphe.extension.youtube.settings.Settings;
 import app.morphe.extension.youtube.shared.EngagementPanel;
@@ -106,6 +108,11 @@ public final class FlyoutUtils {
                                  boolean isPopupWindow, @Nullable PopupWindow popupWindow) {
     }
 
+    private static final List<Pair<String, Integer>> visibleFlyoutButtons = new ArrayList<>();
+
+    private static String currentButtonName = "";
+    private static int currentButtonIndex;
+
     private static WeakReference<View> senderViewRef = new WeakReference<>(null);
 
     private static Dialog flyoutDialog;
@@ -160,6 +167,106 @@ public final class FlyoutUtils {
         if (flyoutPopupWindow != null) {
             flyoutPopupWindow.dismiss();
         }
+    }
+
+    public static void injectFlyoutElements(Object flyoutPanel) {
+        int currentInjectIndex = injectButton(
+                flyoutPanel,
+                AddToQueuePatch.queueButtonDrawable,
+                str("morphe_queue_flyout_title"),
+                v -> AddToQueuePatch.flyoutButtonClickLogic(AddToQueuePatch.queueButtonName),
+                0
+        );
+        if (currentInjectIndex > 0) {
+            injectDivider(flyoutPanel, currentInjectIndex);
+        }
+    }
+
+    public static int injectButton(Object flyoutPanel, Drawable icon, String text,
+                                   View.OnClickListener clickListener, int index) {
+        return injectElement(flyoutPanel, icon, text, clickListener, index, false);
+    }
+
+    @SuppressWarnings("UnusedReturnValue")
+    public static int injectDivider(Object flyoutPanel, int index) {
+        return injectElement(flyoutPanel, null, null, null, index, true);
+    }
+
+    private static int injectElement(Object flyoutPanel, @Nullable Drawable icon, @Nullable String text,
+                                     @Nullable View.OnClickListener clickListener, int index,
+                                     boolean isDivider) {
+        try {
+            FlyoutMenuInfo menuInfo = getFlyoutMenuInfo(flyoutPanel, index);
+            if (menuInfo == null) {
+                return -1;
+            }
+
+            Context context = Utils.getContext();
+            if (context == null) {
+                return -1;
+            }
+
+            View view = isDivider
+                    ? createFlyoutDivider(context)
+                    : createFlyoutButton(context, icon, text, clickListener);
+
+            int fixedIndex = menuInfo.adjustedIndex();
+            menuInfo.menuContainer().addView(view, fixedIndex);
+
+            if (menuInfo.popupWindow() != null) {
+                menuInfo.popupWindow().update();
+            }
+
+            // For new layout only:
+            // Skip an index to inject the next element after the current button.
+            if (menuInfo.isPopupWindow()) {
+                fixedIndex++;
+            }
+
+            return fixedIndex;
+        } catch (Exception ex) {
+            Logger.printException(() -> "injectElement failure", ex);
+        }
+
+        return -1;
+    }
+
+    /**
+     * Injection point.
+     */
+    public static void setCurrentButtonInfo(@Nullable Enum<?> buttonEnum, @Nullable Object buttonInfo) {
+        if (buttonEnum == null) {
+            return;
+        }
+
+        if (buttonInfo instanceof CharSequence charSequence && charSequence.toString().isEmpty()) {
+            return;
+        }
+
+        if (buttonInfo instanceof View view && view.getVisibility() == View.GONE) {
+            return;
+        }
+
+        if (currentButtonIndex == 0 && !visibleFlyoutButtons.isEmpty()) {
+            visibleFlyoutButtons.clear();
+        }
+
+        currentButtonName = buttonEnum.name();
+        currentButtonIndex++;
+
+        visibleFlyoutButtons.add(new Pair<>(currentButtonName, currentButtonIndex));
+    }
+
+    public static List<Pair<String, Integer>> getVisibleFlyoutButtons() {
+        return visibleFlyoutButtons;
+    }
+
+    public static String getCurrentButtonName() {
+        return currentButtonName;
+    }
+
+    public static void resetCurrentButtonIndex() {
+        currentButtonIndex = 0;
     }
 
     private static void runFlyoutPanelVisibilityHandler(Object flyoutObject) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
@@ -127,9 +127,12 @@ public final class FlyoutUtils {
         }
         flyoutDialog = dialog;
         runFlyoutPanelVisibilityHandler(dialog);
-        dialog.setOnShowListener(dialogInterface -> {
-            injectFlyoutElements(dialog);
-        });
+
+        if (Settings.QUEUE_ADD_FLYOUT_MENU.get()) {
+            dialog.setOnShowListener(dialogInterface -> {
+                injectFlyoutElements(dialog);
+            });
+        }
     }
 
     public static void dismissBottomSheetFlyout() {
@@ -148,7 +151,9 @@ public final class FlyoutUtils {
         flyoutPopupWindow = popupWindow;
         runFlyoutPanelVisibilityHandler(popupWindow);
 
-        injectFlyoutElements(popupWindow);
+        if (Settings.QUEUE_ADD_FLYOUT_MENU.get()) {
+            injectFlyoutElements(popupWindow);
+        }
     }
 
     public static void dismissPopupWindowFlyout() {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
@@ -30,6 +30,7 @@ import android.widget.PopupWindow;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
+
 import com.facebook.litho.ComponentHost;
 
 import java.lang.ref.WeakReference;
@@ -140,7 +141,7 @@ public final class FlyoutUtils {
 
         if (Settings.QUEUE_ADD_FLYOUT_MENU.get()) {
             dialog.setOnShowListener(dialogInterface -> {
-                injectFlyoutElements(dialog);
+                addFlyoutElements(dialog);
             });
         }
     }
@@ -162,7 +163,7 @@ public final class FlyoutUtils {
         runFlyoutPanelVisibilityHandler(popupWindow);
 
         if (Settings.QUEUE_ADD_FLYOUT_MENU.get()) {
-            injectFlyoutElements(popupWindow);
+            addFlyoutElements(popupWindow);
         }
     }
 
@@ -172,8 +173,8 @@ public final class FlyoutUtils {
         }
     }
 
-    public static void injectFlyoutElements(Object flyoutPanel) {
-        int currentInjectIndex = injectButton(
+    private static void addFlyoutElements(Object flyoutPanel) {
+        final int currentInjectIndex = addFlyoutButton(
                 flyoutPanel,
                 AddToQueuePatch.queueButtonDrawable,
                 str("morphe_queue_flyout_title"),
@@ -181,43 +182,45 @@ public final class FlyoutUtils {
                 0
         );
         if (currentInjectIndex > 0) {
-            injectDivider(flyoutPanel, currentInjectIndex);
+            addDivider(flyoutPanel, currentInjectIndex);
         }
     }
 
-    public static int injectButton(Object flyoutPanel, Drawable icon, String text,
-                                   View.OnClickListener clickListener, int index) {
-        return injectElement(flyoutPanel, icon, text, clickListener, index, false);
+    @SuppressWarnings("SameParameterValue")
+    private static int addFlyoutButton(Object flyoutPanel, Drawable icon, String text,
+                                       View.OnClickListener clickListener, int index) {
+        return addFlyoutMenuItem(flyoutPanel, icon, text, clickListener, index, false);
     }
 
     @SuppressWarnings("UnusedReturnValue")
-    public static int injectDivider(Object flyoutPanel, int index) {
-        return injectElement(flyoutPanel, null, null, null, index, true);
+    private static int addDivider(Object flyoutPanel, int index) {
+        return addFlyoutMenuItem(flyoutPanel, null, null, null, index, true);
     }
 
-    private static int injectElement(Object flyoutPanel, @Nullable Drawable icon, @Nullable String text,
-                                     @Nullable View.OnClickListener clickListener, int index,
-                                     boolean isDivider) {
+    private static int addFlyoutMenuItem(Object flyoutPanel, @Nullable Drawable icon, @Nullable String text,
+                                         @Nullable View.OnClickListener clickListener, int index,
+                                         boolean isDivider) {
         try {
             FlyoutMenuInfo menuInfo = getFlyoutMenuInfo(flyoutPanel, index);
             if (menuInfo == null) {
                 return -1;
             }
 
-            Context context = Utils.getContext();
+            Context context = Utils.getActivity();
             if (context == null) {
                 return -1;
             }
 
             View view = isDivider
                     ? createFlyoutDivider(context)
-                    : createFlyoutButton(context, icon, text, clickListener);
+                    : addFlyoutButton(context, icon, text, clickListener);
 
             int fixedIndex = menuInfo.adjustedIndex();
             menuInfo.menuContainer().addView(view, fixedIndex);
 
-            if (menuInfo.popupWindow() != null) {
-                menuInfo.popupWindow().update();
+            PopupWindow popupWindow = menuInfo.popupWindow();
+            if (popupWindow != null) {
+                popupWindow.update();
             }
 
             // For new layout only:
@@ -228,7 +231,7 @@ public final class FlyoutUtils {
 
             return fixedIndex;
         } catch (Exception ex) {
-            Logger.printException(() -> "injectElement failure", ex);
+            Logger.printException(() -> "addFlyoutMenuItem failure", ex);
         }
 
         return -1;
@@ -307,7 +310,7 @@ public final class FlyoutUtils {
     }
 
     @Nullable
-    public static FlyoutMenuInfo getFlyoutMenuInfo(Object flyoutPanel, int initialIndex) {
+    private static FlyoutMenuInfo getFlyoutMenuInfo(Object flyoutPanel, int initialIndex) {
         LinearLayout menuContainer = null;
         PopupWindow popupWindow = null;
         boolean isPopupWindow = false;
@@ -352,17 +355,14 @@ public final class FlyoutUtils {
         return new FlyoutMenuInfo(menuContainer, adjustedIndex, isPopupWindow, popupWindow);
     }
 
-    public static View createFlyoutButton(Context context, @Nullable Drawable icon,
-                                          String text, View.OnClickListener clickListener) {
+    private static View addFlyoutButton(Context context, @Nullable Drawable icon,
+                                        String text, View.OnClickListener clickListener) {
         LinearLayout customButton = new LinearLayout(context);
         customButton.setOrientation(LinearLayout.HORIZONTAL);
         customButton.setGravity(Gravity.CENTER_VERTICAL);
         customButton.setPadding(Dim.dp16, Dim.dp12, Dim.dp16, Dim.dp12);
         customButton.setClickable(true);
-        customButton.setBackgroundColor(Utils.isDarkModeEnabled()
-                ? BLACK_COLOR
-                : WHITE_COLOR
-        );
+        customButton.setBackgroundColor(Utils.getAppBackgroundColor());
 
         LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(Dim.dp24, Dim.dp24);
         layoutParams.rightMargin = Dim.dp16;
@@ -372,7 +372,7 @@ public final class FlyoutUtils {
             iconView.setLayoutParams(layoutParams);
 
             Drawable mutableIcon = icon.mutate();
-            mutableIcon.setTint(Utils.isDarkModeEnabled() ? WHITE_COLOR : BLACK_COLOR);
+            mutableIcon.setTint(Utils.getAppForegroundColor());
             mutableIcon.setTintMode(PorterDuff.Mode.SRC_IN);
             iconView.setImageDrawable(mutableIcon);
 
@@ -383,6 +383,7 @@ public final class FlyoutUtils {
         textView.setText(text);
         textView.setTextSize(16);
         textView.setTypeface(null, Typeface.BOLD);
+        textView.setTextColor(Utils.getAppForegroundColor());
 
         customButton.addView(textView);
         customButton.setOnClickListener(clickListener);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -246,6 +246,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting QUEUE_RESTORE = new BooleanSetting("morphe_queue_restore", FALSE, parent(SAVE_TO_WATCH_LATER_BUTTON));
     public static final BooleanSetting SWAP_SAVE_AND_QUEUE_ACTIONS = new BooleanSetting("morphe_swap_save_and_queue_actions", TRUE, true, parent(SAVE_TO_WATCH_LATER_BUTTON));
     public static final BooleanSetting QUEUE_OVERRIDE_FLYOUT_MENU = new BooleanSetting("morphe_queue_override_flyout_menu", TRUE, true);
+    public static final BooleanSetting QUEUE_ADD_FLYOUT_MENU = new BooleanSetting("morphe_queue_add_flyout_menu", TRUE);
     public static final StringSetting QUEUE_PLAYLIST_ID = new StringSetting("morphe_queue_playlist_id", "");
     public static final BooleanSetting OPEN_CHANNEL_OF_LIVE_AVATAR = new BooleanSetting("morphe_open_channel_of_live_avatar", FALSE);
     public static final BooleanSetting VIDEO_QUALITY_DIALOG_BUTTON = new BooleanSetting("morphe_video_quality_dialog_button", FALSE, true);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/flyout/AddToQueuePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/flyout/AddToQueuePatch.kt
@@ -19,6 +19,7 @@ import app.morphe.patcher.string
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
 import app.morphe.patches.shared.misc.litho.filter.addLithoFilter
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import app.morphe.patches.shared.misc.settings.preference.noTitleUnsortedPreferenceCategory
 import app.morphe.patches.youtube.layout.hide.general.ContextualMenuItemBuilderFingerprint
 import app.morphe.patches.youtube.layout.hide.general.ContextualMenuItemBuilderOnClickFingerprint
 import app.morphe.patches.youtube.misc.auth.authHookPatch
@@ -81,7 +82,10 @@ val addToQueuePatch = bytecodePatch(
 
     execute {
         PreferenceScreen.FEED.addPreferences(
-            SwitchPreference("morphe_queue_override_flyout_menu", summary = true)
+            noTitleUnsortedPreferenceCategory(
+                SwitchPreference("morphe_queue_override_flyout_menu", summary = true),
+                SwitchPreference("morphe_queue_add_flyout_menu", summary = true)
+            )
         )
 
         // Add interface method to get protocol buffer.

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/flyout/AddToQueuePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/flyout/AddToQueuePatch.kt
@@ -238,7 +238,7 @@ val addToQueuePatch = bytecodePatch(
                         iget v$freeRegister, v$enumMethodRegister, $enumIntField
                         invoke-static { v$freeRegister }, $enumMethodCall
                         move-result-object v$freeRegister
-                        invoke-static { v$freeRegister, v$charCheckRegister }, $EXTENSION_CLASS->setCurrentButtonInfo(Ljava/lang/Enum;Ljava/lang/Object;)V
+                        invoke-static { v$freeRegister, v$charCheckRegister }, $EXTENSION_UTILS_CLASS->setCurrentButtonInfo(Ljava/lang/Enum;Ljava/lang/Object;)V
                     """
                 )
             }
@@ -259,7 +259,7 @@ val addToQueuePatch = bytecodePatch(
                             iget p0, p0, $enumIntField
                             invoke-static { p0 }, $enumMethodCall
                             move-result-object p0
-                            invoke-static { p0, v$secondButtonInfoParameterRegister }, $EXTENSION_CLASS->setCurrentButtonInfo(Ljava/lang/Enum;Ljava/lang/Object;)V
+                            invoke-static { p0, v$secondButtonInfoParameterRegister }, $EXTENSION_UTILS_CLASS->setCurrentButtonInfo(Ljava/lang/Enum;Ljava/lang/Object;)V
                         """
                     )
                 }

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -495,8 +495,8 @@ Info: May not work on live streams"</string>
     <string name="morphe_swap_save_and_queue_actions_summary">Tap for queue options, tap and hold to save to watch later</string>
     <string name="morphe_queue_override_flyout_menu_title">Override feed flyout queue button</string>
     <string name="morphe_queue_override_flyout_menu_summary">Opens the Morphe queue instead of the YouTube queue</string>
-    <string name="morphe_queue_add_flyout_menu_title">Add feed flyout queue button</string>
-    <string name="morphe_queue_add_flyout_menu_summary">Adds an additional flyout button. Enable this if \"Add to queue\" is not shown</string>
+    <string name="morphe_queue_add_flyout_menu_title">Add feed flyout queue menu item</string>
+    <string name="morphe_queue_add_flyout_menu_summary">Adds an additional flyout item. Enable this if \"Add to queue\" is not shown</string>
     <string name="morphe_queue_manager_check_failed_auth">Not logged in</string>
     <string name="morphe_queue_manager_check_failed_playlist_id">No playlist ID</string>
     <string name="morphe_queue_manager_check_failed_queue">Queue is empty</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -496,7 +496,7 @@ Info: May not work on live streams"</string>
     <string name="morphe_queue_override_flyout_menu_title">Override feed flyout queue button</string>
     <string name="morphe_queue_override_flyout_menu_summary">Opens the Morphe queue instead of the YouTube queue</string>
     <string name="morphe_queue_add_flyout_menu_title">Add feed flyout queue button</string>
-    <string name="morphe_queue_add_flyout_menu_summary">Adds an additional flyout button. Enable this if an add to queue button is not shown</string>
+    <string name="morphe_queue_add_flyout_menu_summary">Adds an additional flyout button. Enable this if \"Add to queue\" is not shown</string>
     <string name="morphe_queue_manager_check_failed_auth">Not logged in</string>
     <string name="morphe_queue_manager_check_failed_playlist_id">No playlist ID</string>
     <string name="morphe_queue_manager_check_failed_queue">Queue is empty</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -488,6 +488,7 @@ Info: May not work on live streams"</string>
     <string name="morphe_save_to_watch_later_success_toast">Video successfully saved in watch later playlist</string>
     <string name="morphe_save_to_watch_later_already_exists_toast">This video is already saved in watch later playlist</string>
     <string name="morphe_save_to_watch_later_error_toast">Cannot save this video in watch later playlist</string>
+    <string name="morphe_queue_flyout_title">Add to Morphe queue</string>
     <string name="morphe_queue_restore_title">Keep queue between sessions</string>
     <string name="morphe_queue_restore_summary">Queue is kept after restarting the app</string>
     <string name="morphe_swap_save_and_queue_actions_title">Swap Save and Queue actions</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -495,6 +495,8 @@ Info: May not work on live streams"</string>
     <string name="morphe_swap_save_and_queue_actions_summary">Tap for queue options, tap and hold to save to watch later</string>
     <string name="morphe_queue_override_flyout_menu_title">Override feed flyout queue button</string>
     <string name="morphe_queue_override_flyout_menu_summary">Opens the Morphe queue instead of the YouTube queue</string>
+    <string name="morphe_queue_add_flyout_menu_title">Add feed flyout queue button</string>
+    <string name="morphe_queue_add_flyout_menu_summary">Adds an additional flyout button. Enable this if an add to queue button is not shown</string>
     <string name="morphe_queue_manager_check_failed_auth">Not logged in</string>
     <string name="morphe_queue_manager_check_failed_playlist_id">No playlist ID</string>
     <string name="morphe_queue_manager_check_failed_queue">Queue is empty</string>


### PR DESCRIPTION
### Description

Since Google is testing the removal of the stock "Add to queue" button on some accounts, I thought it would be useful to inject new buttons directly into the flyout menu. This will not only restore the "Add to queue" button but could potentially fix other issues—such the lack of a "Save to watch later" button into the flyout menu of some videos (maked as kids)

<img width="1080" height="2400" alt="Screenshot_20260805_111330" src="https://github.com/user-attachments/assets/3aebff6d-d81e-4c3f-b72f-334e40c9544e" />


### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
