### PR TITLE
feat(YouTube Music): Add `Restore playlists in Android Auto` patch

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch.java
@@ -34,86 +34,88 @@ import app.morphe.extension.shared.Utils;
 /**
  * Loads YTM's phone Library when Android Auto requests Playlists.
  *
- * <p>FEmusic_library_landing returns playlist titles and Browse IDs in GridRenderer. Playlist pages
- * contain the playback commands used to create Android Auto media IDs.
+ * <p>FEmusic_library_landing returns playlist names and IDs. A normal playlist page's Play
+ * button supplies the action serialized as Android Auto's media ID.
  */
 @SuppressWarnings("unused")
 public final class RestoreAndroidAutoPlaylistsPatch {
-    private static final String LIBRARY_BROWSE_ID = "FEmusic_library_landing";
-    private static final String LIKED_MUSIC_BROWSE_ID = "VLLM";
-    private static final String EPISODES_FOR_LATER_BROWSE_ID = "VLSE";
+    private static final String LIBRARY_PLAYLISTS_ID = "FEmusic_library_landing";
+    private static final String LIKED_MUSIC_PLAYLIST_ID = "VLLM";
+    private static final String EPISODES_FOR_LATER_PLAYLIST_ID = "VLSE";
     private static final String PLAYLISTS_TITLE_RESOURCE = "library_playlists_shelf_title";
-    private static final Executor REQUEST_EXECUTOR = Utils::runOnBackgroundThread;
+    private static final Executor BACKGROUND_EXECUTOR = Utils::runOnBackgroundThread;
     private static final Set<String> PLAYLIST_CATEGORY_IDS =
             ConcurrentHashMap.newKeySet();
 
-    public interface BrowseService {
-        @NonNull ListenableFuture<?> patch_requestBrowse(
-                @NonNull String browseId, @NonNull Executor executor);
-        @NonNull ListenableFuture<?> patch_requestContinuation(
-                @NonNull Object continuation, @NonNull Executor executor);
+    public interface PlaylistLoader {
+        @NonNull ListenableFuture<?> patch_requestPage(
+                @NonNull String pageId, @NonNull Executor executor);
+        @NonNull ListenableFuture<?> patch_requestMorePlaylists(
+                @NonNull Object loadMoreAction, @NonNull Executor executor);
     }
 
-    public interface BrowseResponse {
-        @NonNull Iterable<?> patch_getTabs();
-        @Nullable Object patch_getContinuationGrid();
-        @Nullable String patch_getPlaylistMediaId();
+    public interface PlaylistResponse {
+        @NonNull Iterable<?> patch_getPages();
+        @Nullable Object patch_getMorePlaylists();
+        @Nullable String patch_getPlaybackId();
     }
 
-    public interface BrowseTab {
-        @Nullable Object patch_getSectionList();
+    public interface PlaylistPage {
+        @Nullable Object patch_getBody();
     }
 
-    public interface SectionList {
-        @NonNull Iterable<?>[] patch_getItemLists();
+    public interface PlaylistBody {
+        @NonNull Iterable<?>[] patch_getGroups();
     }
 
-    public interface PlaylistGrid {
-        @Nullable Iterable<?> patch_getItems();
-        @Nullable Iterable<?> patch_getContinuations();
+    public interface PlaylistListing {
+        @Nullable Iterable<?> patch_getPlaylists();
+        @Nullable Iterable<?> patch_getLoadMoreActions();
     }
 
-    public interface PlaylistShelf {
-        @Nullable Iterable<?> patch_getItems();
+    public interface PlaylistTracks {
+        @Nullable Iterable<?> patch_getTracks();
     }
 
-    public interface LoadChildrenResult {
+    public interface AndroidAutoResult {
         @Nullable String patch_getParentMediaId();
-        void patch_sendResult(@NonNull List<MediaBrowserCompat.MediaItem> items);
+        void patch_sendResult(@NonNull List<MediaBrowserCompat.MediaItem> playlists);
     }
 
-    public interface MusicItem {
-        @Nullable String patch_getBrowseId();
-        @Nullable String patch_getMediaId();
+    public interface PlaylistOrTrack {
+        @Nullable String patch_getPlaylistId();
+        @Nullable String patch_getPlaybackId();
         @Nullable Uri patch_getArtworkUri();
         @Nullable CharSequence patch_getTitle();
         @Nullable CharSequence patch_getSubtitle();
     }
 
     @Nullable
-    private static volatile BrowseService browseService;
+    private static volatile PlaylistLoader playlistLoader;
 
     private RestoreAndroidAutoPlaylistsPatch() {
     }
 
-    /** Injection point. Called from MusicBrowserService's generated superclass during onCreate. */
-    public static void setBrowseService(@Nullable BrowseService service) {
-        if (service == null) return;
-        if (browseService != service) PLAYLIST_CATEGORY_IDS.clear();
-        browseService = service;
-        Logger.printDebug(() -> "BrowseService ready: " +
-                service.getClass().getName());
+    /**
+     * Injection point. Captures YTM's BS_GET_BROWSE_DATA object during MusicBrowserService.onCreate.
+     */
+    public static void setPlaylistLoader(@Nullable PlaylistLoader loader) {
+        if (loader == null) return;
+        if (playlistLoader != loader) PLAYLIST_CATEGORY_IDS.clear();
+        playlistLoader = loader;
+        Logger.printDebug(() -> "Playlist loader ready: " +
+                loader.getClass().getName());
     }
 
-    /** Injection point. A true result skips YTM's loadChildren response. */
-    public static boolean replacePlaylists(@NonNull Object result) {
+    /** Injection point. Returning true skips YTM's loadChildren response. */
+    public static boolean handlePlaylistLoad(@NonNull Object value) {
         try {
-            if (browseService == null || !(result instanceof LoadChildrenResult)) {
+            if (playlistLoader == null || !(value instanceof AndroidAutoResult)) {
                 return false;
             }
-            LoadChildrenResult loadChildrenResult = (LoadChildrenResult) result;
-            if (!isPlaylistRequest(loadChildrenResult)) return false;
-            loadPlaylists(loadChildrenResult);
+            AndroidAutoResult result = (AndroidAutoResult) value;
+            if (!isPlaylistCategoryRequest(result)) return false;
+            loadPlaylists(result);
             return true;
         } catch (RuntimeException ex) {
             Logger.printException(() -> "Could not start Android Auto playlist request", ex);
@@ -129,177 +131,181 @@ public final class RestoreAndroidAutoPlaylistsPatch {
         if (mediaId != null) PLAYLIST_CATEGORY_IDS.add(mediaId);
     }
 
-    private static void loadPlaylists(LoadChildrenResult result) {
-        LibraryState state = new LibraryState();
-        loadLibraryPage(result, state,
-                browseService.patch_requestBrowse(LIBRARY_BROWSE_ID, REQUEST_EXECUTOR), false);
+    private static void loadPlaylists(AndroidAutoResult result) {
+        PlaylistState state = new PlaylistState();
+        loadPlaylistResponse(result, state,
+                playlistLoader.patch_requestPage(
+                        LIBRARY_PLAYLISTS_ID, BACKGROUND_EXECUTOR), false);
     }
 
-    private static void loadLibraryPage(
-            LoadChildrenResult result, LibraryState state, ListenableFuture<?> request,
-            boolean isContinuation) {
-        request.addListener(() -> {
+    private static void loadPlaylistResponse(
+            AndroidAutoResult result, PlaylistState state,
+            ListenableFuture<?> responseFuture,
+            boolean isMorePlaylistsResponse) {
+        responseFuture.addListener(() -> {
             try {
-                BrowseResponse response = (BrowseResponse) request.get();
-                Object continuation = collectPage(response, state, isContinuation);
-                if (continuation != null) {
-                    loadLibraryPage(result, state,
-                            browseService.patch_requestContinuation(
-                                    continuation, REQUEST_EXECUTOR), true);
+                PlaylistResponse response = (PlaylistResponse) responseFuture.get();
+                Object loadMoreAction = collectPlaylistsFromResponse(
+                        response, state, isMorePlaylistsResponse);
+                if (loadMoreAction != null) {
+                    loadPlaylistResponse(result, state,
+                            playlistLoader.patch_requestMorePlaylists(
+                                    loadMoreAction, BACKGROUND_EXECUTOR), true);
                     return;
                 }
-                loadPlaylistMediaItems(result, state.playlists);
+                loadPlayablePlaylists(result, state.playlists);
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
-                Logger.printException(() -> "Library Browse request interrupted", ex);
-                sendResult(result, Collections.emptyList());
+                Logger.printException(() -> "Playlists request interrupted", ex);
+                deliverPlaylists(result, Collections.emptyList());
             } catch (ExecutionException | RuntimeException ex) {
-                Logger.printException(() -> "Library Browse request failed", ex);
-                sendResult(result, Collections.emptyList());
+                Logger.printException(() -> "Playlists request failed", ex);
+                deliverPlaylists(result, Collections.emptyList());
             }
-        }, REQUEST_EXECUTOR);
+        }, BACKGROUND_EXECUTOR);
     }
 
-    private static void sendResult(
-            LoadChildrenResult result, List<MediaBrowserCompat.MediaItem> items) {
+    private static void deliverPlaylists(
+            AndroidAutoResult result, List<MediaBrowserCompat.MediaItem> playlists) {
         try {
-            result.patch_sendResult(items);
+            result.patch_sendResult(playlists);
         } catch (RuntimeException ex) {
             Logger.printException(() -> "Could not deliver Android Auto playlists", ex);
         }
     }
 
-    private static Object collectPage(
-            BrowseResponse response, LibraryState state, boolean isContinuation) {
-        Object continuation = null;
-        if (isContinuation) {
-            Object grid = response.patch_getContinuationGrid();
-            if (grid != null) {
-                continuation = collectPlaylists(
-                        Collections.singletonList(grid), state, null);
+    private static Object collectPlaylistsFromResponse(
+            PlaylistResponse response, PlaylistState state,
+            boolean isMorePlaylistsResponse) {
+        Object loadMoreAction = null;
+        if (isMorePlaylistsResponse) {
+            Object morePlaylists = response.patch_getMorePlaylists();
+            if (morePlaylists != null) {
+                loadMoreAction = collectPlaylists(
+                        Collections.singletonList(morePlaylists), state, null);
             }
         } else {
-            for (Object tab : response.patch_getTabs()) {
-                SectionList sectionList = (SectionList)
-                        ((BrowseTab) tab).patch_getSectionList();
-                if (sectionList == null) continue;
-                for (Iterable<?> sectionItems : sectionList.patch_getItemLists()) {
-                    continuation = collectPlaylists(sectionItems, state, continuation);
+            for (Object page : response.patch_getPages()) {
+                PlaylistBody body = (PlaylistBody) ((PlaylistPage) page).patch_getBody();
+                if (body == null) continue;
+                for (Iterable<?> group : body.patch_getGroups()) {
+                    loadMoreAction = collectPlaylists(group, state, loadMoreAction);
                 }
             }
         }
-        Logger.printDebug(() -> "Found Library playlists: " + state.playlists.size());
-        return continuation;
+        Logger.printDebug(() -> "Found playlists: " + state.playlists.size());
+        return loadMoreAction;
     }
 
     private static Object collectPlaylists(
-            Iterable<?> sectionItems, LibraryState state, Object continuation) {
-        for (Object sectionItem : sectionItems) {
-            if (!(sectionItem instanceof PlaylistGrid)) continue;
-            PlaylistGrid grid = (PlaylistGrid) sectionItem;
-            if (continuation == null) {
-                Iterable<?> continuations = grid.patch_getContinuations();
-                if (continuations != null) {
-                    Iterator<?> iterator = continuations.iterator();
-                    if (iterator.hasNext()) continuation = iterator.next();
+            Iterable<?> group, PlaylistState state, Object loadMoreAction) {
+        for (Object value : group) {
+            if (!(value instanceof PlaylistListing)) continue;
+            PlaylistListing listing = (PlaylistListing) value;
+            if (loadMoreAction == null) {
+                Iterable<?> loadMoreActions = listing.patch_getLoadMoreActions();
+                if (loadMoreActions != null) {
+                    Iterator<?> iterator = loadMoreActions.iterator();
+                    if (iterator.hasNext()) loadMoreAction = iterator.next();
                 }
             }
 
-            Iterable<?> playlistItems = grid.patch_getItems();
-            if (playlistItems == null) continue;
-            for (Object item : playlistItems) {
-                if (!(item instanceof MusicItem)) continue;
+            Iterable<?> playlists = listing.patch_getPlaylists();
+            if (playlists == null) continue;
+            for (Object playlist : playlists) {
+                if (!(playlist instanceof PlaylistOrTrack)) continue;
                 try {
-                    addPlaylist((MusicItem) item, state);
+                    addPlaylist((PlaylistOrTrack) playlist, state);
                 } catch (RuntimeException ex) {
-                    Logger.printException(() -> "Library playlist skipped", ex);
+                    Logger.printException(() -> "Playlist skipped", ex);
                 }
             }
         }
-        return continuation;
+        return loadMoreAction;
     }
 
-    private static void addPlaylist(MusicItem item, LibraryState state) {
-        String browseId = item.patch_getBrowseId();
-        if (browseId == null || state.seenBrowseIds.contains(browseId)) return;
-        // Episodes for Later (VLSE) has no playlist Play command.
-        if (EPISODES_FOR_LATER_BROWSE_ID.equals(browseId)) return;
+    private static void addPlaylist(PlaylistOrTrack playlist, PlaylistState state) {
+        String playlistId = playlist.patch_getPlaylistId();
+        if (playlistId == null || state.seenPlaylistIds.contains(playlistId)) return;
+        // Episodes for Later (VLSE) has no Play button.
+        if (EPISODES_FOR_LATER_PLAYLIST_ID.equals(playlistId)) return;
 
-        CharSequence titleText = item.patch_getTitle();
+        CharSequence titleText = playlist.patch_getTitle();
         String title = titleText == null ? "" : titleText.toString();
         if (title.isEmpty()) return;
-        state.seenBrowseIds.add(browseId);
+        state.seenPlaylistIds.add(playlistId);
         // Subtitle and artwork failures do not block playback.
-        state.playlists.add(new LibraryPlaylist(
-                browseId,
+        state.playlists.add(new Playlist(
+                playlistId,
                 title,
-                subtitleOrEmpty(item),
-                artworkUriOrNull(item)));
+                subtitleOrEmpty(playlist),
+                artworkUriOrNull(playlist)));
     }
 
-    private static void loadPlaylistMediaItems(
-            LoadChildrenResult result, List<LibraryPlaylist> playlists) {
+    private static void loadPlayablePlaylists(
+            AndroidAutoResult result, List<Playlist> playlists) {
         if (playlists.isEmpty()) {
-            sendResult(result, Collections.emptyList());
+            deliverPlaylists(result, Collections.emptyList());
             return;
         }
 
-        // The array preserves Library order when requests finish out of order.
-        MediaBrowserCompat.MediaItem[] items = new MediaBrowserCompat.MediaItem[playlists.size()];
+        // The array preserves playlist order when requests finish out of order.
+        MediaBrowserCompat.MediaItem[] androidAutoPlaylists =
+                new MediaBrowserCompat.MediaItem[playlists.size()];
         AtomicInteger remaining = new AtomicInteger(playlists.size());
         for (int index = 0; index < playlists.size(); index++) {
-            int itemIndex = index;
-            LibraryPlaylist playlist = playlists.get(index);
-            ListenableFuture<?> request = browseService.patch_requestBrowse(
-                    playlist.browseId, REQUEST_EXECUTOR);
-            request.addListener(() -> {
+            int playlistIndex = index;
+            Playlist playlist = playlists.get(index);
+            ListenableFuture<?> responseFuture = playlistLoader.patch_requestPage(
+                    playlist.playlistId, BACKGROUND_EXECUTOR);
+            responseFuture.addListener(() -> {
                 try {
-                    BrowseResponse response = (BrowseResponse) request.get();
-                    // Liked Music (VLLM) has no ButtonRenderer Play command in response.q.
-                    String mediaId = LIKED_MUSIC_BROWSE_ID.equals(playlist.browseId)
-                            ? firstTrackMediaId(response)
-                            : response.patch_getPlaylistMediaId();
-                    if (mediaId != null && !mediaId.isEmpty()) {
-                        items[itemIndex] = createMediaItem(
-                                mediaId, playlist.title, playlist.subtitle, playlist.artwork);
+                    PlaylistResponse response = (PlaylistResponse) responseFuture.get();
+                    // Liked Music (VLLM) has no Play button in response.q; use its first track.
+                    String playbackId = LIKED_MUSIC_PLAYLIST_ID.equals(playlist.playlistId)
+                            ? firstTrackPlaybackId(response)
+                            : response.patch_getPlaybackId();
+                    if (playbackId != null && !playbackId.isEmpty()) {
+                        androidAutoPlaylists[playlistIndex] = createAndroidAutoPlaylist(
+                                playbackId, playlist.title, playlist.subtitle, playlist.artworkUri);
                     }
                 } catch (InterruptedException ex) {
                     Thread.currentThread().interrupt();
-                    Logger.printException(() -> "Playlist Browse request interrupted", ex);
+                    Logger.printException(() -> "Playlist playback request interrupted", ex);
                 } catch (ExecutionException | RuntimeException ex) {
-                    Logger.printException(() -> "Playlist Browse request failed", ex);
+                    Logger.printException(() -> "Playlist playback request failed", ex);
                 } finally {
-                    completePlaylistRequest(result, items, remaining);
+                    finishPlaylistLoading(result, androidAutoPlaylists, remaining);
                 }
-            }, REQUEST_EXECUTOR);
+            }, BACKGROUND_EXECUTOR);
         }
     }
 
-    private static void completePlaylistRequest(
-            LoadChildrenResult result, MediaBrowserCompat.MediaItem[] items,
+    private static void finishPlaylistLoading(
+            AndroidAutoResult result, MediaBrowserCompat.MediaItem[] androidAutoPlaylists,
             AtomicInteger remaining) {
         if (remaining.decrementAndGet() != 0) return;
-        List<MediaBrowserCompat.MediaItem> mediaItems = new ArrayList<>(items.length);
-        for (MediaBrowserCompat.MediaItem item : items) {
-            if (item != null) mediaItems.add(item);
+        List<MediaBrowserCompat.MediaItem> playlists =
+                new ArrayList<>(androidAutoPlaylists.length);
+        for (MediaBrowserCompat.MediaItem playlist : androidAutoPlaylists) {
+            if (playlist != null) playlists.add(playlist);
         }
-        sendResult(result, mediaItems);
+        deliverPlaylists(result, playlists);
     }
 
-    private static String firstTrackMediaId(BrowseResponse response) {
-        for (Object tab : response.patch_getTabs()) {
-            SectionList sectionList = (SectionList)
-                    ((BrowseTab) tab).patch_getSectionList();
-            if (sectionList == null) continue;
-            for (Iterable<?> sectionItems : sectionList.patch_getItemLists()) {
-                for (Object shelf : sectionItems) {
-                    if (!(shelf instanceof PlaylistShelf)) continue;
-                    Iterable<?> playlistTracks = ((PlaylistShelf) shelf).patch_getItems();
-                    if (playlistTracks == null) continue;
-                    for (Object track : playlistTracks) {
-                        if (!(track instanceof MusicItem)) continue;
-                        String mediaId = ((MusicItem) track).patch_getMediaId();
-                        if (mediaId != null && !mediaId.isEmpty()) return mediaId;
+    private static String firstTrackPlaybackId(PlaylistResponse response) {
+        for (Object page : response.patch_getPages()) {
+            PlaylistBody body = (PlaylistBody) ((PlaylistPage) page).patch_getBody();
+            if (body == null) continue;
+            for (Iterable<?> group : body.patch_getGroups()) {
+                for (Object value : group) {
+                    if (!(value instanceof PlaylistTracks)) continue;
+                    Iterable<?> tracks = ((PlaylistTracks) value).patch_getTracks();
+                    if (tracks == null) continue;
+                    for (Object track : tracks) {
+                        if (!(track instanceof PlaylistOrTrack)) continue;
+                        String playbackId = ((PlaylistOrTrack) track).patch_getPlaybackId();
+                        if (playbackId != null && !playbackId.isEmpty()) return playbackId;
                     }
                 }
             }
@@ -307,53 +313,53 @@ public final class RestoreAndroidAutoPlaylistsPatch {
         return null;
     }
 
-    private static String subtitleOrEmpty(MusicItem item) {
+    private static String subtitleOrEmpty(PlaylistOrTrack playlist) {
         try {
-            CharSequence subtitle = item.patch_getSubtitle();
+            CharSequence subtitle = playlist.patch_getSubtitle();
             return subtitle == null ? "" : subtitle.toString();
         } catch (RuntimeException ignored) {
             return "";
         }
     }
 
-    private static Uri artworkUriOrNull(MusicItem item) {
+    private static Uri artworkUriOrNull(PlaylistOrTrack playlist) {
         try {
-            return item.patch_getArtworkUri();
+            return playlist.patch_getArtworkUri();
         } catch (RuntimeException ignored) {
             return null;
         }
     }
 
-    private static MediaBrowserCompat.MediaItem createMediaItem(
-            String mediaId, String title, String subtitle, Uri iconUri) {
+    private static MediaBrowserCompat.MediaItem createAndroidAutoPlaylist(
+            String mediaId, String title, String subtitle, Uri artworkUri) {
         MediaDescriptionCompat description = new MediaDescriptionCompat(
-                mediaId, title, subtitle, null, null, iconUri, null, null);
+                mediaId, title, subtitle, null, null, artworkUri, null, null);
         return new MediaBrowserCompat.MediaItem(
                 description, MediaBrowserCompat.MediaItem.FLAG_PLAYABLE);
     }
 
-    private static boolean isPlaylistRequest(LoadChildrenResult result) {
+    private static boolean isPlaylistCategoryRequest(AndroidAutoResult result) {
         String parentMediaId = result.patch_getParentMediaId();
         return parentMediaId != null && PLAYLIST_CATEGORY_IDS.contains(parentMediaId);
     }
 
-    private static final class LibraryState {
-        private final List<LibraryPlaylist> playlists = new ArrayList<>();
-        private final Set<String> seenBrowseIds = new HashSet<>();
+    private static final class PlaylistState {
+        private final List<Playlist> playlists = new ArrayList<>();
+        private final Set<String> seenPlaylistIds = new HashSet<>();
     }
 
-    private static final class LibraryPlaylist {
-        private final String browseId;
+    private static final class Playlist {
+        private final String playlistId;
         private final String title;
         private final String subtitle;
-        private final Uri artwork;
+        private final Uri artworkUri;
 
-        private LibraryPlaylist(
-                String browseId, String title, String subtitle, Uri artwork) {
-            this.browseId = browseId;
+        private Playlist(
+                String playlistId, String title, String subtitle, Uri artworkUri) {
+            this.playlistId = playlistId;
             this.title = title;
             this.subtitle = subtitle;
-            this.artwork = artwork;
+            this.artworkUri = artworkUri;
         }
     }
 }

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch.java
@@ -40,6 +40,7 @@ import app.morphe.extension.shared.Utils;
 @SuppressWarnings("unused")
 public final class RestoreAndroidAutoPlaylistsPatch {
     private static final String LIBRARY_BROWSE_ID = "FEmusic_library_landing";
+    private static final String LIKED_MUSIC_BROWSE_ID = "VLLM";
     private static final String EPISODES_FOR_LATER_BROWSE_ID = "VLSE";
     private static final String PLAYLISTS_TITLE_RESOURCE = "library_playlists_shelf_title";
     private static final Executor REQUEST_EXECUTOR = Utils::runOnBackgroundThread;
@@ -72,6 +73,10 @@ public final class RestoreAndroidAutoPlaylistsPatch {
         @Nullable Iterable<?> patch_getContinuations();
     }
 
+    public interface PlaylistShelf {
+        @Nullable Iterable<?> patch_getItems();
+    }
+
     public interface LoadChildrenResult {
         @Nullable String patch_getParentMediaId();
         void patch_sendResult(@NonNull List<MediaBrowserCompat.MediaItem> items);
@@ -79,6 +84,7 @@ public final class RestoreAndroidAutoPlaylistsPatch {
 
     public interface MusicItem {
         @Nullable String patch_getBrowseId();
+        @Nullable String patch_getMediaId();
         @Nullable Uri patch_getArtworkUri();
         @Nullable CharSequence patch_getTitle();
         @Nullable CharSequence patch_getSubtitle();
@@ -249,7 +255,10 @@ public final class RestoreAndroidAutoPlaylistsPatch {
             request.addListener(() -> {
                 try {
                     BrowseResponse response = (BrowseResponse) request.get();
-                    String mediaId = response.patch_getPlaylistMediaId();
+                    // Liked Music (VLLM) has no ButtonRenderer Play command in response.q.
+                    String mediaId = LIKED_MUSIC_BROWSE_ID.equals(playlist.browseId)
+                            ? firstTrackMediaId(response)
+                            : response.patch_getPlaylistMediaId();
                     if (mediaId != null && !mediaId.isEmpty()) {
                         items[itemIndex] = createMediaItem(
                                 mediaId, playlist.title, playlist.subtitle, playlist.artwork);
@@ -275,6 +284,27 @@ public final class RestoreAndroidAutoPlaylistsPatch {
             if (item != null) mediaItems.add(item);
         }
         sendResult(result, mediaItems);
+    }
+
+    private static String firstTrackMediaId(BrowseResponse response) {
+        for (Object tab : response.patch_getTabs()) {
+            SectionList sectionList = (SectionList)
+                    ((BrowseTab) tab).patch_getSectionList();
+            if (sectionList == null) continue;
+            for (Iterable<?> sectionItems : sectionList.patch_getItemLists()) {
+                for (Object shelf : sectionItems) {
+                    if (!(shelf instanceof PlaylistShelf)) continue;
+                    Iterable<?> playlistTracks = ((PlaylistShelf) shelf).patch_getItems();
+                    if (playlistTracks == null) continue;
+                    for (Object track : playlistTracks) {
+                        if (!(track instanceof MusicItem)) continue;
+                        String mediaId = ((MusicItem) track).patch_getMediaId();
+                        if (mediaId != null && !mediaId.isEmpty()) return mediaId;
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     private static String subtitleOrEmpty(MusicItem item) {

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch.java
@@ -19,6 +19,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -48,10 +49,13 @@ public final class RestoreAndroidAutoPlaylistsPatch {
     public interface BrowseService {
         @NonNull ListenableFuture<?> patch_requestBrowse(
                 @NonNull String browseId, @NonNull Executor executor);
+        @NonNull ListenableFuture<?> patch_requestContinuation(
+                @NonNull Object continuation, @NonNull Executor executor);
     }
 
     public interface BrowseResponse {
         @NonNull Iterable<?> patch_getTabs();
+        @Nullable Object patch_getContinuationGrid();
         @Nullable String patch_getPlaylistMediaId();
     }
 
@@ -65,6 +69,7 @@ public final class RestoreAndroidAutoPlaylistsPatch {
 
     public interface PlaylistGrid {
         @Nullable Iterable<?> patch_getItems();
+        @Nullable Iterable<?> patch_getContinuations();
     }
 
     public interface LoadChildrenResult {
@@ -120,12 +125,23 @@ public final class RestoreAndroidAutoPlaylistsPatch {
 
     private static void loadPlaylists(LoadChildrenResult result) {
         LibraryState state = new LibraryState();
-        ListenableFuture<?> request = browseService.patch_requestBrowse(
-                LIBRARY_BROWSE_ID, REQUEST_EXECUTOR);
+        loadLibraryPage(result, state,
+                browseService.patch_requestBrowse(LIBRARY_BROWSE_ID, REQUEST_EXECUTOR), false);
+    }
+
+    private static void loadLibraryPage(
+            LoadChildrenResult result, LibraryState state, ListenableFuture<?> request,
+            boolean isContinuation) {
         request.addListener(() -> {
             try {
                 BrowseResponse response = (BrowseResponse) request.get();
-                collectPage(response, state);
+                Object continuation = collectPage(response, state, isContinuation);
+                if (continuation != null) {
+                    loadLibraryPage(result, state,
+                            browseService.patch_requestContinuation(
+                                    continuation, REQUEST_EXECUTOR), true);
+                    return;
+                }
                 loadPlaylistMediaItems(result, state.playlists);
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
@@ -147,22 +163,42 @@ public final class RestoreAndroidAutoPlaylistsPatch {
         }
     }
 
-    private static void collectPage(BrowseResponse response, LibraryState state) {
-        for (Object tab : response.patch_getTabs()) {
-            SectionList sectionList = (SectionList)
-                    ((BrowseTab) tab).patch_getSectionList();
-            if (sectionList == null) continue;
-            for (Iterable<?> sectionItems : sectionList.patch_getItemLists()) {
-                collectPlaylists(sectionItems, state);
+    private static Object collectPage(
+            BrowseResponse response, LibraryState state, boolean isContinuation) {
+        Object continuation = null;
+        if (isContinuation) {
+            Object grid = response.patch_getContinuationGrid();
+            if (grid != null) {
+                continuation = collectPlaylists(
+                        Collections.singletonList(grid), state, null);
+            }
+        } else {
+            for (Object tab : response.patch_getTabs()) {
+                SectionList sectionList = (SectionList)
+                        ((BrowseTab) tab).patch_getSectionList();
+                if (sectionList == null) continue;
+                for (Iterable<?> sectionItems : sectionList.patch_getItemLists()) {
+                    continuation = collectPlaylists(sectionItems, state, continuation);
+                }
             }
         }
         Logger.printDebug(() -> "Found Library playlists: " + state.playlists.size());
+        return continuation;
     }
 
-    private static void collectPlaylists(Iterable<?> sectionItems, LibraryState state) {
+    private static Object collectPlaylists(
+            Iterable<?> sectionItems, LibraryState state, Object continuation) {
         for (Object sectionItem : sectionItems) {
             if (!(sectionItem instanceof PlaylistGrid)) continue;
             PlaylistGrid grid = (PlaylistGrid) sectionItem;
+            if (continuation == null) {
+                Iterable<?> continuations = grid.patch_getContinuations();
+                if (continuations != null) {
+                    Iterator<?> iterator = continuations.iterator();
+                    if (iterator.hasNext()) continuation = iterator.next();
+                }
+            }
+
             Iterable<?> playlistItems = grid.patch_getItems();
             if (playlistItems == null) continue;
             for (Object item : playlistItems) {
@@ -174,6 +210,7 @@ public final class RestoreAndroidAutoPlaylistsPatch {
                 }
             }
         }
+        return continuation;
     }
 
     private static void addPlaylist(MusicItem item, LibraryState state) {

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2489
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.music.patches;
+
+import android.net.Uri;
+import android.support.v4.media.MediaBrowserCompat;
+import android.support.v4.media.MediaDescriptionCompat;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.ResourceUtils;
+import app.morphe.extension.shared.Utils;
+
+/**
+ * Loads YTM's phone Library when Android Auto requests Playlists.
+ *
+ * <p>FEmusic_library_landing returns playlist titles and Browse IDs in GridRenderer. Playlist pages
+ * contain the playback commands used to create Android Auto media IDs.
+ */
+@SuppressWarnings("unused")
+public final class RestoreAndroidAutoPlaylistsPatch {
+    private static final String LIBRARY_BROWSE_ID = "FEmusic_library_landing";
+    private static final String EPISODES_FOR_LATER_BROWSE_ID = "VLSE";
+    private static final String PLAYLISTS_TITLE_RESOURCE = "library_playlists_shelf_title";
+    private static final Executor REQUEST_EXECUTOR = Utils::runOnBackgroundThread;
+    private static final Set<String> PLAYLIST_CATEGORY_IDS =
+            ConcurrentHashMap.newKeySet();
+
+    public interface BrowseService {
+        @NonNull ListenableFuture<?> patch_requestBrowse(
+                @NonNull String browseId, @NonNull Executor executor);
+    }
+
+    public interface BrowseResponse {
+        @NonNull Iterable<?> patch_getTabs();
+        @Nullable String patch_getPlaylistMediaId();
+    }
+
+    public interface BrowseTab {
+        @Nullable Object patch_getSectionList();
+    }
+
+    public interface SectionList {
+        @NonNull Iterable<?>[] patch_getItemLists();
+    }
+
+    public interface PlaylistGrid {
+        @Nullable Iterable<?> patch_getItems();
+    }
+
+    public interface LoadChildrenResult {
+        @Nullable String patch_getParentMediaId();
+        void patch_sendResult(@NonNull List<MediaBrowserCompat.MediaItem> items);
+    }
+
+    public interface MusicItem {
+        @Nullable String patch_getBrowseId();
+        @Nullable Uri patch_getArtworkUri();
+        @Nullable CharSequence patch_getTitle();
+        @Nullable CharSequence patch_getSubtitle();
+    }
+
+    @Nullable
+    private static volatile BrowseService browseService;
+
+    private RestoreAndroidAutoPlaylistsPatch() {
+    }
+
+    /** Injection point. Called from MusicBrowserService's generated superclass during onCreate. */
+    public static void setBrowseService(@Nullable BrowseService service) {
+        if (service == null) return;
+        if (browseService != service) PLAYLIST_CATEGORY_IDS.clear();
+        browseService = service;
+        Logger.printDebug(() -> "BrowseService ready: " +
+                service.getClass().getName());
+    }
+
+    /** Injection point. A true result skips YTM's loadChildren response. */
+    public static boolean replacePlaylists(@NonNull Object result) {
+        try {
+            if (browseService == null || !(result instanceof LoadChildrenResult)) {
+                return false;
+            }
+            LoadChildrenResult loadChildrenResult = (LoadChildrenResult) result;
+            if (!isPlaylistRequest(loadChildrenResult)) return false;
+            loadPlaylists(loadChildrenResult);
+            return true;
+        } catch (RuntimeException ex) {
+            Logger.printException(() -> "Could not start Android Auto playlist request", ex);
+            return false;
+        }
+    }
+
+    /** Injection point. Saves the Playlists parent ID used by later loadChildren requests. */
+    public static void rememberPlaylistCategoryId(
+            @Nullable String mediaId, @Nullable CharSequence title) {
+        if (title == null || !ResourceUtils.getString(PLAYLISTS_TITLE_RESOURCE)
+                .contentEquals(title)) return;
+        if (mediaId != null) PLAYLIST_CATEGORY_IDS.add(mediaId);
+    }
+
+    private static void loadPlaylists(LoadChildrenResult result) {
+        LibraryState state = new LibraryState();
+        ListenableFuture<?> request = browseService.patch_requestBrowse(
+                LIBRARY_BROWSE_ID, REQUEST_EXECUTOR);
+        request.addListener(() -> {
+            try {
+                BrowseResponse response = (BrowseResponse) request.get();
+                collectPage(response, state);
+                loadPlaylistMediaItems(result, state.playlists);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                Logger.printException(() -> "Library Browse request interrupted", ex);
+                sendResult(result, Collections.emptyList());
+            } catch (ExecutionException | RuntimeException ex) {
+                Logger.printException(() -> "Library Browse request failed", ex);
+                sendResult(result, Collections.emptyList());
+            }
+        }, REQUEST_EXECUTOR);
+    }
+
+    private static void sendResult(
+            LoadChildrenResult result, List<MediaBrowserCompat.MediaItem> items) {
+        try {
+            result.patch_sendResult(items);
+        } catch (RuntimeException ex) {
+            Logger.printException(() -> "Could not deliver Android Auto playlists", ex);
+        }
+    }
+
+    private static void collectPage(BrowseResponse response, LibraryState state) {
+        for (Object tab : response.patch_getTabs()) {
+            SectionList sectionList = (SectionList)
+                    ((BrowseTab) tab).patch_getSectionList();
+            if (sectionList == null) continue;
+            for (Iterable<?> sectionItems : sectionList.patch_getItemLists()) {
+                collectPlaylists(sectionItems, state);
+            }
+        }
+        Logger.printDebug(() -> "Found Library playlists: " + state.playlists.size());
+    }
+
+    private static void collectPlaylists(Iterable<?> sectionItems, LibraryState state) {
+        for (Object sectionItem : sectionItems) {
+            if (!(sectionItem instanceof PlaylistGrid)) continue;
+            PlaylistGrid grid = (PlaylistGrid) sectionItem;
+            Iterable<?> playlistItems = grid.patch_getItems();
+            if (playlistItems == null) continue;
+            for (Object item : playlistItems) {
+                if (!(item instanceof MusicItem)) continue;
+                try {
+                    addPlaylist((MusicItem) item, state);
+                } catch (RuntimeException ex) {
+                    Logger.printException(() -> "Library playlist skipped", ex);
+                }
+            }
+        }
+    }
+
+    private static void addPlaylist(MusicItem item, LibraryState state) {
+        String browseId = item.patch_getBrowseId();
+        if (browseId == null || state.seenBrowseIds.contains(browseId)) return;
+        // Episodes for Later (VLSE) has no playlist Play command.
+        if (EPISODES_FOR_LATER_BROWSE_ID.equals(browseId)) return;
+
+        CharSequence titleText = item.patch_getTitle();
+        String title = titleText == null ? "" : titleText.toString();
+        if (title.isEmpty()) return;
+        state.seenBrowseIds.add(browseId);
+        // Subtitle and artwork failures do not block playback.
+        state.playlists.add(new LibraryPlaylist(
+                browseId,
+                title,
+                subtitleOrEmpty(item),
+                artworkUriOrNull(item)));
+    }
+
+    private static void loadPlaylistMediaItems(
+            LoadChildrenResult result, List<LibraryPlaylist> playlists) {
+        if (playlists.isEmpty()) {
+            sendResult(result, Collections.emptyList());
+            return;
+        }
+
+        // The array preserves Library order when requests finish out of order.
+        MediaBrowserCompat.MediaItem[] items = new MediaBrowserCompat.MediaItem[playlists.size()];
+        AtomicInteger remaining = new AtomicInteger(playlists.size());
+        for (int index = 0; index < playlists.size(); index++) {
+            int itemIndex = index;
+            LibraryPlaylist playlist = playlists.get(index);
+            ListenableFuture<?> request = browseService.patch_requestBrowse(
+                    playlist.browseId, REQUEST_EXECUTOR);
+            request.addListener(() -> {
+                try {
+                    BrowseResponse response = (BrowseResponse) request.get();
+                    String mediaId = response.patch_getPlaylistMediaId();
+                    if (mediaId != null && !mediaId.isEmpty()) {
+                        items[itemIndex] = createMediaItem(
+                                mediaId, playlist.title, playlist.subtitle, playlist.artwork);
+                    }
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    Logger.printException(() -> "Playlist Browse request interrupted", ex);
+                } catch (ExecutionException | RuntimeException ex) {
+                    Logger.printException(() -> "Playlist Browse request failed", ex);
+                } finally {
+                    completePlaylistRequest(result, items, remaining);
+                }
+            }, REQUEST_EXECUTOR);
+        }
+    }
+
+    private static void completePlaylistRequest(
+            LoadChildrenResult result, MediaBrowserCompat.MediaItem[] items,
+            AtomicInteger remaining) {
+        if (remaining.decrementAndGet() != 0) return;
+        List<MediaBrowserCompat.MediaItem> mediaItems = new ArrayList<>(items.length);
+        for (MediaBrowserCompat.MediaItem item : items) {
+            if (item != null) mediaItems.add(item);
+        }
+        sendResult(result, mediaItems);
+    }
+
+    private static String subtitleOrEmpty(MusicItem item) {
+        try {
+            CharSequence subtitle = item.patch_getSubtitle();
+            return subtitle == null ? "" : subtitle.toString();
+        } catch (RuntimeException ignored) {
+            return "";
+        }
+    }
+
+    private static Uri artworkUriOrNull(MusicItem item) {
+        try {
+            return item.patch_getArtworkUri();
+        } catch (RuntimeException ignored) {
+            return null;
+        }
+    }
+
+    private static MediaBrowserCompat.MediaItem createMediaItem(
+            String mediaId, String title, String subtitle, Uri iconUri) {
+        MediaDescriptionCompat description = new MediaDescriptionCompat(
+                mediaId, title, subtitle, null, null, iconUri, null, null);
+        return new MediaBrowserCompat.MediaItem(
+                description, MediaBrowserCompat.MediaItem.FLAG_PLAYABLE);
+    }
+
+    private static boolean isPlaylistRequest(LoadChildrenResult result) {
+        String parentMediaId = result.patch_getParentMediaId();
+        return parentMediaId != null && PLAYLIST_CATEGORY_IDS.contains(parentMediaId);
+    }
+
+    private static final class LibraryState {
+        private final List<LibraryPlaylist> playlists = new ArrayList<>();
+        private final Set<String> seenBrowseIds = new HashSet<>();
+    }
+
+    private static final class LibraryPlaylist {
+        private final String browseId;
+        private final String title;
+        private final String subtitle;
+        private final Uri artwork;
+
+        private LibraryPlaylist(
+                String browseId, String title, String subtitle, Uri artwork) {
+            this.browseId = browseId;
+            this.title = title;
+            this.subtitle = subtitle;
+            this.artwork = artwork;
+        }
+    }
+}

--- a/extensions/youtube/stub/src/main/java/android/support/v4/media/MediaBrowserCompat.java
+++ b/extensions/youtube/stub/src/main/java/android/support/v4/media/MediaBrowserCompat.java
@@ -1,10 +1,3 @@
-/*
- * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches/pull/2489
- *
- * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
- */
-
 package android.support.v4.media;
 
 // Used only while compiling; YouTube Music provides the real class at runtime.

--- a/extensions/youtube/stub/src/main/java/android/support/v4/media/MediaBrowserCompat.java
+++ b/extensions/youtube/stub/src/main/java/android/support/v4/media/MediaBrowserCompat.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2489
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package android.support.v4.media;
+
+// Used only while compiling; YouTube Music provides the real class at runtime.
+public class MediaBrowserCompat {
+    public static class MediaItem {
+        public static final int FLAG_PLAYABLE = 2;
+
+        public MediaItem(MediaDescriptionCompat description, int flags) {
+            throw new UnsupportedOperationException("Stub");
+        }
+    }
+}

--- a/extensions/youtube/stub/src/main/java/android/support/v4/media/MediaDescriptionCompat.java
+++ b/extensions/youtube/stub/src/main/java/android/support/v4/media/MediaDescriptionCompat.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2489
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package android.support.v4.media;
+
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.os.Bundle;
+
+// Used only while compiling; YouTube Music provides the real class at runtime.
+public final class MediaDescriptionCompat {
+    public MediaDescriptionCompat(
+            String mediaId,
+            CharSequence title,
+            CharSequence subtitle,
+            CharSequence description,
+            Bitmap icon,
+            Uri iconUri,
+            Bundle extras,
+            Uri mediaUri) {
+        throw new UnsupportedOperationException("Stub");
+    }
+}

--- a/extensions/youtube/stub/src/main/java/com/google/common/util/concurrent/ListenableFuture.java
+++ b/extensions/youtube/stub/src/main/java/com/google/common/util/concurrent/ListenableFuture.java
@@ -1,10 +1,3 @@
-/*
- * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches/pull/2489
- *
- * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
- */
-
 package com.google.common.util.concurrent;
 
 import java.util.concurrent.Executor;

--- a/extensions/youtube/stub/src/main/java/com/google/common/util/concurrent/ListenableFuture.java
+++ b/extensions/youtube/stub/src/main/java/com/google/common/util/concurrent/ListenableFuture.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2489
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package com.google.common.util.concurrent;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+
+// Used only while compiling; YouTube Music provides the real class at runtime.
+public interface ListenableFuture<V> extends Future<V> {
+    void addListener(Runnable listener, Executor executor);
+}

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/Fingerprints.kt
@@ -269,6 +269,18 @@ internal object GridItemsFingerprint : Fingerprint(
     ),
 )
 
+internal object GridDecoderFingerprint : Fingerprint(
+    classFingerprint = MusicReloadShelfEventFingerprint,
+    accessFlags = listOf(
+        AccessFlags.PROTECTED,
+        AccessFlags.FINAL,
+        AccessFlags.BRIDGE,
+        AccessFlags.SYNTHETIC,
+    ),
+    returnType = "Ljava/lang/Object;",
+    parameters = listOf("L"),
+)
+
 // Field c on playlist and track rows contains thumbnail extension 164480666.
 internal object MusicThumbnailExtensionFingerprint : Fingerprint(
     name = "<clinit>",

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/Fingerprints.kt
@@ -1,0 +1,438 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2489
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.patches.music.misc.androidauto.playlists
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation.MatchAfterImmediately
+import app.morphe.patcher.InstructionLocation.MatchAfterWithin
+import app.morphe.patcher.checkCast
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.fieldAccess
+import app.morphe.patcher.literal
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.newInstance
+import app.morphe.patcher.opcode
+import app.morphe.patcher.string
+import app.morphe.util.findInstructionIndicesReversed
+import app.morphe.util.getReference
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference
+
+private const val SINGLE_COLUMN_BROWSE_RESULTS_FIELD_NUMBER = 58_173_949L
+private const val TAB_RENDERER_FIELD_NUMBER = 58_174_010L
+private const val TAB_CONTENT_PRESENT_FLAG = 1L
+private const val MUSIC_ITEM_FIELD_NUMBER = 161_429_595L
+private const val BUTTON_RENDERER_EXTENSION_FIELD_NUMBER = 65_153_809L
+private const val MUSIC_THUMBNAIL_FIELD_NUMBER = 164_480_666L
+
+// Android Auto media-item creation and loadChildren
+
+internal val MEDIA_DESCRIPTION_CONSTRUCTOR_CALL = methodCall(
+    definingClass = "Landroid/support/v4/media/MediaDescriptionCompat;",
+    name = "<init>",
+    parameters = listOf(
+        "Ljava/lang/String;",
+        "Ljava/lang/CharSequence;",
+        "Ljava/lang/CharSequence;",
+        "Ljava/lang/CharSequence;",
+        "Landroid/graphics/Bitmap;",
+        "Landroid/net/Uri;",
+        "Landroid/os/Bundle;",
+        "Landroid/net/Uri;",
+    ),
+    returnType = "V",
+)
+
+internal object MediaItemFactoryFingerprint : Fingerprint(
+    returnType = "Lj$/util/Optional;",
+    parameters = listOf("L", "Ljava/util/Set;", "L"),
+    filters = listOf(MEDIA_DESCRIPTION_CONSTRUCTOR_CALL),
+    custom = { method, _ ->
+        method.findInstructionIndicesReversed(MEDIA_DESCRIPTION_CONSTRUCTOR_CALL).size == 3
+    },
+)
+
+internal object InvalidParentMediaIdFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf("L", "Z"),
+    strings = listOf("Invalid media id: ")
+)
+
+internal fun contentSupplierLoadChildrenFingerprint(
+    contentSupplierType: String,
+    loadChildrenResultType: String,
+) = Fingerprint(
+    definingClass = contentSupplierType,
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf(loadChildrenResultType),
+    custom = { method, _ -> !AccessFlags.STATIC.isSet(method.accessFlags) },
+)
+
+internal fun musicBrowserServiceLoadChildrenFingerprint(loadChildrenResultType: String) = Fingerprint(
+    returnType = "V",
+    parameters = listOf("Ljava/lang/String;", "L", "Landroid/os/Bundle;"),
+    custom = { method, _ ->
+        method.implementation?.instructions?.any { instruction ->
+            instruction.getReference<TypeReference>()?.type == loadChildrenResultType ||
+                instruction.getReference<MethodReference>()?.returnType == loadChildrenResultType
+        } == true
+    },
+)
+
+internal fun musicBrowserServiceOnCreateFingerprint(
+    musicBrowserServiceType: String,
+    componentType: String,
+) = Fingerprint(
+    name = "onCreate",
+    returnType = "V",
+    parameters = emptyList(),
+    filters = listOf(
+        methodCall(
+            name = "generatedComponent",
+            parameters = emptyList(),
+            returnType = "Ljava/lang/Object;",
+        ),
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            type = componentType,
+        ),
+        fieldAccess(
+            opcode = Opcode.IPUT_OBJECT,
+            definingClass = musicBrowserServiceType,
+        ),
+    ),
+)
+
+internal fun browseServiceProviderFingerprint(browseServiceType: String) = Fingerprint(
+    filters = listOf(
+        fieldAccess(opcode = Opcode.IGET_OBJECT),
+        methodCall(
+            parameters = emptyList(),
+            returnType = "Ljava/lang/Object;",
+            opcodes = listOf(Opcode.INVOKE_INTERFACE, Opcode.INVOKE_INTERFACE_RANGE),
+            location = MatchAfterImmediately(),
+        ),
+        opcode(Opcode.MOVE_RESULT_OBJECT, location = MatchAfterImmediately()),
+        checkCast(browseServiceType, location = MatchAfterImmediately()),
+    ),
+)
+
+// Browse requests
+
+internal object BrowseEndpointRequestFingerprint : Fingerprint(
+    returnType = "L",
+    parameters = listOf("L"),
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            type = "Ljava/lang/String;",
+        ),
+        string("FEmusic_home", location = MatchAfterImmediately()),
+    ),
+    // An Object-returning lambda also references FEmusic_home, but does not build the request.
+    custom = { method, _ -> method.returnType != "Ljava/lang/Object;" }
+)
+
+internal fun browseRequestFingerprint(
+    browseServiceType: String,
+    requestBuilderType: String,
+) = Fingerprint(
+    definingClass = browseServiceType,
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "Lcom/google/common/util/concurrent/ListenableFuture;",
+    parameters = listOf(requestBuilderType, "Ljava/util/concurrent/Executor;"),
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            definingClass = requestBuilderType,
+            type = "Ljava/lang/String;",
+        ),
+    ),
+)
+
+internal fun browseIdSetterFingerprint(field: FieldReference) = Fingerprint(
+    definingClass = field.definingClass,
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf("Ljava/lang/String;"),
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IPUT_OBJECT,
+            definingClass = field.definingClass,
+            name = field.name,
+            type = field.type,
+        ),
+    ),
+)
+
+// Browse responses
+
+// Library tabs come from extension 58173949 in the FEmusic_library_landing response.
+internal object BrowseTabsFingerprint : Fingerprint(
+    accessFlags = listOf(
+        AccessFlags.PUBLIC,
+        AccessFlags.FINAL,
+        AccessFlags.DECLARED_SYNCHRONIZED,
+    ),
+    returnType = "L",
+    parameters = emptyList(),
+    filters = listOf(
+        literal(SINGLE_COLUMN_BROWSE_RESULTS_FIELD_NUMBER),
+        methodCall(
+            definingClass = "Lj$/util/stream/Stream;",
+            name = "filter",
+            parameters = listOf("Ljava/util/function/Predicate;"),
+            returnType = "Lj$/util/stream/Stream;",
+        ),
+        newInstance("L", location = MatchAfterWithin(2)),
+    ),
+)
+
+internal fun browseTabMapperFingerprint(mapperType: String) = Fingerprint(
+    definingClass = mapperType,
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "Ljava/lang/Object;",
+    parameters = listOf("Ljava/lang/Object;"),
+    filters = listOf(
+        newInstance("L"),
+        literal(
+            TAB_RENDERER_FIELD_NUMBER,
+            location = MatchAfterWithin(3),
+        ),
+    ),
+)
+
+internal fun sectionListFingerprint(tabType: String) = Fingerprint(
+    definingClass = tabType,
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "L",
+    parameters = emptyList(),
+    filters = listOf(literal(TAB_CONTENT_PRESENT_FLAG)),
+)
+
+internal fun sectionItemsFingerprint(
+    sectionListType: String,
+    returnType: String,
+) = Fingerprint(
+    definingClass = sectionListType,
+    accessFlags = listOf(
+        AccessFlags.PUBLIC,
+        AccessFlags.FINAL,
+        AccessFlags.DECLARED_SYNCHRONIZED,
+    ),
+    returnType = returnType,
+    parameters = emptyList(),
+)
+
+// Library and playlist rows
+
+// FEmusic_library_landing playlists and loaded playlist tracks both use extension 161429595.
+internal object MusicItemExtensionFingerprint : Fingerprint(
+    name = "<clinit>",
+    returnType = "V",
+    parameters = emptyList(),
+    filters = listOf(
+        opcode(Opcode.CONST_CLASS),
+        literal(
+            MUSIC_ITEM_FIELD_NUMBER,
+            location = MatchAfterWithin(2),
+        ),
+    ),
+)
+
+internal object MusicReloadShelfEventFingerprint : Fingerprint(
+    name = "handleMusicReloadShelfEvent",
+    accessFlags = listOf(AccessFlags.PUBLIC),
+    returnType = "V",
+    parameters = listOf("L"),
+)
+
+// GridRenderer uses presence bits 0x1000 and 0x40000 for extension-161429595 rows.
+internal object GridItemsFingerprint : Fingerprint(
+    classFingerprint = MusicReloadShelfEventFingerprint,
+    accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.STATIC),
+    returnType = "Ljava/util/List;",
+    parameters = listOf("L"),
+    filters = listOf(
+        literal(0x1000L),
+        literal(0x40000L),
+    ),
+)
+
+// Field c on playlist and track rows contains thumbnail extension 164480666.
+internal object MusicThumbnailExtensionFingerprint : Fingerprint(
+    name = "<clinit>",
+    returnType = "V",
+    parameters = emptyList(),
+    filters = listOf(
+        opcode(Opcode.CONST_CLASS),
+        literal(
+            MUSIC_THUMBNAIL_FIELD_NUMBER,
+            location = MatchAfterWithin(2),
+        ),
+    ),
+)
+
+internal fun musicThumbnailDecoderFingerprint(artworkType: String) = Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
+    returnType = "Lcom/google/protobuf/MessageLite;",
+    parameters = listOf(artworkType),
+    filters = listOf(
+        methodCall(
+            definingClass = "Lcom/google/protobuf/ExtensionRegistryLite;",
+            name = "getGeneratedRegistry",
+            parameters = emptyList(),
+            returnType = "Lcom/google/protobuf/ExtensionRegistryLite;",
+        ),
+    ),
+)
+
+internal fun androidAutoArtworkFingerprint(
+    payloadFieldTypes: Set<String>,
+) = Fingerprint(
+    filters = listOf(MEDIA_DESCRIPTION_CONSTRUCTOR_CALL),
+    // Before building MediaDescriptionCompat, YTM converts the decoded thumbnail to its artwork Uri.
+    custom = { method, _ ->
+        if (method.parameterTypes.size != 1) return@Fingerprint false
+        val instructions = method.implementation?.instructions ?: return@Fingerprint false
+        val readFieldTypes = instructions
+            .filter { instruction -> instruction.opcode == Opcode.IGET_OBJECT }
+            .mapNotNull { instruction -> instruction.getReference<FieldReference>()?.type }
+            .toSet()
+        instructions.any { instruction ->
+            val reference = instruction.getReference<MethodReference>()
+                ?: return@any false
+            val parameterType = reference.parameterTypes.singleOrNull()?.toString()
+                ?: return@any false
+            reference.returnType == "Landroid/net/Uri;" &&
+                parameterType in payloadFieldTypes && parameterType in readFieldTypes
+        }
+    },
+)
+
+internal fun renderTextFingerprint(textType: String) = Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
+    returnType = "Landroid/text/Spanned;",
+    parameters = listOf(textType, "Ljava/lang/String;"),
+)
+
+internal fun browseEndpointDecoderFingerprint(
+    endpointType: String,
+    decodedEndpointType: String,
+) = Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
+    returnType = decodedEndpointType,
+    parameters = listOf(endpointType),
+)
+
+internal object EndpointMediaIdFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
+    returnType = "Ljava/lang/String;",
+    parameters = listOf("L"),
+    // MediaItemData.createMediaId serializes the row command as Android Auto's media ID.
+    custom = endpointMediaId@{ method, _ ->
+        val endpointType = method.parameterTypes.single().toString()
+        if (endpointType == "Ljava/lang/String;") return@endpointMediaId false
+        val endpointStores = method.instructions
+            .filter { instruction -> instruction.opcode == Opcode.IPUT_OBJECT }
+            .mapNotNull { instruction -> instruction.getReference<FieldReference>() }
+            .filter { field -> field.type == endpointType }
+            .distinct()
+        val wrapperType = endpointStores.singleOrNull()?.definingClass
+            ?: return@endpointMediaId false
+        method.instructions.any { instruction ->
+            val reference = instruction.getReference<MethodReference>()
+                ?: return@any false
+            reference.parameterTypes.map(CharSequence::toString) == listOf(wrapperType) &&
+                reference.returnType == "Ljava/lang/String;"
+        }
+    },
+)
+
+// Playlist playback
+
+internal fun buttonRendererExtensionFingerprint(endpointType: String) = Fingerprint(
+    name = "<clinit>",
+    returnType = "V",
+    parameters = emptyList(),
+    filters = listOf(literal(BUTTON_RENDERER_EXTENSION_FIELD_NUMBER)),
+    // Extension 65153809 is ButtonRenderer in response.q and FeedbackEndpoint in a command.
+    custom = { method, _ ->
+        val containingType = method.instructions
+            .filter { instruction -> instruction.opcode == Opcode.SGET_OBJECT }
+            .mapNotNull { instruction -> instruction.getReference<FieldReference>() }
+            .firstOrNull { field -> field.definingClass == field.type }
+            ?.type
+        containingType != null && containingType != endpointType
+    },
+)
+
+internal fun buttonRendererDecoderFingerprint(
+    containingType: String,
+    buttonRendererType: String,
+    descriptorField: FieldReference,
+) = Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
+    returnType = buttonRendererType,
+    parameters = listOf("Z", containingType),
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.SGET_OBJECT,
+            definingClass = descriptorField.definingClass,
+            name = descriptorField.name,
+            type = descriptorField.type,
+        ),
+    ),
+)
+
+internal fun buttonRendererEndpointCopyFingerprint(
+    buttonRendererType: String,
+    endpointType: String,
+) = Fingerprint(
+    returnType = "V",
+    parameters = listOf("L"),
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            definingClass = buttonRendererType,
+            type = endpointType,
+        ),
+        fieldAccess(
+            opcode = Opcode.IPUT_OBJECT,
+            type = endpointType,
+            location = MatchAfterWithin(4),
+        ),
+    ),
+    // The live-chat ImageButton copies its click command from ButtonRenderer.
+    custom = { method, _ ->
+        val instructions = method.implementation?.instructions?.toList()
+            ?: return@Fingerprint false
+        val copiedEndpointFields = instructions.mapIndexedNotNull { index, instruction ->
+            val field = instruction.getReference<FieldReference>()
+                ?: return@mapIndexedNotNull null
+            if (instruction.opcode != Opcode.IGET_OBJECT ||
+                field.definingClass != buttonRendererType || field.type != endpointType
+            ) {
+                return@mapIndexedNotNull null
+            }
+            val copiedToCommand = instructions.drop(index + 1).take(4).any { nearby ->
+                val target = nearby.getReference<FieldReference>()
+                    ?: return@any false
+                nearby.opcode == Opcode.IPUT_OBJECT &&
+                    target.definingClass != buttonRendererType && target.type == endpointType
+            }
+            field.takeIf { copiedToCommand }
+        }.distinct()
+        copiedEndpointFields.size == 1
+    },
+)

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/Fingerprints.kt
@@ -269,6 +269,19 @@ internal object GridItemsFingerprint : Fingerprint(
     ),
 )
 
+internal fun playlistItemsFingerprint(musicItemType: String) = Fingerprint(
+    accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.STATIC),
+    returnType = "Ljava/util/List;",
+    parameters = listOf("L", "Z"),
+    filters = listOf(opcode(Opcode.CHECK_CAST)),
+    custom = { method, _ ->
+        method.instructions.any { instruction ->
+            instruction.opcode == Opcode.CHECK_CAST &&
+                instruction.getReference<TypeReference>()?.type == musicItemType
+        }
+    },
+)
+
 internal object GridDecoderFingerprint : Fingerprint(
     classFingerprint = MusicReloadShelfEventFingerprint,
     accessFlags = listOf(

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/Fingerprints.kt
@@ -26,14 +26,14 @@ import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.TypeReference
 
-private const val SINGLE_COLUMN_BROWSE_RESULTS_FIELD_NUMBER = 58_173_949L
-private const val TAB_RENDERER_FIELD_NUMBER = 58_174_010L
-private const val TAB_CONTENT_PRESENT_FLAG = 1L
-private const val MUSIC_ITEM_FIELD_NUMBER = 161_429_595L
-private const val BUTTON_RENDERER_EXTENSION_FIELD_NUMBER = 65_153_809L
-private const val MUSIC_THUMBNAIL_FIELD_NUMBER = 164_480_666L
+private const val PAGE_LIST_FIELD_NUMBER = 58_173_949L
+private const val PAGE_FIELD_NUMBER = 58_174_010L
+private const val SECTIONS_PRESENT_FLAG = 1L
+private const val PLAYLIST_OR_TRACK_FIELD_NUMBER = 161_429_595L
+private const val PLAY_BUTTON_FIELD_NUMBER = 65_153_809L
+private const val THUMBNAIL_FIELD_NUMBER = 164_480_666L
 
-// Android Auto media-item creation and loadChildren
+// Android Auto playlist loading
 
 internal val MEDIA_DESCRIPTION_CONSTRUCTOR_CALL = methodCall(
     definingClass = "Landroid/support/v4/media/MediaDescriptionCompat;",
@@ -51,7 +51,7 @@ internal val MEDIA_DESCRIPTION_CONSTRUCTOR_CALL = methodCall(
     returnType = "V",
 )
 
-internal object MediaItemFactoryFingerprint : Fingerprint(
+internal object PlaylistCategoryFingerprint : Fingerprint(
     returnType = "Lj$/util/Optional;",
     parameters = listOf("L", "Ljava/util/Set;", "L"),
     filters = listOf(MEDIA_DESCRIPTION_CONSTRUCTOR_CALL),
@@ -60,36 +60,36 @@ internal object MediaItemFactoryFingerprint : Fingerprint(
     },
 )
 
-internal object InvalidParentMediaIdFingerprint : Fingerprint(
+internal object PlaylistLoadFallbackFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC, AccessFlags.FINAL),
     returnType = "V",
     parameters = listOf("L", "Z"),
     strings = listOf("Invalid media id: ")
 )
 
-internal fun contentSupplierLoadChildrenFingerprint(
-    contentSupplierType: String,
-    loadChildrenResultType: String,
+internal fun playlistLoadHandlerFingerprint(
+    playlistLoadHandlerType: String,
+    androidAutoResultType: String,
 ) = Fingerprint(
-    definingClass = contentSupplierType,
+    definingClass = playlistLoadHandlerType,
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "V",
-    parameters = listOf(loadChildrenResultType),
+    parameters = listOf(androidAutoResultType),
     custom = { method, _ -> !AccessFlags.STATIC.isSet(method.accessFlags) },
 )
 
-internal fun musicBrowserServiceLoadChildrenFingerprint(loadChildrenResultType: String) = Fingerprint(
+internal fun musicBrowserServiceFingerprint(androidAutoResultType: String) = Fingerprint(
     returnType = "V",
     parameters = listOf("Ljava/lang/String;", "L", "Landroid/os/Bundle;"),
     custom = { method, _ ->
         method.implementation?.instructions?.any { instruction ->
-            instruction.getReference<TypeReference>()?.type == loadChildrenResultType ||
-                instruction.getReference<MethodReference>()?.returnType == loadChildrenResultType
+            instruction.getReference<TypeReference>()?.type == androidAutoResultType ||
+                instruction.getReference<MethodReference>()?.returnType == androidAutoResultType
         } == true
     },
 )
 
-internal fun musicBrowserServiceOnCreateFingerprint(
+internal fun playlistLoaderOnCreateFingerprint(
     musicBrowserServiceType: String,
     componentType: String,
 ) = Fingerprint(
@@ -113,7 +113,7 @@ internal fun musicBrowserServiceOnCreateFingerprint(
     ),
 )
 
-internal fun browseServiceProviderFingerprint(browseServiceType: String) = Fingerprint(
+internal fun playlistLoaderProviderFingerprint(playlistLoaderType: String) = Fingerprint(
     filters = listOf(
         fieldAccess(opcode = Opcode.IGET_OBJECT),
         methodCall(
@@ -123,13 +123,13 @@ internal fun browseServiceProviderFingerprint(browseServiceType: String) = Finge
             location = MatchAfterImmediately(),
         ),
         opcode(Opcode.MOVE_RESULT_OBJECT, location = MatchAfterImmediately()),
-        checkCast(browseServiceType, location = MatchAfterImmediately()),
+        checkCast(playlistLoaderType, location = MatchAfterImmediately()),
     ),
 )
 
-// Browse requests
+// Playlist requests
 
-internal object BrowseEndpointRequestFingerprint : Fingerprint(
+internal object CreatePlaylistRequestFingerprint : Fingerprint(
     returnType = "L",
     parameters = listOf("L"),
     filters = listOf(
@@ -143,24 +143,24 @@ internal object BrowseEndpointRequestFingerprint : Fingerprint(
     custom = { method, _ -> method.returnType != "Ljava/lang/Object;" }
 )
 
-internal fun browseRequestFingerprint(
-    browseServiceType: String,
-    requestBuilderType: String,
+internal fun sendPlaylistRequestFingerprint(
+    playlistLoaderType: String,
+    playlistRequestBuilderType: String,
 ) = Fingerprint(
-    definingClass = browseServiceType,
+    definingClass = playlistLoaderType,
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "Lcom/google/common/util/concurrent/ListenableFuture;",
-    parameters = listOf(requestBuilderType, "Ljava/util/concurrent/Executor;"),
+    parameters = listOf(playlistRequestBuilderType, "Ljava/util/concurrent/Executor;"),
     filters = listOf(
         fieldAccess(
             opcode = Opcode.IGET_OBJECT,
-            definingClass = requestBuilderType,
+            definingClass = playlistRequestBuilderType,
             type = "Ljava/lang/String;",
         ),
     ),
 )
 
-internal fun browseIdSetterFingerprint(field: FieldReference) = Fingerprint(
+internal fun setLibraryOrPlaylistIdFingerprint(field: FieldReference) = Fingerprint(
     definingClass = field.definingClass,
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "V",
@@ -175,10 +175,10 @@ internal fun browseIdSetterFingerprint(field: FieldReference) = Fingerprint(
     ),
 )
 
-// Browse responses
+// Playlist responses
 
-// Library tabs come from extension 58173949 in the FEmusic_library_landing response.
-internal object BrowseTabsFingerprint : Fingerprint(
+// Protobuf field 58173949 contains the page list returned by FEmusic_library_landing.
+internal object PlaylistResponseFingerprint : Fingerprint(
     accessFlags = listOf(
         AccessFlags.PUBLIC,
         AccessFlags.FINAL,
@@ -187,7 +187,7 @@ internal object BrowseTabsFingerprint : Fingerprint(
     returnType = "L",
     parameters = emptyList(),
     filters = listOf(
-        literal(SINGLE_COLUMN_BROWSE_RESULTS_FIELD_NUMBER),
+        literal(PAGE_LIST_FIELD_NUMBER),
         methodCall(
             definingClass = "Lj$/util/stream/Stream;",
             name = "filter",
@@ -198,33 +198,33 @@ internal object BrowseTabsFingerprint : Fingerprint(
     ),
 )
 
-internal fun browseTabMapperFingerprint(mapperType: String) = Fingerprint(
-    definingClass = mapperType,
+internal fun createPlaylistPageFingerprint(factoryType: String) = Fingerprint(
+    definingClass = factoryType,
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "Ljava/lang/Object;",
     parameters = listOf("Ljava/lang/Object;"),
     filters = listOf(
         newInstance("L"),
         literal(
-            TAB_RENDERER_FIELD_NUMBER,
+            PAGE_FIELD_NUMBER,
             location = MatchAfterWithin(3),
         ),
     ),
 )
 
-internal fun sectionListFingerprint(tabType: String) = Fingerprint(
-    definingClass = tabType,
+internal fun getPlaylistBodyFingerprint(pageType: String) = Fingerprint(
+    definingClass = pageType,
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "L",
     parameters = emptyList(),
-    filters = listOf(literal(TAB_CONTENT_PRESENT_FLAG)),
+    filters = listOf(literal(SECTIONS_PRESENT_FLAG)),
 )
 
-internal fun sectionItemsFingerprint(
-    sectionListType: String,
+internal fun playlistBodyGroupsFingerprint(
+    bodyType: String,
     returnType: String,
 ) = Fingerprint(
-    definingClass = sectionListType,
+    definingClass = bodyType,
     accessFlags = listOf(
         AccessFlags.PUBLIC,
         AccessFlags.FINAL,
@@ -234,32 +234,33 @@ internal fun sectionItemsFingerprint(
     parameters = emptyList(),
 )
 
-// Library and playlist rows
+// Playlist entries and tracks
 
-// FEmusic_library_landing playlists and loaded playlist tracks both use extension 161429595.
-internal object MusicItemExtensionFingerprint : Fingerprint(
+// Protobuf field 161429595 is shared by Library playlist entries and loaded tracks.
+internal object PlaylistOrTrackFingerprint : Fingerprint(
     name = "<clinit>",
     returnType = "V",
     parameters = emptyList(),
     filters = listOf(
         opcode(Opcode.CONST_CLASS),
         literal(
-            MUSIC_ITEM_FIELD_NUMBER,
+            PLAYLIST_OR_TRACK_FIELD_NUMBER,
             location = MatchAfterWithin(2),
         ),
     ),
 )
 
-internal object MusicReloadShelfEventFingerprint : Fingerprint(
+internal object PlaylistReloadHandlerFingerprint : Fingerprint(
     name = "handleMusicReloadShelfEvent",
     accessFlags = listOf(AccessFlags.PUBLIC),
     returnType = "V",
     parameters = listOf("L"),
 )
 
-// GridRenderer uses presence bits 0x1000 and 0x40000 for extension-161429595 rows.
-internal object GridItemsFingerprint : Fingerprint(
-    classFingerprint = MusicReloadShelfEventFingerprint,
+// The playlist reader checks presence bits 0x1000 and 0x40000 before adding rows from protobuf
+// field 161429595.
+internal object ExtractPlaylistsFingerprint : Fingerprint(
+    classFingerprint = PlaylistReloadHandlerFingerprint,
     accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.STATIC),
     returnType = "Ljava/util/List;",
     parameters = listOf("L"),
@@ -269,7 +270,7 @@ internal object GridItemsFingerprint : Fingerprint(
     ),
 )
 
-internal fun playlistItemsFingerprint(musicItemType: String) = Fingerprint(
+internal fun extractPlaylistTracksFingerprint(playlistOrTrackType: String) = Fingerprint(
     accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.STATIC),
     returnType = "Ljava/util/List;",
     parameters = listOf("L", "Z"),
@@ -277,13 +278,13 @@ internal fun playlistItemsFingerprint(musicItemType: String) = Fingerprint(
     custom = { method, _ ->
         method.instructions.any { instruction ->
             instruction.opcode == Opcode.CHECK_CAST &&
-                instruction.getReference<TypeReference>()?.type == musicItemType
+                instruction.getReference<TypeReference>()?.type == playlistOrTrackType
         }
     },
 )
 
-internal object GridDecoderFingerprint : Fingerprint(
-    classFingerprint = MusicReloadShelfEventFingerprint,
+internal object DecodeMorePlaylistsFingerprint : Fingerprint(
+    classFingerprint = PlaylistReloadHandlerFingerprint,
     accessFlags = listOf(
         AccessFlags.PROTECTED,
         AccessFlags.FINAL,
@@ -294,24 +295,24 @@ internal object GridDecoderFingerprint : Fingerprint(
     parameters = listOf("L"),
 )
 
-// Field c on playlist and track rows contains thumbnail extension 164480666.
-internal object MusicThumbnailExtensionFingerprint : Fingerprint(
+// Protobuf field 164480666 stores the thumbnail payload in field c of playlist entries and tracks.
+internal object PlaylistThumbnailFingerprint : Fingerprint(
     name = "<clinit>",
     returnType = "V",
     parameters = emptyList(),
     filters = listOf(
         opcode(Opcode.CONST_CLASS),
         literal(
-            MUSIC_THUMBNAIL_FIELD_NUMBER,
+            THUMBNAIL_FIELD_NUMBER,
             location = MatchAfterWithin(2),
         ),
     ),
 )
 
-internal fun musicThumbnailDecoderFingerprint(artworkType: String) = Fingerprint(
+internal fun decodePlaylistThumbnailFingerprint(thumbnailType: String) = Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
     returnType = "Lcom/google/protobuf/MessageLite;",
-    parameters = listOf(artworkType),
+    parameters = listOf(thumbnailType),
     filters = listOf(
         methodCall(
             definingClass = "Lcom/google/protobuf/ExtensionRegistryLite;",
@@ -322,7 +323,7 @@ internal fun musicThumbnailDecoderFingerprint(artworkType: String) = Fingerprint
     ),
 )
 
-internal fun androidAutoArtworkFingerprint(
+internal fun playlistArtworkFingerprint(
     payloadFieldTypes: Set<String>,
 ) = Fingerprint(
     filters = listOf(MEDIA_DESCRIPTION_CONSTRUCTOR_CALL),
@@ -345,36 +346,36 @@ internal fun androidAutoArtworkFingerprint(
     },
 )
 
-internal fun renderTextFingerprint(textType: String) = Fingerprint(
+internal fun formatPlaylistTextFingerprint(textType: String) = Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
     returnType = "Landroid/text/Spanned;",
     parameters = listOf(textType, "Ljava/lang/String;"),
 )
 
-internal fun browseEndpointDecoderFingerprint(
-    endpointType: String,
-    decodedEndpointType: String,
+internal fun decodePlaylistActionFingerprint(
+    actionType: String,
+    decodedActionType: String,
 ) = Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
-    returnType = decodedEndpointType,
-    parameters = listOf(endpointType),
+    returnType = decodedActionType,
+    parameters = listOf(actionType),
 )
 
-internal object EndpointMediaIdFingerprint : Fingerprint(
+internal object CreatePlaybackIdFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
     returnType = "Ljava/lang/String;",
     parameters = listOf("L"),
-    // MediaItemData.createMediaId serializes the row command as Android Auto's media ID.
-    custom = endpointMediaId@{ method, _ ->
-        val endpointType = method.parameterTypes.single().toString()
-        if (endpointType == "Ljava/lang/String;") return@endpointMediaId false
-        val endpointStores = method.instructions
+    // MediaItemData.createMediaId serializes the row's click action as Android Auto's media ID.
+    custom = createPlaybackId@{ method, _ ->
+        val actionType = method.parameterTypes.single().toString()
+        if (actionType == "Ljava/lang/String;") return@createPlaybackId false
+        val actionStores = method.instructions
             .filter { instruction -> instruction.opcode == Opcode.IPUT_OBJECT }
             .mapNotNull { instruction -> instruction.getReference<FieldReference>() }
-            .filter { field -> field.type == endpointType }
+            .filter { field -> field.type == actionType }
             .distinct()
-        val wrapperType = endpointStores.singleOrNull()?.definingClass
-            ?: return@endpointMediaId false
+        val wrapperType = actionStores.singleOrNull()?.definingClass
+            ?: return@createPlaybackId false
         method.instructions.any { instruction ->
             val reference = instruction.getReference<MethodReference>()
                 ?: return@any false
@@ -386,29 +387,29 @@ internal object EndpointMediaIdFingerprint : Fingerprint(
 
 // Playlist playback
 
-internal fun buttonRendererExtensionFingerprint(endpointType: String) = Fingerprint(
+internal fun playlistPlayButtonFingerprint(actionType: String) = Fingerprint(
     name = "<clinit>",
     returnType = "V",
     parameters = emptyList(),
-    filters = listOf(literal(BUTTON_RENDERER_EXTENSION_FIELD_NUMBER)),
-    // Extension 65153809 is ButtonRenderer in response.q and FeedbackEndpoint in a command.
+    filters = listOf(literal(PLAY_BUTTON_FIELD_NUMBER)),
+    // Protobuf field 65153809 is ButtonRenderer in response.q and FeedbackEndpoint on click actions.
     custom = { method, _ ->
         val containingType = method.instructions
             .filter { instruction -> instruction.opcode == Opcode.SGET_OBJECT }
             .mapNotNull { instruction -> instruction.getReference<FieldReference>() }
             .firstOrNull { field -> field.definingClass == field.type }
             ?.type
-        containingType != null && containingType != endpointType
+        containingType != null && containingType != actionType
     },
 )
 
-internal fun buttonRendererDecoderFingerprint(
+internal fun decodePlaylistPlayButtonFingerprint(
     containingType: String,
-    buttonRendererType: String,
+    playlistPlayButtonType: String,
     descriptorField: FieldReference,
 ) = Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
-    returnType = buttonRendererType,
+    returnType = playlistPlayButtonType,
     parameters = listOf("Z", containingType),
     filters = listOf(
         fieldAccess(
@@ -420,44 +421,44 @@ internal fun buttonRendererDecoderFingerprint(
     ),
 )
 
-internal fun buttonRendererEndpointCopyFingerprint(
-    buttonRendererType: String,
-    endpointType: String,
+internal fun playlistPlayActionFingerprint(
+    playlistPlayButtonType: String,
+    actionType: String,
 ) = Fingerprint(
     returnType = "V",
     parameters = listOf("L"),
     filters = listOf(
         fieldAccess(
             opcode = Opcode.IGET_OBJECT,
-            definingClass = buttonRendererType,
-            type = endpointType,
+            definingClass = playlistPlayButtonType,
+            type = actionType,
         ),
         fieldAccess(
             opcode = Opcode.IPUT_OBJECT,
-            type = endpointType,
+            type = actionType,
             location = MatchAfterWithin(4),
         ),
     ),
-    // The live-chat ImageButton copies its click command from ButtonRenderer.
+    // The live-chat ImageButton copies its click action from ButtonRenderer.
     custom = { method, _ ->
         val instructions = method.implementation?.instructions?.toList()
             ?: return@Fingerprint false
-        val copiedEndpointFields = instructions.mapIndexedNotNull { index, instruction ->
+        val copiedActionFields = instructions.mapIndexedNotNull { index, instruction ->
             val field = instruction.getReference<FieldReference>()
                 ?: return@mapIndexedNotNull null
             if (instruction.opcode != Opcode.IGET_OBJECT ||
-                field.definingClass != buttonRendererType || field.type != endpointType
+                field.definingClass != playlistPlayButtonType || field.type != actionType
             ) {
                 return@mapIndexedNotNull null
             }
-            val copiedToCommand = instructions.drop(index + 1).take(4).any { nearby ->
+            val copiedToAction = instructions.drop(index + 1).take(4).any { nearby ->
                 val target = nearby.getReference<FieldReference>()
                     ?: return@any false
                 nearby.opcode == Opcode.IPUT_OBJECT &&
-                    target.definingClass != buttonRendererType && target.type == endpointType
+                    target.definingClass != playlistPlayButtonType && target.type == actionType
             }
-            field.takeIf { copiedToCommand }
+            field.takeIf { copiedToAction }
         }.distinct()
-        copiedEndpointFields.size == 1
+        copiedActionFields.size == 1
     },
 )

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/Fingerprints.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches/pull/2489
+ * https://github.com/MorpheApp/morphe-patches
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/RestoreAndroidAutoPlaylistsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/RestoreAndroidAutoPlaylistsPatch.kt
@@ -771,8 +771,10 @@ private fun BytecodePatchContext.patchBrowseService(
         classDef.superclass?.let { superclass -> classDefByOrNull(superclass) }
     }.flatMap { classDef -> classDef.methods.asSequence() }
     val clickTrackingParamsSetterMethod = requestBuilderMethods
+        // YTM 9.32.51 and 9.33.52 also declare a public byte[] clickTrackingParams setter.
         .firstOrNull { method ->
-            method.returnType == "V" &&
+            AccessFlags.PROTECTED.isSet(method.accessFlags) &&
+                method.returnType == "V" &&
                 method.parameterTypes.map(CharSequence::toString) == listOf("[B")
         }
         ?: throw PatchException("Could not resolve the click tracking parameter setter")

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/RestoreAndroidAutoPlaylistsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/RestoreAndroidAutoPlaylistsPatch.kt
@@ -52,6 +52,8 @@ private const val EXTENSION_SECTION_LIST_INTERFACE =
     $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$SectionList;"
 private const val EXTENSION_PLAYLIST_GRID_INTERFACE =
     $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$PlaylistGrid;"
+private const val EXTENSION_PLAYLIST_SHELF_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$PlaylistShelf;"
 private const val EXTENSION_LOAD_CHILDREN_RESULT_INTERFACE =
     $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$LoadChildrenResult;"
 private const val EXTENSION_MUSIC_ITEM_INTERFACE =
@@ -115,6 +117,7 @@ val restoreAndroidAutoPlaylistsPatch = bytecodePatch(
             responseTabsMethod,
             gridItemsMethod,
             gridContinuationsMethod,
+            musicItemType,
             endpointMediaIdMethod,
         )
         patchMusicItem(
@@ -217,6 +220,7 @@ private fun BytecodePatchContext.patchBrowseResponses(
     responseTabsMethod: Method,
     gridItemsMethod: Method,
     gridContinuationsMethod: Method,
+    musicItemType: String,
     endpointMediaIdMethod: Method,
 ) {
     val tabMapperNewInstance = BrowseTabsFingerprint.instructionMatches.last()
@@ -236,6 +240,9 @@ private fun BytecodePatchContext.patchBrowseResponses(
         responseTabsMethod.returnType,
     ).matchAll(2..2)
         .map { match -> match.originalMethod }
+    val playlistItemsMethod = playlistItemsFingerprint(
+        musicItemType,
+    ).originalMethod
     val gridResponseMethod = GridDecoderFingerprint.originalMethod
     val responsePayloadType = gridResponseMethod
         .parameterTypes.single().toString()
@@ -245,8 +252,12 @@ private fun BytecodePatchContext.patchBrowseResponses(
         !AccessFlags.STATIC.isSet(method.accessFlags) && method.parameterTypes.isEmpty() &&
             method.returnType == responsePayloadType
     } ?: throw PatchException("Could not resolve the Browse response payload getter")
-    // The injected PlaylistGrid methods call these private YTM methods.
-    listOf(gridItemsMethod, gridContinuationsMethod).forEach { method ->
+    // The injected PlaylistGrid and PlaylistShelf methods call these private YTM methods.
+    listOf(
+        gridItemsMethod,
+        playlistItemsMethod,
+        gridContinuationsMethod,
+    ).forEach { method ->
         mutableClassDefBy(method.definingClass).findMutableMethodOf(method).apply {
             accessFlags = accessFlags.toPublicAccessFlags()
         }
@@ -262,6 +273,7 @@ private fun BytecodePatchContext.patchBrowseResponses(
     addBrowseTabInterface(sectionListMethod)
     addSectionListInterface(sectionItemMethods)
     addPlaylistGridInterface(gridItemsMethod, gridContinuationsMethod)
+    addPlaylistShelfInterface(playlistItemsMethod)
 }
 
 private fun BytecodePatchContext.addBrowseResponseInterface(
@@ -371,6 +383,27 @@ private fun BytecodePatchContext.addPlaylistGridInterface(
         registerCount = 1,
         instructions = """
             invoke-static { p0 }, $gridContinuationsMethod
+            move-result-object p0
+            return-object p0
+        """,
+    )
+}
+
+private fun BytecodePatchContext.addPlaylistShelfInterface(
+    playlistItemsMethod: Method,
+) {
+    val playlistShelfType = playlistItemsMethod.parameterTypes.first().toString()
+    val playlistShelfClass = mutableClassDefBy(playlistShelfType)
+    playlistShelfClass.interfaces.add(EXTENSION_PLAYLIST_SHELF_INTERFACE)
+    playlistShelfClass.addInterfaceMethod(
+        name = "patch_getItems",
+        parameters = emptyList(),
+        returnType = "Ljava/lang/Iterable;",
+        registerCount = 2,
+        instructions = """
+            const/4 v0, 0x0
+            # false returns extension-161429595 track rows.
+            invoke-static { p0, v0 }, $playlistItemsMethod
             move-result-object p0
             return-object p0
         """,
@@ -546,6 +579,11 @@ private fun BytecodePatchContext.patchMusicItem(
         browseIdDecoderMethod,
         browseEndpointIdField,
     )
+    musicItemClass.addMediaIdGetter(
+        firstEndpointField,
+        secondEndpointField,
+        endpointMediaIdMethod,
+    )
     musicItemClass.addTextGetter("patch_getTitle", titleField, renderTextMethod)
     musicItemClass.addTextGetter("patch_getSubtitle", subtitleField, renderTextMethod)
     musicItemClass.addArtworkUriGetter(
@@ -604,6 +642,45 @@ private fun MutableClass.addBrowseIdGetter(
 
             :use_second_id
             move-object v0, v1
+            :return_id
+            return-object v0
+        """,
+    )
+}
+
+private fun MutableClass.addMediaIdGetter(
+    firstEndpointField: FieldReference,
+    secondEndpointField: FieldReference,
+    endpointMediaIdMethod: Method,
+) {
+    addInterfaceMethod(
+        name = "patch_getMediaId",
+        parameters = emptyList(),
+        returnType = "Ljava/lang/String;",
+        registerCount = 3,
+        instructions = """
+            iget-object v0, p0, $firstEndpointField
+            if-eqz v0, :second_endpoint
+            invoke-static { v0 }, $endpointMediaIdMethod
+            move-result-object v0
+            check-cast v0, Ljava/lang/String;
+            if-eqz v0, :second_endpoint
+            invoke-virtual { v0 }, Ljava/lang/String;->isEmpty()Z
+            move-result v1
+            if-eqz v1, :return_id
+
+            :second_endpoint
+            iget-object v0, p0, $secondEndpointField
+            if-nez v0, :decode_second_endpoint
+            # ART on 9.15.51 otherwise merges this missing-action path with decoded Strings as
+            # Object.
+            const/4 v0, 0x0
+            goto :return_id
+
+            :decode_second_endpoint
+            invoke-static { v0 }, $endpointMediaIdMethod
+            move-result-object v0
+            check-cast v0, Ljava/lang/String;
             :return_id
             return-object v0
         """,
@@ -735,6 +812,7 @@ private fun BytecodePatchContext.patchBrowseService(
             return-object p1
         """,
     )
+
     return browseServiceClass
 }
 

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/RestoreAndroidAutoPlaylistsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/RestoreAndroidAutoPlaylistsPatch.kt
@@ -42,37 +42,37 @@ import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
 
 private const val EXTENSION_CLASS =
     "Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch;"
-private const val EXTENSION_BROWSE_SERVICE_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$BrowseService;"
-private const val EXTENSION_BROWSE_RESPONSE_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$BrowseResponse;"
-private const val EXTENSION_BROWSE_TAB_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$BrowseTab;"
-private const val EXTENSION_SECTION_LIST_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$SectionList;"
-private const val EXTENSION_PLAYLIST_GRID_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$PlaylistGrid;"
-private const val EXTENSION_PLAYLIST_SHELF_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$PlaylistShelf;"
-private const val EXTENSION_LOAD_CHILDREN_RESULT_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$LoadChildrenResult;"
-private const val EXTENSION_MUSIC_ITEM_INTERFACE =
-    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$MusicItem;"
+private const val EXTENSION_PLAYLIST_LOADER_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$PlaylistLoader;"
+private const val EXTENSION_PLAYLIST_RESPONSE_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$PlaylistResponse;"
+private const val EXTENSION_PLAYLIST_PAGE_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$PlaylistPage;"
+private const val EXTENSION_PLAYLIST_BODY_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$PlaylistBody;"
+private const val EXTENSION_PLAYLIST_LISTING_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$PlaylistListing;"
+private const val EXTENSION_PLAYLIST_TRACKS_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$PlaylistTracks;"
+private const val EXTENSION_ANDROID_AUTO_RESULT_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$AndroidAutoResult;"
+private const val EXTENSION_PLAYLIST_OR_TRACK_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$PlaylistOrTrack;"
 
 // move-result can only write to registers 0-255.
-private const val EIGHT_BIT_REGISTER_LIMIT = 256
+private const val MOVE_RESULT_REGISTER_LIMIT = 256
 // iget-object can only address registers 0-15.
-private const val FOUR_BIT_REGISTER_LIMIT = 16
+private const val IGET_REGISTER_LIMIT = 16
 // A MediaDescriptionCompat constructor range starts with its receiver. Media ID and title are the
 // next two registers.
-private const val MEDIA_DESCRIPTION_MEDIA_ID_REGISTER_OFFSET = 1
-private const val MEDIA_DESCRIPTION_TITLE_REGISTER_OFFSET = 2
+private const val MEDIA_ID_REGISTER_OFFSET = 1
+private const val TITLE_REGISTER_OFFSET = 2
 
-private const val MUSIC_ITEM_ARTWORK_FIELD_NAME = "c"
-private const val MUSIC_ITEM_TITLE_FIELD_NAME = "g"
-private const val MUSIC_ITEM_SUBTITLE_FIELD_NAME = "h"
-private const val PLAYLIST_BROWSE_ID_PREFIX = "VL"
-private const val BROWSE_RESPONSE_BUTTON_CONTENT_FIELD_NAME = "q"
+private const val ARTWORK_FIELD_NAME = "c"
+private const val TITLE_FIELD_NAME = "g"
+private const val SUBTITLE_FIELD_NAME = "h"
+private const val PLAYLIST_ID_PREFIX = "VL"
+private const val PLAY_BUTTON_FIELD_NAME = "q"
 private const val LISTENABLE_FUTURE_CLASS =
     "Lcom/google/common/util/concurrent/ListenableFuture;"
 
@@ -88,55 +88,56 @@ val restoreAndroidAutoPlaylistsPatch = bytecodePatch(
     execute {
         hookPlaylistCategoryId()
 
-        val endpointMediaIdMethod = EndpointMediaIdFingerprint.originalMethod
-        val responseTabsMethod = BrowseTabsFingerprint.originalMethod
-        val gridItemsMethod = GridItemsFingerprint.originalMethod
-        val gridType = gridItemsMethod.parameterTypes.single().toString()
-        val gridContinuationsMethod = classDefBy(gridItemsMethod.definingClass).methods
+        val createPlaybackIdMethod = CreatePlaybackIdFingerprint.originalMethod
+        val responsePagesMethod = PlaylistResponseFingerprint.originalMethod
+        val extractPlaylistsMethod = ExtractPlaylistsFingerprint.originalMethod
+        val playlistListingType = extractPlaylistsMethod.parameterTypes.single().toString()
+        val loadMoreActionsMethod = classDefBy(extractPlaylistsMethod.definingClass).methods
             .single { method ->
-                method != gridItemsMethod &&
+                method != extractPlaylistsMethod &&
                     AccessFlags.PRIVATE.isSet(method.accessFlags) &&
                     AccessFlags.STATIC.isSet(method.accessFlags) &&
                     method.returnType == "Ljava/util/List;" &&
-                    method.parameterTypes.map(CharSequence::toString) == listOf(gridType)
+                    method.parameterTypes.map(CharSequence::toString) ==
+                    listOf(playlistListingType)
             }
-        val musicItemType = MusicItemExtensionFingerprint
+        val playlistOrTrackType = PlaylistOrTrackFingerprint
             .instructionMatches
             .first()
             .instruction
             .getReference<TypeReference>()!!
             .type
-        val browseEndpointIdField = BrowseEndpointRequestFingerprint.instructionMatches
+        val playlistIdField = CreatePlaylistRequestFingerprint.instructionMatches
             .first()
             .instruction
             .getReference<FieldReference>()
-            ?: throw PatchException("Could not resolve the Browse endpoint ID field")
-        val browseServiceClass = patchBrowseService(gridContinuationsMethod)
+            ?: throw PatchException("Could not resolve the playlist request ID field")
+        val playlistLoaderClass = patchPlaylistLoader(loadMoreActionsMethod)
 
-        patchBrowseResponses(
-            responseTabsMethod,
-            gridItemsMethod,
-            gridContinuationsMethod,
-            musicItemType,
-            endpointMediaIdMethod,
+        patchPlaylistResponses(
+            responsePagesMethod,
+            extractPlaylistsMethod,
+            loadMoreActionsMethod,
+            playlistOrTrackType,
+            createPlaybackIdMethod,
         )
-        patchMusicItem(
-            musicItemType,
-            browseEndpointIdField,
-            endpointMediaIdMethod,
+        patchPlaylistOrTrack(
+            playlistOrTrackType,
+            playlistIdField,
+            createPlaybackIdMethod,
         )
-        val invalidParentMediaIdMethod = InvalidParentMediaIdFingerprint.originalMethod
-        patchLoadChildrenResult(invalidParentMediaIdMethod)
-        val contentSupplierType = invalidParentMediaIdMethod.definingClass
-        val loadChildrenResultType = invalidParentMediaIdMethod.parameterTypes.first().toString()
+        val playlistLoadFallbackMethod = PlaylistLoadFallbackFingerprint.originalMethod
+        patchAndroidAutoResult(playlistLoadFallbackMethod)
+        val playlistLoadHandlerType = playlistLoadFallbackMethod.definingClass
+        val androidAutoResultType = playlistLoadFallbackMethod.parameterTypes.first().toString()
 
-        hookMusicBrowserService(browseServiceClass.type, loadChildrenResultType)
-        hookLoadChildren(contentSupplierType, loadChildrenResultType)
+        hookPlaylistLoader(playlistLoaderClass.type, androidAutoResultType)
+        hookPlaylistLoad(playlistLoadHandlerType, androidAutoResultType)
     }
 }
 
 private fun BytecodePatchContext.hookPlaylistCategoryId() {
-    val method = MediaItemFactoryFingerprint.method
+    val method = PlaylistCategoryFingerprint.method
 
     // On YTM 9.15.51, Playlists comes from the MediaDescriptionCompat call with FLAG_BROWSABLE.
     method
@@ -147,9 +148,9 @@ private fun BytecodePatchContext.hookPlaylistCategoryId() {
                     index,
                 )
             val mediaIdRegister =
-                instruction.startRegister + MEDIA_DESCRIPTION_MEDIA_ID_REGISTER_OFFSET
+                instruction.startRegister + MEDIA_ID_REGISTER_OFFSET
             val titleRegister =
-                instruction.startRegister + MEDIA_DESCRIPTION_TITLE_REGISTER_OFFSET
+                instruction.startRegister + TITLE_REGISTER_OFFSET
 
             method.addInstructions(
                 index,
@@ -160,38 +161,38 @@ private fun BytecodePatchContext.hookPlaylistCategoryId() {
         }
 }
 
-private fun BytecodePatchContext.hookMusicBrowserService(
-    browseServiceType: String,
-    loadChildrenResultType: String,
+private fun BytecodePatchContext.hookPlaylistLoader(
+    playlistLoaderType: String,
+    androidAutoResultType: String,
 ) {
-    val musicBrowserServiceType = musicBrowserServiceLoadChildrenFingerprint(
-        loadChildrenResultType,
+    val musicBrowserServiceType = musicBrowserServiceFingerprint(
+        androidAutoResultType,
     ).originalMethod.definingClass
-    val browseServiceProviders = browseServiceProviderFingerprint(browseServiceType)
+    val providerMatches = playlistLoaderProviderFingerprint(playlistLoaderType)
         .matchAll()
         .map { match ->
-            val (providerFieldMatch, providerGetterMatch) = match.instructionMatches
+            val (providerFieldMatch, providerGetMatch) = match.instructionMatches
             val providerField = providerFieldMatch.instruction.getReference<FieldReference>()!!
-            val providerGetter = providerGetterMatch.instruction.getReference<MethodReference>()!!
-            providerField to providerGetter
+            val providerGetMethod = providerGetMatch.instruction.getReference<MethodReference>()!!
+            providerField to providerGetMethod
         }
         .distinctBy { (field, _) -> field }
     // During onCreate, MusicBrowserService's generated superclass reads the Dagger provider for
     // the class containing BS_GET_BROWSE_DATA.
-    val (onCreateMethod, browseServiceProvider) = browseServiceProviders.mapNotNull { provider ->
-        musicBrowserServiceOnCreateFingerprint(
+    val (onCreateMethod, providerMatch) = providerMatches.mapNotNull { provider ->
+        playlistLoaderOnCreateFingerprint(
             musicBrowserServiceType,
             provider.first.definingClass,
         ).matchOrNull()?.originalMethod?.let { method -> method to provider }
     }.singleOrNull()
-        ?: throw PatchException("Could not resolve the Browse service used by MusicBrowserService")
-    val (browseProviderField, browseProviderGetter) = browseServiceProvider
+        ?: throw PatchException("Could not resolve the playlist loader used by MusicBrowserService")
+    val (providerField, providerGetMethod) = providerMatch
     val mutableOnCreateMethod = mutableClassDefBy(
         onCreateMethod.definingClass,
     ).findMutableMethodOf(onCreateMethod)
     val componentIndex = mutableOnCreateMethod.indexOfFirstInstructionOrThrow {
         opcode == Opcode.IGET_OBJECT &&
-            getReference<FieldReference>()?.type == browseProviderField.definingClass
+            getReference<FieldReference>()?.type == providerField.definingClass
     }
     val componentRegister = mutableOnCreateMethod
         .getInstruction<TwoRegisterInstruction>(componentIndex)
@@ -200,104 +201,104 @@ private fun BytecodePatchContext.hookMusicBrowserService(
         componentIndex + 1,
         mutableOnCreateMethod.p0Register,
     )
-    if (providerRegister >= FOUR_BIT_REGISTER_LIMIT) {
+    if (providerRegister >= IGET_REGISTER_LIMIT) {
         throw PatchException("MusicBrowserService.onCreate has no free 4-bit register")
     }
 
     mutableOnCreateMethod.addInstructions(
         componentIndex + 1,
         """
-            iget-object v$providerRegister, v$componentRegister, $browseProviderField
-            invoke-interface/range { v$providerRegister .. v$providerRegister }, $browseProviderGetter
+            iget-object v$providerRegister, v$componentRegister, $providerField
+            invoke-interface/range { v$providerRegister .. v$providerRegister }, $providerGetMethod
             move-result-object v$providerRegister
-            check-cast v$providerRegister, $EXTENSION_BROWSE_SERVICE_INTERFACE
-            invoke-static/range { v$providerRegister .. v$providerRegister }, $EXTENSION_CLASS->setBrowseService($EXTENSION_BROWSE_SERVICE_INTERFACE)V
+            check-cast v$providerRegister, $EXTENSION_PLAYLIST_LOADER_INTERFACE
+            invoke-static/range { v$providerRegister .. v$providerRegister }, $EXTENSION_CLASS->setPlaylistLoader($EXTENSION_PLAYLIST_LOADER_INTERFACE)V
         """,
     )
 }
 
-private fun BytecodePatchContext.patchBrowseResponses(
-    responseTabsMethod: Method,
-    gridItemsMethod: Method,
-    gridContinuationsMethod: Method,
-    musicItemType: String,
-    endpointMediaIdMethod: Method,
+private fun BytecodePatchContext.patchPlaylistResponses(
+    responsePagesMethod: Method,
+    extractPlaylistsMethod: Method,
+    loadMoreActionsMethod: Method,
+    playlistOrTrackType: String,
+    createPlaybackIdMethod: Method,
 ) {
-    val tabMapperNewInstance = BrowseTabsFingerprint.instructionMatches.last()
-    val tabMapperType = tabMapperNewInstance
+    val pageFactoryNewInstance = PlaylistResponseFingerprint.instructionMatches.last()
+    val pageFactoryType = pageFactoryNewInstance
         .instruction
         .getReference<TypeReference>()!!
         .type
-    val tabMapper = browseTabMapperFingerprint(tabMapperType)
-    val tabNewInstance = tabMapper.instructionMatches.first()
-    val tabType = tabNewInstance
+    val pageFactory = createPlaylistPageFingerprint(pageFactoryType)
+    val pageNewInstance = pageFactory.instructionMatches.first()
+    val pageType = pageNewInstance
         .instruction
         .getReference<TypeReference>()!!
         .type
-    val sectionListMethod = sectionListFingerprint(tabType).originalMethod
-    val sectionItemMethods = sectionItemsFingerprint(
-        sectionListMethod.returnType,
-        responseTabsMethod.returnType,
+    val getBodyMethod = getPlaylistBodyFingerprint(pageType).originalMethod
+    val bodyGroupMethods = playlistBodyGroupsFingerprint(
+        getBodyMethod.returnType,
+        responsePagesMethod.returnType,
     ).matchAll(2..2)
         .map { match -> match.originalMethod }
-    val playlistItemsMethod = playlistItemsFingerprint(
-        musicItemType,
+    val extractPlaylistTracksMethod = extractPlaylistTracksFingerprint(
+        playlistOrTrackType,
     ).originalMethod
-    val gridResponseMethod = GridDecoderFingerprint.originalMethod
-    val responsePayloadType = gridResponseMethod
+    val morePlaylistsMethod = DecodeMorePlaylistsFingerprint.originalMethod
+    val responsePayloadType = morePlaylistsMethod
         .parameterTypes.single().toString()
     val responsePayloadMethod = classDefBy(
-        responseTabsMethod.definingClass,
+        responsePagesMethod.definingClass,
     ).methods.singleOrNull { method ->
         !AccessFlags.STATIC.isSet(method.accessFlags) && method.parameterTypes.isEmpty() &&
             method.returnType == responsePayloadType
-    } ?: throw PatchException("Could not resolve the Browse response payload getter")
-    // The injected PlaylistGrid and PlaylistShelf methods call these private YTM methods.
+    } ?: throw PatchException("Could not resolve the playlist response payload")
+    // PlaylistListing and PlaylistTracks call these methods from different classes.
     listOf(
-        gridItemsMethod,
-        playlistItemsMethod,
-        gridContinuationsMethod,
+        extractPlaylistsMethod,
+        extractPlaylistTracksMethod,
+        loadMoreActionsMethod,
     ).forEach { method ->
         mutableClassDefBy(method.definingClass).findMutableMethodOf(method).apply {
             accessFlags = accessFlags.toPublicAccessFlags()
         }
     }
 
-    val gridDecoder = addGridDecoder(gridResponseMethod)
-    addBrowseResponseInterface(
-        responseTabsMethod,
+    val morePlaylistsDecoder = addMorePlaylistsDecoder(morePlaylistsMethod)
+    addPlaylistResponseInterface(
+        responsePagesMethod,
         responsePayloadMethod,
-        gridDecoder,
-        endpointMediaIdMethod,
+        morePlaylistsDecoder,
+        createPlaybackIdMethod,
     )
-    addBrowseTabInterface(sectionListMethod)
-    addSectionListInterface(sectionItemMethods)
-    addPlaylistGridInterface(gridItemsMethod, gridContinuationsMethod)
-    addPlaylistShelfInterface(playlistItemsMethod)
+    addPlaylistPageInterface(getBodyMethod)
+    addPlaylistBodyInterface(bodyGroupMethods)
+    addPlaylistListingInterface(extractPlaylistsMethod, loadMoreActionsMethod)
+    addPlaylistTracksInterface(extractPlaylistTracksMethod)
 }
 
-private fun BytecodePatchContext.addBrowseResponseInterface(
-    responseTabsMethod: Method,
+private fun BytecodePatchContext.addPlaylistResponseInterface(
+    responsePagesMethod: Method,
     responsePayloadMethod: Method,
-    gridDecoder: Method,
-    endpointMediaIdMethod: Method,
+    morePlaylistsDecoder: Method,
+    createPlaybackIdMethod: Method,
 ) {
-    val responseClass = mutableClassDefBy(responseTabsMethod.definingClass)
-    responseClass.interfaces.add(EXTENSION_BROWSE_RESPONSE_INTERFACE)
-    addPlaylistMediaIdGetter(responseClass, responseTabsMethod, endpointMediaIdMethod)
+    val responseClass = mutableClassDefBy(responsePagesMethod.definingClass)
+    responseClass.interfaces.add(EXTENSION_PLAYLIST_RESPONSE_INTERFACE)
+    addPlaylistPlaybackIdGetter(responseClass, responsePagesMethod, createPlaybackIdMethod)
     responseClass.addInterfaceMethod(
-        name = "patch_getTabs",
+        name = "patch_getPages",
         parameters = emptyList(),
         returnType = "Ljava/lang/Iterable;",
         registerCount = 1,
         instructions = """
-            invoke-virtual { p0 }, $responseTabsMethod
+            invoke-virtual { p0 }, $responsePagesMethod
             move-result-object p0
             return-object p0
         """,
     )
     responseClass.addInterfaceMethod(
-        name = "patch_getContinuationGrid",
+        name = "patch_getMorePlaylists",
         parameters = emptyList(),
         returnType = "Ljava/lang/Object;",
         registerCount = 2,
@@ -306,50 +307,50 @@ private fun BytecodePatchContext.addBrowseResponseInterface(
             move-result-object p0
             # The cloned method does not read its first argument.
             const/4 v0, 0x0
-            invoke-static { v0, p0 }, $gridDecoder
+            invoke-static { v0, p0 }, $morePlaylistsDecoder
             move-result-object p0
             return-object p0
         """,
     )
 }
 
-private fun BytecodePatchContext.addBrowseTabInterface(
-    sectionListMethod: Method,
+private fun BytecodePatchContext.addPlaylistPageInterface(
+    getBodyMethod: Method,
 ) {
-    val tabClass = mutableClassDefBy(sectionListMethod.definingClass)
-    tabClass.interfaces.add(EXTENSION_BROWSE_TAB_INTERFACE)
-    tabClass.addInterfaceMethod(
-        name = "patch_getSectionList",
+    val pageClass = mutableClassDefBy(getBodyMethod.definingClass)
+    pageClass.interfaces.add(EXTENSION_PLAYLIST_PAGE_INTERFACE)
+    pageClass.addInterfaceMethod(
+        name = "patch_getBody",
         parameters = emptyList(),
         returnType = "Ljava/lang/Object;",
         registerCount = 1,
         instructions = """
-            invoke-virtual { p0 }, $sectionListMethod
+            invoke-virtual { p0 }, $getBodyMethod
             move-result-object p0
             return-object p0
         """,
     )
 }
 
-private fun BytecodePatchContext.addSectionListInterface(
-    sectionItemMethods: List<Method>,
+private fun BytecodePatchContext.addPlaylistBodyInterface(
+    bodyGroupMethods: List<Method>,
 ) {
-    val (firstItemMethod, secondItemMethod) = sectionItemMethods
-    val sectionListClass = mutableClassDefBy(firstItemMethod.definingClass)
-    sectionListClass.interfaces.add(EXTENSION_SECTION_LIST_INTERFACE)
-    sectionListClass.addInterfaceMethod(
-        name = "patch_getItemLists",
+    val (firstGroupMethod, secondGroupMethod) = bodyGroupMethods
+    val bodyClass = mutableClassDefBy(firstGroupMethod.definingClass)
+    bodyClass.interfaces.add(EXTENSION_PLAYLIST_BODY_INTERFACE)
+    bodyClass.addInterfaceMethod(
+        name = "patch_getGroups",
         parameters = emptyList(),
         returnType = "[Ljava/lang/Iterable;",
         registerCount = 4,
         instructions = """
             const/4 v0, 0x2
             new-array v0, v0, [Ljava/lang/Iterable;
-            invoke-virtual { p0 }, $firstItemMethod
+            invoke-virtual { p0 }, $firstGroupMethod
             move-result-object v1
             const/4 v2, 0x0
             aput-object v1, v0, v2
-            invoke-virtual { p0 }, $secondItemMethod
+            invoke-virtual { p0 }, $secondGroupMethod
             move-result-object v1
             const/4 v2, 0x1
             aput-object v1, v0, v2
@@ -358,141 +359,143 @@ private fun BytecodePatchContext.addSectionListInterface(
     )
 }
 
-private fun BytecodePatchContext.addPlaylistGridInterface(
-    gridItemsMethod: Method,
-    gridContinuationsMethod: Method,
+private fun BytecodePatchContext.addPlaylistListingInterface(
+    extractPlaylistsMethod: Method,
+    loadMoreActionsMethod: Method,
 ) {
-    val gridType = gridItemsMethod.parameterTypes.single().toString()
-    val gridClass = mutableClassDefBy(gridType)
-    gridClass.interfaces.add(EXTENSION_PLAYLIST_GRID_INTERFACE)
-    gridClass.addInterfaceMethod(
-        name = "patch_getItems",
+    val playlistListingType = extractPlaylistsMethod.parameterTypes.single().toString()
+    val playlistListingClass = mutableClassDefBy(playlistListingType)
+    playlistListingClass.interfaces.add(EXTENSION_PLAYLIST_LISTING_INTERFACE)
+    playlistListingClass.addInterfaceMethod(
+        name = "patch_getPlaylists",
         parameters = emptyList(),
         returnType = "Ljava/lang/Iterable;",
         registerCount = 1,
         instructions = """
-            invoke-static { p0 }, $gridItemsMethod
+            invoke-static { p0 }, $extractPlaylistsMethod
             move-result-object p0
             return-object p0
         """,
     )
-    gridClass.addInterfaceMethod(
-        name = "patch_getContinuations",
+    playlistListingClass.addInterfaceMethod(
+        name = "patch_getLoadMoreActions",
         parameters = emptyList(),
         returnType = "Ljava/lang/Iterable;",
         registerCount = 1,
         instructions = """
-            invoke-static { p0 }, $gridContinuationsMethod
+            invoke-static { p0 }, $loadMoreActionsMethod
             move-result-object p0
             return-object p0
         """,
     )
 }
 
-private fun BytecodePatchContext.addPlaylistShelfInterface(
-    playlistItemsMethod: Method,
+private fun BytecodePatchContext.addPlaylistTracksInterface(
+    extractPlaylistTracksMethod: Method,
 ) {
-    val playlistShelfType = playlistItemsMethod.parameterTypes.first().toString()
-    val playlistShelfClass = mutableClassDefBy(playlistShelfType)
-    playlistShelfClass.interfaces.add(EXTENSION_PLAYLIST_SHELF_INTERFACE)
-    playlistShelfClass.addInterfaceMethod(
-        name = "patch_getItems",
+    val playlistTracksType = extractPlaylistTracksMethod.parameterTypes.first().toString()
+    val playlistTracksClass = mutableClassDefBy(playlistTracksType)
+    playlistTracksClass.interfaces.add(EXTENSION_PLAYLIST_TRACKS_INTERFACE)
+    playlistTracksClass.addInterfaceMethod(
+        name = "patch_getTracks",
         parameters = emptyList(),
         returnType = "Ljava/lang/Iterable;",
         registerCount = 2,
         instructions = """
             const/4 v0, 0x0
-            # false returns extension-161429595 track rows.
-            invoke-static { p0, v0 }, $playlistItemsMethod
+            # false returns tracks from protobuf field 161429595.
+            invoke-static { p0, v0 }, $extractPlaylistTracksMethod
             move-result-object p0
             return-object p0
         """,
     )
 }
 
-private fun BytecodePatchContext.addPlaylistMediaIdGetter(
+private fun BytecodePatchContext.addPlaylistPlaybackIdGetter(
     responseClass: MutableClass,
-    responseTabsMethod: Method,
-    endpointMediaIdMethod: Method,
+    responsePagesMethod: Method,
+    createPlaybackIdMethod: Method,
 ) {
-    val endpointType = endpointMediaIdMethod.parameterTypes.single().toString()
-    val initializerMethod = buttonRendererExtensionFingerprint(endpointType).originalMethod
-    val buttonRendererType = initializerMethod.instructions
+    val playActionType = createPlaybackIdMethod.parameterTypes.single().toString()
+    val playlistPlayButtonInitializerMethod = playlistPlayButtonFingerprint(
+        playActionType,
+    ).originalMethod
+    val playlistPlayButtonType = playlistPlayButtonInitializerMethod.instructions
         .first { instruction -> instruction.opcode == Opcode.CONST_CLASS }
         .getReference<TypeReference>()!!
         .type
-    val containingType = initializerMethod.instructions
+    val containingType = playlistPlayButtonInitializerMethod.instructions
         .asSequence()
         .filter { instruction -> instruction.opcode == Opcode.SGET_OBJECT }
         .mapNotNull { instruction -> instruction.getReference<FieldReference>() }
         .first { field -> field.definingClass == field.type }
         .type
-    val descriptorField = initializerMethod.instructions
+    val descriptorField = playlistPlayButtonInitializerMethod.instructions
         .first { instruction -> instruction.opcode == Opcode.SPUT_OBJECT }
         .getReference<FieldReference>()!!
-    val buttonRendererDecoderMethod = buttonRendererDecoderFingerprint(
+    val decodePlaylistPlayButtonMethod = decodePlaylistPlayButtonFingerprint(
         containingType,
-        buttonRendererType,
+        playlistPlayButtonType,
         descriptorField,
     ).originalMethod
-    val commandEndpointField = buttonRendererEndpointCopyFingerprint(
-        buttonRendererType,
-        endpointType,
+    val playlistPlayActionField = playlistPlayActionFingerprint(
+        playlistPlayButtonType,
+        playActionType,
     ).matchAll()
         .map { match ->
-            val (playEndpointReadMatch, _) = match.instructionMatches
-            playEndpointReadMatch.instruction.getReference<FieldReference>()!!
+            val (playActionReadMatch, _) = match.instructionMatches
+            playActionReadMatch.instruction.getReference<FieldReference>()!!
         }
         .distinct()
         .singleOrNull()
-        ?: throw PatchException("Could not resolve the ButtonRenderer command endpoint")
+        ?: throw PatchException("Could not resolve the playlist Play action")
 
-    val responsePayloadField = responseTabsMethod.instructions
+    val responsePayloadField = responsePagesMethod.instructions
         .asSequence()
         .filter { instruction -> instruction.opcode == Opcode.IGET_OBJECT }
         .mapNotNull { instruction -> instruction.getReference<FieldReference>() }
         .filter { field ->
-            field.definingClass == responseTabsMethod.definingClass &&
-                field.type != responseTabsMethod.returnType
+            field.definingClass == responsePagesMethod.definingClass &&
+                field.type != responsePagesMethod.returnType
         }
         .distinct()
         .singleOrNull()
-        ?: throw PatchException("Could not resolve the Browse response payload field")
-    val buttonContentField = classDefBy(responsePayloadField.type).fields.singleOrNull { field ->
+        ?: throw PatchException("Could not resolve the playlist response payload field")
+    val playButtonField = classDefBy(responsePayloadField.type).fields.singleOrNull { field ->
         !AccessFlags.STATIC.isSet(field.accessFlags) &&
-            field.name == BROWSE_RESPONSE_BUTTON_CONTENT_FIELD_NAME &&
+            field.name == PLAY_BUTTON_FIELD_NAME &&
             field.type == containingType
-    } ?: throw PatchException("Could not resolve the playlist ButtonRenderer content field")
+    } ?: throw PatchException("Could not resolve the playlist Play button field")
 
-    // response.q stores the playlist Play command in ButtonRenderer extension 65153809.
+    // response.q stores the playlist Play button in protobuf field 65153809.
     responseClass.addInterfaceMethod(
-        name = "patch_getPlaylistMediaId",
+        name = "patch_getPlaybackId",
         parameters = emptyList(),
         returnType = "Ljava/lang/String;",
         registerCount = 2,
         instructions = """
             iget-object p0, p0, $responsePayloadField
-            iget-object p0, p0, $buttonContentField
+            iget-object p0, p0, $playButtonField
             # true returns the Play ButtonRenderer or null.
             const/4 v0, 0x1
-            invoke-static { v0, p0 }, $buttonRendererDecoderMethod
+            invoke-static { v0, p0 }, $decodePlaylistPlayButtonMethod
             move-result-object p0
-            if-eqz p0, :no_play_endpoint
-            iget-object p0, p0, $commandEndpointField
-            if-eqz p0, :no_play_endpoint
-            invoke-static { p0 }, $endpointMediaIdMethod
+            if-eqz p0, :no_play_button
+            iget-object p0, p0, $playlistPlayActionField
+            if-eqz p0, :no_play_button
+            invoke-static { p0 }, $createPlaybackIdMethod
             move-result-object p0
             return-object p0
-            :no_play_endpoint
+            :no_play_button
             const/4 p0, 0x0
             return-object p0
         """,
     )
 }
 
-private fun BytecodePatchContext.addGridDecoder(method: Method): Method {
+private fun BytecodePatchContext.addMorePlaylistsDecoder(method: Method): Method {
     val decoder = method.cloneMutable(
-        name = "patch_decodeGrid",
+        name = "patch_decodeMorePlaylists",
         accessFlags = AccessFlags.PUBLIC.value or AccessFlags.STATIC.value,
         // The original method clears its receiver register before reading the response from p1.
         // The added first parameter keeps that register layout in the static clone.
@@ -504,132 +507,132 @@ private fun BytecodePatchContext.addGridDecoder(method: Method): Method {
     return decoder
 }
 
-private fun BytecodePatchContext.patchMusicItem(
-    musicItemType: String,
-    browseEndpointIdField: FieldReference,
-    endpointMediaIdMethod: Method,
+private fun BytecodePatchContext.patchPlaylistOrTrack(
+    playlistOrTrackType: String,
+    playlistIdField: FieldReference,
+    createPlaybackIdMethod: Method,
 ) {
-    val musicItemFields = classDefBy(musicItemType).fields.toList()
+    val playlistOrTrackFields = classDefBy(playlistOrTrackType).fields.toList()
 
-    fun musicItemField(name: String) = musicItemFields
+    fun playlistOrTrackField(name: String) = playlistOrTrackFields
         .first { field ->
             !AccessFlags.STATIC.isSet(field.accessFlags) && field.name == name
         }
 
-    val artworkField = musicItemField(MUSIC_ITEM_ARTWORK_FIELD_NAME)
-    val titleField = musicItemField(MUSIC_ITEM_TITLE_FIELD_NAME)
-    val subtitleField = musicItemField(MUSIC_ITEM_SUBTITLE_FIELD_NAME)
+    val artworkField = playlistOrTrackField(ARTWORK_FIELD_NAME)
+    val titleField = playlistOrTrackField(TITLE_FIELD_NAME)
+    val subtitleField = playlistOrTrackField(SUBTITLE_FIELD_NAME)
     if (artworkField.type == titleField.type || titleField.type != subtitleField.type) {
-        throw PatchException("Unexpected music item artwork, title, or subtitle fields")
+        throw PatchException("Unexpected playlist/track artwork, title, or subtitle fields")
     }
-    val artworkPayloadType = MusicThumbnailExtensionFingerprint.originalMethod.instructions
+    val playlistThumbnailPayloadType = PlaylistThumbnailFingerprint.originalMethod.instructions
         .first { instruction -> instruction.opcode == Opcode.CONST_CLASS }
         .getReference<TypeReference>()!!
         .type
-    val artworkPayloadFields = classDefBy(artworkPayloadType).fields
+    val playlistThumbnailPayloadFields = classDefBy(playlistThumbnailPayloadType).fields
         .filter { field -> !AccessFlags.STATIC.isSet(field.accessFlags) }
         .toList()
-    val artworkDecoderMethod = musicThumbnailDecoderFingerprint(
+    val decodePlaylistThumbnailMethod = decodePlaylistThumbnailFingerprint(
         artworkField.type,
     ).originalMethod
-    val artworkMethod = androidAutoArtworkFingerprint(
-        artworkPayloadFields.map(FieldReference::getType).toSet(),
+    val artworkCallsiteMethod = playlistArtworkFingerprint(
+        playlistThumbnailPayloadFields.map(FieldReference::getType).toSet(),
     ).originalMethod
-    val artworkReadTypes = artworkMethod.instructions
+    val artworkReadTypes = artworkCallsiteMethod.instructions
         .filter { instruction -> instruction.opcode == Opcode.IGET_OBJECT }
         .mapNotNull { instruction -> instruction.getReference<FieldReference>()?.type }
         .toSet()
-    val artworkUriMethod = artworkMethod.instructions
+    val artworkUriMethod = artworkCallsiteMethod.instructions
         .mapNotNull { instruction -> instruction.getReference<MethodReference>() }
         .filter { method ->
             method.returnType == "Landroid/net/Uri;" && method.parameterTypes.size == 1 &&
                 method.parameterTypes.single().toString() in artworkReadTypes
         }
         .singleOrNull { method ->
-            artworkPayloadFields.any { field ->
+            playlistThumbnailPayloadFields.any { field ->
                 field.type == method.parameterTypes.single().toString()
             }
         }
         ?: throw PatchException("Could not resolve the Android Auto artwork Uri helper")
-    val artworkPayloadField = artworkPayloadFields.singleOrNull { field ->
+    val playlistThumbnailPayloadField = playlistThumbnailPayloadFields.singleOrNull { field ->
         field.type == artworkUriMethod.parameterTypes.single().toString()
     } ?: throw PatchException("Could not resolve the artwork payload field")
-    val renderTextMethod = renderTextFingerprint(titleField.type).originalMethod
+    val formatPlaylistTextMethod = formatPlaylistTextFingerprint(titleField.type).originalMethod
 
-    val endpointType = endpointMediaIdMethod.parameterTypes.single().toString()
-    val endpointFields = musicItemFields
+    val actionType = createPlaybackIdMethod.parameterTypes.single().toString()
+    val actionFields = playlistOrTrackFields
         .filter { field ->
-            !AccessFlags.STATIC.isSet(field.accessFlags) && field.type == endpointType
+            !AccessFlags.STATIC.isSet(field.accessFlags) && field.type == actionType
+        }
+    if (actionFields.size != 2) {
+        throw PatchException("Could not resolve the two playlist/track click actions")
     }
-    if (endpointFields.size != 2) {
-        throw PatchException("Could not resolve the two music row endpoints")
-    }
-    val (firstEndpointField, secondEndpointField) = endpointFields
+    val (firstActionField, secondActionField) = actionFields
 
-    val browseIdDecoderMethod = browseEndpointDecoderFingerprint(
-        endpointType,
-        browseEndpointIdField.definingClass,
+    val decodePlaylistActionMethod = decodePlaylistActionFingerprint(
+        actionType,
+        playlistIdField.definingClass,
     ).originalMethod
 
-    val musicItemClass = mutableClassDefBy(musicItemType)
-    musicItemClass.interfaces.add(EXTENSION_MUSIC_ITEM_INTERFACE)
-    musicItemClass.addBrowseIdGetter(
-        firstEndpointField,
-        secondEndpointField,
-        browseIdDecoderMethod,
-        browseEndpointIdField,
+    val playlistOrTrackClass = mutableClassDefBy(playlistOrTrackType)
+    playlistOrTrackClass.interfaces.add(EXTENSION_PLAYLIST_OR_TRACK_INTERFACE)
+    playlistOrTrackClass.addPlaylistIdGetter(
+        firstActionField,
+        secondActionField,
+        decodePlaylistActionMethod,
+        playlistIdField,
     )
-    musicItemClass.addMediaIdGetter(
-        firstEndpointField,
-        secondEndpointField,
-        endpointMediaIdMethod,
+    playlistOrTrackClass.addPlaybackIdGetter(
+        firstActionField,
+        secondActionField,
+        createPlaybackIdMethod,
     )
-    musicItemClass.addTextGetter("patch_getTitle", titleField, renderTextMethod)
-    musicItemClass.addTextGetter("patch_getSubtitle", subtitleField, renderTextMethod)
-    musicItemClass.addArtworkUriGetter(
+    playlistOrTrackClass.addTextGetter("patch_getTitle", titleField, formatPlaylistTextMethod)
+    playlistOrTrackClass.addTextGetter("patch_getSubtitle", subtitleField, formatPlaylistTextMethod)
+    playlistOrTrackClass.addArtworkUriGetter(
         artworkField,
-        artworkDecoderMethod,
-        artworkPayloadField,
+        decodePlaylistThumbnailMethod,
+        playlistThumbnailPayloadField,
         artworkUriMethod,
     )
 }
 
-// Fields i and k can both contain Browse endpoints; conflicting VL IDs are ignored.
-private fun MutableClass.addBrowseIdGetter(
-    firstEndpointField: FieldReference,
-    secondEndpointField: FieldReference,
-    browseIdDecoderMethod: Method,
-    browseEndpointIdField: FieldReference,
+// Fields i and k can both contain click actions; conflicting VL playlist IDs are ignored.
+private fun MutableClass.addPlaylistIdGetter(
+    firstActionField: FieldReference,
+    secondActionField: FieldReference,
+    decodePlaylistActionMethod: Method,
+    playlistIdField: FieldReference,
 ) {
     addInterfaceMethod(
-        name = "patch_getBrowseId",
+        name = "patch_getPlaylistId",
         parameters = emptyList(),
         returnType = "Ljava/lang/String;",
         registerCount = 4,
         instructions = """
             const/4 v0, 0x0
-            iget-object v1, p0, $firstEndpointField
-            if-eqz v1, :second_endpoint
-            invoke-static { v1 }, $browseIdDecoderMethod
+            iget-object v1, p0, $firstActionField
+            if-eqz v1, :second_action
+            invoke-static { v1 }, $decodePlaylistActionMethod
             move-result-object v1
-            if-eqz v1, :second_endpoint
-            iget-object v1, v1, $browseEndpointIdField
-            if-eqz v1, :second_endpoint
-            const-string v2, "$PLAYLIST_BROWSE_ID_PREFIX"
+            if-eqz v1, :second_action
+            iget-object v1, v1, $playlistIdField
+            if-eqz v1, :second_action
+            const-string v2, "$PLAYLIST_ID_PREFIX"
             invoke-virtual { v1, v2 }, Ljava/lang/String;->startsWith(Ljava/lang/String;)Z
             move-result v2
-            if-eqz v2, :second_endpoint
+            if-eqz v2, :second_action
             move-object v0, v1
 
-            :second_endpoint
-            iget-object v1, p0, $secondEndpointField
+            :second_action
+            iget-object v1, p0, $secondActionField
             if-eqz v1, :return_id
-            invoke-static { v1 }, $browseIdDecoderMethod
+            invoke-static { v1 }, $decodePlaylistActionMethod
             move-result-object v1
             if-eqz v1, :return_id
-            iget-object v1, v1, $browseEndpointIdField
+            iget-object v1, v1, $playlistIdField
             if-eqz v1, :return_id
-            const-string v2, "$PLAYLIST_BROWSE_ID_PREFIX"
+            const-string v2, "$PLAYLIST_ID_PREFIX"
             invoke-virtual { v1, v2 }, Ljava/lang/String;->startsWith(Ljava/lang/String;)Z
             move-result v2
             if-eqz v2, :return_id
@@ -648,37 +651,37 @@ private fun MutableClass.addBrowseIdGetter(
     )
 }
 
-private fun MutableClass.addMediaIdGetter(
-    firstEndpointField: FieldReference,
-    secondEndpointField: FieldReference,
-    endpointMediaIdMethod: Method,
+private fun MutableClass.addPlaybackIdGetter(
+    firstActionField: FieldReference,
+    secondActionField: FieldReference,
+    createPlaybackIdMethod: Method,
 ) {
     addInterfaceMethod(
-        name = "patch_getMediaId",
+        name = "patch_getPlaybackId",
         parameters = emptyList(),
         returnType = "Ljava/lang/String;",
         registerCount = 3,
         instructions = """
-            iget-object v0, p0, $firstEndpointField
-            if-eqz v0, :second_endpoint
-            invoke-static { v0 }, $endpointMediaIdMethod
+            iget-object v0, p0, $firstActionField
+            if-eqz v0, :second_action
+            invoke-static { v0 }, $createPlaybackIdMethod
             move-result-object v0
             check-cast v0, Ljava/lang/String;
-            if-eqz v0, :second_endpoint
+            if-eqz v0, :second_action
             invoke-virtual { v0 }, Ljava/lang/String;->isEmpty()Z
             move-result v1
             if-eqz v1, :return_id
 
-            :second_endpoint
-            iget-object v0, p0, $secondEndpointField
-            if-nez v0, :decode_second_endpoint
+            :second_action
+            iget-object v0, p0, $secondActionField
+            if-nez v0, :decode_second_action
             # ART on 9.15.51 otherwise merges this missing-action path with decoded Strings as
             # Object.
             const/4 v0, 0x0
             goto :return_id
 
-            :decode_second_endpoint
-            invoke-static { v0 }, $endpointMediaIdMethod
+            :decode_second_action
+            invoke-static { v0 }, $createPlaybackIdMethod
             move-result-object v0
             check-cast v0, Ljava/lang/String;
             :return_id
@@ -690,7 +693,7 @@ private fun MutableClass.addMediaIdGetter(
 private fun MutableClass.addTextGetter(
     name: String,
     field: FieldReference,
-    renderTextMethod: Method,
+    formatTextMethod: Method,
 ) {
     addInterfaceMethod(
         name = name,
@@ -701,7 +704,7 @@ private fun MutableClass.addTextGetter(
             iget-object v0, p0, $field
             # The second argument is optional text-to-speech content.
             const/4 v1, 0x0
-            invoke-static { v0, v1 }, $renderTextMethod
+            invoke-static { v0, v1 }, $formatTextMethod
             move-result-object v0
             return-object v0
         """,
@@ -710,8 +713,8 @@ private fun MutableClass.addTextGetter(
 
 private fun MutableClass.addArtworkUriGetter(
     artworkField: FieldReference,
-    artworkDecoderMethod: Method,
-    artworkPayloadField: FieldReference,
+    decodeThumbnailMethod: Method,
+    thumbnailPayloadField: FieldReference,
     artworkUriMethod: MethodReference,
 ) {
     addInterfaceMethod(
@@ -722,11 +725,11 @@ private fun MutableClass.addArtworkUriGetter(
         instructions = """
             iget-object v0, p0, $artworkField
             if-eqz v0, :no_artwork
-            invoke-static { v0 }, $artworkDecoderMethod
+            invoke-static { v0 }, $decodeThumbnailMethod
             move-result-object v0
             if-eqz v0, :no_artwork
-            check-cast v0, ${artworkPayloadField.definingClass}
-            iget-object v0, v0, $artworkPayloadField
+            check-cast v0, ${thumbnailPayloadField.definingClass}
+            iget-object v0, v0, $thumbnailPayloadField
             invoke-static { v0 }, $artworkUriMethod
             move-result-object v0
             return-object v0
@@ -737,40 +740,45 @@ private fun MutableClass.addArtworkUriGetter(
     )
 }
 
-private fun BytecodePatchContext.patchBrowseService(
-    gridContinuationsMethod: Method,
+private fun BytecodePatchContext.patchPlaylistLoader(
+    loadMoreActionsMethod: Method,
 ): MutableClass {
-    val endpointRequestMethod = BrowseEndpointRequestFingerprint.originalMethod
-    val requestBuilderType = endpointRequestMethod.returnType
-    val requestBuilderFactoryMethod = endpointRequestMethod.instructions.asSequence()
+    val createPlaylistRequestMethod = CreatePlaylistRequestFingerprint.originalMethod
+    val playlistRequestBuilderType = createPlaylistRequestMethod.returnType
+    val playlistRequestFactoryMethod = createPlaylistRequestMethod.instructions.asSequence()
         .mapNotNull { instruction -> instruction.getReference<MethodReference>() }
         .firstOrNull { reference ->
-            reference.parameterTypes.isEmpty() && reference.returnType == requestBuilderType
+            reference.parameterTypes.isEmpty() &&
+                reference.returnType == playlistRequestBuilderType
         }
-        ?: throw PatchException("Could not resolve the Browse request factory")
-    val browseServiceType = requestBuilderFactoryMethod.definingClass
-    val continuationTypes = gridContinuationsMethod.instructions.asSequence()
+        ?: throw PatchException("Could not resolve the playlist request factory")
+    val playlistLoaderType = playlistRequestFactoryMethod.definingClass
+    val loadMoreActionTypes = loadMoreActionsMethod.instructions.asSequence()
         .mapNotNull { instruction -> instruction.getReference<MethodReference>() }
         .map { reference -> reference.returnType }
         .toSet()
-    val continuationBuilderMethod = classDefBy(browseServiceType).methods.singleOrNull { method ->
-        method.returnType == requestBuilderType &&
-            method.parameterTypes.singleOrNull()?.toString() in continuationTypes
+    val createLoadMoreRequestMethod = classDefBy(
+        playlistLoaderType,
+    ).methods.singleOrNull { method ->
+        method.returnType == playlistRequestBuilderType &&
+            method.parameterTypes.singleOrNull()?.toString() in loadMoreActionTypes
     }
-        ?: throw PatchException("Could not resolve the continuation request factory")
-    val requestFingerprint = browseRequestFingerprint(
-        browseServiceType,
-        requestBuilderType,
+        ?: throw PatchException("Could not resolve the load-more request factory")
+    val playlistRequestFingerprint = sendPlaylistRequestFingerprint(
+        playlistLoaderType,
+        playlistRequestBuilderType,
     )
-    val browseRequestMethod = requestFingerprint.originalMethod
-    val requestBrowseIdField = requestFingerprint.instructionMatches.single()
+    val sendPlaylistRequestMethod = playlistRequestFingerprint.originalMethod
+    val libraryOrPlaylistIdField = playlistRequestFingerprint.instructionMatches.single()
         .instruction
         .getReference<FieldReference>()!!
 
-    val requestBuilderMethods = generateSequence(classDefBy(requestBuilderType)) { classDef ->
+    val playlistRequestBuilderMethods = generateSequence(
+        classDefBy(playlistRequestBuilderType),
+    ) { classDef ->
         classDef.superclass?.let { superclass -> classDefByOrNull(superclass) }
     }.flatMap { classDef -> classDef.methods.asSequence() }
-    val clickTrackingParamsSetterMethod = requestBuilderMethods
+    val clickTrackingParamsSetterMethod = playlistRequestBuilderMethods
         // YTM 9.32.51 and 9.33.52 also declare a public byte[] clickTrackingParams setter.
         .firstOrNull { method ->
             AccessFlags.PROTECTED.isSet(method.accessFlags) &&
@@ -778,69 +786,72 @@ private fun BytecodePatchContext.patchBrowseService(
                 method.parameterTypes.map(CharSequence::toString) == listOf("[B")
         }
         ?: throw PatchException("Could not resolve the click tracking parameter setter")
-    val browseIdSetterMethod = browseIdSetterFingerprint(requestBrowseIdField).originalMethod
-    val browseServiceClass = mutableClassDefBy(browseServiceType)
-    browseServiceClass.interfaces.add(EXTENSION_BROWSE_SERVICE_INTERFACE)
-    browseServiceClass.addInterfaceMethod(
-        name = "patch_requestBrowse",
+    val setLibraryOrPlaylistIdMethod = setLibraryOrPlaylistIdFingerprint(
+        libraryOrPlaylistIdField,
+    ).originalMethod
+    val playlistLoaderClass = mutableClassDefBy(playlistLoaderType)
+    playlistLoaderClass.interfaces.add(EXTENSION_PLAYLIST_LOADER_INTERFACE)
+    playlistLoaderClass.addInterfaceMethod(
+        name = "patch_requestPage",
         parameters = listOf("Ljava/lang/String;", "Ljava/util/concurrent/Executor;"),
         returnType = LISTENABLE_FUTURE_CLASS,
         registerCount = 5,
         instructions = """
-            invoke-virtual { p0 }, $requestBuilderFactoryMethod
+            invoke-virtual { p0 }, $playlistRequestFactoryMethod
             move-result-object v0
-            invoke-virtual { v0, p1 }, $browseIdSetterMethod
-            # Browse requests require clickTrackingParams, even when it is empty.
+            invoke-virtual { v0, p1 }, $setLibraryOrPlaylistIdMethod
+            # Playlist requests require clickTrackingParams, even when it is empty.
             const/4 v1, 0x0
             new-array v1, v1, [B
             invoke-virtual { v0, v1 }, $clickTrackingParamsSetterMethod
-            invoke-virtual { p0, v0, p2 }, $browseRequestMethod
+            invoke-virtual { p0, v0, p2 }, $sendPlaylistRequestMethod
             move-result-object v0
             return-object v0
         """,
     )
-    val continuationType = continuationBuilderMethod.parameterTypes.single().toString()
-    browseServiceClass.addInterfaceMethod(
-        name = "patch_requestContinuation",
+    val loadMoreActionType = createLoadMoreRequestMethod
+        .parameterTypes.single().toString()
+    playlistLoaderClass.addInterfaceMethod(
+        name = "patch_requestMorePlaylists",
         parameters = listOf("Ljava/lang/Object;", "Ljava/util/concurrent/Executor;"),
         returnType = LISTENABLE_FUTURE_CLASS,
         registerCount = 3,
         instructions = """
-            check-cast p1, $continuationType
-            invoke-virtual { p0, p1 }, $continuationBuilderMethod
+            check-cast p1, $loadMoreActionType
+            invoke-virtual { p0, p1 }, $createLoadMoreRequestMethod
             move-result-object p1
-            invoke-virtual { p0, p1, p2 }, $browseRequestMethod
+            invoke-virtual { p0, p1, p2 }, $sendPlaylistRequestMethod
             move-result-object p1
             return-object p1
         """,
     )
 
-    return browseServiceClass
+    return playlistLoaderClass
 }
 
-private fun BytecodePatchContext.patchLoadChildrenResult(
-    invalidParentMediaIdMethod: Method,
+private fun BytecodePatchContext.patchAndroidAutoResult(
+    playlistLoadFallbackMethod: Method,
 ) {
-    val loadChildrenResultType = invalidParentMediaIdMethod.parameterTypes.first().toString()
-    val loadChildrenResultClass = mutableClassDefBy(loadChildrenResultType)
-    loadChildrenResultClass.interfaces.add(EXTENSION_LOAD_CHILDREN_RESULT_INTERFACE)
+    val androidAutoResultType = playlistLoadFallbackMethod.parameterTypes.first().toString()
+    val androidAutoResultClass = mutableClassDefBy(androidAutoResultType)
+    androidAutoResultClass.interfaces.add(EXTENSION_ANDROID_AUTO_RESULT_INTERFACE)
     // LoadChildrenResult.toString() labels the String read by the invalid-ID branch as parentMediaId.
-    val parentMediaIdFieldPath = invalidParentMediaIdMethod.instructions.asSequence()
+    val parentMediaIdFieldPath = playlistLoadFallbackMethod.instructions.asSequence()
         .filter { instruction -> instruction.opcode == Opcode.IGET_OBJECT }
         .mapNotNull { instruction -> instruction.getReference<FieldReference>() }
         .windowed(2)
         .first { (resultField, parentMediaIdField) ->
-            resultField.definingClass == loadChildrenResultType &&
+            resultField.definingClass == androidAutoResultType &&
                 parentMediaIdField.definingClass == resultField.type &&
                 parentMediaIdField.type == "Ljava/lang/String;"
         }
 
     // YTM 9.15.51's invalid-ID path calls b(List), which forwards to c(List, null).
-    val resultDeliveryMethod = invalidParentMediaIdMethod.instructions.asSequence()
+    val resultDeliveryMethod = playlistLoadFallbackMethod.instructions.asSequence()
         .mapNotNull { instruction -> instruction.getReference<MethodReference>() }
         .first { reference ->
             val parameters = reference.parameterTypes.map(CharSequence::toString)
-            reference.definingClass == loadChildrenResultType && reference.returnType == "V" &&
+            reference.definingClass == androidAutoResultType && reference.returnType == "V" &&
                 parameters.size in 1..2 &&
                 parameters.firstOrNull() == "Ljava/util/List;" &&
                 parameters.drop(1).all { it.startsWith("L") || it.startsWith("[") }
@@ -852,7 +863,7 @@ private fun BytecodePatchContext.patchLoadChildrenResult(
         }
         append("return-object p0")
     }
-    loadChildrenResultClass.addInterfaceMethod(
+    androidAutoResultClass.addInterfaceMethod(
         name = "patch_getParentMediaId",
         parameters = emptyList(),
         returnType = "Ljava/lang/String;",
@@ -860,7 +871,7 @@ private fun BytecodePatchContext.patchLoadChildrenResult(
         instructions = parentMediaIdInstructions,
     )
     val hasExtraDeliveryParameter = resultDeliveryMethod.parameterTypes.size == 2
-    loadChildrenResultClass.addInterfaceMethod(
+    androidAutoResultClass.addInterfaceMethod(
         name = "patch_sendResult",
         parameters = listOf("Ljava/util/List;"),
         returnType = "V",
@@ -903,27 +914,27 @@ private fun MutableClass.addInterfaceMethod(
     )
 }
 
-private fun BytecodePatchContext.hookLoadChildren(
-    contentSupplierType: String,
-    loadChildrenResultType: String,
+private fun BytecodePatchContext.hookPlaylistLoad(
+    playlistLoadHandlerType: String,
+    androidAutoResultType: String,
 ) {
-    val loadChildrenMethod = contentSupplierLoadChildrenFingerprint(
-        contentSupplierType,
-        loadChildrenResultType,
+    val playlistLoadHandlerMethod = playlistLoadHandlerFingerprint(
+        playlistLoadHandlerType,
+        androidAutoResultType,
     ).method
-    val handledRegister = loadChildrenMethod.findFreeRegister(0)
-    if (handledRegister >= EIGHT_BIT_REGISTER_LIMIT) {
-        throw PatchException("ContentSupplier load-children method has no free 8-bit register")
+    val handledRegister = playlistLoadHandlerMethod.findFreeRegister(0)
+    if (handledRegister >= MOVE_RESULT_REGISTER_LIMIT) {
+        throw PatchException("Playlist load handler has no free 8-bit register")
     }
 
-    loadChildrenMethod.addInstructionsWithLabels(
+    playlistLoadHandlerMethod.addInstructionsWithLabels(
         0,
         """
-            invoke-static/range { p1 .. p1 }, $EXTENSION_CLASS->replacePlaylists(Ljava/lang/Object;)Z
+            invoke-static/range { p1 .. p1 }, $EXTENSION_CLASS->handlePlaylistLoad(Ljava/lang/Object;)Z
             move-result v$handledRegister
             if-eqz v$handledRegister, :resume
             return-void
         """,
-        ExternalLabel("resume", loadChildrenMethod.getInstruction<Instruction>(0)),
+        ExternalLabel("resume", playlistLoadHandlerMethod.getInstruction<Instruction>(0)),
     )
 }

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/RestoreAndroidAutoPlaylistsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/RestoreAndroidAutoPlaylistsPatch.kt
@@ -19,6 +19,7 @@ import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMuta
 import app.morphe.patcher.util.smali.ExternalLabel
 import app.morphe.patches.music.misc.extension.sharedExtensionPatch
 import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
+import app.morphe.util.cloneMutable
 import app.morphe.util.findFreeRegister
 import app.morphe.util.findInstructionIndicesReversedOrThrow
 import app.morphe.util.findMutableMethodOf
@@ -88,6 +89,15 @@ val restoreAndroidAutoPlaylistsPatch = bytecodePatch(
         val endpointMediaIdMethod = EndpointMediaIdFingerprint.originalMethod
         val responseTabsMethod = BrowseTabsFingerprint.originalMethod
         val gridItemsMethod = GridItemsFingerprint.originalMethod
+        val gridType = gridItemsMethod.parameterTypes.single().toString()
+        val gridContinuationsMethod = classDefBy(gridItemsMethod.definingClass).methods
+            .single { method ->
+                method != gridItemsMethod &&
+                    AccessFlags.PRIVATE.isSet(method.accessFlags) &&
+                    AccessFlags.STATIC.isSet(method.accessFlags) &&
+                    method.returnType == "Ljava/util/List;" &&
+                    method.parameterTypes.map(CharSequence::toString) == listOf(gridType)
+            }
         val musicItemType = MusicItemExtensionFingerprint
             .instructionMatches
             .first()
@@ -99,11 +109,12 @@ val restoreAndroidAutoPlaylistsPatch = bytecodePatch(
             .instruction
             .getReference<FieldReference>()
             ?: throw PatchException("Could not resolve the Browse endpoint ID field")
-        val browseServiceClass = patchBrowseService()
+        val browseServiceClass = patchBrowseService(gridContinuationsMethod)
 
         patchBrowseResponses(
             responseTabsMethod,
             gridItemsMethod,
+            gridContinuationsMethod,
             endpointMediaIdMethod,
         )
         patchMusicItem(
@@ -205,6 +216,7 @@ private fun BytecodePatchContext.hookMusicBrowserService(
 private fun BytecodePatchContext.patchBrowseResponses(
     responseTabsMethod: Method,
     gridItemsMethod: Method,
+    gridContinuationsMethod: Method,
     endpointMediaIdMethod: Method,
 ) {
     val tabMapperNewInstance = BrowseTabsFingerprint.instructionMatches.last()
@@ -224,21 +236,38 @@ private fun BytecodePatchContext.patchBrowseResponses(
         responseTabsMethod.returnType,
     ).matchAll(2..2)
         .map { match -> match.originalMethod }
-    mutableClassDefBy(gridItemsMethod.definingClass).findMutableMethodOf(gridItemsMethod).apply {
-        accessFlags = accessFlags.toPublicAccessFlags()
+    val gridResponseMethod = GridDecoderFingerprint.originalMethod
+    val responsePayloadType = gridResponseMethod
+        .parameterTypes.single().toString()
+    val responsePayloadMethod = classDefBy(
+        responseTabsMethod.definingClass,
+    ).methods.singleOrNull { method ->
+        !AccessFlags.STATIC.isSet(method.accessFlags) && method.parameterTypes.isEmpty() &&
+            method.returnType == responsePayloadType
+    } ?: throw PatchException("Could not resolve the Browse response payload getter")
+    // The injected PlaylistGrid methods call these private YTM methods.
+    listOf(gridItemsMethod, gridContinuationsMethod).forEach { method ->
+        mutableClassDefBy(method.definingClass).findMutableMethodOf(method).apply {
+            accessFlags = accessFlags.toPublicAccessFlags()
+        }
     }
 
+    val gridDecoder = addGridDecoder(gridResponseMethod)
     addBrowseResponseInterface(
         responseTabsMethod,
+        responsePayloadMethod,
+        gridDecoder,
         endpointMediaIdMethod,
     )
     addBrowseTabInterface(sectionListMethod)
     addSectionListInterface(sectionItemMethods)
-    addPlaylistGridInterface(gridItemsMethod)
+    addPlaylistGridInterface(gridItemsMethod, gridContinuationsMethod)
 }
 
 private fun BytecodePatchContext.addBrowseResponseInterface(
     responseTabsMethod: Method,
+    responsePayloadMethod: Method,
+    gridDecoder: Method,
     endpointMediaIdMethod: Method,
 ) {
     val responseClass = mutableClassDefBy(responseTabsMethod.definingClass)
@@ -251,6 +280,21 @@ private fun BytecodePatchContext.addBrowseResponseInterface(
         registerCount = 1,
         instructions = """
             invoke-virtual { p0 }, $responseTabsMethod
+            move-result-object p0
+            return-object p0
+        """,
+    )
+    responseClass.addInterfaceMethod(
+        name = "patch_getContinuationGrid",
+        parameters = emptyList(),
+        returnType = "Ljava/lang/Object;",
+        registerCount = 2,
+        instructions = """
+            invoke-virtual { p0 }, $responsePayloadMethod
+            move-result-object p0
+            # The cloned method does not read its first argument.
+            const/4 v0, 0x0
+            invoke-static { v0, p0 }, $gridDecoder
             move-result-object p0
             return-object p0
         """,
@@ -304,6 +348,7 @@ private fun BytecodePatchContext.addSectionListInterface(
 
 private fun BytecodePatchContext.addPlaylistGridInterface(
     gridItemsMethod: Method,
+    gridContinuationsMethod: Method,
 ) {
     val gridType = gridItemsMethod.parameterTypes.single().toString()
     val gridClass = mutableClassDefBy(gridType)
@@ -315,6 +360,17 @@ private fun BytecodePatchContext.addPlaylistGridInterface(
         registerCount = 1,
         instructions = """
             invoke-static { p0 }, $gridItemsMethod
+            move-result-object p0
+            return-object p0
+        """,
+    )
+    gridClass.addInterfaceMethod(
+        name = "patch_getContinuations",
+        parameters = emptyList(),
+        returnType = "Ljava/lang/Iterable;",
+        registerCount = 1,
+        instructions = """
+            invoke-static { p0 }, $gridContinuationsMethod
             move-result-object p0
             return-object p0
         """,
@@ -399,6 +455,20 @@ private fun BytecodePatchContext.addPlaylistMediaIdGetter(
             return-object p0
         """,
     )
+}
+
+private fun BytecodePatchContext.addGridDecoder(method: Method): Method {
+    val decoder = method.cloneMutable(
+        name = "patch_decodeGrid",
+        accessFlags = AccessFlags.PUBLIC.value or AccessFlags.STATIC.value,
+        // The original method clears its receiver register before reading the response from p1.
+        // The added first parameter keeps that register layout in the static clone.
+        parameters = listOf(
+            ImmutableMethodParameter(method.definingClass, null, null),
+        ) + method.parameters,
+    )
+    mutableClassDefBy(method.definingClass).methods.add(decoder)
+    return decoder
 }
 
 private fun BytecodePatchContext.patchMusicItem(
@@ -590,7 +660,9 @@ private fun MutableClass.addArtworkUriGetter(
     )
 }
 
-private fun BytecodePatchContext.patchBrowseService(): MutableClass {
+private fun BytecodePatchContext.patchBrowseService(
+    gridContinuationsMethod: Method,
+): MutableClass {
     val endpointRequestMethod = BrowseEndpointRequestFingerprint.originalMethod
     val requestBuilderType = endpointRequestMethod.returnType
     val requestBuilderFactoryMethod = endpointRequestMethod.instructions.asSequence()
@@ -600,6 +672,15 @@ private fun BytecodePatchContext.patchBrowseService(): MutableClass {
         }
         ?: throw PatchException("Could not resolve the Browse request factory")
     val browseServiceType = requestBuilderFactoryMethod.definingClass
+    val continuationTypes = gridContinuationsMethod.instructions.asSequence()
+        .mapNotNull { instruction -> instruction.getReference<MethodReference>() }
+        .map { reference -> reference.returnType }
+        .toSet()
+    val continuationBuilderMethod = classDefBy(browseServiceType).methods.singleOrNull { method ->
+        method.returnType == requestBuilderType &&
+            method.parameterTypes.singleOrNull()?.toString() in continuationTypes
+    }
+        ?: throw PatchException("Could not resolve the continuation request factory")
     val requestFingerprint = browseRequestFingerprint(
         browseServiceType,
         requestBuilderType,
@@ -637,6 +718,21 @@ private fun BytecodePatchContext.patchBrowseService(): MutableClass {
             invoke-virtual { p0, v0, p2 }, $browseRequestMethod
             move-result-object v0
             return-object v0
+        """,
+    )
+    val continuationType = continuationBuilderMethod.parameterTypes.single().toString()
+    browseServiceClass.addInterfaceMethod(
+        name = "patch_requestContinuation",
+        parameters = listOf("Ljava/lang/Object;", "Ljava/util/concurrent/Executor;"),
+        returnType = LISTENABLE_FUTURE_CLASS,
+        registerCount = 3,
+        instructions = """
+            check-cast p1, $continuationType
+            invoke-virtual { p0, p1 }, $continuationBuilderMethod
+            move-result-object p1
+            invoke-virtual { p0, p1, p2 }, $browseRequestMethod
+            move-result-object p1
+            return-object p1
         """,
     )
     return browseServiceClass

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/RestoreAndroidAutoPlaylistsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/playlists/RestoreAndroidAutoPlaylistsPatch.kt
@@ -1,0 +1,753 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2489
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.patches.music.misc.androidauto.playlists
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableClass
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
+import app.morphe.patcher.util.smali.ExternalLabel
+import app.morphe.patches.music.misc.extension.sharedExtensionPatch
+import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
+import app.morphe.util.findFreeRegister
+import app.morphe.util.findInstructionIndicesReversedOrThrow
+import app.morphe.util.findMutableMethodOf
+import app.morphe.util.getReference
+import app.morphe.util.indexOfFirstInstructionOrThrow
+import app.morphe.util.p0Register
+import app.morphe.util.toPublicAccessFlags
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.Method
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction
+import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference
+import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
+
+private const val EXTENSION_CLASS =
+    "Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch;"
+private const val EXTENSION_BROWSE_SERVICE_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$BrowseService;"
+private const val EXTENSION_BROWSE_RESPONSE_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$BrowseResponse;"
+private const val EXTENSION_BROWSE_TAB_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$BrowseTab;"
+private const val EXTENSION_SECTION_LIST_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$SectionList;"
+private const val EXTENSION_PLAYLIST_GRID_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$PlaylistGrid;"
+private const val EXTENSION_LOAD_CHILDREN_RESULT_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$LoadChildrenResult;"
+private const val EXTENSION_MUSIC_ITEM_INTERFACE =
+    $$"Lapp/morphe/extension/music/patches/RestoreAndroidAutoPlaylistsPatch$MusicItem;"
+
+// move-result can only write to registers 0-255.
+private const val EIGHT_BIT_REGISTER_LIMIT = 256
+// iget-object can only address registers 0-15.
+private const val FOUR_BIT_REGISTER_LIMIT = 16
+// A MediaDescriptionCompat constructor range starts with its receiver. Media ID and title are the
+// next two registers.
+private const val MEDIA_DESCRIPTION_MEDIA_ID_REGISTER_OFFSET = 1
+private const val MEDIA_DESCRIPTION_TITLE_REGISTER_OFFSET = 2
+
+private const val MUSIC_ITEM_ARTWORK_FIELD_NAME = "c"
+private const val MUSIC_ITEM_TITLE_FIELD_NAME = "g"
+private const val MUSIC_ITEM_SUBTITLE_FIELD_NAME = "h"
+private const val PLAYLIST_BROWSE_ID_PREFIX = "VL"
+private const val BROWSE_RESPONSE_BUTTON_CONTENT_FIELD_NAME = "q"
+private const val LISTENABLE_FUTURE_CLASS =
+    "Lcom/google/common/util/concurrent/ListenableFuture;"
+
+@Suppress("unused")
+val restoreAndroidAutoPlaylistsPatch = bytecodePatch(
+    name = "Restore playlists in Android Auto",
+    description = "Restores YouTube Music playlists in Android Auto.",
+) {
+    dependsOn(sharedExtensionPatch)
+
+    compatibleWith(COMPATIBILITY_YOUTUBE_MUSIC)
+
+    execute {
+        hookPlaylistCategoryId()
+
+        val endpointMediaIdMethod = EndpointMediaIdFingerprint.originalMethod
+        val responseTabsMethod = BrowseTabsFingerprint.originalMethod
+        val gridItemsMethod = GridItemsFingerprint.originalMethod
+        val musicItemType = MusicItemExtensionFingerprint
+            .instructionMatches
+            .first()
+            .instruction
+            .getReference<TypeReference>()!!
+            .type
+        val browseEndpointIdField = BrowseEndpointRequestFingerprint.instructionMatches
+            .first()
+            .instruction
+            .getReference<FieldReference>()
+            ?: throw PatchException("Could not resolve the Browse endpoint ID field")
+        val browseServiceClass = patchBrowseService()
+
+        patchBrowseResponses(
+            responseTabsMethod,
+            gridItemsMethod,
+            endpointMediaIdMethod,
+        )
+        patchMusicItem(
+            musicItemType,
+            browseEndpointIdField,
+            endpointMediaIdMethod,
+        )
+        val invalidParentMediaIdMethod = InvalidParentMediaIdFingerprint.originalMethod
+        patchLoadChildrenResult(invalidParentMediaIdMethod)
+        val contentSupplierType = invalidParentMediaIdMethod.definingClass
+        val loadChildrenResultType = invalidParentMediaIdMethod.parameterTypes.first().toString()
+
+        hookMusicBrowserService(browseServiceClass.type, loadChildrenResultType)
+        hookLoadChildren(contentSupplierType, loadChildrenResultType)
+    }
+}
+
+private fun BytecodePatchContext.hookPlaylistCategoryId() {
+    val method = MediaItemFactoryFingerprint.method
+
+    // On YTM 9.15.51, Playlists comes from the MediaDescriptionCompat call with FLAG_BROWSABLE.
+    method
+        .findInstructionIndicesReversedOrThrow(MEDIA_DESCRIPTION_CONSTRUCTOR_CALL)
+        .forEach { index ->
+            val instruction =
+                method.getInstruction<RegisterRangeInstruction>(
+                    index,
+                )
+            val mediaIdRegister =
+                instruction.startRegister + MEDIA_DESCRIPTION_MEDIA_ID_REGISTER_OFFSET
+            val titleRegister =
+                instruction.startRegister + MEDIA_DESCRIPTION_TITLE_REGISTER_OFFSET
+
+            method.addInstructions(
+                index,
+                """
+                    invoke-static/range { v$mediaIdRegister .. v$titleRegister }, $EXTENSION_CLASS->rememberPlaylistCategoryId(Ljava/lang/String;Ljava/lang/CharSequence;)V
+                """,
+            )
+        }
+}
+
+private fun BytecodePatchContext.hookMusicBrowserService(
+    browseServiceType: String,
+    loadChildrenResultType: String,
+) {
+    val musicBrowserServiceType = musicBrowserServiceLoadChildrenFingerprint(
+        loadChildrenResultType,
+    ).originalMethod.definingClass
+    val browseServiceProviders = browseServiceProviderFingerprint(browseServiceType)
+        .matchAll()
+        .map { match ->
+            val (providerFieldMatch, providerGetterMatch) = match.instructionMatches
+            val providerField = providerFieldMatch.instruction.getReference<FieldReference>()!!
+            val providerGetter = providerGetterMatch.instruction.getReference<MethodReference>()!!
+            providerField to providerGetter
+        }
+        .distinctBy { (field, _) -> field }
+    // During onCreate, MusicBrowserService's generated superclass reads the Dagger provider for
+    // the class containing BS_GET_BROWSE_DATA.
+    val (onCreateMethod, browseServiceProvider) = browseServiceProviders.mapNotNull { provider ->
+        musicBrowserServiceOnCreateFingerprint(
+            musicBrowserServiceType,
+            provider.first.definingClass,
+        ).matchOrNull()?.originalMethod?.let { method -> method to provider }
+    }.singleOrNull()
+        ?: throw PatchException("Could not resolve the Browse service used by MusicBrowserService")
+    val (browseProviderField, browseProviderGetter) = browseServiceProvider
+    val mutableOnCreateMethod = mutableClassDefBy(
+        onCreateMethod.definingClass,
+    ).findMutableMethodOf(onCreateMethod)
+    val componentIndex = mutableOnCreateMethod.indexOfFirstInstructionOrThrow {
+        opcode == Opcode.IGET_OBJECT &&
+            getReference<FieldReference>()?.type == browseProviderField.definingClass
+    }
+    val componentRegister = mutableOnCreateMethod
+        .getInstruction<TwoRegisterInstruction>(componentIndex)
+        .registerA
+    val providerRegister = mutableOnCreateMethod.findFreeRegister(
+        componentIndex + 1,
+        mutableOnCreateMethod.p0Register,
+    )
+    if (providerRegister >= FOUR_BIT_REGISTER_LIMIT) {
+        throw PatchException("MusicBrowserService.onCreate has no free 4-bit register")
+    }
+
+    mutableOnCreateMethod.addInstructions(
+        componentIndex + 1,
+        """
+            iget-object v$providerRegister, v$componentRegister, $browseProviderField
+            invoke-interface/range { v$providerRegister .. v$providerRegister }, $browseProviderGetter
+            move-result-object v$providerRegister
+            check-cast v$providerRegister, $EXTENSION_BROWSE_SERVICE_INTERFACE
+            invoke-static/range { v$providerRegister .. v$providerRegister }, $EXTENSION_CLASS->setBrowseService($EXTENSION_BROWSE_SERVICE_INTERFACE)V
+        """,
+    )
+}
+
+private fun BytecodePatchContext.patchBrowseResponses(
+    responseTabsMethod: Method,
+    gridItemsMethod: Method,
+    endpointMediaIdMethod: Method,
+) {
+    val tabMapperNewInstance = BrowseTabsFingerprint.instructionMatches.last()
+    val tabMapperType = tabMapperNewInstance
+        .instruction
+        .getReference<TypeReference>()!!
+        .type
+    val tabMapper = browseTabMapperFingerprint(tabMapperType)
+    val tabNewInstance = tabMapper.instructionMatches.first()
+    val tabType = tabNewInstance
+        .instruction
+        .getReference<TypeReference>()!!
+        .type
+    val sectionListMethod = sectionListFingerprint(tabType).originalMethod
+    val sectionItemMethods = sectionItemsFingerprint(
+        sectionListMethod.returnType,
+        responseTabsMethod.returnType,
+    ).matchAll(2..2)
+        .map { match -> match.originalMethod }
+    mutableClassDefBy(gridItemsMethod.definingClass).findMutableMethodOf(gridItemsMethod).apply {
+        accessFlags = accessFlags.toPublicAccessFlags()
+    }
+
+    addBrowseResponseInterface(
+        responseTabsMethod,
+        endpointMediaIdMethod,
+    )
+    addBrowseTabInterface(sectionListMethod)
+    addSectionListInterface(sectionItemMethods)
+    addPlaylistGridInterface(gridItemsMethod)
+}
+
+private fun BytecodePatchContext.addBrowseResponseInterface(
+    responseTabsMethod: Method,
+    endpointMediaIdMethod: Method,
+) {
+    val responseClass = mutableClassDefBy(responseTabsMethod.definingClass)
+    responseClass.interfaces.add(EXTENSION_BROWSE_RESPONSE_INTERFACE)
+    addPlaylistMediaIdGetter(responseClass, responseTabsMethod, endpointMediaIdMethod)
+    responseClass.addInterfaceMethod(
+        name = "patch_getTabs",
+        parameters = emptyList(),
+        returnType = "Ljava/lang/Iterable;",
+        registerCount = 1,
+        instructions = """
+            invoke-virtual { p0 }, $responseTabsMethod
+            move-result-object p0
+            return-object p0
+        """,
+    )
+}
+
+private fun BytecodePatchContext.addBrowseTabInterface(
+    sectionListMethod: Method,
+) {
+    val tabClass = mutableClassDefBy(sectionListMethod.definingClass)
+    tabClass.interfaces.add(EXTENSION_BROWSE_TAB_INTERFACE)
+    tabClass.addInterfaceMethod(
+        name = "patch_getSectionList",
+        parameters = emptyList(),
+        returnType = "Ljava/lang/Object;",
+        registerCount = 1,
+        instructions = """
+            invoke-virtual { p0 }, $sectionListMethod
+            move-result-object p0
+            return-object p0
+        """,
+    )
+}
+
+private fun BytecodePatchContext.addSectionListInterface(
+    sectionItemMethods: List<Method>,
+) {
+    val (firstItemMethod, secondItemMethod) = sectionItemMethods
+    val sectionListClass = mutableClassDefBy(firstItemMethod.definingClass)
+    sectionListClass.interfaces.add(EXTENSION_SECTION_LIST_INTERFACE)
+    sectionListClass.addInterfaceMethod(
+        name = "patch_getItemLists",
+        parameters = emptyList(),
+        returnType = "[Ljava/lang/Iterable;",
+        registerCount = 4,
+        instructions = """
+            const/4 v0, 0x2
+            new-array v0, v0, [Ljava/lang/Iterable;
+            invoke-virtual { p0 }, $firstItemMethod
+            move-result-object v1
+            const/4 v2, 0x0
+            aput-object v1, v0, v2
+            invoke-virtual { p0 }, $secondItemMethod
+            move-result-object v1
+            const/4 v2, 0x1
+            aput-object v1, v0, v2
+            return-object v0
+        """,
+    )
+}
+
+private fun BytecodePatchContext.addPlaylistGridInterface(
+    gridItemsMethod: Method,
+) {
+    val gridType = gridItemsMethod.parameterTypes.single().toString()
+    val gridClass = mutableClassDefBy(gridType)
+    gridClass.interfaces.add(EXTENSION_PLAYLIST_GRID_INTERFACE)
+    gridClass.addInterfaceMethod(
+        name = "patch_getItems",
+        parameters = emptyList(),
+        returnType = "Ljava/lang/Iterable;",
+        registerCount = 1,
+        instructions = """
+            invoke-static { p0 }, $gridItemsMethod
+            move-result-object p0
+            return-object p0
+        """,
+    )
+}
+
+private fun BytecodePatchContext.addPlaylistMediaIdGetter(
+    responseClass: MutableClass,
+    responseTabsMethod: Method,
+    endpointMediaIdMethod: Method,
+) {
+    val endpointType = endpointMediaIdMethod.parameterTypes.single().toString()
+    val initializerMethod = buttonRendererExtensionFingerprint(endpointType).originalMethod
+    val buttonRendererType = initializerMethod.instructions
+        .first { instruction -> instruction.opcode == Opcode.CONST_CLASS }
+        .getReference<TypeReference>()!!
+        .type
+    val containingType = initializerMethod.instructions
+        .asSequence()
+        .filter { instruction -> instruction.opcode == Opcode.SGET_OBJECT }
+        .mapNotNull { instruction -> instruction.getReference<FieldReference>() }
+        .first { field -> field.definingClass == field.type }
+        .type
+    val descriptorField = initializerMethod.instructions
+        .first { instruction -> instruction.opcode == Opcode.SPUT_OBJECT }
+        .getReference<FieldReference>()!!
+    val buttonRendererDecoderMethod = buttonRendererDecoderFingerprint(
+        containingType,
+        buttonRendererType,
+        descriptorField,
+    ).originalMethod
+    val commandEndpointField = buttonRendererEndpointCopyFingerprint(
+        buttonRendererType,
+        endpointType,
+    ).matchAll()
+        .map { match ->
+            val (playEndpointReadMatch, _) = match.instructionMatches
+            playEndpointReadMatch.instruction.getReference<FieldReference>()!!
+        }
+        .distinct()
+        .singleOrNull()
+        ?: throw PatchException("Could not resolve the ButtonRenderer command endpoint")
+
+    val responsePayloadField = responseTabsMethod.instructions
+        .asSequence()
+        .filter { instruction -> instruction.opcode == Opcode.IGET_OBJECT }
+        .mapNotNull { instruction -> instruction.getReference<FieldReference>() }
+        .filter { field ->
+            field.definingClass == responseTabsMethod.definingClass &&
+                field.type != responseTabsMethod.returnType
+        }
+        .distinct()
+        .singleOrNull()
+        ?: throw PatchException("Could not resolve the Browse response payload field")
+    val buttonContentField = classDefBy(responsePayloadField.type).fields.singleOrNull { field ->
+        !AccessFlags.STATIC.isSet(field.accessFlags) &&
+            field.name == BROWSE_RESPONSE_BUTTON_CONTENT_FIELD_NAME &&
+            field.type == containingType
+    } ?: throw PatchException("Could not resolve the playlist ButtonRenderer content field")
+
+    // response.q stores the playlist Play command in ButtonRenderer extension 65153809.
+    responseClass.addInterfaceMethod(
+        name = "patch_getPlaylistMediaId",
+        parameters = emptyList(),
+        returnType = "Ljava/lang/String;",
+        registerCount = 2,
+        instructions = """
+            iget-object p0, p0, $responsePayloadField
+            iget-object p0, p0, $buttonContentField
+            # true returns the Play ButtonRenderer or null.
+            const/4 v0, 0x1
+            invoke-static { v0, p0 }, $buttonRendererDecoderMethod
+            move-result-object p0
+            if-eqz p0, :no_play_endpoint
+            iget-object p0, p0, $commandEndpointField
+            if-eqz p0, :no_play_endpoint
+            invoke-static { p0 }, $endpointMediaIdMethod
+            move-result-object p0
+            return-object p0
+            :no_play_endpoint
+            const/4 p0, 0x0
+            return-object p0
+        """,
+    )
+}
+
+private fun BytecodePatchContext.patchMusicItem(
+    musicItemType: String,
+    browseEndpointIdField: FieldReference,
+    endpointMediaIdMethod: Method,
+) {
+    val musicItemFields = classDefBy(musicItemType).fields.toList()
+
+    fun musicItemField(name: String) = musicItemFields
+        .first { field ->
+            !AccessFlags.STATIC.isSet(field.accessFlags) && field.name == name
+        }
+
+    val artworkField = musicItemField(MUSIC_ITEM_ARTWORK_FIELD_NAME)
+    val titleField = musicItemField(MUSIC_ITEM_TITLE_FIELD_NAME)
+    val subtitleField = musicItemField(MUSIC_ITEM_SUBTITLE_FIELD_NAME)
+    if (artworkField.type == titleField.type || titleField.type != subtitleField.type) {
+        throw PatchException("Unexpected music item artwork, title, or subtitle fields")
+    }
+    val artworkPayloadType = MusicThumbnailExtensionFingerprint.originalMethod.instructions
+        .first { instruction -> instruction.opcode == Opcode.CONST_CLASS }
+        .getReference<TypeReference>()!!
+        .type
+    val artworkPayloadFields = classDefBy(artworkPayloadType).fields
+        .filter { field -> !AccessFlags.STATIC.isSet(field.accessFlags) }
+        .toList()
+    val artworkDecoderMethod = musicThumbnailDecoderFingerprint(
+        artworkField.type,
+    ).originalMethod
+    val artworkMethod = androidAutoArtworkFingerprint(
+        artworkPayloadFields.map(FieldReference::getType).toSet(),
+    ).originalMethod
+    val artworkReadTypes = artworkMethod.instructions
+        .filter { instruction -> instruction.opcode == Opcode.IGET_OBJECT }
+        .mapNotNull { instruction -> instruction.getReference<FieldReference>()?.type }
+        .toSet()
+    val artworkUriMethod = artworkMethod.instructions
+        .mapNotNull { instruction -> instruction.getReference<MethodReference>() }
+        .filter { method ->
+            method.returnType == "Landroid/net/Uri;" && method.parameterTypes.size == 1 &&
+                method.parameterTypes.single().toString() in artworkReadTypes
+        }
+        .singleOrNull { method ->
+            artworkPayloadFields.any { field ->
+                field.type == method.parameterTypes.single().toString()
+            }
+        }
+        ?: throw PatchException("Could not resolve the Android Auto artwork Uri helper")
+    val artworkPayloadField = artworkPayloadFields.singleOrNull { field ->
+        field.type == artworkUriMethod.parameterTypes.single().toString()
+    } ?: throw PatchException("Could not resolve the artwork payload field")
+    val renderTextMethod = renderTextFingerprint(titleField.type).originalMethod
+
+    val endpointType = endpointMediaIdMethod.parameterTypes.single().toString()
+    val endpointFields = musicItemFields
+        .filter { field ->
+            !AccessFlags.STATIC.isSet(field.accessFlags) && field.type == endpointType
+    }
+    if (endpointFields.size != 2) {
+        throw PatchException("Could not resolve the two music row endpoints")
+    }
+    val (firstEndpointField, secondEndpointField) = endpointFields
+
+    val browseIdDecoderMethod = browseEndpointDecoderFingerprint(
+        endpointType,
+        browseEndpointIdField.definingClass,
+    ).originalMethod
+
+    val musicItemClass = mutableClassDefBy(musicItemType)
+    musicItemClass.interfaces.add(EXTENSION_MUSIC_ITEM_INTERFACE)
+    musicItemClass.addBrowseIdGetter(
+        firstEndpointField,
+        secondEndpointField,
+        browseIdDecoderMethod,
+        browseEndpointIdField,
+    )
+    musicItemClass.addTextGetter("patch_getTitle", titleField, renderTextMethod)
+    musicItemClass.addTextGetter("patch_getSubtitle", subtitleField, renderTextMethod)
+    musicItemClass.addArtworkUriGetter(
+        artworkField,
+        artworkDecoderMethod,
+        artworkPayloadField,
+        artworkUriMethod,
+    )
+}
+
+// Fields i and k can both contain Browse endpoints; conflicting VL IDs are ignored.
+private fun MutableClass.addBrowseIdGetter(
+    firstEndpointField: FieldReference,
+    secondEndpointField: FieldReference,
+    browseIdDecoderMethod: Method,
+    browseEndpointIdField: FieldReference,
+) {
+    addInterfaceMethod(
+        name = "patch_getBrowseId",
+        parameters = emptyList(),
+        returnType = "Ljava/lang/String;",
+        registerCount = 4,
+        instructions = """
+            const/4 v0, 0x0
+            iget-object v1, p0, $firstEndpointField
+            if-eqz v1, :second_endpoint
+            invoke-static { v1 }, $browseIdDecoderMethod
+            move-result-object v1
+            if-eqz v1, :second_endpoint
+            iget-object v1, v1, $browseEndpointIdField
+            if-eqz v1, :second_endpoint
+            const-string v2, "$PLAYLIST_BROWSE_ID_PREFIX"
+            invoke-virtual { v1, v2 }, Ljava/lang/String;->startsWith(Ljava/lang/String;)Z
+            move-result v2
+            if-eqz v2, :second_endpoint
+            move-object v0, v1
+
+            :second_endpoint
+            iget-object v1, p0, $secondEndpointField
+            if-eqz v1, :return_id
+            invoke-static { v1 }, $browseIdDecoderMethod
+            move-result-object v1
+            if-eqz v1, :return_id
+            iget-object v1, v1, $browseEndpointIdField
+            if-eqz v1, :return_id
+            const-string v2, "$PLAYLIST_BROWSE_ID_PREFIX"
+            invoke-virtual { v1, v2 }, Ljava/lang/String;->startsWith(Ljava/lang/String;)Z
+            move-result v2
+            if-eqz v2, :return_id
+            if-eqz v0, :use_second_id
+            invoke-virtual { v0, v1 }, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+            move-result v2
+            if-nez v2, :return_id
+            const/4 v0, 0x0
+            return-object v0
+
+            :use_second_id
+            move-object v0, v1
+            :return_id
+            return-object v0
+        """,
+    )
+}
+
+private fun MutableClass.addTextGetter(
+    name: String,
+    field: FieldReference,
+    renderTextMethod: Method,
+) {
+    addInterfaceMethod(
+        name = name,
+        parameters = emptyList(),
+        returnType = "Ljava/lang/CharSequence;",
+        registerCount = 3,
+        instructions = """
+            iget-object v0, p0, $field
+            # The second argument is optional text-to-speech content.
+            const/4 v1, 0x0
+            invoke-static { v0, v1 }, $renderTextMethod
+            move-result-object v0
+            return-object v0
+        """,
+    )
+}
+
+private fun MutableClass.addArtworkUriGetter(
+    artworkField: FieldReference,
+    artworkDecoderMethod: Method,
+    artworkPayloadField: FieldReference,
+    artworkUriMethod: MethodReference,
+) {
+    addInterfaceMethod(
+        name = "patch_getArtworkUri",
+        parameters = emptyList(),
+        returnType = "Landroid/net/Uri;",
+        registerCount = 2,
+        instructions = """
+            iget-object v0, p0, $artworkField
+            if-eqz v0, :no_artwork
+            invoke-static { v0 }, $artworkDecoderMethod
+            move-result-object v0
+            if-eqz v0, :no_artwork
+            check-cast v0, ${artworkPayloadField.definingClass}
+            iget-object v0, v0, $artworkPayloadField
+            invoke-static { v0 }, $artworkUriMethod
+            move-result-object v0
+            return-object v0
+            :no_artwork
+            const/4 v0, 0x0
+            return-object v0
+        """,
+    )
+}
+
+private fun BytecodePatchContext.patchBrowseService(): MutableClass {
+    val endpointRequestMethod = BrowseEndpointRequestFingerprint.originalMethod
+    val requestBuilderType = endpointRequestMethod.returnType
+    val requestBuilderFactoryMethod = endpointRequestMethod.instructions.asSequence()
+        .mapNotNull { instruction -> instruction.getReference<MethodReference>() }
+        .firstOrNull { reference ->
+            reference.parameterTypes.isEmpty() && reference.returnType == requestBuilderType
+        }
+        ?: throw PatchException("Could not resolve the Browse request factory")
+    val browseServiceType = requestBuilderFactoryMethod.definingClass
+    val requestFingerprint = browseRequestFingerprint(
+        browseServiceType,
+        requestBuilderType,
+    )
+    val browseRequestMethod = requestFingerprint.originalMethod
+    val requestBrowseIdField = requestFingerprint.instructionMatches.single()
+        .instruction
+        .getReference<FieldReference>()!!
+
+    val requestBuilderMethods = generateSequence(classDefBy(requestBuilderType)) { classDef ->
+        classDef.superclass?.let { superclass -> classDefByOrNull(superclass) }
+    }.flatMap { classDef -> classDef.methods.asSequence() }
+    val clickTrackingParamsSetterMethod = requestBuilderMethods
+        .firstOrNull { method ->
+            method.returnType == "V" &&
+                method.parameterTypes.map(CharSequence::toString) == listOf("[B")
+        }
+        ?: throw PatchException("Could not resolve the click tracking parameter setter")
+    val browseIdSetterMethod = browseIdSetterFingerprint(requestBrowseIdField).originalMethod
+    val browseServiceClass = mutableClassDefBy(browseServiceType)
+    browseServiceClass.interfaces.add(EXTENSION_BROWSE_SERVICE_INTERFACE)
+    browseServiceClass.addInterfaceMethod(
+        name = "patch_requestBrowse",
+        parameters = listOf("Ljava/lang/String;", "Ljava/util/concurrent/Executor;"),
+        returnType = LISTENABLE_FUTURE_CLASS,
+        registerCount = 5,
+        instructions = """
+            invoke-virtual { p0 }, $requestBuilderFactoryMethod
+            move-result-object v0
+            invoke-virtual { v0, p1 }, $browseIdSetterMethod
+            # Browse requests require clickTrackingParams, even when it is empty.
+            const/4 v1, 0x0
+            new-array v1, v1, [B
+            invoke-virtual { v0, v1 }, $clickTrackingParamsSetterMethod
+            invoke-virtual { p0, v0, p2 }, $browseRequestMethod
+            move-result-object v0
+            return-object v0
+        """,
+    )
+    return browseServiceClass
+}
+
+private fun BytecodePatchContext.patchLoadChildrenResult(
+    invalidParentMediaIdMethod: Method,
+) {
+    val loadChildrenResultType = invalidParentMediaIdMethod.parameterTypes.first().toString()
+    val loadChildrenResultClass = mutableClassDefBy(loadChildrenResultType)
+    loadChildrenResultClass.interfaces.add(EXTENSION_LOAD_CHILDREN_RESULT_INTERFACE)
+    // LoadChildrenResult.toString() labels the String read by the invalid-ID branch as parentMediaId.
+    val parentMediaIdFieldPath = invalidParentMediaIdMethod.instructions.asSequence()
+        .filter { instruction -> instruction.opcode == Opcode.IGET_OBJECT }
+        .mapNotNull { instruction -> instruction.getReference<FieldReference>() }
+        .windowed(2)
+        .first { (resultField, parentMediaIdField) ->
+            resultField.definingClass == loadChildrenResultType &&
+                parentMediaIdField.definingClass == resultField.type &&
+                parentMediaIdField.type == "Ljava/lang/String;"
+        }
+
+    // YTM 9.15.51's invalid-ID path calls b(List), which forwards to c(List, null).
+    val resultDeliveryMethod = invalidParentMediaIdMethod.instructions.asSequence()
+        .mapNotNull { instruction -> instruction.getReference<MethodReference>() }
+        .first { reference ->
+            val parameters = reference.parameterTypes.map(CharSequence::toString)
+            reference.definingClass == loadChildrenResultType && reference.returnType == "V" &&
+                parameters.size in 1..2 &&
+                parameters.firstOrNull() == "Ljava/util/List;" &&
+                parameters.drop(1).all { it.startsWith("L") || it.startsWith("[") }
+        }
+
+    val parentMediaIdInstructions = buildString {
+        parentMediaIdFieldPath.forEach { field ->
+            appendLine("iget-object p0, p0, $field")
+        }
+        append("return-object p0")
+    }
+    loadChildrenResultClass.addInterfaceMethod(
+        name = "patch_getParentMediaId",
+        parameters = emptyList(),
+        returnType = "Ljava/lang/String;",
+        registerCount = 1,
+        instructions = parentMediaIdInstructions,
+    )
+    val hasExtraDeliveryParameter = resultDeliveryMethod.parameterTypes.size == 2
+    loadChildrenResultClass.addInterfaceMethod(
+        name = "patch_sendResult",
+        parameters = listOf("Ljava/util/List;"),
+        returnType = "V",
+        registerCount = if (hasExtraDeliveryParameter) 3 else 2,
+        instructions = if (hasExtraDeliveryParameter) {
+            """
+                const/4 v0, 0x0
+                invoke-virtual { p0, p1, v0 }, $resultDeliveryMethod
+                return-void
+            """
+        } else {
+            """
+                invoke-virtual { p0, p1 }, $resultDeliveryMethod
+                return-void
+            """
+        },
+    )
+}
+
+private fun MutableClass.addInterfaceMethod(
+    name: String,
+    parameters: List<String>,
+    returnType: String,
+    registerCount: Int,
+    instructions: String,
+) {
+    methods.add(
+        ImmutableMethod(
+            type,
+            name,
+            parameters.map { parameter -> ImmutableMethodParameter(parameter, null, null) },
+            returnType,
+            AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+            null,
+            null,
+            MutableMethodImplementation(registerCount),
+        ).toMutable().apply {
+            addInstructions(0, instructions)
+        },
+    )
+}
+
+private fun BytecodePatchContext.hookLoadChildren(
+    contentSupplierType: String,
+    loadChildrenResultType: String,
+) {
+    val loadChildrenMethod = contentSupplierLoadChildrenFingerprint(
+        contentSupplierType,
+        loadChildrenResultType,
+    ).method
+    val handledRegister = loadChildrenMethod.findFreeRegister(0)
+    if (handledRegister >= EIGHT_BIT_REGISTER_LIMIT) {
+        throw PatchException("ContentSupplier load-children method has no free 8-bit register")
+    }
+
+    loadChildrenMethod.addInstructionsWithLabels(
+        0,
+        """
+            invoke-static/range { p1 .. p1 }, $EXTENSION_CLASS->replacePlaylists(Ljava/lang/Object;)Z
+            move-result v$handledRegister
+            if-eqz v$handledRegister, :resume
+            return-void
+        """,
+        ExternalLabel("resume", loadChildrenMethod.getInstruction<Instruction>(0)),
+    )
+}


### PR DESCRIPTION
### Description

YouTube Music currently restricts playlists from working in Android Auto due to a server-side check.

This patch uses the phone app’s separate Browse client to request `FEmusic_library_landing` and fill the Android Auto Playlists section from its response. This allows saved playlists to appear and be played in Android Auto.

Closes #137

### Test results

Tested on Android 16 (API 36) using Android Auto 17.4.663004.

Every supported YouTube Music version was tested with both MicroG-RE 6.1.4 and CoreGMS v0.3.13.3.250932 pre-release:

- 9.15.51
- 9.29.54
- 9.30.52
- 9.31.51
- 9.32 and 9.33

### Notes

- Search on Android Auto does not work (server-side).
- Episodes for Later is hidden. YouTube Music does not provide a play command Android Auto needs to play it.

