### PR TITLE
fix(YouTube - Captions): Auto captions do not show when video is unmuted

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AutoCaptionsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/AutoCaptionsPatch.java
@@ -31,18 +31,16 @@ public class AutoCaptionsPatch {
      * Injection point.
      */
     public static boolean disableAutoCaptions(boolean original) {
-        AutoCaptionsStyle style = Settings.AUTO_CAPTIONS_STYLE.get();
-        final boolean withVolumeAutoCaptioningEnabled = (style == AutoCaptionsStyle.BOTH_ENABLED)
-                || (style == AutoCaptionsStyle.WITH_VOLUME_ONLY);
-
-        if (!withVolumeAutoCaptioningEnabled) {
-            // Disable auto-captioning only
-            // when 'withVolumeAutoCaptioningEnabled'
-            // field is false
-            return !captionsButtonStatus.get() || original;
+        // After the guard window (150ms), respect the user's manual CC button toggle.
+        if (captionsButtonStatus.get()) {
+            return original;
         }
 
-        return original;
+        // During the initial video load window, force captions on or off based on setting.
+        AutoCaptionsStyle style = Settings.AUTO_CAPTIONS_STYLE.get();
+        boolean wantCaptions = (style == AutoCaptionsStyle.BOTH_ENABLED)
+                || (style == AutoCaptionsStyle.WITH_VOLUME_ONLY);
+        return !wantCaptions;
     }
 
     /**


### PR DESCRIPTION
## Summary

"Always show" and "Show when unmuted" auto captions settings were not working — captions only appeared when muted, then disappeared when unmuted.

## Cause

`disableAutoCaptions()` returned `original` for the `BOTH_ENABLED` / `WITH_VOLUME_ONLY` cases. This relied on YouTube's subtitle manager natively returning `true` during unmuted playback.

Starting around YouTube 20.26, auto-captioning moved behind a mute-only feature flag (`45692436` / `NoVolumeCaptionsFeatureFlagFingerprint`). The subtitle manager's native decision during unmuted playback became `false`, so `return original` effectively meant "no captions when unmuted."

The muted path was handled correctly (`disableMuteAutoCaptions` overrides the feature flag), but `disableAutoCaptions` was never updated to actively force captions on for unmuted playback.

## Fix

Simplified `disableAutoCaptions` to explicitly force captions on or off during the initial video load window based on the user's setting, then defer to `original` after the 150ms guard to respect manual CC button toggles.