### PR TITLE
fix(YouTube - Navigation bar): Merge disable translucent navigation bar/status into a single setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/NavigationBarPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/NavigationBarPatch.java
@@ -65,11 +65,7 @@ public final class NavigationBarPatch {
 
     private static final boolean SWAP_CREATE_WITH_NOTIFICATIONS_BUTTON = Settings.SWAP_CREATE_WITH_NOTIFICATIONS_BUTTON.get();
 
-    private static final boolean DISABLE_TRANSLUCENT_STATUS_BAR = Settings.DISABLE_TRANSLUCENT_STATUS_BAR.get();
-
-    private static final boolean DISABLE_TRANSLUCENT_NAVIGATION_BAR_LIGHT = Settings.DISABLE_TRANSLUCENT_NAVIGATION_BAR_LIGHT.get();
-
-    private static final boolean DISABLE_TRANSLUCENT_NAVIGATION_BAR_DARK = Settings.DISABLE_TRANSLUCENT_NAVIGATION_BAR_DARK.get();
+    private static final boolean DISABLE_TRANSLUCENT_NAVIGATION = Settings.DISABLE_TRANSLUCENT_NAVIGATION.get();
 
     private static final boolean NARROW_NAVIGATION_BUTTONS = Settings.NARROW_NAVIGATION_BUTTONS.get();
 
@@ -150,46 +146,24 @@ public final class NavigationBarPatch {
      * Injection point.
      */
     public static boolean allowCollapsingToolbarLayout(boolean original) {
-        if (DISABLE_TRANSLUCENT_STATUS_BAR) return false;
+        if (DISABLE_TRANSLUCENT_NAVIGATION) return false;
         return original;
     }
 
     /**
      * Injection point.
      */
-    public static boolean useTranslucentNavigationStatusBar(boolean original) {
+    public static boolean useTranslucentNavigation(boolean original) {
         // Must check Android version, as forcing this on Android 11 or lower causes app hang and crash.
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             return original;
         }
 
-        if (DISABLE_TRANSLUCENT_STATUS_BAR) {
+        if (DISABLE_TRANSLUCENT_NAVIGATION) {
             return false;
         }
 
         return original;
-    }
-
-    /**
-     * Injection point.
-     */
-    public static boolean useTranslucentNavigationButtons(boolean original) {
-        // Feature requires Android 13+
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-            return original;
-        }
-
-        if (!DISABLE_TRANSLUCENT_NAVIGATION_BAR_DARK && !DISABLE_TRANSLUCENT_NAVIGATION_BAR_LIGHT) {
-            return original;
-        }
-
-        if (DISABLE_TRANSLUCENT_NAVIGATION_BAR_DARK && DISABLE_TRANSLUCENT_NAVIGATION_BAR_LIGHT) {
-            return false;
-        }
-
-        return Utils.isDarkModeEnabled()
-                ? !DISABLE_TRANSLUCENT_NAVIGATION_BAR_DARK
-                : !DISABLE_TRANSLUCENT_NAVIGATION_BAR_LIGHT;
     }
 
     // Navigation search and settings button

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -413,7 +413,7 @@ public class Settings extends SharedYouTubeSettings {
 
     // General (Layout)
     public static final BooleanSetting DISABLE_LAYOUT_UPDATES = new BooleanSetting("morphe_disable_layout_updates", FALSE, true,"morphe_disable_layout_updates_user_dialog_message");
-    public static final BooleanSetting DISABLE_TRANSLUCENT_STATUS_BAR = new BooleanSetting("morphe_disable_translucent_status_bar", FALSE, true, "morphe_disable_translucent_status_bar_user_dialog_message");
+    public static final BooleanSetting DISABLE_TRANSLUCENT_STATUS_BAR = new BooleanSetting("morphe_disable_translucent_status_bar", FALSE, true);
     public static final BooleanSetting RESTORE_OLD_SETTINGS_MENUS = new BooleanSetting("morphe_restore_old_settings_menus", FALSE, true);
     public static final EnumSetting<FormFactor> CHANGE_FORM_FACTOR = new EnumSetting<>("morphe_change_form_factor", FormFactor.DEFAULT, true, "morphe_change_form_factor_user_dialog_message");
     public static final BooleanSetting TABLET_LAYOUT_IN_PLAYER = new BooleanSetting("morphe_tablet_layout_in_player", FALSE, true, new TabletLayoutInPlayerAvailability());

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -413,7 +413,6 @@ public class Settings extends SharedYouTubeSettings {
 
     // General (Layout)
     public static final BooleanSetting DISABLE_LAYOUT_UPDATES = new BooleanSetting("morphe_disable_layout_updates", FALSE, true,"morphe_disable_layout_updates_user_dialog_message");
-    public static final BooleanSetting DISABLE_TRANSLUCENT_STATUS_BAR = new BooleanSetting("morphe_disable_translucent_status_bar", FALSE, true);
     public static final BooleanSetting RESTORE_OLD_SETTINGS_MENUS = new BooleanSetting("morphe_restore_old_settings_menus", FALSE, true);
     public static final EnumSetting<FormFactor> CHANGE_FORM_FACTOR = new EnumSetting<>("morphe_change_form_factor", FormFactor.DEFAULT, true, "morphe_change_form_factor_user_dialog_message");
     public static final BooleanSetting TABLET_LAYOUT_IN_PLAYER = new BooleanSetting("morphe_tablet_layout_in_player", FALSE, true, new TabletLayoutInPlayerAvailability());
@@ -453,8 +452,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting NARROW_NAVIGATION_BUTTONS = new BooleanSetting("morphe_narrow_navigation_buttons", FALSE, true, parentNot(HIDE_NAVIGATION_BAR));
     public static final BooleanSetting DISABLE_AUTO_HIDE_NAVIGATION_BAR = new BooleanSetting("morphe_disable_auto_hide_navigation_bar", FALSE, true, parentNot(HIDE_NAVIGATION_BAR));
     public static final BooleanSetting NAVIGATION_BAR_ANIMATIONS = new BooleanSetting("morphe_navigation_bar_animations", FALSE, parentNot(HIDE_NAVIGATION_BAR));
-    public static final BooleanSetting DISABLE_TRANSLUCENT_NAVIGATION_BAR_LIGHT = new BooleanSetting("morphe_disable_translucent_navigation_bar_light", FALSE, true, parentNot(HIDE_NAVIGATION_BAR));
-    public static final BooleanSetting DISABLE_TRANSLUCENT_NAVIGATION_BAR_DARK = new BooleanSetting("morphe_disable_translucent_navigation_bar_dark", FALSE, true, parentNot(HIDE_NAVIGATION_BAR));
+    public static final BooleanSetting DISABLE_TRANSLUCENT_NAVIGATION = new BooleanSetting("morphe_disable_translucent_navigation", FALSE, true, parentNot(HIDE_NAVIGATION_BAR));
 
     // Toolbar
     public static final BooleanSetting HIDE_TOOLBAR_CAST_BUTTON = new BooleanSetting("morphe_hide_toolbar_cast_button", TRUE, true);
@@ -702,6 +700,9 @@ public class Settings extends SharedYouTubeSettings {
     private static final StringSetting  DEPRECATED_SB_CATEGORY_MUSIC_OFFTOPIC_COLOR = new StringSetting("sb_music_offtopic_color", "#CCFF9900", false, false);
     private static final StringSetting  DEPRECATED_SB_CATEGORY_UNSUBMITTED = new StringSetting("sb_unsubmitted", SKIP_AUTOMATICALLY.morpheKeyValue, false, false);
     private static final StringSetting  DEPRECATED_SB_CATEGORY_UNSUBMITTED_COLOR = new StringSetting("sb_unsubmitted_color", "#FFFFFFFF", false, false);
+    private static final BooleanSetting DEPRECATED_DISABLE_TRANSLUCENT_STATUS_BAR = new BooleanSetting("morphe_disable_translucent_status_bar", FALSE);
+    private static final BooleanSetting DEPRECATED_DISABLE_TRANSLUCENT_NAVIGATION_BAR_LIGHT = new BooleanSetting("morphe_disable_translucent_navigation_bar_light", FALSE);
+    private static final BooleanSetting DEPRECATED_DISABLE_TRANSLUCENT_NAVIGATION_BAR_DARK = new BooleanSetting("morphe_disable_translucent_navigation_bar_dark", FALSE);
 
     static {
         migrateOldSettingToNew(DEPRECATED_BYPASS_URL_REDIRECTS, BYPASS_LINK_REDIRECTS);
@@ -769,6 +770,15 @@ public class Settings extends SharedYouTubeSettings {
         migrateOldSettingToNew(DEPRECATED_SB_CATEGORY_MUSIC_OFFTOPIC_COLOR, SB_CATEGORY_MUSIC_OFFTOPIC_COLOR);
         migrateOldSettingToNew(DEPRECATED_SB_CATEGORY_UNSUBMITTED, SB_CATEGORY_UNSUBMITTED);
         migrateOldSettingToNew(DEPRECATED_SB_CATEGORY_UNSUBMITTED_COLOR, SB_CATEGORY_UNSUBMITTED_COLOR);
+
+        if (DEPRECATED_DISABLE_TRANSLUCENT_STATUS_BAR.get()
+                || DEPRECATED_DISABLE_TRANSLUCENT_NAVIGATION_BAR_LIGHT.get()
+                || DEPRECATED_DISABLE_TRANSLUCENT_NAVIGATION_BAR_DARK.get()) {
+            DISABLE_TRANSLUCENT_NAVIGATION.save(true);
+            DEPRECATED_DISABLE_TRANSLUCENT_STATUS_BAR.resetToDefault();
+            DEPRECATED_DISABLE_TRANSLUCENT_NAVIGATION_BAR_LIGHT.resetToDefault();
+            DEPRECATED_DISABLE_TRANSLUCENT_NAVIGATION_BAR_DARK.resetToDefault();
+        }
 
         // 20.37+ YT removed parts of the code for the legacy tablet miniplayer.
         // This check must remain until the Tablet type is eventually removed.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 # Dependencies must also be addded to LicensesDialog.java
 
 [versions]
-morphe-patcher = "1.8.0-dev.5" # TODO: Change to stable
-morphe-patches-library = "1.6.0-dev.2"
+morphe-patcher = "1.8.0"
+morphe-patches-library = "1.6.1-dev.1"
 # Tracking https://github.com/google/smali/issues/100.
 smali = "d92701d947"
 agp = "9.1.0"

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/Fingerprints.kt
@@ -11,6 +11,7 @@
 package app.morphe.patches.youtube.layout.buttons.navigation
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionFilter
 import app.morphe.patcher.InstructionLocation.MatchAfterImmediately
 import app.morphe.patcher.InstructionLocation.MatchAfterWithin
 import app.morphe.patcher.OpcodesFilter
@@ -23,7 +24,6 @@ import app.morphe.patcher.parametersMatch
 import app.morphe.patcher.string
 import app.morphe.patches.all.misc.resources.ResourceType
 import app.morphe.patches.all.misc.resources.resourceLiteral
-import app.morphe.patches.youtube.layout.hide.general.YouTubeDoodlesImageViewFingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 
@@ -134,15 +134,90 @@ internal object PivotBarChangedFingerprint : Fingerprint(
     )
 )
 
+/** Translucent navigation bar buttons feature flag. */
+internal val TRANSLUCENT_STATUS_BAR_FILTER = literal(45400535L)
+
 internal object TranslucentNavigationStatusBarFeatureFlagFingerprint : Fingerprint(
     filters = listOf(
-        literal(45400535L) // Translucent status bar feature flag.
+        TRANSLUCENT_STATUS_BAR_FILTER
     )
 )
 
-/**
+internal fun translucentImmersiveFingerprint(filter: InstructionFilter) = object : Fingerprint(
+    classFingerprint = Fingerprint(
+        accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
+        parameters = listOf("Landroid/app/Activity;", "L"),
+        filters = listOf(
+            methodCall(
+                opcode = Opcode.INVOKE_STATIC,
+                smali = "Ljava/util/Collections;->newSetFromMap(Ljava/util/Map;)Ljava/util/Set;"
+            ),
+            filter
+        )
+    ),
+    filters = listOf(filter)
+) {}
+
+internal fun translucentCheckOnTextFingerprint(filter: InstructionFilter) = object : Fingerprint(
+    classFingerprint = Fingerprint(
+        accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.FINAL),
+        parameters = listOf("Landroid/graphics/Rect;"),
+        returnType = "V",
+        filters = listOf(
+            filter,
+            methodCall(
+                opcode = Opcode.INVOKE_VIRTUAL,
+                smali = "Landroid/view/View;->onCheckIsTextEditor()Z"
+            )
+        )
+    ),
+    filters = listOf(filter)
+) {}
+
+internal fun translucentUpdateStatusBarFingerprint(filter: InstructionFilter) = object : Fingerprint(
+    classFingerprint = Fingerprint(
+        accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+        name = "run",
+        parameters = listOf(),
+        returnType = "V",
+        filters = listOf(
+            filter,
+            methodCall(
+                opcode = Opcode.INVOKE_VIRTUAL,
+                smali = "Landroid/view/ViewGroup;->setFitsSystemWindows(Z)V"
+            ),
+            methodCall(
+                opcode = Opcode.INVOKE_VIRTUAL,
+                smali = "Lcom/google/android/apps/youtube/app/watchwhile/MainActivity;->getWindow()Landroid/view/Window;"
+            )
+        )
+    ),
+    filters = listOf(filter)
+) {}
+
+internal fun translucentYouTabFingerprint(filter: InstructionFilter) = object : Fingerprint(
+    classFingerprint = Fingerprint(
+        returnType = "Landroid/view/View;",
+        parameters = listOf(
+            "Landroid/view/LayoutInflater;",
+            "Landroid/view/ViewGroup;",
+            "Landroid/os/Bundle;"
+        ),
+        filters = listOf(
+            filter,
+            opcode(Opcode.MOVE_RESULT, MatchAfterWithin(15)),
+            string("instance_activated_text_color"),
+            string("instance_secondary_text_color")
+        )
+    ),
+    filters = listOf(filter)
+) {}
+
+
+/*
  * YouTube nav buttons.
  */
+
 internal object TranslucentNavigationButtonsFeatureFlagFingerprint : Fingerprint(
     filters = listOf(
         literal(45630927L) // Translucent navigation bar buttons feature flag.

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
@@ -1,6 +1,7 @@
 /*
  * Copyright 2026 Morphe.
  * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2451
  *
  * Original hard forked code:
  * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
@@ -16,6 +17,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.methodCall
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
@@ -45,6 +47,7 @@ import app.morphe.patches.youtube.misc.toolbar.toolBarHookPatch
 import app.morphe.patches.youtube.shared.ActionBarSearchResultsFingerprint
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import app.morphe.util.addInstructionsAtControlFlowLabel
+import app.morphe.util.findInstructionIndicesReversedOrThrow
 import app.morphe.util.getFreeRegisterProvider
 import app.morphe.util.getReference
 import app.morphe.util.insertLiteralOverride
@@ -110,11 +113,9 @@ val navigationBarPatch = bytecodePatch(
             navPreferences += SwitchPreference("morphe_disable_auto_hide_navigation_bar", summary = true)
         }
 
-        if (!is_21_30_or_greater) {
-            PreferenceScreen.GENERAL.addPreferences(
-                SwitchPreference("morphe_disable_translucent_status_bar", summary = true)
-            )
-        }
+        PreferenceScreen.GENERAL.addPreferences(
+            SwitchPreference("morphe_disable_translucent_status_bar", summary = true)
+        )
 
         PreferenceScreen.GENERAL.addPreferences(
             PreferenceScreenPreference(
@@ -151,8 +152,48 @@ val navigationBarPatch = bytecodePatch(
         addBottomBarContainerHook("$EXTENSION_CLASS->hideNavigationBar(Landroid/view/View;)V")
 
         // Force on/off translucent effect on status bar and navigation buttons.
-        if (!is_21_30_or_greater) {
-            TranslucentNavigationStatusBarFeatureFlagFingerprint.matchAll().forEach {
+        if (is_20_31_or_greater) {
+            val translucentStatusBarFilter = if (is_21_30_or_greater) {
+                TRANSLUCENT_STATUS_BAR_FILTER
+            } else {
+                methodCall(TranslucentNavigationStatusBarFeatureFlagFingerprint.originalMethod)
+            }
+
+            arrayOf(
+                translucentImmersiveFingerprint(translucentStatusBarFilter),
+                translucentCheckOnTextFingerprint(translucentStatusBarFilter),
+                translucentUpdateStatusBarFingerprint(translucentStatusBarFilter),
+                translucentYouTabFingerprint(translucentStatusBarFilter)
+            ).forEach { fingerprint ->
+                fingerprint.matchAll().forEach {
+                    if (is_21_30_or_greater) {
+                        it.method.insertLiteralOverride(
+                            it.instructionMatches.last().index,
+                            "$EXTENSION_CLASS->useTranslucentNavigationStatusBar(Z)Z"
+                        )
+                        return@forEach
+                    }
+
+                    it.method.apply {
+                        findInstructionIndicesReversedOrThrow(translucentStatusBarFilter).forEach { index ->
+                            val instruction = getInstruction(index + 1)
+                            if (instruction.opcode != Opcode.MOVE_RESULT) {
+                                return@forEach
+                            }
+                            val register = (instruction as OneRegisterInstruction).registerA
+                            addInstructions(
+                                index + 2,
+                                """
+                                    invoke-static { v$register }, $EXTENSION_CLASS->useTranslucentNavigationStatusBar(Z)Z
+                                    move-result v$register
+                                """
+                            )
+                        }
+                    }
+                }
+            }
+        } else {
+            TranslucentNavigationStatusBarFeatureFlagFingerprint.let {
                 it.method.insertLiteralOverride(
                     it.instructionMatches.first().index,
                     "$EXTENSION_CLASS->useTranslucentNavigationStatusBar(Z)Z"
@@ -167,13 +208,11 @@ val navigationBarPatch = bytecodePatch(
             )
         }
 
-        if (!is_21_30_or_greater) {
-            TranslucentNavigationButtonsSystemFeatureFlagFingerprint.matchAll().forEach {
-                it.method.insertLiteralOverride(
-                    it.instructionMatches.first().index,
-                    "$EXTENSION_CLASS->useTranslucentNavigationButtons(Z)Z"
-                )
-            }
+        TranslucentNavigationButtonsSystemFeatureFlagFingerprint.matchAll().forEach {
+            it.method.insertLiteralOverride(
+                it.instructionMatches.first().index,
+                "$EXTENSION_CLASS->useTranslucentNavigationButtons(Z)Z"
+            )
         }
 
         TranslucentNavigationButtonsFeatureFlagFingerprint.matchAll().forEach {
@@ -183,7 +222,8 @@ val navigationBarPatch = bytecodePatch(
             )
         }
 
-        if (is_20_46_or_greater && !is_21_30_or_greater) {
+        // Edit: This override may no longer be needed since the status bar changes are now more precise.
+        if (false) if (is_20_46_or_greater) {
             // Feature interferes with translucent status bar and must be forced off.
             CollapsingToolbarLayoutFeatureFlagFingerprint.matchAll().forEach {
                 it.method.insertLiteralOverride(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
@@ -105,17 +105,12 @@ val navigationBarPatch = bytecodePatch(
             SwitchPreference("morphe_narrow_navigation_buttons", summary = true),
             SwitchPreference("morphe_hide_navigation_button_labels"),
             SwitchPreference("morphe_navigation_bar_animations", summary = true),
-            SwitchPreference("morphe_disable_translucent_navigation_bar_light", summary = true),
-            SwitchPreference("morphe_disable_translucent_navigation_bar_dark", summary = true)
+            SwitchPreference("morphe_disable_translucent_navigation", summary = true)
         )
 
         if (is_20_31_or_greater) {
             navPreferences += SwitchPreference("morphe_disable_auto_hide_navigation_bar", summary = true)
         }
-
-        PreferenceScreen.GENERAL.addPreferences(
-            SwitchPreference("morphe_disable_translucent_status_bar", summary = true)
-        )
 
         PreferenceScreen.GENERAL.addPreferences(
             PreferenceScreenPreference(
@@ -162,14 +157,14 @@ val navigationBarPatch = bytecodePatch(
             arrayOf(
                 translucentImmersiveFingerprint(translucentStatusBarFilter),
                 translucentCheckOnTextFingerprint(translucentStatusBarFilter),
-                translucentUpdateStatusBarFingerprint(translucentStatusBarFilter),
-                translucentYouTabFingerprint(translucentStatusBarFilter)
+                translucentYouTabFingerprint(translucentStatusBarFilter),
+                translucentUpdateStatusBarFingerprint(translucentStatusBarFilter)
             ).forEach { fingerprint ->
                 fingerprint.matchAll().forEach {
                     if (is_21_30_or_greater) {
                         it.method.insertLiteralOverride(
                             it.instructionMatches.last().index,
-                            "$EXTENSION_CLASS->useTranslucentNavigationStatusBar(Z)Z"
+                            "$EXTENSION_CLASS->useTranslucentNavigation(Z)Z"
                         )
                         return@forEach
                     }
@@ -184,7 +179,7 @@ val navigationBarPatch = bytecodePatch(
                             addInstructions(
                                 index + 2,
                                 """
-                                    invoke-static { v$register }, $EXTENSION_CLASS->useTranslucentNavigationStatusBar(Z)Z
+                                    invoke-static { v$register }, $EXTENSION_CLASS->useTranslucentNavigation(Z)Z
                                     move-result v$register
                                 """
                             )
@@ -196,7 +191,31 @@ val navigationBarPatch = bytecodePatch(
             TranslucentNavigationStatusBarFeatureFlagFingerprint.let {
                 it.method.insertLiteralOverride(
                     it.instructionMatches.first().index,
-                    "$EXTENSION_CLASS->useTranslucentNavigationStatusBar(Z)Z"
+                    "$EXTENSION_CLASS->useTranslucentNavigation(Z)Z"
+                )
+            }
+        }
+
+        TranslucentNavigationButtonsSystemFeatureFlagFingerprint.matchAll().forEach {
+            it.method.insertLiteralOverride(
+                it.instructionMatches.first().index,
+                "$EXTENSION_CLASS->useTranslucentNavigation(Z)Z"
+            )
+        }
+
+        TranslucentNavigationButtonsFeatureFlagFingerprint.matchAll().forEach {
+            it.method.insertLiteralOverride(
+                it.instructionMatches.first().index,
+                "$EXTENSION_CLASS->useTranslucentNavigation(Z)Z"
+            )
+        }
+
+        if (is_20_46_or_greater) {
+            // Feature interferes with translucent status bar and must be forced off.
+            CollapsingToolbarLayoutFeatureFlagFingerprint.matchAll().forEach {
+                it.method.insertLiteralOverride(
+                    it.instructionMatches.first().index,
+                    "$EXTENSION_CLASS->allowCollapsingToolbarLayout(Z)Z"
                 )
             }
         }
@@ -206,31 +225,6 @@ val navigationBarPatch = bytecodePatch(
                 it.instructionMatches.first().index,
                 "$EXTENSION_CLASS->useAnimatedNavigationButtons(Z)Z"
             )
-        }
-
-        TranslucentNavigationButtonsSystemFeatureFlagFingerprint.matchAll().forEach {
-            it.method.insertLiteralOverride(
-                it.instructionMatches.first().index,
-                "$EXTENSION_CLASS->useTranslucentNavigationButtons(Z)Z"
-            )
-        }
-
-        TranslucentNavigationButtonsFeatureFlagFingerprint.matchAll().forEach {
-            it.method.insertLiteralOverride(
-                it.instructionMatches.first().index,
-                "$EXTENSION_CLASS->useTranslucentNavigationButtons(Z)Z"
-            )
-        }
-
-        // Edit: This override may no longer be needed since the status bar changes are now more precise.
-        if (false) if (is_20_46_or_greater) {
-            // Feature interferes with translucent status bar and must be forced off.
-            CollapsingToolbarLayoutFeatureFlagFingerprint.matchAll().forEach {
-                it.method.insertLiteralOverride(
-                    it.instructionMatches.first().index,
-                    "$EXTENSION_CLASS->allowCollapsingToolbarLayout(Z)Z"
-                )
-            }
         }
 
         arrayOf(

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -740,9 +740,6 @@ To access Settings, enable the Settings button via General → Toolbar → Show 
     <string name="morphe_disable_auto_hide_navigation_bar_summary">Keeps the navigation bar visible while scrolling</string>
     <string name="morphe_disable_translucent_status_bar_title">Disable translucent status bar</string>
     <string name="morphe_disable_translucent_status_bar_summary">Makes the status bar fully opaque</string>
-    <string name="morphe_disable_translucent_status_bar_user_dialog_message">"Limitations:
-• A black bar may appear at the top of the video player.
-• The system navigation bar can change to transparent, and it\'s not possible to comment on videos."</string>
     <string name="morphe_disable_translucent_navigation_bar_light_title">Disable light translucent bar</string>
     <string name="morphe_disable_translucent_navigation_bar_light_summary">Makes the navigation bar fully opaque in light mode</string>
     <string name="morphe_disable_translucent_navigation_bar_dark_title">Disable dark translucent bar</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -738,12 +738,8 @@ To access Settings, enable the Settings button via General → Toolbar → Show 
     <string name="morphe_navigation_bar_animations_summary">Animates transitions when switching between tabs</string>
     <string name="morphe_disable_auto_hide_navigation_bar_title">Disable auto-hiding navigation bar</string>
     <string name="morphe_disable_auto_hide_navigation_bar_summary">Keeps the navigation bar visible while scrolling</string>
-    <string name="morphe_disable_translucent_status_bar_title">Disable translucent status bar</string>
-    <string name="morphe_disable_translucent_status_bar_summary">Makes the status bar fully opaque</string>
-    <string name="morphe_disable_translucent_navigation_bar_light_title">Disable light translucent bar</string>
-    <string name="morphe_disable_translucent_navigation_bar_light_summary">Makes the navigation bar fully opaque in light mode</string>
-    <string name="morphe_disable_translucent_navigation_bar_dark_title">Disable dark translucent bar</string>
-    <string name="morphe_disable_translucent_navigation_bar_dark_summary">Makes the navigation bar fully opaque in dark mode</string>
+    <string name="morphe_disable_translucent_navigation_title">Disable translucent navigation bar</string>
+    <string name="morphe_disable_translucent_navigation_summary">Makes the navigation and status bar fully opaque</string>
 
     <string name="morphe_toolbar_screen_title">Toolbar</string>
     <string name="morphe_toolbar_screen_summary">Choose which components appear in the toolbar</string>


### PR DESCRIPTION
### Description

Fixes the player showing a black bar at the top of the video player.

The navigation bar and status bar were merged together into a single setting. 21.30+ has layout issues if only one is disabled but the other is enabled.

The light/dark mode settings were merged together into a single setting, because with YT 21.04+ changing light/dark device mode while the app is open can break some layouts until the app is restarted.

Otherwise all known layout bugs are fixed.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
