### PR TITLE
perf(YouTube): Cache app version comparison in LithoFilterPatch

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/components/LithoFilterPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/components/LithoFilterPatch.java
@@ -82,6 +82,9 @@ public final class LithoFilterPatch {
      */
     private static final int LITHO_LAYOUT_THREAD_POOL_SIZE = 1;
 
+    private static final boolean IS_20_22_OR_GREATER =
+            Utils.getAppVersionName().compareTo("20.22.00") >= 0;
+
     private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 
     /**
@@ -186,7 +189,7 @@ public final class LithoFilterPatch {
                 accessibility = "";
             }
 
-            byte[] buffer = is_20_22_or_greater()
+            byte[] buffer = IS_20_22_OR_GREATER
                     ? bytes
                     : bufferThreadLocal.get();
             // Potentially the buffer may have been null or never set up until now.
@@ -207,10 +210,6 @@ public final class LithoFilterPatch {
         }
 
         return false;
-    }
-
-    private static boolean is_20_22_or_greater() {
-        return Utils.getAppVersionName().compareTo("20.22.00") >= 0;
     }
 
     /**


### PR DESCRIPTION
### Description

In `LithoFilterPatch.java`, `is_20_22_or_greater()` is called inside `isFiltered()` on every single Litho component evaluation during feed scrolling and search rendering.

Previously, `is_20_22_or_greater()` dynamically resolved `Utils.getAppVersionName()` and performed a character-by-character `compareTo("20.22.00")` string comparison on every invocation (hundreds of times per second during fast scrolling).

Since the application version is immutable throughout the process lifecycle, this PR caches the comparison once into a `static final boolean IS_20_22_OR_GREATER` at class load time, eliminating redundant string operations in the critical UI rendering path while maintaining full backward compatibility.

---

### Changes
* Added `static final boolean IS_20_22_OR_GREATER` in `LithoFilterPatch.java`.
* Inlined `IS_20_22_OR_GREATER` in `isFiltered()`.
* Removed redundant private `is_20_22_or_greater()` method.

---

### Test results

- [x] Tested on `21.04.223`
