### PR TITLE
fix(Spoof video streams): Restore missing YT method

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/spoof/SpoofVideoStreamsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/spoof/SpoofVideoStreamsPatch.kt
@@ -26,6 +26,7 @@ val spoofVideoStreamsPatch = spoofVideoStreamsPatch(
     fixMediaSessionFeatureFlag = { is_8_40_or_greater },
     fixReelItemWatchResponseFeatureFlag = { false },
     useNewRequestBuilderFingerprint = { is_9_19_or_greater },
+    restoreMissingCuepointMethod = { false },
 
     block = {
         dependsOn(

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/Fingerprints.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.patches.shared.misc.spoof
 
 import app.morphe.patcher.Fingerprint
@@ -18,6 +28,14 @@ import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 private const val STREAMING_DATA_OUTER_CLASS =
     $$"Lcom/google/protos/youtube/api/innertube/StreamingDataOuterClass$StreamingData;"
+
+internal object CuepointListFingerprint : Fingerprint(
+    definingClass = "Lcom/google/android/apps/youtube/proto/streaming/CuepointListOuterClass\$CuepointList;",
+    name = "<clinit>",
+    filters = listOf(
+        methodCall(name = "registerDefaultInstance")
+    )
+)
 
 internal object BuildInitPlaybackRequestFingerprint : Fingerprint(
     returnType = $$"Lorg/chromium/net/UrlRequest$Builder;",
@@ -101,7 +119,7 @@ internal object BuildRequestFingerprint : Fingerprint(
         val parameterTypesSize = parameterTypes.size
         (parameterTypesSize == 6 || parameterTypesSize == 7 || parameterTypesSize == 8) &&
                 parameterTypes[1] == "Ljava/util/Map;" // URL headers.
-                && indexOfNewUrlRequestBuilderInstruction(methodDef) >= 0
+                && indexOfNewUrlRequestBuilderExecutorInstruction(methodDef) >= 0
     }
 )
 
@@ -275,7 +293,7 @@ internal object ReelItemWatchResponseFeatureFlagFingerprint : Fingerprint(
     )
 )
 
-internal fun indexOfNewUrlRequestBuilderInstruction(method: Method) = method.indexOfFirstInstruction {
+internal fun indexOfNewUrlRequestBuilderExecutorInstruction(method: Method) = method.indexOfFirstInstruction {
     val reference = getReference<MethodReference>()
     opcode == Opcode.INVOKE_VIRTUAL && reference?.definingClass == "Lorg/chromium/net/CronetEngine;"
             && reference.name == "newUrlRequestBuilder"

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/SpoofVideoStreamsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/SpoofVideoStreamsPatch.kt
@@ -79,6 +79,7 @@ internal fun spoofVideoStreamsPatch(
     fixMediaSessionFeatureFlag: BytecodePatchBuilder.() -> Boolean,
     fixReelItemWatchResponseFeatureFlag: BytecodePatchBuilder.() -> Boolean,
     useNewRequestBuilderFingerprint: BytecodePatchBuilder.() -> Boolean,
+    restoreMissingCuepointMethod: BytecodePatchBuilder.() -> Boolean,
     block: BytecodePatchBuilder.() -> Unit,
     executeBlock: BytecodePatchContext.() -> Unit = {},
 ) = bytecodePatch(
@@ -433,6 +434,70 @@ internal fun spoofVideoStreamsPatch(
                     it.instructionMatches.first().index,
                     "$EXTENSION_CLASS->useReelItemWatchResponseFeatureFlag(Z)Z"
                 )
+            }
+        }
+
+        // Restore missing method sometimes called by
+        // com.google.android.libraries.youtube.media.interfaces.NetFetchCallbacks$CppProxy
+        // Method is present in YT 21.13+ but not older targets.
+        // https://github.com/MorpheApp/morphe-patches/pull/2284#issuecomment-5204046377
+        if (restoreMissingCuepointMethod()) {
+            CuepointListFingerprint.classDef.apply {
+                if (methods.none {
+                        it.name == "parseFrom"
+                                && it.parameterTypes.isNotEmpty()
+                                && it.parameterTypes.first() == "Ljava/nio/ByteBuffer;"
+                    }
+                ) {
+                    val cuepointListType = $$"Lcom/google/android/apps/youtube/proto/streaming/CuepointListOuterClass$CuepointList;"
+                    val cueField = fields.single {
+                        it.type == cuepointListType
+                    }
+                    val superClass = superclass!!
+
+                    // Verify the superclass method exists.
+                    Fingerprint(
+                        definingClass = superClass,
+                        name = "parseFrom",
+                        returnType = superClass,
+                        parameters = listOf(
+                            superClass,
+                            "Ljava/nio/ByteBuffer;",
+                            "Lcom/google/protobuf/ExtensionRegistryLite;"
+                        )
+                    ).method
+
+                    methods.add(
+                        ImmutableMethod(
+                            type,
+                            "parseFrom",
+                            listOf(
+                                ImmutableMethodParameter("Ljava/nio/ByteBuffer;", null, null),
+                                ImmutableMethodParameter(
+                                    "Lcom/google/protobuf/ExtensionRegistryLite;",
+                                    null,
+                                    null
+                                )
+                            ),
+                            cuepointListType,
+                            AccessFlags.PUBLIC.value or AccessFlags.STATIC.value,
+                            null,
+                            null,
+                            MutableMethodImplementation(3),
+                        ).toMutable().apply {
+                            addInstructions(
+                                0,
+                                """    
+                                    sget-object v0, $cueField
+                                    invoke-static { v0, p0, p1 }, $superClass->parseFrom(${superClass}Ljava/nio/ByteBuffer;Lcom/google/protobuf/ExtensionRegistryLite;)$superClass
+                                    move-result-object p0
+                                    check-cast p0, $cuepointListType
+                                    return-object p0
+                                """
+                            )
+                        }
+                    )
+                }
             }
         }
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playservice/VersionCheckPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playservice/VersionCheckPatch.kt
@@ -23,6 +23,8 @@ var is_20_31_or_greater : Boolean by Delegates.notNull()
     private set
 var is_20_34_or_greater : Boolean by Delegates.notNull()
     private set
+var is_20_35_or_greater : Boolean by Delegates.notNull()
+    private set
 var is_20_37_or_greater : Boolean by Delegates.notNull()
     private set
 var is_20_38_or_greater : Boolean by Delegates.notNull()
@@ -105,6 +107,7 @@ val versionCheckPatch = bytecodePatch {
         is_20_30_or_greater = isEqualsOrGreaterThan("20.30.00")
         is_20_31_or_greater = isEqualsOrGreaterThan("20.31.00")
         is_20_34_or_greater = isEqualsOrGreaterThan("20.34.00")
+        is_20_35_or_greater = isEqualsOrGreaterThan("20.35.00")
         is_20_37_or_greater = isEqualsOrGreaterThan("20.37.00")
         is_20_38_or_greater = isEqualsOrGreaterThan("20.38.00")
         is_20_39_or_greater = isEqualsOrGreaterThan("20.39.00")

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/spoof/SpoofVideoStreamsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/spoof/SpoofVideoStreamsPatch.kt
@@ -7,6 +7,7 @@ import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.shared.misc.spoof.spoofVideoStreamsPatch
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.playservice.is_20_31_or_greater
+import app.morphe.patches.youtube.misc.playservice.is_20_35_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_20_39_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_21_21_or_greater
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
@@ -34,6 +35,7 @@ val spoofVideoStreamsPatch = spoofVideoStreamsPatch(
         is_20_31_or_greater
     },
     useNewRequestBuilderFingerprint = { is_21_21_or_greater },
+    restoreMissingCuepointMethod = { is_20_35_or_greater },
 
     block = {
         compatibleWith(COMPATIBILITY_YOUTUBE)


### PR DESCRIPTION
### Description

Restores a YouTube method that is missing in 20.35 to 21.12, but can still be [called by YouTube](https://www.github.com/MorpheApp/morphe-patches/pull/2284#issuecomment-5204046377) itself.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
