### PR TITLE
feat(YouTube): Add `Force fullscreen landscape mode` patch

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ForceFullscreenLandscapePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ForceFullscreenLandscapePatch.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2431
  *
- * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
 
 package app.morphe.extension.youtube.patches;

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ForceFullscreenLandscapePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ForceFullscreenLandscapePatch.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
+package app.morphe.extension.youtube.patches;
+
+import android.app.Activity;
+import android.content.pm.ActivityInfo;
+
+import androidx.annotation.Nullable;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.youtube.settings.Settings;
+
+@SuppressWarnings("unused")
+public final class ForceFullscreenLandscapePatch {
+    private static final String FULLSCREEN = "WATCH_WHILE_FULLSCREEN";
+    private static final String ENTERING_FULLSCREEN = "WATCH_WHILE_SLIDING_MAXIMIZED_FULLSCREEN";
+
+    private static boolean orientationForced;
+    private static int previousRequestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
+
+    private ForceFullscreenLandscapePatch() {
+    }
+
+    /**
+     * Injection point.
+     */
+    public static void onPlayerTypeChanged(@Nullable Enum<?> playerType) {
+        if (playerType == null) return;
+
+        String name = playerType.name();
+        boolean isFullscreen = FULLSCREEN.equals(name) || ENTERING_FULLSCREEN.equals(name);
+
+        Activity activity = Utils.getActivity();
+        if (activity == null) {
+            Logger.printDebug(() -> "Cannot change fullscreen orientation (activity is null)");
+            return;
+        }
+
+        if (Settings.FORCE_FULLSCREEN_LANDSCAPE.get() && isFullscreen) {
+            if (orientationForced) return;
+
+            previousRequestedOrientation = activity.getRequestedOrientation();
+            orientationForced = true;
+            Logger.printDebug(() -> "Forcing landscape orientation for fullscreen video");
+            activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
+        } else if (orientationForced) {
+            orientationForced = false;
+            int orientationToRestore = previousRequestedOrientation;
+            previousRequestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
+            Logger.printDebug(() -> "Restoring orientation after fullscreen video");
+            activity.setRequestedOrientation(orientationToRestore);
+        }
+    }
+}

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -198,6 +198,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting DISABLE_FULLSCREEN_DRAGGED_DOWN_GESTURE = new BooleanSetting("morphe_disable_fullscreen_dragged_down_gesture", FALSE);
     public static final BooleanSetting DISABLE_ROLLING_NUMBER_ANIMATIONS = new BooleanSetting("morphe_disable_rolling_number_animations", FALSE);
     public static final EnumSetting<FullscreenMode> EXIT_FULLSCREEN = new EnumSetting<>("morphe_exit_fullscreen", FullscreenMode.DISABLED);
+    public static final BooleanSetting FORCE_FULLSCREEN_LANDSCAPE = new BooleanSetting("morphe_force_fullscreen_landscape", FALSE);
     public static final BooleanSetting HIDE_AUTOPLAY_PREVIEW = new BooleanSetting("morphe_hide_autoplay_preview", FALSE, true);
     public static final BooleanSetting HIDE_CHANNEL_BAR = new BooleanSetting("morphe_hide_channel_bar", FALSE);
     public static final BooleanSetting HIDE_CHANNEL_WATERMARK = new BooleanSetting("morphe_hide_channel_watermark", TRUE);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/ForceFullscreenLandscapePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/ForceFullscreenLandscapePatch.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
