### PR TITLE
chore(YouTube - Playback speed): Finish separating playback speed observations from commands

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
@@ -156,6 +156,18 @@ public final class VideoInformation {
      */
     public static final Event<Float> onPlaybackAudioPitchChange = new Event<>();
 
+    private static boolean isPatchIncluded() {
+        return false;  // Modified during patching.
+    }
+
+    private static boolean isPlaybackAudioPitchEnabled() {
+        return isPatchIncluded() && Settings.ENABLE_PLAYBACK_AUDIO_PITCH.get();
+    }
+
+    private static boolean isPlaybackAudioPitchLinked() {
+        return isPlaybackAudioPitchEnabled() && !Settings.PLAYBACK_AUDIO_TIME_STRETCHING.get();
+    }
+
     private static int desiredVideoResolution = AUTOMATIC_VIDEO_QUALITY_VALUE;
 
     private static boolean qualityNeedsUpdating;
@@ -372,10 +384,9 @@ public final class VideoInformation {
         Logger.printDebug(() -> "Video speed updated: " + playbackSpeed);
         playbackSpeedFormattedString = formatSpeedStringX(speed);
         Utils.runOnMainThreadNowOrLater(() -> onPlaybackSpeedChange.invoke(speed));
-        if (!Settings.PLAYBACK_AUDIO_TIME_STRETCHING.get()) {
+        if (isPlaybackAudioPitchLinked() || (isPatchIncluded() && !isPlaybackAudioPitchEnabled())) {
             updatePlaybackAudioPitchValue(speed);
         }
-        changePlaybackSpeed(playbackSpeed);
         return true;
     }
 
@@ -385,7 +396,7 @@ public final class VideoInformation {
      * @return true if the pitch actually changed.
      */
     private static boolean updatePlaybackAudioPitchValue(float pitch) {
-        if (!Settings.ENABLE_PLAYBACK_AUDIO_PITCH.get()) {
+        if (!isPlaybackAudioPitchEnabled()) {
             pitch = 1.0f;
         }
         if (playbackAudioPitch == pitch) {
@@ -397,7 +408,7 @@ public final class VideoInformation {
         playbackAudioPitchFormattedString = formatSpeedStringX(pitch);
         final float updatedPitch = pitch;
         Utils.runOnMainThreadNowOrLater(() -> onPlaybackAudioPitchChange.invoke(updatedPitch));
-        if (!Settings.PLAYBACK_AUDIO_TIME_STRETCHING.get()) {
+        if (isPlaybackAudioPitchLinked()) {
             updatePlaybackSpeedValue(pitch);
         }
         return true;
@@ -428,8 +439,9 @@ public final class VideoInformation {
         if (!Settings.PLAYBACK_AUDIO_TIME_STRETCHING.get() && previousPlaybackSpeed != playbackSpeed) {
             RememberPlaybackSpeedPatch.userSelectedPlaybackSpeed(playbackSpeed);
             changePlaybackSpeed(playbackSpeed);
+        } else {
+            setPlaybackParameters(playbackSpeed, playbackAudioPitch);
         }
-        setPlaybackParameters(playbackSpeed, playbackAudioPitch);
     }
 
     /**
@@ -441,6 +453,9 @@ public final class VideoInformation {
     public static void userSelectedPlaybackSpeed(float userSelectedPlaybackSpeed) {
         Logger.printDebug(() -> "User selected playback speed: " + userSelectedPlaybackSpeed);
         updatePlaybackSpeedValue(userSelectedPlaybackSpeed);
+        if (isPlaybackAudioPitchLinked()) {
+            RememberPlaybackSpeedPatch.userSelectedPlaybackAudioPitch(userSelectedPlaybackSpeed);
+        }
 
         // An exception occurs when the playback speed dialog is opened by an overlay button while 'Restore old playback speed menu' is off.
         // Update the formatted string value to avoid the exception.
@@ -863,7 +878,13 @@ public final class VideoInformation {
         if (!playbackSpeedFormattedString.equals(newlyLoadedPlaybackSpeedFormattedString)) {
             playbackSpeedFormattedString = newlyLoadedPlaybackSpeedFormattedString;
 
+            final float previousPlaybackAudioPitch = playbackAudioPitch;
             VideoInformation.userSelectedPlaybackSpeed(newlyLoadedPlaybackSpeed);
+            if (previousPlaybackAudioPitch != playbackAudioPitch) {
+                final float pitch = playbackAudioPitch;
+                Utils.runOnMainThreadNowOrLater(() ->
+                        setPlaybackParameters(newlyLoadedPlaybackSpeed, pitch));
+            }
 
             // Rest of the implementation added by patch.
             // RememberPlaybackSpeedPatch.userSelectedPlaybackSpeed(newlyLoadedPlaybackSpeed);
@@ -882,9 +903,8 @@ public final class VideoInformation {
         }
 
         RememberPlaybackSpeedPatch.userSelectedPlaybackSpeed(playbackSpeed);
-        if (!Settings.PLAYBACK_AUDIO_TIME_STRETCHING.get()) {
+        if (isPlaybackAudioPitchLinked()) {
             RememberPlaybackSpeedPatch.userSelectedPlaybackAudioPitch(playbackAudioPitch);
-            setPlaybackParameters(playbackSpeed, playbackAudioPitch);
         }
         changePlaybackSpeed(playbackSpeed);
     }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
@@ -245,15 +245,17 @@ public final class VideoInformation {
             // playbackSpeed = DEFAULT_PLAYBACK_SPEED; // Captured at video start, interferes otherwise.
             playbackSpeedFormattedString = "";
             final float audioPitchOverride = RememberPlaybackSpeedPatch.getPlaybackAudioPitchOverride();
-            final boolean noRegularVideoPlaying = PlayerType.getCurrent().isNoneOrHidden();
+            final PlayerType playerType = PlayerType.getCurrent();
+            final boolean noWatchWhilePlayerActive = playerType.isNoneOrHidden() ||
+                    playerType == PlayerType.INLINE_MINIMAL;
             final float newPlaybackAudioPitch = audioPitchOverride > 0.0f &&
                     isPlaybackAudioPitchEnabled() && Settings.PLAYBACK_AUDIO_TIME_STRETCHING.get()
                     ? audioPitchOverride
-                    : !isPlaybackAudioPitchEnabled() || noRegularVideoPlaying
+                    : !isPlaybackAudioPitchEnabled() || noWatchWhilePlayerActive
                             ? DEFAULT_PLAYBACK_AUDIO_PITCH
                             : playbackAudioPitch;
             if (playbackAudioPitch != newPlaybackAudioPitch ||
-                    (noRegularVideoPlaying && newPlaybackAudioPitch != DEFAULT_PLAYBACK_AUDIO_PITCH)) {
+                    (noWatchWhilePlayerActive && newPlaybackAudioPitch != DEFAULT_PLAYBACK_AUDIO_PITCH)) {
                 playbackAudioPitch = newPlaybackAudioPitch;
                 playbackAudioPitchNeedsApplying = true;
             }
@@ -813,12 +815,16 @@ public final class VideoInformation {
             return;
         }
 
-        updatePlaybackSpeedValue(playbackSpeed);
+        final boolean playbackSpeedChanged = updatePlaybackSpeedValue(playbackSpeed);
         if (isPlaybackAudioPitchLinked()) {
             updatePlaybackAudioPitchValue(playbackSpeed);
         }
-        playbackAudioPitchNeedsApplying = false;
+        final float playbackAudioPitchToApply = playbackAudioPitch;
         currentPlaybackSpeedMenuInterface.patch_setSpeed(playbackSpeed);
+        if (playbackAudioPitchNeedsApplying && !playbackSpeedChanged) {
+            setPlaybackParameters(playbackSpeed, playbackAudioPitchToApply);
+        }
+        playbackAudioPitchNeedsApplying = false;
     }
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
@@ -147,6 +147,7 @@ public final class VideoInformation {
      * The current playback audio pitch
      */
     private static float playbackAudioPitch = DEFAULT_PLAYBACK_AUDIO_PITCH;
+    private static boolean playbackAudioPitchNeedsApplying;
     /**
      * The current playback speed in native panel.
      */
@@ -243,11 +244,13 @@ public final class VideoInformation {
             // playbackSpeed = DEFAULT_PLAYBACK_SPEED; // Captured at video start, interferes otherwise.
             playbackSpeedFormattedString = "";
             final float audioPitchOverride = RememberPlaybackSpeedPatch.getPlaybackAudioPitchOverride();
-            if (audioPitchOverride > 0.0f && isPlaybackAudioPitchEnabled() &&
-                    Settings.PLAYBACK_AUDIO_TIME_STRETCHING.get()) {
-                playbackAudioPitch = audioPitchOverride;
-            } else {
-                playbackAudioPitch = DEFAULT_PLAYBACK_AUDIO_PITCH;
+            final float newPlaybackAudioPitch = audioPitchOverride > 0.0f &&
+                    isPlaybackAudioPitchEnabled() && Settings.PLAYBACK_AUDIO_TIME_STRETCHING.get()
+                    ? audioPitchOverride
+                    : DEFAULT_PLAYBACK_AUDIO_PITCH;
+            if (playbackAudioPitch != newPlaybackAudioPitch) {
+                playbackAudioPitch = newPlaybackAudioPitch;
+                playbackAudioPitchNeedsApplying = true;
             }
             playbackAudioPitchFormattedString = "";
             desiredVideoResolution = AUTOMATIC_VIDEO_QUALITY_VALUE;
@@ -425,6 +428,11 @@ public final class VideoInformation {
         // An exception occurs when the playback speed dialog is opened by an overlay button while 'Restore old playback speed menu' is off.
         // Update the formatted string value to avoid the exception.
         updatePlaybackSpeedValue(currentVideoSpeed);
+        if (playbackAudioPitchNeedsApplying && Settings.PLAYBACK_SPEED_DEFAULT.get() <= 0.0f) {
+            playbackAudioPitchNeedsApplying = false;
+            final float pitch = playbackAudioPitch;
+            Utils.runOnMainThreadNowOrLater(() -> setPlaybackParameters(currentVideoSpeed, pitch));
+        }
     }
 
     /**
@@ -804,6 +812,7 @@ public final class VideoInformation {
         if (isPlaybackAudioPitchLinked()) {
             updatePlaybackAudioPitchValue(playbackSpeed);
         }
+        playbackAudioPitchNeedsApplying = false;
         currentPlaybackSpeedMenuInterface.patch_setSpeed(playbackSpeed);
     }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
@@ -29,6 +29,7 @@ import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.patches.components.ContextInterface;
 import app.morphe.extension.youtube.patches.voiceovertranslation.VoiceOverTranslationPatch;
 import app.morphe.extension.youtube.shared.Event;
+import app.morphe.extension.youtube.shared.PlayerType;
 import app.morphe.extension.youtube.shared.ShortsPlayerState;
 import app.morphe.extension.youtube.shared.VideoState;
 import app.morphe.extension.youtube.patches.playback.speed.RememberPlaybackSpeedPatch;
@@ -244,11 +245,15 @@ public final class VideoInformation {
             // playbackSpeed = DEFAULT_PLAYBACK_SPEED; // Captured at video start, interferes otherwise.
             playbackSpeedFormattedString = "";
             final float audioPitchOverride = RememberPlaybackSpeedPatch.getPlaybackAudioPitchOverride();
+            final boolean noRegularVideoPlaying = PlayerType.getCurrent().isNoneOrHidden();
             final float newPlaybackAudioPitch = audioPitchOverride > 0.0f &&
                     isPlaybackAudioPitchEnabled() && Settings.PLAYBACK_AUDIO_TIME_STRETCHING.get()
                     ? audioPitchOverride
-                    : DEFAULT_PLAYBACK_AUDIO_PITCH;
-            if (playbackAudioPitch != newPlaybackAudioPitch) {
+                    : !isPlaybackAudioPitchEnabled() || noRegularVideoPlaying
+                            ? DEFAULT_PLAYBACK_AUDIO_PITCH
+                            : playbackAudioPitch;
+            if (playbackAudioPitch != newPlaybackAudioPitch ||
+                    (noRegularVideoPlaying && newPlaybackAudioPitch != DEFAULT_PLAYBACK_AUDIO_PITCH)) {
                 playbackAudioPitch = newPlaybackAudioPitch;
                 playbackAudioPitchNeedsApplying = true;
             }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
@@ -243,8 +243,11 @@ public final class VideoInformation {
             // playbackSpeed = DEFAULT_PLAYBACK_SPEED; // Captured at video start, interferes otherwise.
             playbackSpeedFormattedString = "";
             final float audioPitchOverride = RememberPlaybackSpeedPatch.getPlaybackAudioPitchOverride();
-            if (audioPitchOverride > 0.0f && Settings.ENABLE_PLAYBACK_AUDIO_PITCH.get()) {
+            if (audioPitchOverride > 0.0f && isPlaybackAudioPitchEnabled() &&
+                    Settings.PLAYBACK_AUDIO_TIME_STRETCHING.get()) {
                 playbackAudioPitch = audioPitchOverride;
+            } else {
+                playbackAudioPitch = DEFAULT_PLAYBACK_AUDIO_PITCH;
             }
             playbackAudioPitchFormattedString = "";
             desiredVideoResolution = AUTOMATIC_VIDEO_QUALITY_VALUE;
@@ -797,6 +800,10 @@ public final class VideoInformation {
             return;
         }
 
+        updatePlaybackSpeedValue(playbackSpeed);
+        if (isPlaybackAudioPitchLinked()) {
+            updatePlaybackAudioPitchValue(playbackSpeed);
+        }
         currentPlaybackSpeedMenuInterface.patch_setSpeed(playbackSpeed);
     }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/RememberPlaybackSpeedPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/RememberPlaybackSpeedPatch.java
@@ -31,7 +31,7 @@ public final class RememberPlaybackSpeedPatch {
 
     private static volatile boolean newVideoStarted;
 
-    private static volatile boolean newAudioStarted; // Actually video, just a flag for audio pitch
+    private static volatile boolean newAudioStarted = true; // Actually video, just a flag for audio pitch
 
     private static long lastTimeSpeedChanged;
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlaybackSpeedDialogButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlaybackSpeedDialogButton.java
@@ -94,7 +94,7 @@ public class PlaybackSpeedDialogButton {
                         VideoInformation.getPlaybackSpeed() == defaultSpeed)
                         ? 1.0f
                         : defaultSpeed;
-                VideoInformation.changePlaybackSpeed(speed);
+                VideoInformation.setPlaybackSpeed(speed);
             } catch (Exception ex) {
                 Logger.printException(() -> "speed button long click failure", ex);
             }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlaybackSpeedDialogButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlaybackSpeedDialogButton.java
@@ -95,6 +95,9 @@ public class PlaybackSpeedDialogButton {
                         ? 1.0f
                         : defaultSpeed;
                 VideoInformation.setPlaybackSpeed(speed);
+                if (speed == 1.0f) {
+                    VideoInformation.setAudioPitch(1.0f);
+                }
             } catch (Exception ex) {
                 Logger.printException(() -> "speed button long click failure", ex);
             }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/PlaybackSpeedPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/PlaybackSpeedPatch.kt
@@ -16,9 +16,11 @@ import app.morphe.patches.shared.misc.settings.preference.PreferenceCategory
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference.Sorting
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
+import app.morphe.patches.youtube.video.information.EXTENSION_CLASS
 import app.morphe.patches.youtube.video.speed.button.playbackSpeedButtonPatch
 import app.morphe.patches.youtube.video.speed.custom.customPlaybackSpeedPatch
 import app.morphe.patches.youtube.video.speed.remember.rememberPlaybackSpeedPatch
+import app.morphe.util.setExtensionIsPatchIncluded
 
 /**
  * Speed menu settings. Used to organize all speed related settings together.
@@ -40,6 +42,8 @@ val playbackSpeedPatch = bytecodePatch(
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {
+        setExtensionIsPatchIncluded(EXTENSION_CLASS)
+
         PreferenceScreen.VIDEO.addPreferences(
             PreferenceCategory(
                 key = "morphe_zz_video_key", // Dummy key to force the speed settings last.


### PR DESCRIPTION
This is a follow-up to [#2501](https://github.com/MorpheApp/morphe-patches/pull/2501). That PR stopped YouTube callbacks from overwriting remembered values and moved observer notifications to the main thread. This PR addresses the remaining player-command and pitch issues in dev.11.

1. **Problem:** `videoSpeedChanged` callbacks from YouTube still pass through a helper that sends the reported speed back to YouTube, which can recreate the #2465 feedback loop.
   - **How it works in dev.11:** [`updatePlaybackSpeedValue`](https://github.com/MorpheApp/morphe-patches/blob/d1881c22222bc76cac6b7bea23b7debc031bec6e/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L366-L381) calls `changePlaybackSpeed` for every speed change, including values received through `videoSpeedChanged`.
   - **How it works in this PR:** [`updatePlaybackSpeedValue`](https://github.com/zappybiby/morphe-patches/blob/c1a27da3b951a3d429200f4d17e91eb10fbdf374/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L381-L394) only updates Morphe's current state. Player commands remain in the methods used for explicit selections.

2. **Problem:** Explicit speed and pitch changes can apply the same playback parameters twice.
   - **How it works in dev.11:** [`setAudioPitch`](https://github.com/MorpheApp/morphe-patches/blob/d1881c22222bc76cac6b7bea23b7debc031bec6e/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L420-L438) and [`setPlaybackSpeed`](https://github.com/MorpheApp/morphe-patches/blob/d1881c22222bc76cac6b7bea23b7debc031bec6e/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L879-L895) can apply playback parameters both directly and through YouTube's normal speed path.
   - **How it works in this PR:** [`setAudioPitch`](https://github.com/zappybiby/morphe-patches/blob/c1a27da3b951a3d429200f4d17e91eb10fbdf374/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L434-L449) and [`setPlaybackSpeed`](https://github.com/zappybiby/morphe-patches/blob/c1a27da3b951a3d429200f4d17e91eb10fbdf374/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L907-L918) use YouTube's normal path when speed changes. Pitch-only changes, including relinking at the current speed, are still applied directly.

3. **Problem:** The native speed panel can still reach player-control code from its worker-thread callback. Once that command is removed, a linked pitch change also needs to be applied because YouTube has already applied the selected speed.
   - **How it works in dev.11:** [`setPlaybackSpeedFormattedString`](https://github.com/MorpheApp/morphe-patches/blob/d1881c22222bc76cac6b7bea23b7debc031bec6e/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L851-L868) calls `userSelectedPlaybackSpeed`, which reaches the player command still present in [`updatePlaybackSpeedValue`](https://github.com/MorpheApp/morphe-patches/blob/d1881c22222bc76cac6b7bea23b7debc031bec6e/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L366-L381).
   - **How it works in this PR:** [`setPlaybackSpeedFormattedString`](https://github.com/zappybiby/morphe-patches/blob/c1a27da3b951a3d429200f4d17e91eb10fbdf374/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L873-L899) updates Morphe's state without issuing a speed command, then applies a changed pitch once on the main thread.

4. **Problem:** Selecting a speed while speed and pitch are linked does not save the matching pitch.
   - **How it works in dev.11:** [`userSelectedPlaybackSpeed`](https://github.com/MorpheApp/morphe-patches/blob/d1881c22222bc76cac6b7bea23b7debc031bec6e/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L441-L451) updates the linked pitch in memory but does not save it.
   - **How it works in this PR:** [`userSelectedPlaybackSpeed`](https://github.com/zappybiby/morphe-patches/blob/c1a27da3b951a3d429200f4d17e91eb10fbdf374/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L456-L468) also saves the selected speed as the linked pitch.

5. **Problem:** Saved audio-pitch settings can keep pitch-linking logic active when pitch controls are disabled or the app is repatched without the Playback speed patch.
   - **How it works in dev.11:** The [speed and pitch update helpers](https://github.com/MorpheApp/morphe-patches/blob/d1881c22222bc76cac6b7bea23b7debc031bec6e/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L366-L405) read the saved settings directly, and [`PlaybackSpeedPatch`](https://github.com/MorpheApp/morphe-patches/blob/d1881c22222bc76cac6b7bea23b7debc031bec6e/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/PlaybackSpeedPatch.kt#L38-L48) does not mark its extension logic as included.
   - **How it works in this PR:** [`isPlaybackAudioPitchEnabled` and `isPlaybackAudioPitchLinked`](https://github.com/zappybiby/morphe-patches/blob/c1a27da3b951a3d429200f4d17e91eb10fbdf374/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L159-L169) require the patch and pitch controls to be enabled, and [`PlaybackSpeedPatch`](https://github.com/zappybiby/morphe-patches/blob/c1a27da3b951a3d429200f4d17e91eb10fbdf374/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/PlaybackSpeedPatch.kt#L40-L47) sets the patch-included marker during patching.

6. **Problem:** Starting another video can leave the previous video's pitch applied after its speed resets, and linked default speed and pitch values can be applied out of sync.
   - **How it works in dev.11:** [`initialize`](https://github.com/MorpheApp/morphe-patches/blob/d1881c22222bc76cac6b7bea23b7debc031bec6e/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L222-L244) leaves the cached pitch unchanged when there is no pitch override. [`changePlaybackSpeed`](https://github.com/MorpheApp/morphe-patches/blob/d1881c22222bc76cac6b7bea23b7debc031bec6e/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L772-L790) also sends a default speed to YouTube without first synchronizing linked pitch.
   - **How it works in this PR:** [`initialize`](https://github.com/zappybiby/morphe-patches/blob/c1a27da3b951a3d429200f4d17e91eb10fbdf374/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L234-L257) restores a saved pitch only in unlinked mode and otherwise resets it to `1.0`. [`changePlaybackSpeed`](https://github.com/zappybiby/morphe-patches/blob/c1a27da3b951a3d429200f4d17e91eb10fbdf374/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java#L790-L807) synchronizes linked speed and pitch before sending the command to YouTube.

7. **Problem:** Long-pressing the playback-speed overlay button to reset to `1.0` does not save the reset when remembering playback speed is enabled.
   - **How it works in dev.11:** The [long-press listener](https://github.com/MorpheApp/morphe-patches/blob/d1881c22222bc76cac6b7bea23b7debc031bec6e/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlaybackSpeedDialogButton.java#L89-L100) calls `changePlaybackSpeed` directly and relies on dev.11's notification path to save the reported value.
   - **How it works in this PR:** The [long-press listener](https://github.com/zappybiby/morphe-patches/blob/c1a27da3b951a3d429200f4d17e91eb10fbdf374/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlaybackSpeedDialogButton.java#L89-L100) uses `setPlaybackSpeed`, so the reset follows the same save-and-apply path as the other Morphe speed controls.
