### PR TITLE
feat(YouTube - Hide Shorts components): Add "Hide Save button" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/ShortsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/ShortsFilter.java
@@ -207,6 +207,11 @@ public final class ShortsFilter extends Filter {
                 "reel_like_toggled_button.e"
         );
 
+        StringFilterGroup saveButton = new StringFilterGroup(
+                Settings.HIDE_SHORTS_SAVE_BUTTON,
+                "reel_save_button.e"
+        );
+
         StringFilterGroup previewComment = new StringFilterGroup(
                 Settings.HIDE_SHORTS_PREVIEW_COMMENT,
                 // Preview comment that can popup while a Short is playing.
@@ -402,6 +407,7 @@ public final class ShortsFilter extends Filter {
                 infoPanel,
                 joinButton,
                 likeButton,
+                saveButton,
                 likeFountain,
                 livePreview,
                 pausedOverlayButtons,

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -483,6 +483,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_SHORTS_HOME = new BooleanSetting("morphe_hide_shorts_home", FALSE);
     public static final BooleanSetting HIDE_SHORTS_INFO_PANEL = new BooleanSetting("morphe_hide_shorts_info_panel", TRUE);
     public static final BooleanSetting HIDE_SHORTS_JOIN_BUTTON = new BooleanSetting("morphe_hide_shorts_join_button", TRUE);
+    public static final BooleanSetting HIDE_SHORTS_SAVE_BUTTON = new BooleanSetting("morphe_hide_shorts_save_button", TRUE);
     public static final BooleanSetting HIDE_SHORTS_LIKE_BUTTON = new BooleanSetting("morphe_hide_shorts_like_button", FALSE);
     public static final BooleanSetting HIDE_SHORTS_LIKE_FOUNTAIN = new BooleanSetting("morphe_hide_shorts_like_fountain", TRUE);
     public static final BooleanSetting HIDE_SHORTS_LIVE_PREVIEW = new BooleanSetting("morphe_hide_shorts_live_preview", FALSE);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
@@ -94,6 +94,7 @@ private val hideShortsComponentsResourcePatch = resourcePatch {
                     //SwitchPreference("morphe_hide_shorts_like_fountain"),
                     SwitchPreference("morphe_hide_shorts_like_button"),
                     SwitchPreference("morphe_hide_shorts_comments_button"),
+                    SwitchPreference("morphe_hide_shorts_save_button"),
                     SwitchPreference("morphe_hide_shorts_share_button"),
                     SwitchPreference("morphe_hide_shorts_remix_button"),
                     SwitchPreference("morphe_hide_shorts_sound_button"),

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -879,6 +879,8 @@ To show the \'Audio Track\' menu, change \'Spoof video streams\' to any client e
     <string name="morphe_hide_shorts_like_fountain_title">Hide Like button fountain animation</string>
     <string name="morphe_hide_shorts_like_button_title">Hide Like button</string>
     <string name="morphe_hide_shorts_comments_button_title">Hide Comments button</string>
+    <!-- 'Save' should be translated using the same localized wording YouTube displays for the button. -->
+    <string name="morphe_hide_shorts_save_button_title">Hide Save button</string>
     <!-- 'Share' should be translated using the same localized wording YouTube displays for the button. -->
     <string name="morphe_hide_shorts_share_button_title">Hide Share button</string>
     <!-- 'Remix' should be translated using the same localized wording YouTube displays for the button. -->


### PR DESCRIPTION
### Description

Hides an A/B Shorts player "Save" button.

<img width="398" height="847" alt="image" src="https://github.com/user-attachments/assets/8ccb3f0d-d1b4-4fce-af33-e10f4ab29e4c" />


### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
