### PR TITLE
fix(Disable Play Store updates): Change manifest version code but preserve existing internal version code checks

### DIFF
--- a/extensions/all/change-version-code/build.gradle.kts
+++ b/extensions/all/change-version-code/build.gradle.kts
@@ -1,0 +1,23 @@
+import java.lang.Boolean.TRUE
+
+extension {
+    name = "extensions/all/versioncode/change-version-code.mpe"
+}
+
+android {
+    namespace = "app.morphe.extension"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+dependencies {
+    compileOnly(libs.annotation)
+}

--- a/extensions/all/change-version-code/src/main/AndroidManifest.xml
+++ b/extensions/all/change-version-code/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/extensions/all/change-version-code/src/main/java/app/morphe/extension/all/versioncode/DisablePlayStoreUpdatesPatch.java
+++ b/extensions/all/change-version-code/src/main/java/app/morphe/extension/all/versioncode/DisablePlayStoreUpdatesPatch.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2470
+ *
+ * File-Specific License Notice (GPLv3 Section 7 Terms)
+ *
+ * This file is part of the Morphe project and is licensed under
+ * the GNU General Public License version 3 (GPLv3), with the Additional
+ * Terms under Section 7 described in the LICENSE file.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Section 7b: Notice Preservation
+ * -------------------------------
+ * This entire comment block must be preserved in all copies,
+ * distributions, and derivative works of this file, in both
+ * original and modified source forms.
+ *
+ * Portions of this software are provided "AS IS" by the Morphe software project.
+ * Any express or implied warranties, including the implied warranties of
+ * merchantability and fitness for a particular purpose, are disclaimed.
+ */
+
+package app.morphe.extension.all.versioncode;
+
+@SuppressWarnings("unused")
+public class DisablePlayStoreUpdatesPatch {
+
+    private static int originalVersionCode() {
+        return 0; // Return value is changed during patching.
+    }
+
+    /**
+     * Injection point.
+     */
+    public static int getVersionCode(int versionCode) {
+        if (versionCode == Integer.MAX_VALUE) {
+            return originalVersionCode();
+        }
+        return versionCode;
+    }
+
+    /**
+     * Injection point.
+     */
+    public static long getVersionCode(long versionCode) {
+        final long lowerBitMask = 0x00000000FFFFFFFFL;
+        if ((versionCode & lowerBitMask) == Integer.MAX_VALUE) {
+            // Keep the upper 32 bits (versionCodeMajor) untouched,
+            // swap in the original version code for the lower 32 bits.
+            return (versionCode & 0xFFFFFFFF00000000L)
+                    | (originalVersionCode() & lowerBitMask);
+        }
+        return versionCode;
+    }
+}

--- a/extensions/all/change-version-code/src/main/java/app/morphe/extension/all/versioncode/DisablePlayStoreUpdatesPatch.java
+++ b/extensions/all/change-version-code/src/main/java/app/morphe/extension/all/versioncode/DisablePlayStoreUpdatesPatch.java
@@ -23,6 +23,11 @@
 
 package app.morphe.extension.all.versioncode;
 
+import android.content.pm.PackageInfo;
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
 @SuppressWarnings("unused")
 public class DisablePlayStoreUpdatesPatch {
 
@@ -33,7 +38,9 @@ public class DisablePlayStoreUpdatesPatch {
     /**
      * Injection point.
      */
-    public static int getVersionCode(int versionCode) {
+    public static int getVersionCode(PackageInfo info) {
+        final int versionCode = info.versionCode;
+
         if (versionCode == Integer.MAX_VALUE) {
             return originalVersionCode();
         }
@@ -43,7 +50,10 @@ public class DisablePlayStoreUpdatesPatch {
     /**
      * Injection point.
      */
-    public static long getVersionCode(long versionCode) {
+    @RequiresApi(api = Build.VERSION_CODES.P)
+    public static long getVersionCodeLong(PackageInfo info) {
+        final long versionCode = info.getLongVersionCode();
+
         final long lowerBitMask = 0x00000000FFFFFFFFL;
         if ((versionCode & lowerBitMask) == Integer.MAX_VALUE) {
             // Keep the upper 32 bits (versionCodeMajor) untouched,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 [versions]
 morphe-patcher = "1.8.0"
-morphe-patches-library = "1.6.1-dev.3"
+morphe-patches-library = "1.6.1-dev.4"
 # Tracking https://github.com/google/smali/issues/100.
 smali = "d92701d947"
 agp = "9.1.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 [versions]
 morphe-patcher = "1.8.0"
-morphe-patches-library = "1.6.1-dev.1"
+morphe-patches-library = "1.6.1-dev.3"
 # Tracking https://github.com/google/smali/issues/100.
 smali = "d92701d947"
 agp = "9.1.0"

--- a/patches/src/main/kotlin/app/morphe/patches/all/misc/updates/DisablePlayStoreUpdatesPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/all/misc/updates/DisablePlayStoreUpdatesPatch.kt
@@ -27,18 +27,21 @@
 package app.morphe.patches.all.misc.updates
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.fieldAccess
 import app.morphe.patcher.methodCall
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
-import app.morphe.util.addInstructionsOutsideTryBlock
+import app.morphe.util.addInstructionsAtControlFlowLabel
 import app.morphe.util.getNode
+import app.morphe.util.instructionCodeOffsets
 import app.morphe.util.matchAllMethodIndicesForEach
 import app.morphe.util.returnEarly
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import org.w3c.dom.Element
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/all/versioncode/DisablePlayStoreUpdatesPatch;"
@@ -84,33 +87,20 @@ internal val disablePlayStoreUpdatesPatch = bytecodePatch(
             name = "originalVersionCode"
         ).method.returnEarly(originalVersionCode)
 
-        fun MutableMethod.addExtensionCall(index: Int, isLong: Boolean) {
-            val instruction = getInstruction<OneRegisterInstruction>(index)
-            val register = instruction.registerA
-            val smali = if (isLong) {
-                """
-                    invoke-static/range { v$register .. v${register + 1} }, $EXTENSION_CLASS->getVersionCode(J)J
-                    move-result-wide v$register
-                """
-            } else {
-                """
-                    invoke-static/range { v$register .. v$register }, $EXTENSION_CLASS->getVersionCode(I)I
-                    move-result v$register
-                """
-            }
-
-            // Must add outside try block.
-            addInstructionsOutsideTryBlock(
-                index + 1,
-                smali
-            )
-        }
-
         fieldAccess(
             opcode = Opcode.IGET,
             smali = "Landroid/content/pm/PackageInfo;->versionCode:I"
         ).matchAllMethodIndicesForEach(requireMatches = false) { index ->
-            addExtensionCall(index, isLong = false)
+            val instruction = this.getInstruction<TwoRegisterInstruction>(index)
+            val register = instruction.registerA
+
+            addInstructionsOutsideTryBlock(
+                index + 1,
+                """
+                    invoke-static/range { v$register .. v$register }, $EXTENSION_CLASS->getVersionCode(I)I
+                    move-result v$register
+                """
+            )
         }
 
         // Check long version code, which is a combination of
@@ -124,8 +114,65 @@ internal val disablePlayStoreUpdatesPatch = bytecodePatch(
             if (instruction.opcode != Opcode.MOVE_RESULT_WIDE) {
                 return@matchAllMethodIndicesForEach
             }
+            val register = (instruction as OneRegisterInstruction).registerA
 
-            addExtensionCall(moveResultIndex, isLong = true)
+            // Add between method call and move-result to avoid try/catch label issues.
+            addInstructions(
+                moveResultIndex,
+                """
+                    move-result-wide v$register
+                    invoke-static/range { v$register .. v${register + 1} }, $EXTENSION_CLASS->getVersionCode(J)J
+                """
+            )
         }
+    }
+}
+
+/**
+ * Inserts instructions immediately after a given index, without extending any
+ * existing try/catch block that ends at that index.
+ *
+ * A plain addInstructions(index + 1, ...) call inserts before the instruction
+ * the try block's end label is anchored to, which drags that label forward
+ * and silently pulls the inserted code into the try block.
+ *
+ * Effectively this changes the code from:
+ * (original code)
+ * :try_end
+ * .catch Exception; {:try_start .. :try_end} :handler
+ * (following code)
+ *
+ * Into:
+ * (original code)
+ * :try_end
+ * .catch Exception; {:try_start .. :try_end} :handler
+ * (patch code)
+ * (following code)
+ *
+ * Instead of the incorrect result of using [MutableMethod.addInstructions]
+ * (original code)
+ * (patch code)
+ * :try_end
+ * .catch Exception; {:try_start .. :try_end} :handler
+ * (following code)
+ */
+fun MutableMethod.addInstructionsOutsideTryBlock(insertIndex: Int, instructions: String) {
+    val implementation = this.implementation!!
+
+    if (insertIndex >= implementation.instructions.size) {
+        addInstructions(insertIndex, instructions)
+        return
+    }
+
+    // Only use the label-shifting logic if the instruction at insertIndex is the end of a try block.
+    // This avoids inserting code after control flow labels that might be jumped to from elsewhere.
+    val offsets = instructionCodeOffsets()
+    val nextOffset = offsets[insertIndex]
+    val isTryEnd = implementation.tryBlocks.any { it.startCodeAddress + it.codeUnitCount == nextOffset }
+
+    if (isTryEnd) {
+        addInstructionsAtControlFlowLabel(insertIndex, instructions)
+    } else {
+        addInstructions(insertIndex, instructions)
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/all/misc/updates/DisablePlayStoreUpdatesPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/all/misc/updates/DisablePlayStoreUpdatesPatch.kt
@@ -27,22 +27,22 @@
 package app.morphe.patches.all.misc.updates
 
 import app.morphe.patcher.Fingerprint
-import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.fieldAccess
 import app.morphe.patcher.methodCall
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
-import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
-import app.morphe.util.addInstructionsAtControlFlowLabel
+import app.morphe.util.getFreeRegisterProvider
 import app.morphe.util.getNode
-import app.morphe.util.instructionCodeOffsets
 import app.morphe.util.matchAllMethodIndicesForEach
 import app.morphe.util.returnEarly
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import org.w3c.dom.Element
+import java.util.logging.Logger
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/all/versioncode/DisablePlayStoreUpdatesPatch;"
 
@@ -87,92 +87,84 @@ internal val disablePlayStoreUpdatesPatch = bytecodePatch(
             name = "originalVersionCode"
         ).method.returnEarly(originalVersionCode)
 
-        fieldAccess(
-            opcode = Opcode.IGET,
-            smali = "Landroid/content/pm/PackageInfo;->versionCode:I"
+        val logger by lazy { Logger.getLogger(this::class.java.name) }
+
+        Fingerprint(
+            filters = listOf(
+                fieldAccess(
+                    opcode = Opcode.IGET,
+                    smali = "Landroid/content/pm/PackageInfo;->versionCode:I"
+                )
+            ),
+            custom = { _, classDef ->
+                !classDef.type.startsWith("Lapp/morphe/extension")
+            }
         ).matchAllMethodIndicesForEach(requireMatches = false) { index ->
             val instruction = this.getInstruction<TwoRegisterInstruction>(index)
-            val register = instruction.registerA
+            val moveResultRegister = instruction.registerA
+            val packageInfoRegister = instruction.registerB
+            val moveResultIndex = index + 1
 
-            addInstructionsOutsideTryBlock(
-                index + 1,
-                """
-                    invoke-static/range { v$register .. v$register }, $EXTENSION_CLASS->getVersionCode(I)I
-                    move-result v$register
-                """
+            if (moveResultRegister >= 16) {
+                val provider = getFreeRegisterProvider(
+                    moveResultIndex,
+                    moveResultRegister,
+                    packageInfoRegister
+                )
+                if (!provider.hasFreeRegisters()) {
+                    logger.warning("Method does not have enough free registers, version code may not be overridden for: $this")
+                    return@matchAllMethodIndicesForEach
+                }
+                val free = provider.getFreeRegister()
+                if (free >= 16) {
+                    logger.warning("No 4-bit register available, version code may not be overridden for: $this")
+                    return@matchAllMethodIndicesForEach
+                }
+
+                addInstruction(
+                    moveResultIndex,
+                    """
+                        move-result v$free
+                        move/from16 v$moveResultRegister, v$free
+                    """
+                )
+            } else {
+                addInstruction(
+                    moveResultIndex,
+                    "move-result v$moveResultRegister"
+                )
+            }
+
+            replaceInstruction(
+                index,
+                "invoke-static/range { v$packageInfoRegister .. v$packageInfoRegister }, " +
+                        "$EXTENSION_CLASS->getVersionCode(Landroid/content/pm/PackageInfo;)I"
             )
         }
 
-        // Check long version code, which is a combination of
+        // Replace long version code, which is a combination of
         // regular version code and versionCodeMajor.
-        methodCall(
-            opcode = Opcode.INVOKE_VIRTUAL,
-            smali = "Landroid/content/pm/PackageInfo;->getLongVersionCode()J"
+        Fingerprint(
+            filters = listOf(
+                methodCall(
+                    opcode = Opcode.INVOKE_VIRTUAL,
+                    smali = "Landroid/content/pm/PackageInfo;->getLongVersionCode()J"
+                )
+            ),
+            custom = { _, classDef ->
+                !classDef.type.startsWith("Lapp/morphe/extension")
+            }
         ).matchAllMethodIndicesForEach(requireMatches = false) { index ->
-            val moveResultIndex = index + 1
-            val instruction = getInstruction(moveResultIndex)
-            if (instruction.opcode != Opcode.MOVE_RESULT_WIDE) {
+            if (getInstruction(index + 1).opcode != Opcode.MOVE_RESULT_WIDE) {
                 return@matchAllMethodIndicesForEach
             }
-            val register = (instruction as OneRegisterInstruction).registerA
+            val register = getInstruction<FiveRegisterInstruction>(index).registerC
 
-            // Add between method call and move-result to avoid try/catch label issues.
-            addInstructions(
-                moveResultIndex,
-                """
-                    move-result-wide v$register
-                    invoke-static/range { v$register .. v${register + 1} }, $EXTENSION_CLASS->getVersionCode(J)J
-                """
+            replaceInstruction(
+                index,
+                "invoke-static/range { v$register .. v$register }, " +
+                        "$EXTENSION_CLASS->getVersionCodeLong(Landroid/content/pm/PackageInfo;)J"
             )
         }
-    }
-}
-
-/**
- * Inserts instructions immediately after a given index, without extending any
- * existing try/catch block that ends at that index.
- *
- * A plain addInstructions(index + 1, ...) call inserts before the instruction
- * the try block's end label is anchored to, which drags that label forward
- * and silently pulls the inserted code into the try block.
- *
- * Effectively this changes the code from:
- * (original code)
- * :try_end
- * .catch Exception; {:try_start .. :try_end} :handler
- * (following code)
- *
- * Into:
- * (original code)
- * :try_end
- * .catch Exception; {:try_start .. :try_end} :handler
- * (patch code)
- * (following code)
- *
- * Instead of the incorrect result of using [MutableMethod.addInstructions]
- * (original code)
- * (patch code)
- * :try_end
- * .catch Exception; {:try_start .. :try_end} :handler
- * (following code)
- */
-fun MutableMethod.addInstructionsOutsideTryBlock(insertIndex: Int, instructions: String) {
-    val implementation = this.implementation!!
-
-    if (insertIndex >= implementation.instructions.size) {
-        addInstructions(insertIndex, instructions)
-        return
-    }
-
-    // Only use the label-shifting logic if the instruction at insertIndex is the end of a try block.
-    // This avoids inserting code after control flow labels that might be jumped to from elsewhere.
-    val offsets = instructionCodeOffsets()
-    val nextOffset = offsets[insertIndex]
-    val isTryEnd = implementation.tryBlocks.any { it.startCodeAddress + it.codeUnitCount == nextOffset }
-
-    if (isTryEnd) {
-        addInstructionsAtControlFlowLabel(insertIndex, instructions)
-    } else {
-        addInstructions(insertIndex, instructions)
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/all/misc/updates/DisablePlayStoreUpdatesPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/all/misc/updates/DisablePlayStoreUpdatesPatch.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2470
  *
  * Original code hard forked from:
  * https://github.com/ReVanced/revanced-patches/blob/724e6d61b2ecd868c1a9a37d465a688e83a74799/patches/src/main/kotlin/app/revanced/patches/all/misc/versioncode/ChangeVersionCodePatch.kt
@@ -26,24 +26,106 @@
 
 package app.morphe.patches.all.misc.updates
 
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.fieldAccess
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import app.morphe.util.addInstructionsOutsideTryBlock
 import app.morphe.util.getNode
+import app.morphe.util.matchAllMethodIndicesForEach
+import app.morphe.util.returnEarly
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import org.w3c.dom.Element
 
+private const val EXTENSION_CLASS = "Lapp/morphe/extension/all/versioncode/DisablePlayStoreUpdatesPatch;"
+
+private var originalVersionCode: Int = 0
+
 @Suppress("unused")
-internal val disablePlayStoreUpdatesPatch = resourcePatch(
-    name = "Disable Play Store updates",
-    description = "Disables Play Store updates by setting the version code to the maximum allowed. " +
-            "This patch does not work if the app is installed by mounting and may cause unexpected " +
-            "issues with some apps.",
-    default = false
-) {
+private val disablePlayStoreUpdatesResourcePatch = resourcePatch {
+    execute {
+        document("AndroidManifest.xml").use { document ->
+            val manifest = document.getNode("manifest") as Element
+
+            originalVersionCode = manifest.getAttribute("android:versionCode").toInt()
+        }
+    }
+
     finalize {
         document("AndroidManifest.xml").use { document ->
             val manifest = document.getNode("manifest") as Element
 
             //  Max allowed by Play Store is 2100000000, but Android allows max int value.
             manifest.setAttribute("android:versionCode", Int.MAX_VALUE.toString())
+        }
+    }
+}
+
+@Suppress("unused")
+internal val disablePlayStoreUpdatesPatch = bytecodePatch(
+    name = "Disable Play Store updates",
+    description = "Disables Play Store updates by setting the version code to the maximum allowed. " +
+            "This patch may cause unexpected issues with some apps and does not work if the " +
+            "app is installed by root mounting",
+    default = false
+) {
+
+    dependsOn(disablePlayStoreUpdatesResourcePatch)
+
+    extendWith("extensions/all/versioncode/change-version-code.mpe")
+
+    finalize {
+        Fingerprint(
+            definingClass = EXTENSION_CLASS,
+            name = "originalVersionCode"
+        ).method.returnEarly(originalVersionCode)
+
+        fun MutableMethod.addExtensionCall(index: Int, isLong: Boolean) {
+            val instruction = getInstruction<OneRegisterInstruction>(index)
+            val register = instruction.registerA
+            val smali = if (isLong) {
+                """
+                    invoke-static/range { v$register .. v${register + 1} }, $EXTENSION_CLASS->getVersionCode(J)J
+                    move-result-wide v$register
+                """
+            } else {
+                """
+                    invoke-static/range { v$register .. v$register }, $EXTENSION_CLASS->getVersionCode(I)I
+                    move-result v$register
+                """
+            }
+
+            // Must add outside try block.
+            addInstructionsOutsideTryBlock(
+                index + 1,
+                smali
+            )
+        }
+
+        fieldAccess(
+            opcode = Opcode.IGET,
+            smali = "Landroid/content/pm/PackageInfo;->versionCode:I"
+        ).matchAllMethodIndicesForEach(requireMatches = false) { index ->
+            addExtensionCall(index, isLong = false)
+        }
+
+        // Check long version code, which is a combination of
+        // regular version code and versionCodeMajor.
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            smali = "Landroid/content/pm/PackageInfo;->getLongVersionCode()J"
+        ).matchAllMethodIndicesForEach(requireMatches = false) { index ->
+            val moveResultIndex = index + 1
+            val instruction = getInstruction(moveResultIndex)
+            if (instruction.opcode != Opcode.MOVE_RESULT_WIDE) {
+                return@matchAllMethodIndicesForEach
+            }
+
+            addExtensionCall(moveResultIndex, isLong = true)
         }
     }
 }


### PR DESCRIPTION
Add bytecode patch to preserve the original version code of the app for all internal checks.

This should fix strange behavior in some apps such as Facebook, which can show weird black icon overlays on the feed images if disable play store patch is included. Presumably the app is sending the version code with server requests and the response has newer/different data the app doesn't understand.

This change may also improve compatibility with logging in or any other internal app checks, but is not confirmed.

Tested on Reddit but should work without issues on all apps.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
