### PR TITLE
fix(YouTube): Prevent playback speed/quality UI text from wrapping at large font sizes

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
@@ -456,6 +456,8 @@ public class CustomPlaybackSpeedPatch {
                     normalLabel.setTextColor(Utils.getAppForegroundColor());
                     normalLabel.setTextSize(10);
                     normalLabel.setGravity(Gravity.CENTER);
+                    normalLabel.setSingleLine(true);
+                    normalLabel.setEllipsize(TextUtils.TruncateAt.END);
 
                     FrameLayout.LayoutParams labelParams = new FrameLayout.LayoutParams(
                             FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT,

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlayerOverlayButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlayerOverlayButton.java
@@ -10,6 +10,7 @@ package app.morphe.extension.youtube.videoplayer;
 import android.content.res.Configuration;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
+import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -19,7 +20,6 @@ import android.widget.TextView;
 import androidx.annotation.Nullable;
 
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,6 +27,7 @@ import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.youtube.patches.HidePlayerOverlayButtonsPatch;
 import app.morphe.extension.youtube.patches.VersionCheckPatch;
 import app.morphe.extension.youtube.settings.Settings;
@@ -379,7 +380,8 @@ public class PlayerOverlayButton {
         TextView textOverlay = new TextView(sourceButton.getContext());
         textOverlay.setId(View.generateViewId());
         textOverlay.setGravity(Gravity.CENTER);
-        textOverlay.setTextSize(14);
+        // Fixed size regardless of the system font-size setting, since the button has no room to grow.
+        textOverlay.setTextSize(TypedValue.COMPLEX_UNIT_PX, Dim.dp(14));
         textOverlay.setTextColor(0xFFFFFFFF);
         textOverlay.setTypeface(Typeface.create("sans-serif-condensed", Typeface.BOLD));
         textOverlay.setOnClickListener(onClickListener);


### PR DESCRIPTION
### Description

Fixes the "Normal" label overlapping the 1.0x button in the custom playback speed dialog, and locks the quality/speed overlay button text to a fixed size so it no longer wraps when the system font size is increased.
___
![Screenshot_2026-08-10-10-25-35-266_ru.fourpda.client-edit.jpg](https://github.com/user-attachments/assets/e69f3153-0932-4422-9966-5bf3d5b3a74c)
->
![Screenshot_2026-08-09-20-21-10-968_com.google.android.youtube.test-edit.jpg](https://github.com/user-attachments/assets/0e1b3002-6b5f-41dd-b6db-c59318464a89)
___
![Screenshot_2026-08-10-10-24-28-790_app.morphe.android.youtube-edit.jpg](https://github.com/user-attachments/assets/d3a548f4-0a73-438d-a7ba-8ca3291d7965)
->
![Screenshot_2026-08-10-10-24-40-836_com.google.android.youtube.test-edit.jpg](https://github.com/user-attachments/assets/b1b5bb91-448a-4608-acdc-34e3647ce118)






