### PR TITLE
fix(Network proxy): Avoid platform HTTPS fallback

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/NetworkProxyPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/NetworkProxyPatch.java
@@ -24,7 +24,6 @@ import org.chromium.net.Proxy;
 import org.chromium.net.ProxyOptions;
 
 import java.io.IOException;
-import java.lang.ref.WeakReference;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.URL;
@@ -33,12 +32,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicReference;
 
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.requests.CronetTransport;
 import app.morphe.extension.shared.requests.Requester;
-import app.morphe.extension.shared.requests.proxy.CronetFallbackHttpURLConnection;
-import app.morphe.extension.shared.requests.proxy.CronetHttpURLConnection;
 import app.morphe.extension.shared.requests.proxy.ProxyFallbackHttpURLConnection;
 
 @SuppressWarnings("unused")
@@ -47,21 +44,12 @@ public final class NetworkProxyPatch {
     private static final int ALL_PROXIES_FAILED_BEHAVIOR_ALLOW_DIRECT = 1;
     private static final String PROXY_AUTHORIZATION_HEADER = "Proxy-Authorization";
     private static final String BASIC_AUTHORIZATION_PREFIX = "Basic ";
-    private static final String JAVA_CRONET_ENGINE_VERSION_PREFIX = "CronetHttpURLConnection/";
     private static final Executor DIRECT_EXECUTOR = Runnable::run;
-    private static final AtomicReference<CronetEngine> REQUESTER_CRONET_ENGINE =
-            new AtomicReference<>();
+    private static final Requester.ConnectionProvider REQUESTER_CONNECTION_PROVIDER =
+            NetworkProxyPatch::openConnection;
 
     private static final ThreadLocal<Boolean> PROXY_OPTIONS_APPLIED_ON_CURRENT_THREAD =
             new ThreadLocal<>();
-
-    /**
-     * Last engine successfully built with proxy options on this thread. Provider selection may
-     * keep an earlier successful engine when a later provider fails, so only a newer successful
-     * build may replace this candidate. {@link #setMainCronetEngine(CronetEngine)} consumes it.
-     */
-    private static final ThreadLocal<WeakReference<CronetEngine>>
-            LAST_PROXY_CONFIGURED_ENGINE_ON_CURRENT_THREAD = new ThreadLocal<>();
 
     private static final Proxy.HttpConnectCallback CONNECT_CALLBACK = new Proxy.HttpConnectCallback() {
         @Override
@@ -81,6 +69,13 @@ public final class NetworkProxyPatch {
     /**
      * Injection point.
      */
+    public static void initialize() {
+        Requester.setConnectionProvider(REQUESTER_CONNECTION_PROVIDER);
+    }
+
+    /**
+     * Injection point.
+     */
     private static boolean useProxyListInt() {
         return false; // Modify during patching,
     }
@@ -89,10 +84,10 @@ public final class NetworkProxyPatch {
      * Injection point.
      */
     public static void applyProxyOptions(CronetEngine.Builder builder) {
+        initialize();
         PROXY_OPTIONS_APPLIED_ON_CURRENT_THREAD.remove();
 
         if (!PROXY_ENABLED.get()) {
-            clearProxyState();
             return;
         }
 
@@ -101,7 +96,6 @@ public final class NetworkProxyPatch {
 
             if (!config.isValid()) {
                 Logger.printException(() -> "Ignoring invalid proxy settings: " + config.host + ":" + config.port);
-                clearProxyState();
                 return;
             }
 
@@ -113,8 +107,8 @@ public final class NetworkProxyPatch {
 
             builder.setProxyOptions(createProxyOptions(proxies, config.allowDirectFallback));
             PROXY_OPTIONS_APPLIED_ON_CURRENT_THREAD.set(true);
-            Requester.setConnectionProvider(NetworkProxyPatch::openConnection);
         } catch (Throwable ex) {
+            PROXY_OPTIONS_APPLIED_ON_CURRENT_THREAD.remove();
             Logger.printException(() -> "applyProxyOptions failure", ex);
         }
     }
@@ -122,30 +116,12 @@ public final class NetworkProxyPatch {
     /**
      * Injection point.
      */
-    public static void recordProxyConfiguredCronetEngine(CronetEngine engine) {
+    public static void recordCronetEngine(CronetEngine engine) {
         boolean proxyOptionsApplied =
                 Boolean.TRUE.equals(PROXY_OPTIONS_APPLIED_ON_CURRENT_THREAD.get());
         PROXY_OPTIONS_APPLIED_ON_CURRENT_THREAD.remove();
-
-        if (!proxyOptionsApplied || engine == null) {
-            return;
-        }
-
-        try {
-            String version = engine.getVersionString();
-            if (version != null && version.startsWith(JAVA_CRONET_ENGINE_VERSION_PREFIX)) {
-                // This fallback delegates openConnection to URL.openConnection and ignores the
-                // ProxyOptions configured on the Cronet builder.
-                Logger.printInfo(() -> "Ignoring Java fallback Cronet engine for extension requests");
-                return;
-            }
-
-            // Do not retain every engine built by optional features. The application-wide engine
-            // factory runs synchronously on this thread and publishes only its own return value.
-            LAST_PROXY_CONFIGURED_ENGINE_ON_CURRENT_THREAD.set(new WeakReference<>(engine));
-        } catch (Throwable ex) {
-            Logger.printException(() -> "recordProxyConfiguredCronetEngine failure", ex);
-        }
+        CronetTransport.registerCronetEngine(engine, proxyOptionsApplied);
+        initialize();
     }
 
     /**
@@ -153,34 +129,8 @@ public final class NetworkProxyPatch {
      */
     public static void setMainCronetEngine(CronetEngine engine) {
         PROXY_OPTIONS_APPLIED_ON_CURRENT_THREAD.remove();
-        WeakReference<CronetEngine> candidateReference =
-                LAST_PROXY_CONFIGURED_ENGINE_ON_CURRENT_THREAD.get();
-        LAST_PROXY_CONFIGURED_ENGINE_ON_CURRENT_THREAD.remove();
-
-        if (engine == null
-                || candidateReference == null
-                || candidateReference.get() != engine) {
-            return;
-        }
-
-        try {
-            if (!PROXY_ENABLED.get() || !getProxyConfig().isValid()) {
-                clearProxyState();
-                return;
-            }
-
-            REQUESTER_CRONET_ENGINE.set(engine);
-            Requester.setConnectionProvider(NetworkProxyPatch::openConnection);
-        } catch (Throwable ex) {
-            Logger.printException(() -> "setMainCronetEngine failure", ex);
-        }
-    }
-
-    private static void clearProxyState() {
-        PROXY_OPTIONS_APPLIED_ON_CURRENT_THREAD.remove();
-        LAST_PROXY_CONFIGURED_ENGINE_ON_CURRENT_THREAD.remove();
-        REQUESTER_CRONET_ENGINE.set(null);
-        Requester.setConnectionProvider(null);
+        CronetTransport.setMainCronetEngine(engine);
+        initialize();
     }
 
     private static ProxyOptions createProxyOptions(ArrayList<Proxy> proxies, boolean allowDirectFallback) {
@@ -201,83 +151,44 @@ public final class NetworkProxyPatch {
     }
 
     private static HttpURLConnection openConnection(URL url) throws IOException {
-        ProxyConfig config = getProxyConfig();
-        if (!PROXY_ENABLED.get() || !config.isValid()) {
-            return openDirectConnection(url);
-        }
-
         String protocol = url.getProtocol();
         boolean httpTarget = "http".equalsIgnoreCase(protocol);
         boolean httpsTarget = "https".equalsIgnoreCase(protocol);
         if (!httpTarget && !httpsTarget) {
-            return openDirectConnection(url);
+            throw new IOException("Unsupported URL protocol: " + protocol);
         }
 
-        boolean proxyAuthenticationEnabled = PROXY_AUTH_ENABLED.get();
-
-        // An HTTPS proxy cannot be represented by java.net.Proxy. Cronet is also required for
-        // authenticated CONNECT requests and for applying the configured direct fallback.
-        // Authenticated plain HTTP requests stay on HttpURLConnection because they do not use
-        // CONNECT and therefore need an explicit Proxy-Authorization header.
-        if (config.httpsProxy
-                || (httpsTarget && proxyAuthenticationEnabled)
-                || (config.allowDirectFallback && !proxyAuthenticationEnabled)) {
-            return openCronetConnection(url, config);
+        if (!PROXY_ENABLED.get()) {
+            return CronetTransport.openConnection(url, false, true);
         }
 
-        return openHttpProxyConnection(url, config);
+        ProxyConfig config = getProxyConfig();
+        if (!config.isValid()) {
+            throw new IOException("Invalid proxy settings: " + config.host + ":" + config.port);
+        }
+
+        // Plain HTTP does not use CONNECT, so proxy authentication needs an explicit header.
+        if (httpTarget && !config.httpsProxy && PROXY_AUTH_ENABLED.get()) {
+            return openAuthenticatedHttpProxyConnection(url, config);
+        }
+
+        // Cronet handles proxy failure and direct fallback internally.
+        return CronetTransport.openConnection(url, true, config.allowDirectFallback);
     }
 
-    private static HttpURLConnection openCronetConnection(URL url, ProxyConfig config)
-            throws IOException {
-        CronetEngine engine = REQUESTER_CRONET_ENGINE.get();
-        if (engine != null) {
-            try {
-                HttpURLConnection connection = new CronetHttpURLConnection(
-                        (HttpURLConnection) engine.openConnection(url),
-                        ex -> discardCronetEngine(engine, ex)
-                );
-                if (!config.allowDirectFallback) {
-                    return connection;
-                }
-
-                return new CronetFallbackHttpURLConnection(
-                        connection,
-                        openDirectConnection(url),
-                        ex -> Logger.printInfo(
-                                () -> "Cronet engine is unavailable; using direct fallback",
-                                ex
-                        )
-                );
-            } catch (IllegalStateException ex) {
-                discardCronetEngine(engine, ex);
-            }
-        }
-
-        if (config.allowDirectFallback) {
-            return openDirectConnection(url);
-        }
-
-        throw new IOException("Proxy-configured Cronet engine is not available");
-    }
-
-    private static void discardCronetEngine(CronetEngine engine, IllegalStateException ex) {
-        if (REQUESTER_CRONET_ENGINE.compareAndSet(engine, null)) {
-            Logger.printInfo(() -> "Proxy Cronet engine is no longer available", ex);
-        }
-    }
-
-    private static HttpURLConnection openHttpProxyConnection(URL url, ProxyConfig config)
-            throws IOException {
-        if (config.httpsProxy) {
-            throw new IOException("HTTPS proxy connections require Cronet");
+    private static HttpURLConnection openAuthenticatedHttpProxyConnection(
+            URL url,
+            ProxyConfig config
+    ) throws IOException {
+        if (!"http".equalsIgnoreCase(url.getProtocol())) {
+            throw new IOException("Java proxy transport is restricted to plaintext HTTP");
         }
 
         HttpURLConnection connection = (HttpURLConnection) url.openConnection(new java.net.Proxy(
                 java.net.Proxy.Type.HTTP,
                 InetSocketAddress.createUnresolved(config.host, config.port)
         ));
-
+        connection.setInstanceFollowRedirects(false);
         setProxyAuthorizationHeader(connection);
 
         if (!config.allowDirectFallback) {
@@ -286,7 +197,7 @@ public final class NetworkProxyPatch {
 
         return new ProxyFallbackHttpURLConnection(
                 connection,
-                openDirectConnection(url),
+                openDirectHttpConnection(url),
                 ex -> Logger.printInfo(
                         () -> "HTTP proxy is unavailable; using direct fallback",
                         ex
@@ -294,8 +205,14 @@ public final class NetworkProxyPatch {
         );
     }
 
-    private static HttpURLConnection openDirectConnection(URL url) throws IOException {
-        return (HttpURLConnection) url.openConnection();
+    private static HttpURLConnection openDirectHttpConnection(URL url) throws IOException {
+        if (!"http".equalsIgnoreCase(url.getProtocol())) {
+            throw new IOException("Platform connection is restricted to plaintext HTTP");
+        }
+
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setInstanceFollowRedirects(false);
+        return connection;
     }
 
     private static ProxyConfig getProxyConfig() {

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/NetworkProxyPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/NetworkProxyPatch.java
@@ -36,6 +36,7 @@ import java.util.concurrent.Executor;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.requests.CronetTransport;
 import app.morphe.extension.shared.requests.Requester;
+import app.morphe.extension.shared.requests.proxy.PlaintextHttpURLConnection;
 import app.morphe.extension.shared.requests.proxy.ProxyFallbackHttpURLConnection;
 
 @SuppressWarnings("unused")
@@ -184,11 +185,12 @@ public final class NetworkProxyPatch {
             throw new IOException("Java proxy transport is restricted to plaintext HTTP");
         }
 
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection(new java.net.Proxy(
-                java.net.Proxy.Type.HTTP,
-                InetSocketAddress.createUnresolved(config.host, config.port)
-        ));
-        connection.setInstanceFollowRedirects(false);
+        HttpURLConnection connection = new PlaintextHttpURLConnection(
+                (HttpURLConnection) url.openConnection(new java.net.Proxy(
+                        java.net.Proxy.Type.HTTP,
+                        InetSocketAddress.createUnresolved(config.host, config.port)
+                ))
+        );
         setProxyAuthorizationHeader(connection);
 
         if (!config.allowDirectFallback) {
@@ -210,9 +212,9 @@ public final class NetworkProxyPatch {
             throw new IOException("Platform connection is restricted to plaintext HTTP");
         }
 
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-        connection.setInstanceFollowRedirects(false);
-        return connection;
+        return new PlaintextHttpURLConnection(
+                (HttpURLConnection) url.openConnection()
+        );
     }
 
     private static ProxyConfig getProxyConfig() {

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/requests/CronetTransport.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/requests/CronetTransport.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2510
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/requests/CronetTransport.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/requests/CronetTransport.java
@@ -23,6 +23,7 @@ import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.requests.proxy.CronetFallbackHttpURLConnection;
 import app.morphe.extension.shared.requests.proxy.CronetHttpURLConnection;
 import app.morphe.extension.shared.requests.proxy.DeferredHttpURLConnection;
+import app.morphe.extension.shared.requests.proxy.PlaintextHttpURLConnection;
 
 public final class CronetTransport {
     private static final String JAVA_CRONET_ENGINE_VERSION_PREFIX = "CronetHttpURLConnection/";
@@ -359,9 +360,9 @@ public final class CronetTransport {
             throw new IOException("Platform connection is restricted to plaintext HTTP");
         }
 
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-        connection.setInstanceFollowRedirects(false);
-        return connection;
+        return new PlaintextHttpURLConnection(
+                (HttpURLConnection) url.openConnection()
+        );
     }
 
     private static final class EngineRegistration {

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/requests/CronetTransport.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/requests/CronetTransport.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.requests;
+
+import org.chromium.net.CronetEngine;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.requests.proxy.CronetFallbackHttpURLConnection;
+import app.morphe.extension.shared.requests.proxy.CronetHttpURLConnection;
+import app.morphe.extension.shared.requests.proxy.DeferredHttpURLConnection;
+
+public final class CronetTransport {
+    private static final String JAVA_CRONET_ENGINE_VERSION_PREFIX = "CronetHttpURLConnection/";
+    private static final long ENGINE_WAIT_TIMEOUT_MILLISECONDS = 5000;
+    private static final Object ENGINE_LOCK = new Object();
+    private static final ArrayList<EngineRegistration> ENGINE_REGISTRATIONS = new ArrayList<>();
+
+    private static WeakReference<CronetEngine> mainEngineReference = new WeakReference<>(null);
+
+    private CronetTransport() {
+    }
+
+    /**
+     * Registers an engine returned by {@code CronetEngine.Builder.buildExperimental()}.
+     */
+    public static boolean registerCronetEngine(CronetEngine engine, boolean proxyConfigured) {
+        if (!isUsableEngine(engine)) {
+            return false;
+        }
+
+        boolean registrationChanged = false;
+        synchronized (ENGINE_LOCK) {
+            removeReleasedEnginesLocked();
+
+            EngineRegistration registration = findRegistrationLocked(engine);
+            if (registration == null) {
+                ENGINE_REGISTRATIONS.add(new EngineRegistration(engine, proxyConfigured));
+                registrationChanged = true;
+            } else if (proxyConfigured && !registration.proxyConfigured) {
+                registration.proxyConfigured = true;
+                registrationChanged = true;
+            }
+
+            ENGINE_LOCK.notifyAll();
+        }
+
+        if (registrationChanged) {
+            Logger.printDebug(() -> "Registered Cronet engine, proxy configured: "
+                    + proxyConfigured);
+        }
+        return true;
+    }
+
+    /**
+     * Gives the application-wide engine priority over other registered engines.
+     */
+    public static boolean setMainCronetEngine(CronetEngine engine) {
+        if (!isUsableEngine(engine)) {
+            return false;
+        }
+
+        synchronized (ENGINE_LOCK) {
+            removeReleasedEnginesLocked();
+            if (findRegistrationLocked(engine) == null) {
+                ENGINE_REGISTRATIONS.add(new EngineRegistration(engine, false));
+            }
+            mainEngineReference = new WeakReference<>(engine);
+            ENGINE_LOCK.notifyAll();
+        }
+        return true;
+    }
+
+    /**
+     * Opens a connection without falling back to the platform HTTPS stack.
+     *
+     * @param requireProxy Whether the preferred engine must have proxy options.
+     * @param allowDirectFallback Whether an unproxied engine, or platform HTTP, may be used.
+     */
+    public static HttpURLConnection openConnection(
+            URL url,
+            boolean requireProxy,
+            boolean allowDirectFallback
+    ) throws IOException {
+        boolean https = "https".equalsIgnoreCase(url.getProtocol());
+        List<CronetEngine> engines = getEligibleEngines(
+                requireProxy,
+                allowDirectFallback
+        );
+        HttpURLConnection connection = createCronetConnectionChain(url, engines);
+        if (connection != null) {
+            return addDirectHttpFallback(url, connection, allowDirectFallback);
+        }
+
+        if (!requireProxy && allowDirectFallback && !https) {
+            return openDirectHttpConnection(url);
+        }
+
+        return new DeferredHttpURLConnection(
+                url,
+                connectTimeout -> openConnectionAfterWaiting(
+                        url,
+                        requireProxy,
+                        allowDirectFallback,
+                        connectTimeout
+                )
+        );
+    }
+
+    private static HttpURLConnection openConnectionAfterWaiting(
+            URL url,
+            boolean requireProxy,
+            boolean allowDirectFallback,
+            int connectTimeoutMilliseconds
+    ) throws IOException {
+        long waitTimeoutMilliseconds = connectTimeoutMilliseconds > 0
+                ? Math.min(connectTimeoutMilliseconds, ENGINE_WAIT_TIMEOUT_MILLISECONDS)
+                : ENGINE_WAIT_TIMEOUT_MILLISECONDS;
+        List<CronetEngine> engines = awaitEngines(
+                requireProxy,
+                allowDirectFallback,
+                waitTimeoutMilliseconds
+        );
+
+        HttpURLConnection connection = createCronetConnectionChain(url, engines);
+        if (connection != null) {
+            return addDirectHttpFallback(url, connection, allowDirectFallback);
+        }
+
+        boolean https = "https".equalsIgnoreCase(url.getProtocol());
+        if (allowDirectFallback && !https) {
+            return openDirectHttpConnection(url);
+        }
+
+        if (connectTimeoutMilliseconds > 0
+                && waitTimeoutMilliseconds == connectTimeoutMilliseconds
+                && !Utils.isCurrentlyOnMainThread()) {
+            throw new SocketTimeoutException("Timed out waiting for a Cronet engine");
+        }
+
+        throw new IOException(
+                https
+                        ? "Cronet engine is not available; platform HTTPS fallback is disabled"
+                        : "Cronet engine is not available"
+        );
+    }
+
+    private static HttpURLConnection addDirectHttpFallback(
+            URL url,
+            HttpURLConnection connection,
+            boolean allowDirectFallback
+    ) throws IOException {
+        if (!allowDirectFallback || "https".equalsIgnoreCase(url.getProtocol())) {
+            return connection;
+        }
+
+        return new CronetFallbackHttpURLConnection(
+                connection,
+                openDirectHttpConnection(url),
+                ex -> Logger.printInfo(
+                        () -> "Cronet engine is unavailable; using direct HTTP fallback",
+                        ex
+                )
+        );
+    }
+
+    private static List<CronetEngine> awaitEngines(
+            boolean requireProxy,
+            boolean allowDirectFallback,
+            long waitTimeoutMilliseconds
+    ) throws IOException {
+        long deadlineNanos = System.nanoTime()
+                + TimeUnit.MILLISECONDS.toNanos(waitTimeoutMilliseconds);
+
+        synchronized (ENGINE_LOCK) {
+            while (true) {
+                List<CronetEngine> engines = getEligibleEnginesLocked(
+                        requireProxy,
+                        allowDirectFallback
+                );
+                if (!engines.isEmpty() || Utils.isCurrentlyOnMainThread()) {
+                    return engines;
+                }
+
+                long remainingNanos = deadlineNanos - System.nanoTime();
+                if (remainingNanos <= 0) {
+                    return engines;
+                }
+
+                try {
+                    long waitMilliseconds = TimeUnit.NANOSECONDS.toMillis(remainingNanos);
+                    int waitNanoseconds = (int) (remainingNanos
+                            - TimeUnit.MILLISECONDS.toNanos(waitMilliseconds));
+                    ENGINE_LOCK.wait(waitMilliseconds, waitNanoseconds);
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while waiting for a Cronet engine", ex);
+                }
+            }
+        }
+    }
+
+    private static List<CronetEngine> getEligibleEngines(
+            boolean requireProxy,
+            boolean allowDirectFallback
+    ) {
+        synchronized (ENGINE_LOCK) {
+            return getEligibleEnginesLocked(requireProxy, allowDirectFallback);
+        }
+    }
+
+    private static List<CronetEngine> getEligibleEnginesLocked(
+            boolean requireProxy,
+            boolean allowDirectFallback
+    ) {
+        removeReleasedEnginesLocked();
+
+        ArrayList<CronetEngine> engines = new ArrayList<>();
+        appendEnginesLocked(engines, requireProxy);
+        if (requireProxy && allowDirectFallback) {
+            appendEnginesLocked(engines, false);
+        }
+        return engines;
+    }
+
+    private static void appendEnginesLocked(
+            ArrayList<CronetEngine> engines,
+            boolean proxyConfigured
+    ) {
+        CronetEngine mainEngine = mainEngineReference.get();
+        EngineRegistration mainRegistration = findRegistrationLocked(mainEngine);
+        if (mainRegistration != null && mainRegistration.proxyConfigured == proxyConfigured) {
+            engines.add(mainEngine);
+        }
+
+        for (int i = ENGINE_REGISTRATIONS.size() - 1; i >= 0; i--) {
+            EngineRegistration registration = ENGINE_REGISTRATIONS.get(i);
+            CronetEngine engine = registration.engineReference.get();
+            if (engine != null
+                    && engine != mainEngine
+                    && registration.proxyConfigured == proxyConfigured) {
+                engines.add(engine);
+            }
+        }
+    }
+
+    private static HttpURLConnection createCronetConnectionChain(
+            URL url,
+            List<CronetEngine> engines
+    ) throws IOException {
+        HttpURLConnection connection = null;
+        IOException openFailure = null;
+        for (int i = engines.size() - 1; i >= 0; i--) {
+            CronetEngine engine = engines.get(i);
+            try {
+                HttpURLConnection engineConnection = new CronetHttpURLConnection(
+                        (HttpURLConnection) engine.openConnection(url),
+                        ex -> discardCronetEngine(engine, ex)
+                );
+                connection = connection == null
+                        ? engineConnection
+                        : new CronetFallbackHttpURLConnection(
+                                engineConnection,
+                                connection,
+                                ex -> discardCronetEngine(engine, ex)
+                        );
+            } catch (IllegalStateException ex) {
+                discardCronetEngine(engine, ex);
+            } catch (IOException ex) {
+                if (openFailure != null) {
+                    ex.addSuppressed(openFailure);
+                }
+                openFailure = ex;
+            }
+        }
+        if (connection == null && openFailure != null) {
+            throw openFailure;
+        }
+        return connection;
+    }
+
+    private static boolean isUsableEngine(CronetEngine engine) {
+        if (engine == null) {
+            return false;
+        }
+
+        try {
+            String version = engine.getVersionString();
+            if (version != null && version.startsWith(JAVA_CRONET_ENGINE_VERSION_PREFIX)) {
+                Logger.printInfo(() -> "Ignoring Java fallback Cronet engine for extension requests");
+                return false;
+            }
+            return true;
+        } catch (Throwable ex) {
+            Logger.printException(() -> "Cronet engine validation failure", ex);
+            return false;
+        }
+    }
+
+    private static void discardCronetEngine(CronetEngine engine, IllegalStateException ex) {
+        boolean removed = false;
+        synchronized (ENGINE_LOCK) {
+            for (int i = ENGINE_REGISTRATIONS.size() - 1; i >= 0; i--) {
+                if (ENGINE_REGISTRATIONS.get(i).engineReference.get() == engine) {
+                    ENGINE_REGISTRATIONS.remove(i);
+                    removed = true;
+                }
+            }
+            if (mainEngineReference.get() == engine) {
+                mainEngineReference = new WeakReference<>(null);
+            }
+        }
+
+        if (removed) {
+            Logger.printInfo(() -> "Cronet engine is no longer available", ex);
+        }
+    }
+
+    private static EngineRegistration findRegistrationLocked(CronetEngine engine) {
+        if (engine == null) {
+            return null;
+        }
+
+        for (EngineRegistration registration : ENGINE_REGISTRATIONS) {
+            if (registration.engineReference.get() == engine) {
+                return registration;
+            }
+        }
+        return null;
+    }
+
+    private static void removeReleasedEnginesLocked() {
+        for (int i = ENGINE_REGISTRATIONS.size() - 1; i >= 0; i--) {
+            if (ENGINE_REGISTRATIONS.get(i).engineReference.get() == null) {
+                ENGINE_REGISTRATIONS.remove(i);
+            }
+        }
+        if (mainEngineReference.get() == null) {
+            mainEngineReference = new WeakReference<>(null);
+        }
+    }
+
+    private static HttpURLConnection openDirectHttpConnection(URL url) throws IOException {
+        if (!"http".equalsIgnoreCase(url.getProtocol())) {
+            throw new IOException("Platform connection is restricted to plaintext HTTP");
+        }
+
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setInstanceFollowRedirects(false);
+        return connection;
+    }
+
+    private static final class EngineRegistration {
+        private final WeakReference<CronetEngine> engineReference;
+        private boolean proxyConfigured;
+
+        private EngineRegistration(CronetEngine engine, boolean proxyConfigured) {
+            this.engineReference = new WeakReference<>(engine);
+            this.proxyConfigured = proxyConfigured;
+        }
+    }
+}

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/requests/proxy/CronetHttpURLConnection.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/requests/proxy/CronetHttpURLConnection.java
@@ -197,10 +197,16 @@ public final class CronetHttpURLConnection extends DelegatingHttpURLConnection {
     @Override
     public synchronized OutputStream getOutputStream() throws IOException {
         if (outputStream == null) {
+            if (!getDoOutput()) {
+                setDoOutput(true);
+            }
             OutputStream delegateOutputStream = executeRequestStartWithDeadline(
                     super::getOutputStream,
                     requestStartDeadline()
             );
+            if (delegateOutputStream == null) {
+                throw new IOException("Cronet returned a null output stream");
+            }
             markRequestStarted();
             outputStream = new WriteTimeoutOutputStream(delegateOutputStream);
         }

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/requests/proxy/DeferredHttpURLConnection.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/requests/proxy/DeferredHttpURLConnection.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2510
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/requests/proxy/DeferredHttpURLConnection.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/requests/proxy/DeferredHttpURLConnection.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.requests.proxy;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.ProtocolException;
+import java.net.SocketTimeoutException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Defers connection selection until request I/O and charges it to the connect timeout.
+ */
+public final class DeferredHttpURLConnection extends DelegatingHttpURLConnection {
+    private final PendingHttpURLConnection pendingConnection;
+    private final ConnectionFactory connectionFactory;
+
+    public DeferredHttpURLConnection(URL url, ConnectionFactory connectionFactory) {
+        this(new PendingHttpURLConnection(url), connectionFactory);
+    }
+
+    private DeferredHttpURLConnection(
+            PendingHttpURLConnection pendingConnection,
+            ConnectionFactory connectionFactory
+    ) {
+        super(pendingConnection);
+        this.pendingConnection = pendingConnection;
+        this.connectionFactory = connectionFactory;
+    }
+
+    private synchronized void selectConnection() throws IOException {
+        if (delegate != pendingConnection) {
+            return;
+        }
+
+        int connectTimeout = pendingConnection.getConnectTimeout();
+        long startNanos = System.nanoTime();
+        HttpURLConnection selectedConnection =
+                connectionFactory.openConnection(connectTimeout);
+
+        int remainingConnectTimeout = connectTimeout;
+        if (connectTimeout > 0) {
+            long elapsedMilliseconds = TimeUnit.NANOSECONDS.toMillis(
+                    System.nanoTime() - startNanos
+            );
+            if (elapsedMilliseconds >= connectTimeout) {
+                try {
+                    selectedConnection.disconnect();
+                } catch (RuntimeException ignored) {
+                    // Preserve the timeout.
+                }
+                throw new SocketTimeoutException(
+                        "Timed out while waiting for a network transport"
+                );
+            }
+            remainingConnectTimeout = (int) Math.max(
+                    1,
+                    connectTimeout - elapsedMilliseconds
+            );
+        }
+
+        pendingConnection.applyTo(selectedConnection, remainingConnectTimeout);
+        delegate = selectedConnection;
+    }
+
+    @Override
+    public void connect() throws IOException {
+        selectConnection();
+        super.connect();
+    }
+
+    @Override
+    protected void beforeResponse() throws IOException {
+        selectConnection();
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        selectConnection();
+        return super.getOutputStream();
+    }
+
+    @FunctionalInterface
+    public interface ConnectionFactory {
+        HttpURLConnection openConnection(int connectTimeoutMilliseconds) throws IOException;
+    }
+
+    private static final class PendingHttpURLConnection extends HttpURLConnection {
+        private PendingHttpURLConnection(URL url) {
+            super(url);
+        }
+
+        private void applyTo(
+                HttpURLConnection connection,
+                int connectTimeoutMilliseconds
+        ) throws ProtocolException {
+            connection.setConnectTimeout(connectTimeoutMilliseconds);
+            connection.setReadTimeout(getReadTimeout());
+            connection.setRequestMethod(getRequestMethod());
+            connection.setDoInput(getDoInput());
+            connection.setDoOutput(getDoOutput());
+            connection.setAllowUserInteraction(getAllowUserInteraction());
+            connection.setUseCaches(getUseCaches());
+            connection.setIfModifiedSince(getIfModifiedSince());
+            connection.setDefaultUseCaches(getDefaultUseCaches());
+            connection.setInstanceFollowRedirects(getInstanceFollowRedirects());
+
+            if (fixedContentLengthLong >= 0) {
+                connection.setFixedLengthStreamingMode(fixedContentLengthLong);
+            } else if (fixedContentLength >= 0) {
+                connection.setFixedLengthStreamingMode(fixedContentLength);
+            } else if (chunkLength > 0) {
+                connection.setChunkedStreamingMode(chunkLength);
+            }
+
+            for (Map.Entry<String, List<String>> entry : getRequestProperties().entrySet()) {
+                List<String> values = entry.getValue();
+                if (values.isEmpty()) {
+                    continue;
+                }
+
+                connection.setRequestProperty(entry.getKey(), values.get(0));
+                for (int i = 1; i < values.size(); i++) {
+                    connection.addRequestProperty(entry.getKey(), values.get(i));
+                }
+            }
+        }
+
+        @Override
+        public void connect() {
+            throw new IllegalStateException("Pending connection cannot perform I/O");
+        }
+
+        @Override
+        public void disconnect() {
+        }
+
+        @Override
+        public boolean usingProxy() {
+            return false;
+        }
+    }
+}

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/requests/proxy/PlaintextHttpURLConnection.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/requests/proxy/PlaintextHttpURLConnection.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2510
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/requests/proxy/PlaintextHttpURLConnection.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/requests/proxy/PlaintextHttpURLConnection.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.requests.proxy;
+
+import java.net.HttpURLConnection;
+
+/**
+ * Prevents a platform HTTP connection from following redirects into HTTPS.
+ */
+public final class PlaintextHttpURLConnection extends DelegatingHttpURLConnection {
+    public PlaintextHttpURLConnection(HttpURLConnection delegate) {
+        super(requireHttp(delegate));
+        super.setInstanceFollowRedirects(false);
+    }
+
+    private static HttpURLConnection requireHttp(HttpURLConnection connection) {
+        if (connection == null
+                || !"http".equalsIgnoreCase(connection.getURL().getProtocol())) {
+            throw new IllegalArgumentException(
+                    "Platform connection is restricted to plaintext HTTP"
+            );
+        }
+        return connection;
+    }
+
+    @Override
+    public void setInstanceFollowRedirects(boolean followRedirects) {
+        super.setInstanceFollowRedirects(false);
+    }
+
+    @Override
+    public boolean getInstanceFollowRedirects() {
+        return false;
+    }
+}

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/AiSListRequester.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/AiSListRequester.java
@@ -13,7 +13,6 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
 
@@ -75,7 +74,7 @@ public final class AiSListRequester {
         HttpURLConnection connection = null;
         final long start = System.currentTimeMillis();
         try {
-            connection = (HttpURLConnection) new URL(url).openConnection();
+            connection = Requester.openConnection(url);
             connection.setFixedLengthStreamingMode(0);
             connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
             connection.setReadTimeout(READ_TIMEOUT_MS);

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/proxy/NetworkProxyPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/proxy/NetworkProxyPatch.kt
@@ -1,12 +1,16 @@
 package app.morphe.patches.music.misc.proxy
 
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patches.music.misc.extension.sharedExtensionPatch
+import app.morphe.patches.music.misc.extension.hooks.youTubeMusicApplicationInitHook
+import app.morphe.patches.music.misc.extension.hooks.youTubeMusicApplicationInitOnCreateHook
 import app.morphe.patches.music.misc.playservice.is_8_51_or_greater
 import app.morphe.patches.music.misc.playservice.is_9_20_or_greater
 import app.morphe.patches.music.misc.playservice.versionCheckPatch
 import app.morphe.patches.music.misc.settings.PreferenceScreen
 import app.morphe.patches.music.misc.settings.settingsPatch
 import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
+import app.morphe.patches.shared.misc.proxy.EXTENSION_CLASS
 import app.morphe.patches.shared.misc.proxy.baseNetworkProxyPatch
 
 @Suppress("unused")
@@ -30,5 +34,16 @@ val networkProxyPatch = baseNetworkProxyPatch(
         )
 
         compatibleWith(COMPATIBILITY_YOUTUBE_MUSIC)
+    },
+    executeBlock = {
+        listOf(
+            youTubeMusicApplicationInitHook,
+            youTubeMusicApplicationInitOnCreateHook
+        ).forEach { hook ->
+            hook.fingerprint.method.addInstruction(
+                0,
+                "invoke-static { }, $EXTENSION_CLASS->initialize()V"
+            )
+        }
     }
 )

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/proxy/NetworkProxyPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/proxy/NetworkProxyPatch.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/1823
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
 package app.morphe.patches.music.misc.proxy
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/proxy/BaseNetworkProxyPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/proxy/BaseNetworkProxyPatch.kt
@@ -86,7 +86,7 @@ internal fun baseNetworkProxyPatch(
                 val register = getInstruction<OneRegisterInstruction>(index).registerA
                 addInstruction(
                     index,
-                    "invoke-static { v$register }, $EXTENSION_CLASS->recordProxyConfiguredCronetEngine($CRONET_ENGINE_CLASS)V"
+                    "invoke-static { v$register }, $EXTENSION_CLASS->recordCronetEngine($CRONET_ENGINE_CLASS)V"
                 )
             }
         }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/proxy/NetworkProxyPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/proxy/NetworkProxyPatch.kt
@@ -1,7 +1,11 @@
 package app.morphe.patches.youtube.misc.proxy
 
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patches.shared.misc.proxy.EXTENSION_CLASS
 import app.morphe.patches.shared.misc.proxy.baseNetworkProxyPatch
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
+import app.morphe.patches.youtube.misc.extension.hooks.applicationInitHook
+import app.morphe.patches.youtube.misc.extension.hooks.applicationInitOnCrateHook
 import app.morphe.patches.youtube.misc.playservice.is_20_47_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_21_12_or_greater
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
@@ -30,5 +34,13 @@ val networkProxyPatch = baseNetworkProxyPatch(
         )
 
         compatibleWith(COMPATIBILITY_YOUTUBE)
+    },
+    executeBlock = {
+        listOf(applicationInitHook, applicationInitOnCrateHook).forEach { hook ->
+            hook.fingerprint.method.addInstruction(
+                0,
+                "invoke-static { }, $EXTENSION_CLASS->initialize()V"
+            )
+        }
     }
 )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/proxy/NetworkProxyPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/proxy/NetworkProxyPatch.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/1823
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
 package app.morphe.patches.youtube.misc.proxy
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction


### PR DESCRIPTION
### Description

Routes extension HTTPS requests through usable native Cronet engines when the `Network proxy` patch is included, including when the proxy setting is disabled.

Previously, `Requester` could fall back to `URL.openConnection()`, which can reach YouTube's guarded Java SSL stack.

This change:

- Registers native Cronet engines as they are built and prioritizes the main engine.
- Rejects Java fallback Cronet and prevents platform HTTPS fallback.
- Keeps Java proxy handling restricted to plaintext HTTP.
- Routes AiSList requests through `Requester`.
- Ensures Cronet POST output streams work consistently on YouTube and YouTube Music.

Related to #2412

### Additional context

This change follows up on a possible cause suggested in #2479: `Requester` falling back to `URL.openConnection()` even when the proxy is disabled.

The original warning was not reliably reproducible, so there is no affected-device before-and-after confirmation yet. For that reason, `Network proxy` remains excluded by default until the fix is confirmed on affected devices.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)