### PR TITLE
chore(Spoof video streams): Minor fix for Android VR

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
@@ -308,8 +308,9 @@ public class SpoofVideoStreamsPatch {
                     Logger.printException(() -> "Ignoring request with no ID: " + url);
                     return;
                 }
+                boolean isInline = "1".equals(uri.getQueryParameter("inline"));
 
-                StreamingDataRequest.fetchRequest(id, requestHeaders);
+                StreamingDataRequest.fetchRequest(id, isInline, requestHeaders);
             } catch (Exception ex) {
                 Logger.printException(() -> "buildRequest failure", ex);
             }

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/requests/StreamingDataRequest.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/requests/StreamingDataRequest.java
@@ -131,17 +131,19 @@ public class StreamingDataRequest {
     }
 
     private final String videoId;
+    private final boolean isInline;
 
     private final Future<StreamData> future;
 
-    private StreamingDataRequest(String videoId, Map<String, String> playerHeaders) {
+    private StreamingDataRequest(String videoId, boolean isInline, Map<String, String> playerHeaders) {
         this.videoId = videoId;
-        this.future = Utils.submitOnBackgroundThread(() -> fetch(videoId, playerHeaders));
+        this.isInline = isInline;
+        this.future = Utils.submitOnBackgroundThread(() -> fetch(videoId, isInline, playerHeaders));
     }
 
-    public static void fetchRequest(String videoId, Map<String, String> fetchHeaders) {
+    public static void fetchRequest(String videoId, boolean isInline, Map<String, String> fetchHeaders) {
         // Always fetch, even if there is an existing request for the same video.
-        cache.put(videoId, new StreamingDataRequest(videoId, fetchHeaders));
+        cache.put(videoId, new StreamingDataRequest(videoId, isInline, fetchHeaders));
     }
 
     @Nullable
@@ -265,7 +267,8 @@ public class StreamingDataRequest {
 
     @Nullable
     private static StreamData buildPlayerResponseBuffer(ClientType clientType,
-                                                        HttpURLConnection connection) {
+                                                        HttpURLConnection connection,
+                                                        boolean isInline) {
         if (connection == null) {
             return null;
         }
@@ -346,18 +349,33 @@ public class StreamingDataRequest {
             if (clientType.requireSABR && playerResponse.hasPlayerConfig()) {
                 PlayerConfig.Builder playerConfigBuilder = playerResponse.getPlayerConfig().toBuilder();
 
-                // In some clients, 'playerGestureConfig' is missing from the response.
-                // Add 'playerGestureConfig' using proto builder.
-                PlayerGestureConfig.Builder playerGestureConfigBuilder = playerConfigBuilder.getPlayerGestureConfig().toBuilder();
-                playerGestureConfigBuilder.setDownAndOutPortraitAllowed(true);
-                playerGestureConfigBuilder.setDownAndOutLandscapeAllowed(true);
-                playerConfigBuilder.setPlayerGestureConfig(playerGestureConfigBuilder);
-
-                playerConfigBuffer = playerConfigBuilder.build().toByteArray();
-
                 // If 'androidMedialibConfig' exists in the response, all playerConfigs are compatible.
                 // Override all playerConfigs.
                 hasAndroidMedia = playerConfigBuilder.hasAndroidMedialibConfig();
+
+                if (hasAndroidMedia) {
+                    // In some clients, 'playerGestureConfig' is missing from the response.
+                    // Add 'playerGestureConfig' using proto builder.
+                    PlayerGestureConfig.Builder playerGestureConfigBuilder = playerConfigBuilder.getPlayerGestureConfig().toBuilder();
+                    playerGestureConfigBuilder.setDownAndOutPortraitAllowed(true);
+                    playerGestureConfigBuilder.setDownAndOutLandscapeAllowed(true);
+                    playerConfigBuilder.setPlayerGestureConfig(playerGestureConfigBuilder);
+
+                    // In autoplay in feed, 'inline' query parameters and unique player parameters are used when sending requests.
+                    // To minimize code modifications, simply add 'inlinePlaybackConfig' using proto builder.
+                    if (isInline) {
+                        AudioConfig.Builder audioConfigBuilder = playerConfigBuilder.getAudioConfig().toBuilder();
+                        audioConfigBuilder.setMuteOnStart(true);
+                        playerConfigBuilder.setAudioConfig(audioConfigBuilder);
+
+                        InlinePlaybackConfig.Builder inlinePlaybackConfigBuilder = playerConfigBuilder.getInlinePlaybackConfig().toBuilder();
+                        inlinePlaybackConfigBuilder.setShowAudioControls(true);
+                        inlinePlaybackConfigBuilder.setShowScrubbingControls(true);
+                        playerConfigBuilder.setInlinePlaybackConfig(inlinePlaybackConfigBuilder);
+                    }
+                }
+
+                playerConfigBuffer = playerConfigBuilder.build().toByteArray();
             }
 
             return new StreamData(streamingDataBuffer, playerConfigBuffer, hasAndroidMedia);
@@ -375,7 +393,7 @@ public class StreamingDataRequest {
         return false;
     }
 
-    private static StreamData fetch(String videoId, @Nullable Map<String, String> playerHeaders) {
+    private static StreamData fetch(String videoId, boolean isInline, @Nullable Map<String, String> playerHeaders) {
         final boolean debugEnabled = BaseSettings.DEBUG.get();
         final long fetchStartTime = System.currentTimeMillis();
 
@@ -390,13 +408,13 @@ public class StreamingDataRequest {
             final boolean showErrorToast = (++i == clientOrderToUse.length) || debugEnabled;
 
             HttpURLConnection connection = send(clientType, videoId, playerHeaders, showErrorToast);
-            StreamData streamingData = buildPlayerResponseBuffer(clientType, connection);
+            StreamData streamingData = buildPlayerResponseBuffer(clientType, connection, isInline);
 
             if (clientType == ClientType.TV_SABR && fallbackWithTVDash) {
                 fallbackWithTVDash = false;
                 clientType = ClientType.TV_DASH;
                 HttpURLConnection fallBackConnection = send(clientType, videoId, playerHeaders, showErrorToast);
-                streamingData = buildPlayerResponseBuffer(clientType, fallBackConnection);
+                streamingData = buildPlayerResponseBuffer(clientType, fallBackConnection, isInline);
             }
 
             if (streamingData != null) {
@@ -461,6 +479,6 @@ public class StreamingDataRequest {
     @NonNull
     @Override
     public String toString() {
-        return "StreamingDataRequest{" + "videoId='" + videoId + '\'' + '}';
+        return "StreamingDataRequest{" + "videoId='" + videoId + "', isInline='" + isInline + '\'' + '}';
     }
 }

--- a/extensions/shared-youtube/library/src/main/proto/app/morphe/extension/shared/innertube/player_response.proto
+++ b/extensions/shared-youtube/library/src/main/proto/app/morphe/extension/shared/innertube/player_response.proto
@@ -51,8 +51,14 @@ message Format {
 }
 
 message PlayerConfig {
+  optional AudioConfig audioConfig = 55405814;
   optional AndroidMedialibConfig androidMedialibConfig = 78958444;
   optional PlayerGestureConfig playerGestureConfig = 262192541;
+  optional InlinePlaybackConfig inlinePlaybackConfig = 399288314;
+}
+
+message AudioConfig {
+  optional bool muteOnStart = 4;
 }
 
 message AndroidMedialibConfig {
@@ -62,4 +68,9 @@ message AndroidMedialibConfig {
 message PlayerGestureConfig {
   optional bool downAndOutPortraitAllowed = 1;
   optional bool downAndOutLandscapeAllowed = 2;
+}
+
+message InlinePlaybackConfig {
+  optional bool showScrubbingControls = 1;
+  optional bool showAudioControls = 2;
 }


### PR DESCRIPTION
### Description

Follow-up to #2479.

There was an issue where mute was not applied by default in autoplay in feed when Android VR (SABR) was used as the default client.

### Additional context

N/A

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