+package app.morphe.patches.youtube.layout.player.fullscreen
+
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import app.morphe.patches.youtube.misc.playertype.addPlayerTypeHook
+import app.morphe.patches.youtube.misc.playertype.playerTypeHookPatch
+import app.morphe.patches.youtube.misc.settings.PreferenceScreen
+import app.morphe.patches.youtube.misc.settings.settingsPatch
+import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
+
+private const val FORCE_LANDSCAPE_EXTENSION_CLASS =
+    "Lapp/morphe/extension/youtube/patches/ForceFullscreenLandscapePatch;"
+
+@Suppress("unused")
+val forceFullscreenLandscapePatch = bytecodePatch(
+    name = "Force fullscreen landscape",
+    description = "Adds an option to force landscape orientation whenever the regular video player enters fullscreen mode.",
+) {
+    compatibleWith(COMPATIBILITY_YOUTUBE)
+
+    dependsOn(
+        playerTypeHookPatch,
+        settingsPatch,
+    )
+
+    execute {
+        PreferenceScreen.PLAYER.addPreferences(
+            SwitchPreference("morphe_force_fullscreen_landscape", summary = true),
+        )
+
+        addPlayerTypeHook(
+            "$FORCE_LANDSCAPE_EXTENSION_CLASS->onPlayerTypeChanged(Ljava/lang/Enum;)V",
+        )
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/ForceFullscreenLandscapePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/ForceFullscreenLandscapePatch.kt
@@ -1,8 +1,8 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2431
  *
- * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
 
 package app.morphe.patches.youtube.layout.player.fullscreen
@@ -21,7 +21,7 @@ private const val FORCE_LANDSCAPE_EXTENSION_CLASS =
 @Suppress("unused")
 val forceFullscreenLandscapePatch = bytecodePatch(
     name = "Force fullscreen landscape",
-    description = "Adds an option to force landscape orientation whenever the regular video player enters fullscreen mode.",
+    description = "Adds an option to force fullscreen portrait mode when viewing videos with landscape aspect ratio.",
 ) {
     compatibleWith(COMPATIBILITY_YOUTUBE)
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playertype/PlayerTypeHookPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playertype/PlayerTypeHookPatch.kt
@@ -37,20 +37,16 @@ val playerTypeHookPatch = bytecodePatch(
     dependsOn(sharedExtensionPatch, resourceMappingPatch)
 
     execute {
-        Fingerprint(
-            definingClass = "/YouTubePlayerOverlaysLayout;",
-            accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
-            returnType = "V",
-            parameters = listOf(
-                PlayerTypeEnumFingerprint.originalClassDef.type
-            )
-        ).method.apply {
-            playerTypeMethodRef = WeakReference(this)
-            addInstruction(
-                0,
-                "invoke-static { p1 }, $EXTENSION_CLASS->setPlayerType(Ljava/lang/Enum;)V",
-            )
-        }
+        playerTypeMethodRef = WeakReference(
+            Fingerprint(
+                definingClass = "/YouTubePlayerOverlaysLayout;",
+                accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+                returnType = "V",
+                parameters = listOf(PlayerTypeEnumFingerprint.originalClassDef.type)
+            ).method
+        )
+
+        addPlayerTypeHook("$EXTENSION_CLASS->setPlayerType(Ljava/lang/Enum;)V")
 
         ReelWatchPagerFingerprint.let {
             it.method.apply {

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playertype/PlayerTypeHookPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/playertype/PlayerTypeHookPatch.kt
@@ -6,6 +6,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.fieldAccess
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import app.morphe.patches.all.misc.resources.ResourceType
 import app.morphe.patches.all.misc.resources.resourceLiteral
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
@@ -13,8 +14,22 @@ import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import java.lang.ref.WeakReference
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/PlayerTypeHookPatch;"
+
+private lateinit var playerTypeMethodRef: WeakReference<MutableMethod>
+
+/**
+ * Adds a callback that is invoked whenever the regular player's type changes.
+ *
+ * @param methodDescriptor static method accepting the original player type enum.
+ */
+internal fun addPlayerTypeHook(methodDescriptor: String) =
+    playerTypeMethodRef.get()!!.addInstruction(
+        0,
+        "invoke-static { p1 }, $methodDescriptor",
+    )
 
 val playerTypeHookPatch = bytecodePatch(
     description = "Hook to get the current player type and video playback state.",
@@ -29,10 +44,13 @@ val playerTypeHookPatch = bytecodePatch(
             parameters = listOf(
                 PlayerTypeEnumFingerprint.originalClassDef.type
             )
-        ).method.addInstruction(
-            0,
-            "invoke-static { p1 }, $EXTENSION_CLASS->setPlayerType(Ljava/lang/Enum;)V",
-        )
+        ).method.apply {
+            playerTypeMethodRef = WeakReference(this)
+            addInstruction(
+                0,
+                "invoke-static { p1 }, $EXTENSION_CLASS->setPlayerType(Ljava/lang/Enum;)V",
+            )
+        }
 
         ReelWatchPagerFingerprint.let {
             it.method.apply {

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -923,6 +923,10 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
     <string name="morphe_exit_fullscreen_entry_3">Landscape only</string>
     <string name="morphe_exit_fullscreen_entry_4">Portrait and landscape</string>
 
+    <!-- layout.player.fullscreen.forceFullscreenLandscapePatch -->
+    <string name="morphe_force_fullscreen_landscape_title">Force landscape in fullscreen</string>
+    <string name="morphe_force_fullscreen_landscape_summary">Rotates the regular video player to landscape whenever fullscreen mode is entered</string>
+
     <!-- layout.player.fullscreen.disableFullscreenGesturesPatch -->
     <string name="morphe_disable_fullscreen_gestures_title">Fullscreen gestures</string>
     <string name="morphe_disable_fullscreen_gestures_summary">Player gestures to enter or exit from fullscreen mode</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -925,7 +925,7 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
 
     <!-- layout.player.fullscreen.forceFullscreenLandscapePatch -->
     <string name="morphe_force_fullscreen_landscape_title">Force landscape in fullscreen</string>
-    <string name="morphe_force_fullscreen_landscape_summary">Rotates the regular video player to landscape whenever fullscreen mode is entered</string>
+    <string name="morphe_force_fullscreen_landscape_summary">Uses fullscreen portrait mode to view landscape videos</string>
 
     <!-- layout.player.fullscreen.disableFullscreenGesturesPatch -->
     <string name="morphe_disable_fullscreen_gestures_title">Fullscreen gestures</string>


### PR DESCRIPTION
### Description

Adds an optional **Force landscape in fullscreen** setting under Player. When enabled, the regular video player requests sensor-landscape whenever it enters fullscreen, including on tablets and foldable inner displays where stock YouTube otherwise keeps the activity in portrait. The previous requested orientation is restored after leaving fullscreen or disabling the option.

The implementation hooks player-type transitions so it covers fullscreen-button, gesture, and other entry paths rather than only automatically opening a video fullscreen. The option defaults to disabled.

### Additional context

This large-screen stock behavior has previously been reported in ReVanced issue https://github.com/ReVanced/revanced-patches/issues/1840 and on foldables in https://github.com/inotia00/ReVanced_Extended/issues/2294.

### Test results

- [x] Full repository build (`:patches:build`)
- [x] Applied only `Force fullscreen landscape` plus internal dependencies to stock YouTube `21.04.223`
- [x] Tested the original always-enabled implementation on a Samsung Galaxy Tab S10 Ultra (SM-X820)
- [ ] Tested on both the minimum and maximum supported YouTube versions
- [ ] Tested on experimental supported versions (optional)