### PR TITLE
fix(Reddit): Add legacy app target of `2024.02.0` to allow logging in then upgrading the patched installation

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/reddit/misc/fix/signature/SpoofSignaturePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/misc/fix/signature/SpoofSignaturePatch.kt
@@ -10,7 +10,10 @@ package app.morphe.patches.reddit.misc.fix.signature
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.all.misc.installer.changeInstallerSource
 import app.morphe.patches.reddit.misc.extension.sharedExtensionPatch
-import app.morphe.patches.reddit.shared.Constants.COMPATIBILITY_REDDIT
+import app.morphe.patches.reddit.misc.version.is_2024_03_0_or_greater
+import app.morphe.patches.reddit.misc.version.versionCheckPatch
+import app.morphe.patches.reddit.shared.Constants.COMPATIBILITY_REDDIT_INCLUDING_LEGACY
+import java.util.logging.Logger
 
 private const val EXTENSION_CLASS =
     "Lapp/morphe/extension/reddit/patches/SpoofSignaturePatch;"
@@ -20,11 +23,19 @@ val spoofSignaturePatch = bytecodePatch(
     name = "Spoof signature",
     description = "Spoofs the signature of the app to fix notification issues."
 ) {
-    compatibleWith(COMPATIBILITY_REDDIT)
+    compatibleWith(COMPATIBILITY_REDDIT_INCLUDING_LEGACY)
 
-    dependsOn(sharedExtensionPatch, changeInstallerSource)
+    dependsOn(sharedExtensionPatch, changeInstallerSource, versionCheckPatch)
 
     execute {
+        if (!is_2024_03_0_or_greater) {
+            Logger.getLogger(this::class.java.name).warning(
+                "Reddit 2024.02.0 has limited support. No meaningful patches are " +
+                        "available, and this should only be used to successfully login " +
+                        "and then upgrade the installation to a newer version of Reddit."
+            )
+        }
+
         ApplicationFingerprint.classDef.setSuperClass(EXTENSION_CLASS)
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/misc/settings/SettingsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/misc/settings/SettingsPatch.kt
@@ -11,6 +11,7 @@ import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patcher.string
@@ -24,6 +25,7 @@ import app.morphe.patches.all.misc.updates.disablePlayStoreUpdatesPatch
 import app.morphe.patches.reddit.misc.extension.hooks.redditActivityOnCreateHook
 import app.morphe.patches.reddit.misc.extension.sharedExtensionPatch
 import app.morphe.patches.reddit.misc.fix.signature.spoofSignaturePatch
+import app.morphe.patches.reddit.misc.version.is_2024_03_0_or_greater
 import app.morphe.patches.reddit.misc.version.is_2026_14_0_or_greater
 import app.morphe.patches.reddit.misc.version.is_2026_25_0_or_greater
 import app.morphe.patches.reddit.misc.version.is_2026_30_0_or_greater
@@ -40,6 +42,7 @@ import app.morphe.util.registersUsed
 import app.morphe.util.returnEarly
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import java.util.logging.Logger
 
 private const val EXTENSION_CLASS =
     "Lapp/morphe/extension/reddit/settings/RedditActivityHook;"
@@ -96,6 +99,18 @@ val settingsPatch = bytecodePatch(
         setAddResourceLocale(localesReddit)
         addAppResources("shared")
         addAppResources("reddit")
+
+        if (!is_2024_03_0_or_greater) {
+            throw PatchException(
+                """
+                    
+                    !!!
+                    !!! Reddit 2024.02.0 supports only 1 patch.
+                    !!! Select the recommended patches to patch this legacy app version.
+                    !!!
+                """
+            )
+        }
 
         // Turn off Google Play in app update prompt.
         GooglePlayUpdateCheckFingerprint.method.returnEarly(null);

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/misc/version/VersionCheckPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/misc/version/VersionCheckPatch.kt
@@ -7,6 +7,8 @@ import kotlin.properties.Delegates
 
 // Use notNull delegate so an exception is thrown if these fields are accessed before they are set.
 
+var is_2024_03_0_or_greater: Boolean by Delegates.notNull()
+    private set
 var is_2026_04_0_or_greater: Boolean by Delegates.notNull()
     private set
 var is_2026_11_0_or_greater: Boolean by Delegates.notNull()
@@ -31,6 +33,7 @@ val versionCheckPatch = bytecodePatch {
             return versionName >= version
         }
 
+        is_2024_03_0_or_greater = isEqualsOrGreaterThan("2024.03.0")
         is_2026_04_0_or_greater = isEqualsOrGreaterThan("2026.04.0")
         is_2026_11_0_or_greater = isEqualsOrGreaterThan("2026.11.0")
         is_2026_14_0_or_greater = isEqualsOrGreaterThan("2026.14.0")

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/shared/Constants.kt
@@ -39,4 +39,11 @@ internal object Constants {
             )
         )
     )
+
+    val COMPATIBILITY_REDDIT_INCLUDING_LEGACY = COMPATIBILITY_REDDIT.including(
+        AppTarget(
+            version = "2024.02.0",
+            minSdk = 28
+        )
+    )
 }


### PR DESCRIPTION
Adds Reddit `2024.02.0` target with only a single patch: `Spoof signature`

This solves login issues for some users by:
- Patching and installing Reddit `2024.02.0`
- Login to Reddit using email/password (Must use email/password, Google sign-in will not work)
- Upgrade the existing patched app by repatching Reddit 2026.14.0 or later (do _not_ uninstall patched 2024.02.0)


### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
