### PR TITLE
feat(YouTube - Swipe controls): Add "Ignore swipes when locked" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -550,6 +550,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final EnumSetting<SwipeZoneAction> SWIPE_LEFT_ZONE = new EnumSetting<>("morphe_swipe_left_zone", SwipeZoneAction.OFF, true);
     public static final EnumSetting<SwipeZoneAction> SWIPE_RIGHT_ZONE = new EnumSetting<>("morphe_swipe_right_zone", SwipeZoneAction.OFF, true);
     public static final EnumSetting<SwipeZoneAction> SWIPE_TOP_ZONE = new EnumSetting<>("morphe_swipe_top_zone", SwipeZoneAction.OFF, true);
+    public static final BooleanSetting SWIPE_IGNORE_WHEN_LOCKED = new BooleanSetting("morphe_swipe_ignore_when_locked", FALSE, new AnySwipeZoneAvailability());
     public static final BooleanSetting SWIPE_PRESS_TO_ENGAGE = new BooleanSetting("morphe_swipe_press_to_engage", FALSE, true, new AnySwipeZoneAvailability());
     public static final BooleanSetting SWIPE_HAPTIC_FEEDBACK = new BooleanSetting("morphe_swipe_haptic_feedback", TRUE, true, new AnySwipeZoneAvailability());
     public static final IntegerSetting SWIPE_MAGNITUDE_THRESHOLD = new IntegerSetting("morphe_swipe_threshold", 30, true, new AnySwipeZoneAvailability());

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/SwipeControlsConfigurationProvider.kt
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/SwipeControlsConfigurationProvider.kt
@@ -157,6 +157,12 @@ class SwipeControlsConfigurationProvider {
 
     //region gesture adjustments
     /**
+     * Indicates whether swipe gestures should be ignored while the native lock screen is engaged.
+     */
+    val shouldIgnoreSwipesWhenLocked: Boolean
+        get() = Settings.SWIPE_IGNORE_WHEN_LOCKED.get()
+
+    /**
      * Indicates whether press-to-swipe mode is enabled, requiring a press before swiping to activate controls.
      */
     val shouldEnablePressToSwipe = Settings.SWIPE_PRESS_TO_ENGAGE.get()

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/SwipeControlsHostActivity.kt
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/SwipeControlsHostActivity.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.MotionEvent
+import android.view.View
 import android.view.ViewGroup
 import android.view.WindowInsets
 import app.morphe.extension.shared.Logger.printDebug
@@ -250,6 +251,8 @@ class SwipeControlsHostActivity : Activity() {
         }
 
     companion object {
+        private const val LOCK_MODE_OVERLAY_NAME = "player_overlay_lock_mode"
+
         /**
          * The currently active swipe controls host.
          * The reference may be null.
@@ -257,6 +260,44 @@ class SwipeControlsHostActivity : Activity() {
         @JvmStatic
         var currentHost: WeakReference<SwipeControlsHostActivity> = WeakReference(null)
             private set
+
+        /**
+         * Container of the native lock screen overlay.
+         * The reference may be null.
+         */
+        private var lockModeOverlay: WeakReference<ViewGroup> = WeakReference(null)
+
+        /**
+         * Whether the native lock screen is currently engaged.
+         *
+         * The container is attached for the entire playback session, and only its Litho content
+         * is mounted while the screen is locked, so the mounted content is what tells both states apart.
+         */
+        val isPlayerLocked: Boolean
+            get() {
+                val overlay = lockModeOverlay.get() ?: return false
+
+                for (i in 0 until overlay.childCount) {
+                    val child = overlay.getChildAt(i)
+                    if (child is ViewGroup && child.childCount > 0) {
+                        return true
+                    }
+                }
+
+                return false
+            }
+
+        /**
+         * Injection point.
+         */
+        @Suppress("unused")
+        @JvmStatic
+        fun setPlayerOverlay(overlay: View, overlayName: String?) {
+            // The same container class wraps every player overlay, and only the name tells them apart.
+            if (LOCK_MODE_OVERLAY_NAME == overlayName && overlay is ViewGroup) {
+                lockModeOverlay = WeakReference(overlay)
+            }
+        }
 
         /**
          * Injection point.

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/controller/gesture/core/BaseGestureController.kt
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/controller/gesture/core/BaseGestureController.kt
@@ -56,43 +56,45 @@ abstract class BaseGestureController(
     private var didCancelDownstream = false
 
     override fun submitTouchEvent(motionEvent: MotionEvent): Boolean {
-        // ignore if swipe is disabled
+        // Ignore if swipe is disabled.
         if (!controller.config.enableSwipeControls) {
             return false
         }
 
-        // ignore if status bar is visible
+        // Ignore if status bar is visible.
         if (controller.statusBarVisible) {
             return false
         }
 
-        // create a copy of the event so we can modify it
-        // without causing any issues downstream
+        // Ignore if the native lock screen is engaged.
+        if (controller.config.shouldIgnoreSwipesWhenLocked && SwipeControlsHostActivity.isPlayerLocked) {
+            return false
+        }
+
+        // Create a copy of the event so we can modify it without causing any issues downstream.
         val me = MotionEvent.obtain(motionEvent)
 
-        // check if we should drop this motion
+        // Check if we should drop this motion.
         val dropped = shouldDropMotion(me)
         if (dropped) {
             me.action = MotionEvent.ACTION_CANCEL
         }
 
-        // send the event to the detector
-        // if we force intercept events, the event is always consumed
+        // Send the event to the detector if we force intercept events, the event is always consumed.
         val consumed = detector.onTouchEvent(me) || shouldForceInterceptEvents
 
-        // evaluate swipe zone before recycling
+        // Evaluate swipe zone before recycling.
         val inSwipeZone = isInSwipeZone(me)
 
-        // invoke the custom onUp handler
+        // Invoke the custom onUp handler.
         if (me.action == MotionEvent.ACTION_UP || me.action == MotionEvent.ACTION_CANCEL) {
             onUp(me)
         }
 
-        // recycle the copy
+        // Recycle the copy.
         me.recycle()
 
-        // do not consume dropped events
-        // or events outside any swipe zone
+        // Do not consume dropped events or events outside any swipe zone.
         return !dropped && consumed && inSwipeZone
     }
 
@@ -117,10 +119,10 @@ abstract class BaseGestureController(
             return false
         }
 
-        // submit to swipe detector
+        // Submit to swipe detector.
         submitForSwipe(from, to, distanceX, distanceY)
 
-        // call swipe callback if in a swipe
+        // Call swipe callback if in a swipe.
         return if (currentSwipe != SwipeDetector.SwipeDirection.NONE) {
             val consumed = onSwipe(
                 from,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/swipecontrols/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/swipecontrols/Fingerprints.kt
@@ -1,8 +1,12 @@
 package app.morphe.patches.youtube.interaction.swipecontrols
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.fieldAccess
 import app.morphe.patcher.literal
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.opcode
 import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
 
 internal object SwipeControlsHostActivityFingerprint : Fingerprint(
     definingClass = EXTENSION_CLASS,
@@ -15,4 +19,26 @@ internal object SwipeChangeVideoFingerprint : Fingerprint(
     filters = listOf(
         literal(45631116L) // Swipe to change fullscreen video feature flag.
     )
+)
+
+internal object PlayerOverlayContainerFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = $$"Landroid/view/ViewGroup$LayoutParams;",
+    parameters = listOf(),
+    filters = listOf(
+        opcode(Opcode.NEW_INSTANCE),
+        literal(-1),
+        fieldAccess(
+            opcode = Opcode.IGET_BOOLEAN,
+            definingClass = "this"
+        ),
+        methodCall(
+            opcode = Opcode.INVOKE_DIRECT,
+            name = "<init>",
+            parameters = listOf("I", "I", "Z")
+        )
+    ),
+    custom = { _, classDef ->
+        classDef.fields.any { field -> field.type == "Ljava/lang/String;" }
+    }
 )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/swipecontrols/SwipeControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/swipecontrols/SwipeControlsPatch.kt
@@ -194,15 +194,14 @@ val swipeControlsPatch = bytecodePatch(
         }
 
         PlayerOverlayContainerFingerprint.let {
-            val containerClass = it.classDef
-            val overlayNameField = containerClass.fields.first { field ->
+            val overlayNameField = it.classDef.fields.first { field ->
                 field.type == "Ljava/lang/String;"
             }
 
             it.method.addInstructions(
                 0,
                 """
-                    iget-object v0, p0, ${containerClass.type}->${overlayNameField.name}:Ljava/lang/String;
+                    iget-object v0, p0, $overlayNameField
                     invoke-static { p0, v0 }, $EXTENSION_CLASS->setPlayerOverlay(Landroid/view/View;Ljava/lang/String;)V
                 """
             )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/swipecontrols/SwipeControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/swipecontrols/SwipeControlsPatch.kt
@@ -10,6 +10,7 @@
 
 package app.morphe.patches.youtube.interaction.swipecontrols
 
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
@@ -95,6 +96,7 @@ private val swipeControlsResourcePatch = resourcePatch {
                 tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference"
             ),
             ListPreference("morphe_swipe_speed_step"),
+            SwitchPreference("morphe_swipe_ignore_when_locked", summary = true),
             SwitchPreference("morphe_swipe_press_to_engage", summary = true),
             SwitchPreference("morphe_swipe_haptic_feedback"),
             SwitchPreference("morphe_swipe_save_and_restore_brightness", summary = true),
@@ -189,6 +191,21 @@ val swipeControlsPatch = bytecodePatch(
                     "$EXTENSION_CLASS->allowSwipeChangeVideo(Z)Z"
                 )
             }
+        }
+
+        PlayerOverlayContainerFingerprint.let {
+            val containerClass = it.classDef
+            val overlayNameField = containerClass.fields.first { field ->
+                field.type == "Ljava/lang/String;"
+            }
+
+            it.method.addInstructions(
+                0,
+                """
+                    iget-object v0, p0, ${containerClass.type}->${overlayNameField.name}:Ljava/lang/String;
+                    invoke-static { p0, v0 }, $EXTENSION_CLASS->setPlayerOverlay(Landroid/view/View;Ljava/lang/String;)V
+                """
+            )
         }
     }
 }

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -570,6 +570,9 @@ To fix this, turn on \'Spoof video streams\' and change the \'Default client\' t
     <string name="morphe_swipe_zone_label_volume">Volume</string>
     <string name="morphe_swipe_zone_label_native">Native</string>
     <string name="morphe_swipe_zone_label_off">Off</string>
+    <string name="morphe_swipe_ignore_when_locked_title">Ignore swipes when locked</string>
+    <!-- 'Lock screen' should be translated using the same localized wording YouTube displays for the player menu item. -->
+    <string name="morphe_swipe_ignore_when_locked_summary">Swipe gestures are ignored while the player is locked with \'Lock screen\'</string>
     <string name="morphe_swipe_press_to_engage_title">Enable press to swipe gesture</string>
     <string name="morphe_swipe_press_to_engage_summary">Requires pressing and holding before a swipe gesture is recognized</string>
     <string name="morphe_swipe_haptic_feedback_title">Enable haptic feedback</string>


### PR DESCRIPTION
### Description

Adds an "Ignore swipes when locked" setting that suppresses volume, brightness and speed swipe gestures while the player's native "Lock screen" mode is engaged. The lock state is detected by hooking the player overlay container and checking whether the `player_overlay_lock_mode` overlay currently has mounted Litho content.

Closes #896

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
