### PR TITLE
fix: Rename `Change package name` to `Clone app`

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/all/misc/clone/CloneAppPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/all/misc/clone/CloneAppPatch.kt
@@ -119,7 +119,7 @@ private fun applyGetPackageName(oldPackageName: String, vararg classesToChange: 
 @Suppress("unused")
 val cloneAppPatch = resourcePatch(
     name = "Clone app",
-    description = "Changes the app package name to allow allow installing the same app multiple times. " +
+    description = "Changes the app package name to allow installing the same app multiple times. " +
             "By default \".morphe\" is appended the package name. Each cloned install must " +
             "use a unique package name. Cloning does not work with all apps and using this patch " +
             "may cause app crashes or other unexpected behavior.",

--- a/patches/src/main/kotlin/app/morphe/patches/all/misc/clone/CloneAppPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/all/misc/clone/CloneAppPatch.kt
@@ -24,7 +24,7 @@
  * merchantability and fitness for a particular purpose, are disclaimed.
  */
 
-package app.morphe.patches.all.misc.packagename
+package app.morphe.patches.all.misc.clone
 
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
@@ -117,10 +117,12 @@ private fun applyGetPackageName(oldPackageName: String, vararg classesToChange: 
 }
 
 @Suppress("unused")
-val changePackageNamePatch = resourcePatch(
-    name = "Change package name",
-    description = "Appends \".morphe\" to the package name by default. " +
-            "Changing the package name of the app can lead to unexpected issues.",
+val cloneAppPatch = resourcePatch(
+    name = "Clone app",
+    description = "Changes the app package name to allow allow installing the same app multiple times. " +
+            "By default \".morphe\" is appended the package name. Each cloned install must " +
+            "use a unique package name. Cloning does not work with all apps and using this patch " +
+            "may cause app crashes or other unexpected behavior.",
     default = false
 ) {
     packageNameOption = stringOption(
@@ -128,7 +130,7 @@ val changePackageNamePatch = resourcePatch(
         default = "Default",
         values = mapOf("Default" to "Default"),
         title = "Package name",
-        description = "The name of the package to rename the app to.",
+        description = "Package name to use for the cloned app.",
         required = true,
     ) {
         it == "Default" || it!!.matches(Regex("^[a-z]\\w*(\\.[a-z]\\w*)+$"))
@@ -195,7 +197,7 @@ val changePackageNamePatch = resourcePatch(
 
         if (incompatibleAppPackages.contains(packageName)) {
             return@finalize Logger.getLogger(this::class.java.name).severe(
-                "'$packageName' does not work correctly with \"Change package name\"",
+                "'$packageName' does not work correctly with \"Clone app\", and no changes were made.",
             )
         }
 

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/fileprovider/FileProviderPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/fileprovider/FileProviderPatch.kt
@@ -2,7 +2,7 @@ package app.morphe.patches.music.misc.fileprovider
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.patches.all.misc.packagename.setOrGetFallbackPackageName
+import app.morphe.patches.all.misc.clone.setOrGetFallbackPackageName
 
 internal fun fileProviderPatch(
     youtubePackageName: String,
@@ -11,7 +11,7 @@ internal fun fileProviderPatch(
     description = "Fixes broken YouTube Music file provider that prevents sharing with specific apps such as Instagram."
 ) {
     finalize {
-        // Must do modification last, so change package name value is correctly set.
+        // Must do modification last, so "clone app" package name value is correctly set.
         val musicChangedPackageName = setOrGetFallbackPackageName(musicPackageName)
 
         // For some reason, if the app gets "android.support.FILE_PROVIDER_PATHS",

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/settings/SettingsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/settings/SettingsPatch.kt
@@ -10,7 +10,7 @@ package app.morphe.patches.music.misc.settings
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.all.misc.fix.openurllinks.removeLinkVerification
-import app.morphe.patches.all.misc.packagename.setOrGetFallbackPackageName
+import app.morphe.patches.all.misc.clone.setOrGetFallbackPackageName
 import app.morphe.patches.all.misc.resources.addAppResources
 import app.morphe.patches.all.misc.resources.addResourcesPatch
 import app.morphe.patches.all.misc.resources.localesYouTube

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
@@ -22,7 +22,7 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.folderOption
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patcher.patch.stringOption
-import app.morphe.patches.all.misc.packagename.setOrGetFallbackPackageName
+import app.morphe.patches.all.misc.clone.setOrGetFallbackPackageName
 import app.morphe.patches.shared.misc.fix.bitmap.fixRecycledBitmapPatch
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.patches.shared.misc.settings.preference.BasePreference
@@ -203,7 +203,7 @@ internal fun baseCustomBrandingPatch(
                 val useCustomIcon = customIcon != null
                 val isRootInstall = setOrGetFallbackPackageName(originalAppPackageName) == originalAppPackageName
 
-                // Can only check if app is root installation by checking if change package name patch is in use.
+                // Can only check if app is root installation by checking if 'Clone app' package name patch is in use.
                 // and can only do that in the finalize block here.
                 // The UI preferences cannot be selectively added here, because the settings finalize block
                 // may have already run and the settings are already wrote to file.

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/gms/GmsCoreSupportPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/gms/GmsCoreSupportPatch.kt
@@ -24,8 +24,8 @@ import app.morphe.patcher.patch.ResourcePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patcher.string
-import app.morphe.patches.all.misc.packagename.changePackageNamePatch
-import app.morphe.patches.all.misc.packagename.setOrGetFallbackPackageName
+import app.morphe.patches.all.misc.clone.cloneAppPatch
+import app.morphe.patches.all.misc.clone.setOrGetFallbackPackageName
 import app.morphe.patches.shared.misc.gms.Constants.ACTIONS
 import app.morphe.patches.shared.misc.gms.Constants.AUTHORITIES
 import app.morphe.patches.shared.misc.gms.Constants.PERMISSIONS
@@ -82,7 +82,7 @@ fun gmsCoreSupportPatch(
 ) {
 
     dependsOn(
-        changePackageNamePatch,
+        cloneAppPatch,
         gmsCoreSupportResourcePatchFactory(),
         extensionPatch,
     )
@@ -499,7 +499,7 @@ private object Constants {
  *
  * @param fromPackageName The package name of the original app.
  * @param toPackageNameDefault The package name to fall back to if no custom package name
- *                             is specified in Change package name.
+ *                             is specified in "Clone app".
  * @param spoofedPackageSignature The signature of the package to spoof to.
  * @param executeBlock The additional execution block of the patch.
  * @param block The additional block to build the patch.
@@ -513,7 +513,7 @@ fun gmsCoreSupportResourcePatch(
     block: ResourcePatchBuilder.() -> Unit = {},
 ) = resourcePatch {
     dependsOn(
-        changePackageNamePatch,
+        cloneAppPatch,
         linkHandlingPatch(fromPackageName, screen)
     )
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/settings/SettingsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/settings/SettingsPatch.kt
@@ -18,7 +18,7 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
 import app.morphe.patches.all.misc.fix.openurllinks.removeLinkVerification
-import app.morphe.patches.all.misc.packagename.setOrGetFallbackPackageName
+import app.morphe.patches.all.misc.clone.setOrGetFallbackPackageName
 import app.morphe.patches.all.misc.resources.addAppResources
 import app.morphe.patches.all.misc.resources.addResourcesPatch
 import app.morphe.patches.all.misc.resources.localesYouTube


### PR DESCRIPTION
### Description

For the same reasons `Change version code` was renamed to `Disable Play Store updates`, this PR renames `Change package name` to `Clone app`.

This makes the patch easier to understand why the user might want to use it.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
