### PR TITLE
feat(Theme): Change the app background color from the app settings

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/lyrics/ui/LyricsPanelView.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/lyrics/ui/LyricsPanelView.java
@@ -50,6 +50,7 @@ import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.shared.ui.ViewAnimations;
 
@@ -641,9 +642,9 @@ public final class LyricsPanelView extends FrameLayout implements LyricsManager.
     private static int lineTextColor() {
         final int colorId = ResourceUtils.getIdentifier(ResourceType.COLOR, APP_PRIMARY_TEXT_COLOR);
         if (colorId == 0) {
-            return Utils.getAppForegroundColor();
+            return ThemeUtils.getAppForegroundColor();
         }
-        return ResourceUtils.getColor(APP_PRIMARY_TEXT_COLOR, Utils.getAppForegroundColor());
+        return ResourceUtils.getColor(APP_PRIMARY_TEXT_COLOR, ThemeUtils.getAppForegroundColor());
     }
 
     private static String sourceText(String providerName) {

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/theme/ThemePatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/theme/ThemePatch.java
@@ -1,5 +1,7 @@
 package app.morphe.extension.music.patches.theme;
 
+import androidx.annotation.ColorInt;
+
 import app.morphe.extension.shared.theme.BaseThemePatch;
 
 @SuppressWarnings("unused")
@@ -21,7 +23,8 @@ public class ThemePatch extends BaseThemePatch {
      * @param originalValue The original color value.
      * @return The new or original color value.
      */
-    public static int getValue(int originalValue) {
+    @ColorInt
+    public static int getValue(@ColorInt int originalValue) {
         return processColorValue(originalValue, DARK_VALUES, null);
     }
 }

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/theme/ThemePatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/theme/ThemePatch.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2524
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.music.patches.theme;
 
 import androidx.annotation.ColorInt;

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/MusicActivityHook.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/MusicActivityHook.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.music.settings;
 
 import android.annotation.SuppressLint;
@@ -20,6 +30,7 @@ import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.BaseActivityHook;
 import app.morphe.extension.shared.spoof.SpoofAppVersionPatch;
+import app.morphe.extension.shared.theme.ThemeUtils;
 
 /**
  * Hooks {@code com.google.android.gms.common.api.GoogleApiActivity}
@@ -89,9 +100,9 @@ public class MusicActivityHook extends BaseActivityHook {
         Drawable navigationIcon = MusicPreferenceFragment.getBackButtonDrawable();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             navigationIcon.setColorFilter(new BlendModeColorFilter(
-                    Utils.getAppForegroundColor(), BlendMode.SRC_IN));
+                    ThemeUtils.getAppForegroundColor(), BlendMode.SRC_IN));
         } else {
-            navigationIcon.setColorFilter(Utils.getAppForegroundColor(), PorterDuff.Mode.SRC_IN);
+            navigationIcon.setColorFilter(ThemeUtils.getAppForegroundColor(), PorterDuff.Mode.SRC_IN);
         }
 
         return navigationIcon;

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/preference/LastFMTokenPreference.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/preference/LastFMTokenPreference.java
@@ -27,6 +27,7 @@ import android.widget.TextView;
 import app.morphe.extension.music.patches.scrobbling.lastfm.LastFM;
 import app.morphe.extension.music.settings.Settings;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.CustomDialog;
 import app.morphe.extension.shared.ui.Dim;
 
@@ -90,7 +91,7 @@ public class LastFMTokenPreference extends Preference {
         TextView instruction = new TextView(context);
         instruction.setText(str("morphe_music_lastfm_token_dialog_instruction"));
         instruction.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14);
-        instruction.setTextColor(Utils.getAppForegroundColor());
+        instruction.setTextColor(ThemeUtils.getAppForegroundColor());
         LinearLayout.LayoutParams instructionParams = new LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
                 LinearLayout.LayoutParams.WRAP_CONTENT);
@@ -119,7 +120,7 @@ public class LastFMTokenPreference extends Preference {
 
         TextView status = new TextView(context);
         status.setTextSize(TypedValue.COMPLEX_UNIT_SP, 12);
-        status.setTextColor(Utils.getAppForegroundColor());
+        status.setTextColor(ThemeUtils.getAppForegroundColor());
         status.setVisibility(View.GONE);
         LinearLayout.LayoutParams statusParams = new LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
@@ -158,7 +159,7 @@ public class LastFMTokenPreference extends Preference {
                         return;
                     }
                     showStatus(status, str("morphe_music_lastfm_token_status_logging_in"),
-                            Utils.getAppForegroundColor());
+                            ThemeUtils.getAppForegroundColor());
                     Utils.runOnBackgroundThread(() -> {
                         try {
                             LastFM.Session session = LastFM.getMobileSession(username, password);
@@ -210,10 +211,10 @@ public class LastFMTokenPreference extends Preference {
         EditText editText = new EditText(context);
         editText.setSingleLine(true);
         editText.setTextSize(16);
-        editText.setTextColor(Utils.getAppForegroundColor());
+        editText.setTextColor(ThemeUtils.getAppForegroundColor());
         ShapeDrawable background = new ShapeDrawable(new RoundRectShape(
                 Dim.roundedCorners(10), null, null));
-        background.getPaint().setColor(Utils.getEditTextBackground());
+        background.getPaint().setColor(ThemeUtils.getEditTextBackground());
         editText.setPadding(Dim.dp12, Dim.dp8, Dim.dp12, Dim.dp8);
         editText.setBackground(background);
         editText.setClipToOutline(true);

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/preference/ListenBrainzTokenPreference.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/preference/ListenBrainzTokenPreference.java
@@ -29,6 +29,7 @@ import app.morphe.extension.music.patches.scrobbling.listenbrainz.ListenBrainz;
 import app.morphe.extension.music.settings.Settings;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.CustomDialog;
 import app.morphe.extension.shared.ui.Dim;
 
@@ -90,7 +91,7 @@ public class ListenBrainzTokenPreference extends Preference {
         TextView instruction = new TextView(context);
         instruction.setText(str("morphe_music_listenbrainz_token_dialog_instruction"));
         instruction.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14);
-        instruction.setTextColor(Utils.getAppForegroundColor());
+        instruction.setTextColor(ThemeUtils.getAppForegroundColor());
         LinearLayout.LayoutParams instructionParams = new LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
                 LinearLayout.LayoutParams.WRAP_CONTENT);
@@ -110,7 +111,7 @@ public class ListenBrainzTokenPreference extends Preference {
 
         TextView status = new TextView(context);
         status.setTextSize(TypedValue.COMPLEX_UNIT_SP, 12);
-        status.setTextColor(Utils.getAppForegroundColor());
+        status.setTextColor(ThemeUtils.getAppForegroundColor());
         status.setVisibility(View.GONE);
 
         Pair<Dialog, LinearLayout> dialogPair = CustomDialog.create(
@@ -173,7 +174,7 @@ public class ListenBrainzTokenPreference extends Preference {
                         showStatus(status, str("morphe_music_listenbrainz_token_status_empty"), STATUS_COLOR_ERROR);
                         return;
                     }
-                    showStatus(status, str("morphe_music_listenbrainz_token_status_validating"), Utils.getAppForegroundColor());
+                    showStatus(status, str("morphe_music_listenbrainz_token_status_validating"), ThemeUtils.getAppForegroundColor());
                     Utils.runOnBackgroundThread(() -> {
                         try {
                             ListenBrainz.TokenValidation validation = ListenBrainz.validateToken(token);
@@ -240,10 +241,10 @@ public class ListenBrainzTokenPreference extends Preference {
         EditText editText = new EditText(context);
         editText.setSingleLine(true);
         editText.setTextSize(16);
-        editText.setTextColor(Utils.getAppForegroundColor());
+        editText.setTextColor(ThemeUtils.getAppForegroundColor());
         ShapeDrawable background = new ShapeDrawable(new RoundRectShape(
                 Dim.roundedCorners(10), null, null));
-        background.getPaint().setColor(Utils.getEditTextBackground());
+        background.getPaint().setColor(ThemeUtils.getEditTextBackground());
         editText.setPadding(Dim.dp12, Dim.dp8, Dim.dp12, Dim.dp8);
         editText.setBackground(background);
         editText.setClipToOutline(true);

--- a/extensions/reddit/src/main/java/app/morphe/extension/reddit/settings/RedditActivityHook.java
+++ b/extensions/reddit/src/main/java/app/morphe/extension/reddit/settings/RedditActivityHook.java
@@ -34,6 +34,7 @@ import app.morphe.extension.reddit.ui.MorpheSettingsIconVectorDrawable;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.Dim;
 import kotlin.jvm.functions.Function0;
 
@@ -152,8 +153,8 @@ public class RedditActivityHook {
         @Override
         public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
             Activity activity = getActivity();
-            final int appForegroundColor = Utils.getAppForegroundColor();
-            final int appBackgroundColor = Utils.getAppBackgroundColor();
+            final int appForegroundColor = ThemeUtils.getAppForegroundColor();
+            final int appBackgroundColor = ThemeUtils.getAppBackgroundColor();
 
             // Ensure the dialog window fills the screen and shows the status bar.
             Dialog dialog = getDialog();

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/SettingsMenuFilterPickerPreference.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/SettingsMenuFilterPickerPreference.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.preference.AbstractPreferenceFragment;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.CustomDialog;
 
 /**
@@ -97,7 +98,7 @@ public class SettingsMenuFilterPickerPreference extends Preference {
             TextView hint = new TextView(context);
             hint.setText(str("morphe_settings_menu_filter_picker_empty"));
             hint.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14);
-            hint.setTextColor(Utils.getAppForegroundColor());
+            hint.setTextColor(ThemeUtils.getAppForegroundColor());
             hint.setPadding(0, 24, 0, 24);
             content.addView(hint, new LinearLayout.LayoutParams(
                     LinearLayout.LayoutParams.MATCH_PARENT,
@@ -218,7 +219,7 @@ public class SettingsMenuFilterPickerPreference extends Preference {
             this.selectedLower = selectedLower;
             this.checkDrawable = Utils.appIsUsingBoldIcons() ? DRAWABLE_CHECKMARK_BOLD : DRAWABLE_CHECKMARK;
             this.childIndentPx = (int) (CHILD_INDENT_DP * context.getResources().getDisplayMetrics().density);
-            this.foregroundColor = Utils.getAppForegroundColor();
+            this.foregroundColor = ThemeUtils.getAppForegroundColor();
         }
 
         @Override public int getCount() { return rows.size(); }

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/BaseActivityHook.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/BaseActivityHook.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.shared.settings;
 
 import android.annotation.SuppressLint;
@@ -15,6 +25,7 @@ import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.preference.ToolbarPreferenceFragment;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.Dim;
 
 /**
@@ -127,7 +138,7 @@ public abstract class BaseActivityHook extends Activity {
         toolbar.setTitleMarginEnd(Dim.dp16);
         TextView toolbarTextView = Utils.getChildView(toolbar, false, view -> view instanceof TextView);
         if (toolbarTextView != null) {
-            toolbarTextView.setTextColor(Utils.getAppForegroundColor());
+            toolbarTextView.setTextColor(ThemeUtils.getAppForegroundColor());
             toolbarTextView.setTextSize(20);
         }
         setToolbarLayoutParams(toolbar);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
@@ -42,6 +42,10 @@ public class SharedYouTubeSettings extends BaseSettings {
     public static final EnumSetting<DarkThemeBackground> THEME_BACKGROUND_DARK = new EnumSetting<>(ThemeBackgroundPatch.SETTINGS_KEY_DARK, ThemeBackgroundPatch.DEFAULT_DARK, true);
     @SuppressWarnings("unused")
     public static final EnumSetting<LightThemeBackground> THEME_BACKGROUND_LIGHT = new EnumSetting<>(ThemeBackgroundPatch.SETTINGS_KEY_LIGHT, ThemeBackgroundPatch.DEFAULT_LIGHT, true);
+    @SuppressWarnings("unused")
+    public static final StringSetting THEME_BACKGROUND_DARK_CUSTOM_COLOR = new StringSetting(ThemeBackgroundPatch.SETTINGS_KEY_DARK_CUSTOM_COLOR, ThemeBackgroundPatch.DEFAULT_DARK_CUSTOM_COLOR, true, new ThemeBackgroundPatch.CustomDarkBackgroundAvailability());
+    @SuppressWarnings("unused")
+    public static final StringSetting THEME_BACKGROUND_LIGHT_CUSTOM_COLOR = new StringSetting(ThemeBackgroundPatch.SETTINGS_KEY_LIGHT_CUSTOM_COLOR, ThemeBackgroundPatch.DEFAULT_LIGHT_CUSTOM_COLOR, true, new ThemeBackgroundPatch.CustomLightBackgroundAvailability());
 
     public static final EnumSetting<BrandingTheme> CUSTOM_BRANDING_ICON = new EnumSetting<>("morphe_custom_branding_icon", CustomBrandingPatch.getDefaultIconStyle(), true);
     public static final EnumSetting<NotificationIconTheme> CUSTOM_BRANDING_NOTIFICATION_ICON = new EnumSetting<>("morphe_custom_branding_notification_icon", NotificationIconTheme.FOLLOW, true);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
@@ -11,6 +11,9 @@ import app.morphe.extension.shared.patches.CustomBrandingPatch.BrandingTheme;
 import app.morphe.extension.shared.patches.CustomBrandingPatch.NotificationIconTheme;
 import app.morphe.extension.shared.spoof.SpoofVideoStreamsPatch.JavaScriptClientAvailability;
 import app.morphe.extension.shared.spoof.js.JavaScriptVariant;
+import app.morphe.extension.shared.theme.ThemeBackgroundPatch;
+import app.morphe.extension.shared.theme.ThemeBackgroundPatch.DarkThemeBackground;
+import app.morphe.extension.shared.theme.ThemeBackgroundPatch.LightThemeBackground;
 
 /**
  * Settings shared by YouTube and YouTube Music.
@@ -34,6 +37,11 @@ public class SharedYouTubeSettings extends BaseSettings {
     public static final BooleanSetting REMOVE_VIEWER_DISCRETION_DIALOG = new BooleanSetting("morphe_remove_viewer_discretion_dialog", FALSE, true);
 
     public static final BooleanSetting CHECK_WATCH_HISTORY_DOMAIN_NAME = new BooleanSetting("morphe_check_watch_history_domain_name", TRUE, false, false);
+
+    @SuppressWarnings("unused")
+    public static final EnumSetting<DarkThemeBackground> THEME_BACKGROUND_DARK = new EnumSetting<>(ThemeBackgroundPatch.SETTINGS_KEY_DARK, ThemeBackgroundPatch.DEFAULT_DARK, true);
+    @SuppressWarnings("unused")
+    public static final EnumSetting<LightThemeBackground> THEME_BACKGROUND_LIGHT = new EnumSetting<>(ThemeBackgroundPatch.SETTINGS_KEY_LIGHT, ThemeBackgroundPatch.DEFAULT_LIGHT, true);
 
     public static final EnumSetting<BrandingTheme> CUSTOM_BRANDING_ICON = new EnumSetting<>("morphe_custom_branding_icon", CustomBrandingPatch.getDefaultIconStyle(), true);
     public static final EnumSetting<NotificationIconTheme> CUSTOM_BRANDING_NOTIFICATION_ICON = new EnumSetting<>("morphe_custom_branding_notification_icon", NotificationIconTheme.FOLLOW, true);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
@@ -6,6 +6,7 @@ import static app.morphe.extension.shared.settings.Setting.migrateOldSettingToNe
 import static app.morphe.extension.shared.settings.Setting.parent;
 import static app.morphe.extension.shared.settings.Setting.parentsAny;
 
+import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.patches.CustomBrandingPatch;
 import app.morphe.extension.shared.patches.CustomBrandingPatch.BrandingTheme;
 import app.morphe.extension.shared.patches.CustomBrandingPatch.NotificationIconTheme;
@@ -44,6 +45,7 @@ public class SharedYouTubeSettings extends BaseSettings {
     public static final StringSetting THEME_BACKGROUND_DARK_CUSTOM_COLOR = new StringSetting("morphe_theme_background_dark_custom_color", "#0F0F0F", true, new CustomDarkBackgroundAvailability());
     public static final StringSetting THEME_BACKGROUND_LIGHT_CUSTOM_COLOR = new StringSetting("morphe_theme_background_light_custom_color", "#FFFFFF", true, new CustomLightBackgroundAvailability());
 
+    public static final BooleanSetting THEME_LAST_USED_DARK_MODE = new BooleanSetting("morphe_theme_last_used_dark_mode", Utils.isDarkModeEnabled(), false, false);
     public static final EnumSetting<BrandingTheme> CUSTOM_BRANDING_ICON = new EnumSetting<>("morphe_custom_branding_icon", CustomBrandingPatch.getDefaultIconStyle(), true);
     public static final EnumSetting<NotificationIconTheme> CUSTOM_BRANDING_NOTIFICATION_ICON = new EnumSetting<>("morphe_custom_branding_notification_icon", NotificationIconTheme.FOLLOW, true);
     public static final IntegerSetting CUSTOM_BRANDING_NAME = new IntegerSetting("morphe_custom_branding_name", CustomBrandingPatch.getDefaultAppNameIndex(), true);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
@@ -11,10 +11,10 @@ import app.morphe.extension.shared.patches.CustomBrandingPatch.BrandingTheme;
 import app.morphe.extension.shared.patches.CustomBrandingPatch.NotificationIconTheme;
 import app.morphe.extension.shared.spoof.SpoofVideoStreamsPatch.JavaScriptClientAvailability;
 import app.morphe.extension.shared.spoof.js.JavaScriptVariant;
-import app.morphe.extension.shared.theme.ThemeBackgroundPatch.CustomDarkBackgroundAvailability;
-import app.morphe.extension.shared.theme.ThemeBackgroundPatch.CustomLightBackgroundAvailability;
-import app.morphe.extension.shared.theme.ThemeBackgroundPatch.DarkThemeBackground;
-import app.morphe.extension.shared.theme.ThemeBackgroundPatch.LightThemeBackground;
+import app.morphe.extension.shared.theme.ThemeColorPatch.CustomDarkBackgroundAvailability;
+import app.morphe.extension.shared.theme.ThemeColorPatch.CustomLightBackgroundAvailability;
+import app.morphe.extension.shared.theme.ThemeColorPatch.ThemeColorDark;
+import app.morphe.extension.shared.theme.ThemeColorPatch.ThemeColorLight;
 
 /**
  * Settings shared by YouTube and YouTube Music.
@@ -39,8 +39,8 @@ public class SharedYouTubeSettings extends BaseSettings {
 
     public static final BooleanSetting CHECK_WATCH_HISTORY_DOMAIN_NAME = new BooleanSetting("morphe_check_watch_history_domain_name", TRUE, false, false);
 
-    public static final EnumSetting<DarkThemeBackground> THEME_BACKGROUND_DARK = new EnumSetting<>("morphe_theme_background_dark", DarkThemeBackground.PURE_BLACK, true);
-    public static final EnumSetting<LightThemeBackground> THEME_BACKGROUND_LIGHT = new EnumSetting<>("morphe_theme_background_light", LightThemeBackground.WHITE, true);
+    public static final EnumSetting<ThemeColorDark> THEME_BACKGROUND_DARK = new EnumSetting<>("morphe_theme_background_dark", ThemeColorDark.PURE_BLACK, true);
+    public static final EnumSetting<ThemeColorLight> THEME_BACKGROUND_LIGHT = new EnumSetting<>("morphe_theme_background_light", ThemeColorLight.WHITE, true);
     public static final StringSetting THEME_BACKGROUND_DARK_CUSTOM_COLOR = new StringSetting("morphe_theme_background_dark_custom_color", "#0F0F0F", true, new CustomDarkBackgroundAvailability());
     public static final StringSetting THEME_BACKGROUND_LIGHT_CUSTOM_COLOR = new StringSetting("morphe_theme_background_light_custom_color", "#FFFFFF", true, new CustomLightBackgroundAvailability());
 

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
@@ -11,7 +11,8 @@ import app.morphe.extension.shared.patches.CustomBrandingPatch.BrandingTheme;
 import app.morphe.extension.shared.patches.CustomBrandingPatch.NotificationIconTheme;
 import app.morphe.extension.shared.spoof.SpoofVideoStreamsPatch.JavaScriptClientAvailability;
 import app.morphe.extension.shared.spoof.js.JavaScriptVariant;
-import app.morphe.extension.shared.theme.ThemeBackgroundPatch;
+import app.morphe.extension.shared.theme.ThemeBackgroundPatch.CustomDarkBackgroundAvailability;
+import app.morphe.extension.shared.theme.ThemeBackgroundPatch.CustomLightBackgroundAvailability;
 import app.morphe.extension.shared.theme.ThemeBackgroundPatch.DarkThemeBackground;
 import app.morphe.extension.shared.theme.ThemeBackgroundPatch.LightThemeBackground;
 
@@ -38,10 +39,10 @@ public class SharedYouTubeSettings extends BaseSettings {
 
     public static final BooleanSetting CHECK_WATCH_HISTORY_DOMAIN_NAME = new BooleanSetting("morphe_check_watch_history_domain_name", TRUE, false, false);
 
-    public static final EnumSetting<DarkThemeBackground> THEME_BACKGROUND_DARK = new EnumSetting<>(ThemeBackgroundPatch.SETTINGS_KEY_DARK, ThemeBackgroundPatch.DEFAULT_DARK, true);
-    public static final EnumSetting<LightThemeBackground> THEME_BACKGROUND_LIGHT = new EnumSetting<>(ThemeBackgroundPatch.SETTINGS_KEY_LIGHT, ThemeBackgroundPatch.DEFAULT_LIGHT, true);
-    public static final StringSetting THEME_BACKGROUND_DARK_CUSTOM_COLOR = new StringSetting(ThemeBackgroundPatch.SETTINGS_KEY_DARK_CUSTOM_COLOR, ThemeBackgroundPatch.DEFAULT_DARK_CUSTOM_COLOR, true, new ThemeBackgroundPatch.CustomDarkBackgroundAvailability());
-    public static final StringSetting THEME_BACKGROUND_LIGHT_CUSTOM_COLOR = new StringSetting(ThemeBackgroundPatch.SETTINGS_KEY_LIGHT_CUSTOM_COLOR, ThemeBackgroundPatch.DEFAULT_LIGHT_CUSTOM_COLOR, true, new ThemeBackgroundPatch.CustomLightBackgroundAvailability());
+    public static final EnumSetting<DarkThemeBackground> THEME_BACKGROUND_DARK = new EnumSetting<>("morphe_theme_background_dark", DarkThemeBackground.PURE_BLACK, true);
+    public static final EnumSetting<LightThemeBackground> THEME_BACKGROUND_LIGHT = new EnumSetting<>("morphe_theme_background_light", LightThemeBackground.WHITE, true);
+    public static final StringSetting THEME_BACKGROUND_DARK_CUSTOM_COLOR = new StringSetting("morphe_theme_background_dark_custom_color", "#0F0F0F", true, new CustomDarkBackgroundAvailability());
+    public static final StringSetting THEME_BACKGROUND_LIGHT_CUSTOM_COLOR = new StringSetting("morphe_theme_background_light_custom_color", "#FFFFFF", true, new CustomLightBackgroundAvailability());
 
     public static final EnumSetting<BrandingTheme> CUSTOM_BRANDING_ICON = new EnumSetting<>("morphe_custom_branding_icon", CustomBrandingPatch.getDefaultIconStyle(), true);
     public static final EnumSetting<NotificationIconTheme> CUSTOM_BRANDING_NOTIFICATION_ICON = new EnumSetting<>("morphe_custom_branding_notification_icon", NotificationIconTheme.FOLLOW, true);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
@@ -38,13 +38,9 @@ public class SharedYouTubeSettings extends BaseSettings {
 
     public static final BooleanSetting CHECK_WATCH_HISTORY_DOMAIN_NAME = new BooleanSetting("morphe_check_watch_history_domain_name", TRUE, false, false);
 
-    @SuppressWarnings("unused")
     public static final EnumSetting<DarkThemeBackground> THEME_BACKGROUND_DARK = new EnumSetting<>(ThemeBackgroundPatch.SETTINGS_KEY_DARK, ThemeBackgroundPatch.DEFAULT_DARK, true);
-    @SuppressWarnings("unused")
     public static final EnumSetting<LightThemeBackground> THEME_BACKGROUND_LIGHT = new EnumSetting<>(ThemeBackgroundPatch.SETTINGS_KEY_LIGHT, ThemeBackgroundPatch.DEFAULT_LIGHT, true);
-    @SuppressWarnings("unused")
     public static final StringSetting THEME_BACKGROUND_DARK_CUSTOM_COLOR = new StringSetting(ThemeBackgroundPatch.SETTINGS_KEY_DARK_CUSTOM_COLOR, ThemeBackgroundPatch.DEFAULT_DARK_CUSTOM_COLOR, true, new ThemeBackgroundPatch.CustomDarkBackgroundAvailability());
-    @SuppressWarnings("unused")
     public static final StringSetting THEME_BACKGROUND_LIGHT_CUSTOM_COLOR = new StringSetting(ThemeBackgroundPatch.SETTINGS_KEY_LIGHT_CUSTOM_COLOR, ThemeBackgroundPatch.DEFAULT_LIGHT_CUSTOM_COLOR, true, new ThemeBackgroundPatch.CustomLightBackgroundAvailability());
 
     public static final EnumSetting<BrandingTheme> CUSTOM_BRANDING_ICON = new EnumSetting<>("morphe_custom_branding_icon", CustomBrandingPatch.getDefaultIconStyle(), true);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/preference/ExternalDownloaderPreference.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/preference/ExternalDownloaderPreference.java
@@ -38,6 +38,7 @@ import java.util.function.Function;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.SharedYouTubeSettings;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.CustomDialog;
 import app.morphe.extension.shared.ui.Dim;
 
@@ -409,7 +410,7 @@ public class ExternalDownloaderPreference extends CustomDialogListPreference {
 
         ShapeDrawable editTextBackground = new ShapeDrawable(new RoundRectShape(
                 Dim.roundedCorners(10), null, null));
-        editTextBackground.getPaint().setColor(Utils.getEditTextBackground());
+        editTextBackground.getPaint().setColor(ThemeUtils.getEditTextBackground());
         editText.setPadding(Dim.dp8, Dim.dp8, Dim.dp8, Dim.dp8);
         editText.setBackground(editTextBackground);
         editText.setClipToOutline(true);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/preference/FeatureFlagsManagerPreference.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/preference/FeatureFlagsManagerPreference.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.shared.settings.preference;
 
 import static app.morphe.extension.shared.StringRef.str;
@@ -43,6 +53,7 @@ import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.patches.EnableDebuggingPatch;
 import app.morphe.extension.shared.settings.BaseSettings;
 import app.morphe.extension.shared.settings.SharedYouTubeSettings;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.CustomDialog;
 import app.morphe.extension.shared.ui.Dim;
 
@@ -251,7 +262,7 @@ public class FeatureFlagsManagerPreference extends Preference {
         TextView textview = new TextView(context);
         textview.setTag(tag);
         textview.setTextSize(16);
-        textview.setTextColor(Utils.getAppForegroundColor());
+        textview.setTextColor(ThemeUtils.getAppForegroundColor());
         textview.setGravity(Gravity.CENTER);
 
         return textview;
@@ -275,7 +286,7 @@ public class FeatureFlagsManagerPreference extends Preference {
                 ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f));
         ShapeDrawable background = new ShapeDrawable(new RoundRectShape(
                 Dim.roundedCorners(10), null, null));
-        background.getPaint().setColor(Utils.getEditTextBackground());
+        background.getPaint().setColor(ThemeUtils.getEditTextBackground());
         listView.setPadding(0, Dim.dp4, 0, Dim.dp4);
         listView.setBackground(background);
         listView.setOverScrollMode(View.OVER_SCROLL_NEVER);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/preference/ToolbarPreferenceFragment.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/preference/ToolbarPreferenceFragment.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.shared.settings.preference;
 
 import android.annotation.SuppressLint;
@@ -20,6 +30,7 @@ import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.BaseActivityHook;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.Dim;
 
 @SuppressWarnings({"deprecation", "RedundantSuppression"})
@@ -94,7 +105,7 @@ public class ToolbarPreferenceFragment extends AbstractPreferenceFragment {
                             TextView toolbarTextView = Utils.getChildView(toolbar,
                                     true, TextView.class::isInstance);
                             if (toolbarTextView != null) {
-                                toolbarTextView.setTextColor(Utils.getAppForegroundColor());
+                                toolbarTextView.setTextColor(ThemeUtils.getAppForegroundColor());
                                 toolbarTextView.setTextSize(20);
                             }
 
@@ -123,7 +134,7 @@ public class ToolbarPreferenceFragment extends AbstractPreferenceFragment {
             return;
         }
 
-        window.setNavigationBarColor(Utils.getAppBackgroundColor());
+        window.setNavigationBarColor(ThemeUtils.getAppBackgroundColor());
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             window.setNavigationBarContrastEnforced(true);
         }
@@ -146,14 +157,14 @@ public class ToolbarPreferenceFragment extends AbstractPreferenceFragment {
      * Customizes the back button drawable.
      */
     protected static void customizeBackButtonDrawable(Drawable drawable) {
-        drawable.setTint(Utils.getAppForegroundColor());
+        drawable.setTint(ThemeUtils.getAppForegroundColor());
     }
 
     /**
      * Allows subclasses to customize the dialog's root view background.
      */
     protected void customizeDialogBackground(ViewGroup rootView) {
-        rootView.setBackgroundColor(Utils.getAppBackgroundColor());
+        rootView.setBackgroundColor(ThemeUtils.getAppBackgroundColor());
     }
 
     /**

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/search/BaseSearchResultItem.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/search/BaseSearchResultItem.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.shared.settings.search;
 
 import android.graphics.Color;
@@ -22,6 +32,7 @@ import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.preference.ColorPickerPreference;
 import app.morphe.extension.shared.settings.preference.CustomDialogListPreference;
 import app.morphe.extension.shared.settings.preference.URLLinkPreference;
+import app.morphe.extension.shared.theme.ThemeUtils;
 
 /**
  * Abstract base class for search result items, defining common fields and behavior.
@@ -80,7 +91,7 @@ public abstract class BaseSearchResultItem {
         if (TextUtils.isEmpty(text) || queryPattern == null) return text;
 
         final int adjustedColor = Utils.adjustColorBrightness(
-                Utils.getAppBackgroundColor(), 0.95f, 1.20f);
+                ThemeUtils.getAppBackgroundColor(), 0.95f, 1.20f);
         BackgroundColorSpan highlightSpan = new BackgroundColorSpan(adjustedColor);
         SpannableStringBuilder spannable = new SpannableStringBuilder(text);
 

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/search/BaseSearchResultsAdapter.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/search/BaseSearchResultsAdapter.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.shared.settings.search;
 
 import android.animation.AnimatorSet;
@@ -37,6 +47,7 @@ import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.preference.ColorPickerPreference;
 import app.morphe.extension.shared.settings.preference.CustomDialogListPreference;
 import app.morphe.extension.shared.settings.preference.URLLinkPreference;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.ColorDot;
 
 /**
@@ -520,7 +531,7 @@ public abstract class BaseSearchResultsAdapter extends ArrayAdapter<BaseSearchRe
         if (currentAnimator != null && currentAnimator.isRunning()) {
             currentAnimator.cancel();
         }
-        final int startColor = Utils.getAppBackgroundColor();
+        final int startColor = ThemeUtils.getAppBackgroundColor();
         final int highlightColor = Utils.adjustColorBrightness(
                 startColor,
                 Utils.isDarkModeEnabled() ? 1.25f : 0.8f

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/search/BaseSearchViewController.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/search/BaseSearchViewController.java
@@ -56,6 +56,7 @@ import app.morphe.extension.shared.settings.Setting;
 import app.morphe.extension.shared.settings.preference.ColorPickerPreference;
 import app.morphe.extension.shared.settings.preference.CustomDialogListPreference;
 import app.morphe.extension.shared.settings.preference.NoTitlePreferenceCategory;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.Dim;
 
 /**
@@ -191,7 +192,7 @@ public abstract class BaseSearchViewController {
         // Create overlay container for search results and history.
         overlayContainer = new FrameLayout(activity);
         overlayContainer.setVisibility(View.GONE);
-        overlayContainer.setBackgroundColor(Utils.getAppBackgroundColor());
+        overlayContainer.setBackgroundColor(ThemeUtils.getAppBackgroundColor());
         overlayContainer.setElevation(Dim.dp8);
 
         // Container for search results.
@@ -700,7 +701,7 @@ public abstract class BaseSearchViewController {
      */
     @ColorInt
     public static int getSearchViewBackground() {
-        return Utils.adjustColorBrightness(Utils.getDialogBackgroundColor(), Utils.isDarkModeEnabled() ? 1.11f : 0.95f);
+        return Utils.adjustColorBrightness(ThemeUtils.getDialogBackgroundColor(), Utils.isDarkModeEnabled() ? 1.11f : 0.95f);
     }
 
     /**

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/sponsorblock/SegmentPlaybackController.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/sponsorblock/SegmentPlaybackController.java
@@ -53,6 +53,7 @@ import app.morphe.extension.shared.sponsorblock.objects.CategoryBehaviour;
 import app.morphe.extension.shared.sponsorblock.objects.SegmentCategory;
 import app.morphe.extension.shared.sponsorblock.objects.SponsorSegment;
 import app.morphe.extension.shared.sponsorblock.requests.SBRequester;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.Dim;
 
 /**
@@ -951,13 +952,13 @@ public class SegmentPlaybackController {
 
         ShapeDrawable background = new ShapeDrawable(new RoundRectShape(
                 Dim.roundedCorners(20), null, null));
-        background.getPaint().setColor(Utils.getDialogBackgroundColor());
+        background.getPaint().setColor(ThemeUtils.getDialogBackgroundColor());
         mainLayout.setBackground(background);
 
         TextView textView = new TextView(currentContext);
         textView.setText(messageToToast);
         textView.setTextSize(14);
-        textView.setTextColor(Utils.getAppForegroundColor());
+        textView.setTextColor(ThemeUtils.getAppForegroundColor());
         textView.setGravity(Gravity.CENTER);
         LinearLayout.LayoutParams textParams = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT,

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/sponsorblock/objects/SegmentCategoryPreference.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/sponsorblock/objects/SegmentCategoryPreference.java
@@ -26,6 +26,7 @@ import app.morphe.extension.shared.settings.Setting;
 import app.morphe.extension.shared.settings.preference.ColorPickerPreference;
 import app.morphe.extension.shared.sponsorblock.SponsorBlockApi;
 import app.morphe.extension.shared.sponsorblock.SponsorBlockHelpers;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.ColorDot;
 import app.morphe.extension.shared.ui.Dim;
 
@@ -161,7 +162,7 @@ public class SegmentCategoryPreference extends ColorPickerPreference {
 
         // Force explicit foreground color: dialog children do not always inherit the host
         // settings theme's text color, leaving labels unreadable on dark themes.
-        final int foregroundColor = Utils.getAppForegroundColor();
+        final int foregroundColor = ThemeUtils.getAppForegroundColor();
         for (int i = 0; i < dialogBehaviors.length; i++) {
             RadioButton radioButton = new RadioButton(context);
             radioButton.setText(dialogBehaviors[i].description.toString());

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/BaseThemePatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/BaseThemePatch.java
@@ -44,10 +44,10 @@ public abstract class BaseThemePatch {
 
         if (Utils.isDarkModeEnabled()) {
             if (anyEquals(originalValue, darkValues)) {
-                return Utils.getAppBackgroundColor();
+                return Utils.getThemeDarkColor();
             }
         } else if (lightValues != null && anyEquals(originalValue, lightValues)) {
-            return Utils.getAppBackgroundColor();
+            return Utils.getThemeLightColor();
         }
 
         return originalValue;

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/BaseThemePatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/BaseThemePatch.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2524
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.shared.theme;
 
 import androidx.annotation.ColorInt;

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/BaseThemePatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/BaseThemePatch.java
@@ -1,24 +1,12 @@
 package app.morphe.extension.shared.theme;
 
-import android.content.Context;
-import android.content.res.Resources;
-
 import androidx.annotation.ColorInt;
 import androidx.annotation.Nullable;
 
-import java.util.Objects;
-
-import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
 
 @SuppressWarnings("unused")
 public abstract class BaseThemePatch {
-    // Background colors.
-    @ColorInt
-    protected static final int BLACK_COLOR = ResourceUtils.getColor("yt_black1");
-    @ColorInt
-    protected static final int WHITE_COLOR = ResourceUtils.getColor("yt_white1");
-
     /**
      * Check if a value matches any of the provided values.
      *
@@ -45,12 +33,21 @@ public abstract class BaseThemePatch {
      */
     @ColorInt
     protected static int processColorValue(int originalValue, int[] darkValues, @Nullable int[] lightValues) {
+        // The values that are replaced here are the backgrounds the app hard codes into its
+        // Litho components. They only have to follow along when the app background is changed.
+        // With the background of the app itself the app is left alone. Otherwise, a component
+        // such as the chip bar of the feed is given the color of another background of the app.
+        // It then shows as a lighter gray than it does unpatched.
+        if (ThemeColorPatch.isAppDefaultBackground()) {
+            return originalValue;
+        }
+
         if (Utils.isDarkModeEnabled()) {
             if (anyEquals(originalValue, darkValues)) {
-                return BLACK_COLOR;
+                return Utils.getAppBackgroundColor();
             }
         } else if (lightValues != null && anyEquals(originalValue, lightValues)) {
-            return WHITE_COLOR;
+            return Utils.getAppBackgroundColor();
         }
 
         return originalValue;

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/BaseThemePatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/BaseThemePatch.java
@@ -13,8 +13,6 @@ package app.morphe.extension.shared.theme;
 import androidx.annotation.ColorInt;
 import androidx.annotation.Nullable;
 
-import app.morphe.extension.shared.Utils;
-
 @SuppressWarnings("unused")
 public abstract class BaseThemePatch {
     /**
@@ -52,12 +50,13 @@ public abstract class BaseThemePatch {
             return originalValue;
         }
 
-        if (Utils.isDarkModeEnabled()) {
-            if (anyEquals(originalValue, darkValues)) {
-                return Utils.getThemeDarkColor();
-            }
-        } else if (lightValues != null && anyEquals(originalValue, lightValues)) {
-            return Utils.getThemeLightColor();
+        // The color of a background must not be read from the current context of the app, which
+        // carries the resource variant of one theme only.
+        final boolean dark = ThemeColorPatch.isDarkTheme();
+        int[] values = dark ? darkValues : lightValues;
+
+        if (values != null && anyEquals(originalValue, values)) {
+            return ThemeColorPatch.backgroundColor(dark);
         }
 
         return originalValue;

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/BaseThemePatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/BaseThemePatch.java
@@ -1,6 +1,12 @@
 package app.morphe.extension.shared.theme;
 
+import android.content.Context;
+import android.content.res.Resources;
+
+import androidx.annotation.ColorInt;
 import androidx.annotation.Nullable;
+
+import java.util.Objects;
 
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
@@ -8,7 +14,9 @@ import app.morphe.extension.shared.Utils;
 @SuppressWarnings("unused")
 public abstract class BaseThemePatch {
     // Background colors.
+    @ColorInt
     protected static final int BLACK_COLOR = ResourceUtils.getColor("yt_black1");
+    @ColorInt
     protected static final int WHITE_COLOR = ResourceUtils.getColor("yt_white1");
 
     /**
@@ -35,6 +43,7 @@ public abstract class BaseThemePatch {
      * @param lightValues   Array of light mode color values to match.
      * @return The new or original color value.
      */
+    @ColorInt
     protected static int processColorValue(int originalValue, int[] darkValues, @Nullable int[] lightValues) {
         if (Utils.isDarkModeEnabled()) {
             if (anyEquals(originalValue, darkValues)) {

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundListPreference.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundListPreference.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2524
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.theme;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+
+import androidx.annotation.NonNull;
+
+import app.morphe.extension.shared.settings.preference.IconListPreference;
+import app.morphe.extension.shared.ui.ColorDot;
+
+/**
+ * Shows the color of every background next to its name, the same way the app icons are shown.
+ */
+@SuppressWarnings({"unused", "deprecation"})
+public class ThemeBackgroundListPreference extends IconListPreference {
+
+    public ThemeBackgroundListPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    public ThemeBackgroundListPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public ThemeBackgroundListPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public ThemeBackgroundListPreference(Context context) {
+        super(context);
+    }
+
+    @NonNull
+    @Override
+    protected Drawable[] resolveIconDrawables() {
+        CharSequence[] values = getEntryValues();
+        if (values == null) {
+            return new Drawable[0];
+        }
+
+        final boolean dark = ThemeBackgroundPatch.SETTINGS_KEY_DARK.equals(getKey());
+
+        Drawable[] drawables = new Drawable[values.length];
+        for (int i = 0; i < values.length; i++) {
+            drawables[i] = ColorDot.createColorDotDrawable(
+                    ThemeBackgroundPatch.getBackgroundColor(getContext(), dark, i));
+        }
+
+        return drawables;
+    }
+}

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundListPreference.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundListPreference.java
@@ -13,6 +13,7 @@ import android.util.AttributeSet;
 
 import androidx.annotation.NonNull;
 
+import app.morphe.extension.shared.settings.SharedYouTubeSettings;
 import app.morphe.extension.shared.settings.preference.IconListPreference;
 import app.morphe.extension.shared.ui.ColorDot;
 
@@ -46,10 +47,10 @@ public class ThemeBackgroundListPreference extends IconListPreference {
             return new Drawable[0];
         }
 
-        final boolean dark = ThemeBackgroundPatch.SETTINGS_KEY_DARK.equals(getKey());
+        final boolean dark = SharedYouTubeSettings.THEME_BACKGROUND_DARK.key.equals(getKey());
 
         Drawable[] drawables = new Drawable[values.length];
-        for (int i = 0; i < values.length; i++) {
+        for (int i = 0, length = values.length; i < length; i++) {
             drawables[i] = ColorDot.createColorDotDrawable(
                     ThemeBackgroundPatch.getBackgroundColor(getContext(), dark, i));
         }

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundListPreference.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundListPreference.java
@@ -49,10 +49,11 @@ public class ThemeBackgroundListPreference extends IconListPreference {
 
         final boolean dark = SharedYouTubeSettings.THEME_BACKGROUND_DARK.key.equals(getKey());
 
+        Context context = getContext();
         Drawable[] drawables = new Drawable[values.length];
         for (int i = 0, length = values.length; i < length; i++) {
             drawables[i] = ColorDot.createColorDotDrawable(
-                    ThemeBackgroundPatch.getBackgroundColor(getContext(), dark, i));
+                    ThemeBackgroundPatch.getBackgroundColor(context, dark, i));
         }
 
         return drawables;

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundOverlay.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundOverlay.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2524
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.theme;
+
+import android.content.Context;
+import android.content.om.FabricatedOverlay;
+import android.content.om.OverlayInfo;
+import android.content.om.OverlayManager;
+import android.content.om.OverlayManagerTransaction;
+import android.content.res.loader.ResourcesLoader;
+import android.content.res.loader.ResourcesProvider;
+import android.os.Build;
+import android.util.TypedValue;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+import java.util.Map;
+
+import app.morphe.extension.shared.Logger;
+
+/**
+ * Overrides the color resources of the app with an arbitrary color, using an overlay the app
+ * registers for itself. Unlike the resource variants this needs no value that was compiled in,
+ * but it exists only on Android 14 and later.
+ * <p>
+ * A transaction of {@link OverlayManagerTransaction#newInstance()} is always self targeting and
+ * needs no permission, but the target must declare the resources that may be changed in
+ * {@code res/values/overlayable.xml}.
+ * <p>
+ * Registering only creates the overlay. The system does not apply an overlay an app registers for
+ * itself, and the app loads it into the resources of every context it creates.
+ * <p>
+ * Kept in a class of its own so the API 34 classes are never loaded on an older device.
+ */
+@RequiresApi(api = Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+final class ThemeBackgroundOverlay {
+
+    private static final String OVERLAY_NAME = "morphe_theme_background";
+
+    /**
+     * An overlay is rejected unless the target declares the resources it may change, so the patch
+     * adds this to {@code res/values/overlayable.xml} and both names must stay identical.
+     */
+    private static final String OVERLAYABLE_NAME = "MorpheThemeBackground";
+
+    /**
+     * Gives every color resource of {@code colors} the color it is mapped to.
+     * A resource that is not included keeps the value it has in the app.
+     */
+    static void register(Context context, Map<String, Integer> colors) {
+        String packageName = context.getPackageName();
+        FabricatedOverlay overlay = new FabricatedOverlay(OVERLAY_NAME, packageName);
+        overlay.setTargetOverlayable(OVERLAYABLE_NAME);
+
+        for (Map.Entry<String, Integer> entry : colors.entrySet()) {
+            overlay.setResourceValue(packageName + ":color/" + entry.getKey(),
+                    TypedValue.TYPE_INT_COLOR_ARGB8, entry.getValue(), null);
+        }
+
+        OverlayManagerTransaction transaction = OverlayManagerTransaction.newInstance();
+        transaction.registerFabricatedOverlay(overlay);
+        commit(context, transaction);
+        resourcesLoader = null;
+
+        Logger.printDebug(() -> "Registered overlay of " + colors.size() + " colors");
+    }
+
+    /**
+     * Removes the overlay of the app, and does nothing if the app has none.
+     */
+    static void unregisterIfRegistered(Context context) {
+        if (findOverlay(context) != null) {
+            unregister(context);
+        }
+    }
+
+    private static void unregister(Context context) {
+        // An identifier cannot be created on its own, but an overlay of the same name has the
+        // identifier of the overlay that is registered.
+        FabricatedOverlay overlay = new FabricatedOverlay(OVERLAY_NAME, context.getPackageName());
+
+        OverlayManagerTransaction transaction = OverlayManagerTransaction.newInstance();
+        transaction.unregisterFabricatedOverlay(overlay.getIdentifier());
+        commit(context, transaction);
+        resourcesLoader = null;
+
+        Logger.printDebug(() -> "Unregistered overlay");
+    }
+
+    /**
+     * The overlay is a file of the app, and loading it once is enough for the whole process.
+     */
+    @Nullable
+    private static ResourcesLoader resourcesLoader;
+
+    /**
+     * Loads the overlay into the resources of {@code context}. Without this the overlay is
+     * registered but nothing of the app uses it.
+     */
+    static void applyTo(Context context) {
+        try {
+            ResourcesLoader loader = resourcesLoader;
+            if (loader == null) {
+                OverlayInfo overlayInfo = findOverlay(context);
+                if (overlayInfo == null) {
+                    Logger.printException(() -> "Overlay of the app is not registered");
+                    return;
+                }
+
+                loader = new ResourcesLoader();
+                loader.addProvider(ResourcesProvider.loadOverlay(overlayInfo));
+                resourcesLoader = loader;
+            }
+
+            // Adding the same loader again is ignored, and every context of the app needs it
+            // because the loaders of a context are not inherited.
+            context.getResources().addLoaders(loader);
+        } catch (Exception ex) {
+            Logger.printException(() -> "Could not apply the overlay of the app", ex);
+        }
+    }
+
+    @Nullable
+    private static OverlayInfo findOverlay(Context context) {
+        OverlayManager overlayManager = context.getSystemService(OverlayManager.class);
+        if (overlayManager == null) {
+            return null;
+        }
+
+        for (OverlayInfo overlayInfo : overlayManager.getOverlayInfosForTarget(
+                context.getPackageName())) {
+            if (OVERLAY_NAME.equals(overlayInfo.getOverlayName())) {
+                return overlayInfo;
+            }
+        }
+
+        return null;
+    }
+
+    private static void commit(Context context, OverlayManagerTransaction transaction) {
+        OverlayManager overlayManager = context.getSystemService(OverlayManager.class);
+        if (overlayManager == null) {
+            throw new IllegalStateException("OverlayManager is not available");
+        }
+
+        overlayManager.commit(transaction);
+    }
+
+    private ThemeBackgroundOverlay() {
+    }
+}

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundOverlay.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundOverlay.java
@@ -126,6 +126,22 @@ final class ThemeBackgroundOverlay {
         }
     }
 
+    /**
+     * Removes the overlay from the resources of {@code context}, which is needed to read a color
+     * the app declares. An overlay replaces the color of every configuration, so a context that
+     * uses it cannot resolve the color of another background.
+     */
+    static void removeFrom(Context context) {
+        try {
+            ResourcesLoader loader = resourcesLoader;
+            if (loader != null) {
+                context.getResources().removeLoaders(loader);
+            }
+        } catch (Exception ex) {
+            Logger.printException(() -> "Could not remove the overlay of the app", ex);
+        }
+    }
+
     @Nullable
     private static OverlayInfo findOverlay(Context context) {
         OverlayManager overlayManager = context.getSystemService(OverlayManager.class);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
@@ -15,7 +15,12 @@ import static app.morphe.extension.shared.settings.SharedYouTubeSettings.THEME_B
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Color;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
+import android.view.View;
+import android.view.ViewStub;
+import android.widget.TextView;
 
 import androidx.annotation.ChecksSdkIntAtLeast;
 import androidx.annotation.ColorInt;
@@ -75,7 +80,6 @@ public class ThemeBackgroundPatch {
         MATERIAL_YOU_PRIMARY(true, false),
         MATERIAL_YOU_SECONDARY(true, false),
         MATERIAL_YOU_TERTIARY(true, false),
-        MODERN_YOUTUBE,
         CLASSIC_YOUTUBE,
         CATPPUCCIN_MOCHA,
         DARK_PINK,
@@ -183,6 +187,22 @@ public class ThemeBackgroundPatch {
      */
     private static final int APP_DEFAULT_CONFIG_VALUE = 1;
 
+    /**
+     * Mobile country codes of 100 to 199 are not assigned to any country, so a device never
+     * reports one. Every variant of the patch uses a code of that range, otherwise the system
+     * uses a variant on its own while it draws the splash screen of the app, because that is
+     * resolved with the configuration of the device.
+     */
+    private static final int UNUSED_MOBILE_COUNTRY_CODE = 100;
+
+    /**
+     * Index of the first color of the 9 bit palette, and the index ranges of the two themes.
+     * The patch uses the same numbering.
+     */
+    private static final int PALETTE_INDEX_OFFSET = 100;
+    private static final int DARK_INDEX_OFFSET = 0;
+    private static final int LIGHT_INDEX_OFFSET = 700;
+
     private static int darkConfigValue = -1;
     private static int lightConfigValue = -1;
 
@@ -190,6 +210,11 @@ public class ThemeBackgroundPatch {
      * If a background of the user is in use and its overlay must be loaded into every context.
      */
     private static boolean useOverlay;
+
+    /**
+     * If the colors Morphe uses for itself were resolved with the theme they belong to.
+     */
+    private static boolean morpheColorsUpdated;
 
     /**
      * If a background color of the user can be applied. An overlay that an app registers for
@@ -219,14 +244,21 @@ public class ThemeBackgroundPatch {
             resolveConfigValues(base);
 
             Configuration configuration = base.getResources().getConfiguration();
+
+            // A variant belongs to one theme only, so the background of the theme the app shows
+            // is the one to ask for. The night mode of the device says nothing about it, the app
+            // has a theme setting of its own. A theme change recreates the activity, and the
+            // index of the other theme is used from then on.
+            final int index = Utils.isDarkModeEnabled() ? darkConfigValue : lightConfigValue;
+
             Context context;
-            if (configuration.mcc == darkConfigValue && configuration.mnc == lightConfigValue) {
+            if (configuration.mcc == mobileCountryCode(index)
+                    && configuration.mnc == mobileNetworkCode(index)) {
                 // Context is created from a context that is already wrapped.
                 context = base;
             } else {
                 Configuration override = new Configuration(configuration);
-                override.mcc = darkConfigValue;
-                override.mnc = lightConfigValue;
+                setVariantOf(override, index);
 
                 context = base.createConfigurationContext(override);
             }
@@ -234,6 +266,8 @@ public class ThemeBackgroundPatch {
             if (isCustomBackgroundSupported() && useOverlay) {
                 ThemeBackgroundOverlay.applyTo(context);
             }
+
+            updateMorpheColors(context);
 
             return context;
         } catch (Exception ex) {
@@ -261,22 +295,69 @@ public class ThemeBackgroundPatch {
         updateOverlay(context, dark, light);
     }
 
+    /**
+     * Morphe uses the background of the app for its own dialogs and settings, and it resolves
+     * the color with the context of the app. That context can be of the other theme than the one
+     * the app shows, because the app can use a theme of its own while the device uses the other,
+     * and a background belongs to one theme only. Both colors are resolved again here, with the
+     * theme each of them belongs to.
+     */
+    private static void updateMorpheColors(Context context) {
+        if (morpheColorsUpdated || !Utils.isContextSet()) {
+            return;
+        }
+        morpheColorsUpdated = true;
+
+        Utils.setThemeDarkColor(selectedBackgroundColor(context, true));
+        Utils.setThemeLightColor(selectedBackgroundColor(context, false));
+    }
+
+    private static int selectedBackgroundColor(Context context, boolean dark) {
+        Background background = dark
+                ? THEME_BACKGROUND_DARK.get()
+                : THEME_BACKGROUND_LIGHT.get();
+
+        return getBackgroundColor(context, dark, ((Enum<?>) background).ordinal());
+    }
+
+    /**
+     * Asks for the variant of a background, using a configuration a device never has.
+     *
+     * @param index Index of the background, which the patch uses with the same encoding.
+     */
+    private static void setVariantOf(Configuration configuration, int index) {
+        configuration.mcc = mobileCountryCode(index);
+        configuration.mnc = mobileNetworkCode(index);
+    }
+
+    private static int mobileCountryCode(int index) {
+        return UNUSED_MOBILE_COUNTRY_CODE + (index >> 5);
+    }
+
+    private static int mobileNetworkCode(int index) {
+        return 1 + (index & 31);
+    }
+
     private static int configValue(Background background, boolean dark) {
+        // The two themes use indices that never overlap, so that a variant of one of them
+        // is never used by the other.
+        final int offset = dark ? DARK_INDEX_OFFSET : LIGHT_INDEX_OFFSET;
+
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S && background.isMaterialYou()) {
             // Material-You colors do not exist and resolving them crashes the app.
-            return APP_DEFAULT_CONFIG_VALUE;
+            return offset + APP_DEFAULT_CONFIG_VALUE;
         }
 
         if (background.isCustom() && !isCustomBackgroundSupported()) {
             StringSetting setting = dark
                     ? THEME_BACKGROUND_DARK_CUSTOM_COLOR
                     : THEME_BACKGROUND_LIGHT_CUSTOM_COLOR;
-            return 100 + get9BitColorIndex(setting);
+            return offset + PALETTE_INDEX_OFFSET + get9BitColorIndex(setting);
         }
 
         // A custom background has no resource variant of its own,
         // the color resources are replaced by the overlay instead.
-        return ((Enum<?>) background).ordinal() + 1;
+        return offset + ((Enum<?>) background).ordinal() + 1;
     }
 
     private static int get9BitColorIndex(StringSetting colorSetting) {
@@ -377,11 +458,7 @@ public class ThemeBackgroundPatch {
             // The color of a background is the value its resource variant declares, and the
             // variant is selected the same way the app selects the background it uses.
             Configuration configuration = new Configuration(context.getResources().getConfiguration());
-            if (dark) {
-                configuration.mcc = configValue(background, true);
-            } else {
-                configuration.mnc = configValue(background, false);
-            }
+            setVariantOf(configuration, configValue(background, dark));
 
             final int identifier = ResourceUtils.getIdentifier(ResourceType.COLOR,
                     backgroundColorResourceName(dark));
@@ -395,6 +472,48 @@ public class ThemeBackgroundPatch {
         } catch (Exception ex) {
             Logger.printException(() -> "getBackgroundColor failure", ex);
             return Utils.getAppBackgroundColor();
+        }
+    }
+
+    /**
+     * Injection point.
+     * <p>
+     * Called with the view stub of a new content indicator of the pivot bar, which is the dot
+     * of a tab and the count next to it, before either is shown.
+     */
+    public static void onNewContentIndicator(ViewStub stub) {
+        try {
+            stub.setOnInflateListener((inflatedStub, view) -> {
+                Integer color = getIndicatorColor(view.getContext());
+                if (color == null) {
+                    return;
+                }
+
+                setIndicatorColor(view, color);
+
+                // The pivot bar can set the background of an indicator after it is inflated,
+                // and the color is applied again after the app is done with the view.
+                view.post(() -> setIndicatorColor(view, color));
+            });
+        } catch (Exception ex) {
+            Logger.printException(() -> "onNewContentIndicator failure", ex);
+        }
+    }
+
+    private static void setIndicatorColor(View view, int color) {
+        Drawable background = view.getBackground();
+
+        // Both indicators are a shape with a stroke of the app background color, and only the
+        // fill of the shape is replaced. Mutate is needed, otherwise every user of the
+        // drawable is changed as well.
+        if (background instanceof GradientDrawable) {
+            ((GradientDrawable) background.mutate()).setColor(color);
+        }
+
+        // The count is a text view, and its text must stay readable on the new color.
+        if (view instanceof TextView) {
+            ((TextView) view).setTextColor(
+                    getIndicatorTextColor(view.getContext()));
         }
     }
 

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
@@ -308,8 +308,13 @@ public class ThemeBackgroundPatch {
         }
         morpheColorsUpdated = true;
 
-        Utils.setThemeDarkColor(selectedBackgroundColor(context, true));
-        Utils.setThemeLightColor(selectedBackgroundColor(context, false));
+        // An app without a light theme has no light colors to replace.
+        if (!darkColorResourceNames().isEmpty()) {
+            Utils.setThemeDarkColor(selectedBackgroundColor(context, true));
+        }
+        if (!lightColorResourceNames().isEmpty()) {
+            Utils.setThemeLightColor(selectedBackgroundColor(context, false));
+        }
     }
 
     private static int selectedBackgroundColor(Context context, boolean dark) {
@@ -460,8 +465,13 @@ public class ThemeBackgroundPatch {
             Configuration configuration = new Configuration(context.getResources().getConfiguration());
             setVariantOf(configuration, configValue(background, dark));
 
-            final int identifier = ResourceUtils.getIdentifier(ResourceType.COLOR,
-                    backgroundColorResourceName(dark));
+            final String resourceName = backgroundColorResourceName(dark);
+            if (resourceName.isEmpty()) {
+                // The app has no theme of this kind, and no color of it to show.
+                return Utils.getAppBackgroundColor();
+            }
+
+            final int identifier = ResourceUtils.getIdentifier(ResourceType.COLOR, resourceName);
 
             Context variant = context.createConfigurationContext(configuration);
             if (isCustomBackgroundSupported()) {

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
@@ -310,7 +310,7 @@ public class ThemeBackgroundPatch {
 
     private static int configValue(@Nullable SharedPreferences preferences, Background background, boolean dark) {
         if (background.isMaterialYou() && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-            // Material You colors do not exist and resolving them crashes the app.
+            // Material-You colors do not exist and resolving them crashes the app.
             return APP_DEFAULT_CONFIG_VALUE;
         }
 
@@ -336,13 +336,13 @@ public class ThemeBackgroundPatch {
             color = Color.parseColor(defaultColor);
         }
 
-        int r = (color >> 16) & 0xFF;
-        int g = (color >> 8) & 0xFF;
-        int b = color & 0xFF;
+        final int r = (color >> 16) & 0xFF;
+        final int g = (color >> 8) & 0xFF;
+        final int b = color & 0xFF;
 
-        int r3 = Math.round(r * 7f / 255f);
-        int g3 = Math.round(g * 7f / 255f);
-        int b3 = Math.round(b * 7f / 255f);
+        final int r3 = Math.round(r * 7f / 255f);
+        final int g3 = Math.round(g * 7f / 255f);
+        final int b3 = Math.round(b * 7f / 255f);
 
         return (r3 << 6) | (g3 << 3) | b3;
     }

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
@@ -10,12 +10,20 @@ package app.morphe.extension.shared.theme;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
+import android.graphics.Color;
 import android.os.Build;
 
+import androidx.annotation.ChecksSdkIntAtLeast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.settings.Setting;
+import app.morphe.extension.shared.settings.SharedYouTubeSettings;
 
 /**
  * Changes the app background color while the app runs.
@@ -32,6 +40,10 @@ import app.morphe.extension.shared.Logger;
  * <p>
  * The config value of a background is its ordinal plus one, and {@link #APP_DEFAULT_CONFIG_VALUE}
  * is used for the unpatched colors of the app. The patch relies on the same numbering.
+ * <p>
+ * Only a color that was compiled in can be selected this way, so the {@code CUSTOM} background
+ * uses {@link ThemeBackgroundOverlay} instead to give the same color resources a value of its
+ * own. That needs Android 14 or later.
  */
 @SuppressWarnings("unused")
 public class ThemeBackgroundPatch {
@@ -42,6 +54,11 @@ public class ThemeBackgroundPatch {
          * which only exists on Android 12 and later.
          */
         boolean isMaterialYou();
+
+        /**
+         * If the color of this background is picked by the user and applied with an overlay.
+         */
+        boolean isCustom();
     }
 
     /**
@@ -50,31 +67,43 @@ public class ThemeBackgroundPatch {
      * changes the background of everyone who already selected one.
      */
     public enum DarkThemeBackground implements Background {
-        APP_DEFAULT(false),
-        PURE_BLACK(false),
-        MATERIAL_YOU_NEUTRAL(true),
-        MATERIAL_YOU_PRIMARY(true),
-        MATERIAL_YOU_SECONDARY(true),
-        MATERIAL_YOU_TERTIARY(true),
-        MODERN_YOUTUBE(false),
-        CLASSIC_YOUTUBE(false),
-        CATPPUCCIN_MOCHA(false),
-        DARK_PINK(false),
-        DARK_BLUE(false),
-        DARK_GREEN(false),
-        DARK_YELLOW(false),
-        DARK_ORANGE(false),
-        DARK_RED(false);
+        APP_DEFAULT,
+        PURE_BLACK,
+        MATERIAL_YOU_NEUTRAL(true, false),
+        MATERIAL_YOU_PRIMARY(true, false),
+        MATERIAL_YOU_SECONDARY(true, false),
+        MATERIAL_YOU_TERTIARY(true, false),
+        MODERN_YOUTUBE,
+        CLASSIC_YOUTUBE,
+        CATPPUCCIN_MOCHA,
+        DARK_PINK,
+        DARK_BLUE,
+        DARK_GREEN,
+        DARK_YELLOW,
+        DARK_ORANGE,
+        DARK_RED,
+        CUSTOM(false, true);
 
         private final boolean materialYou;
+        private final boolean custom;
 
-        DarkThemeBackground(boolean materialYou) {
+        DarkThemeBackground() {
+            this(false, false);
+        }
+
+        DarkThemeBackground(boolean materialYou, boolean custom) {
             this.materialYou = materialYou;
+            this.custom = custom;
         }
 
         @Override
         public boolean isMaterialYou() {
             return materialYou;
+        }
+
+        @Override
+        public boolean isCustom() {
+            return custom;
         }
     }
 
@@ -82,37 +111,85 @@ public class ThemeBackgroundPatch {
      * @see DarkThemeBackground
      */
     public enum LightThemeBackground implements Background {
-        APP_DEFAULT(false),
-        WHITE(false),
-        MATERIAL_YOU_NEUTRAL(true),
-        MATERIAL_YOU_PRIMARY(true),
-        MATERIAL_YOU_SECONDARY(true),
-        MATERIAL_YOU_TERTIARY(true),
-        CATPPUCCIN_LATTE(false),
-        LIGHT_PINK(false),
-        LIGHT_BLUE(false),
-        LIGHT_GREEN(false),
-        LIGHT_YELLOW(false),
-        LIGHT_ORANGE(false),
-        LIGHT_RED(false);
+        APP_DEFAULT,
+        WHITE,
+        MATERIAL_YOU_NEUTRAL(true, false),
+        MATERIAL_YOU_PRIMARY(true, false),
+        MATERIAL_YOU_SECONDARY(true, false),
+        MATERIAL_YOU_TERTIARY(true, false),
+        CATPPUCCIN_LATTE,
+        LIGHT_PINK,
+        LIGHT_BLUE,
+        LIGHT_GREEN,
+        LIGHT_YELLOW,
+        LIGHT_ORANGE,
+        LIGHT_RED,
+        CUSTOM(false, true);
 
         private final boolean materialYou;
+        private final boolean custom;
 
-        LightThemeBackground(boolean materialYou) {
+        LightThemeBackground() {
+            this(false, false);
+        }
+
+        LightThemeBackground(boolean materialYou, boolean custom) {
             this.materialYou = materialYou;
+            this.custom = custom;
         }
 
         @Override
         public boolean isMaterialYou() {
             return materialYou;
         }
+
+        @Override
+        public boolean isCustom() {
+            return custom;
+        }
+    }
+
+    /**
+     * Availability of the custom dark background color.
+     */
+    public static final class CustomDarkBackgroundAvailability implements Setting.Availability {
+        @Override
+        public boolean isAvailable() {
+            return isCustomBackgroundSupported()
+                    && SharedYouTubeSettings.THEME_BACKGROUND_DARK.get().isCustom();
+        }
+
+        @Override
+        public List<Setting<?>> getParentSettings() {
+            return List.of(SharedYouTubeSettings.THEME_BACKGROUND_DARK);
+        }
+    }
+
+    /**
+     * Availability of the custom light background color.
+     */
+    public static final class CustomLightBackgroundAvailability implements Setting.Availability {
+        @Override
+        public boolean isAvailable() {
+            return isCustomBackgroundSupported()
+                    && SharedYouTubeSettings.THEME_BACKGROUND_LIGHT.get().isCustom();
+        }
+
+        @Override
+        public List<Setting<?>> getParentSettings() {
+            return List.of(SharedYouTubeSettings.THEME_BACKGROUND_LIGHT);
+        }
     }
 
     public static final String SETTINGS_KEY_DARK = "morphe_theme_background_dark";
     public static final String SETTINGS_KEY_LIGHT = "morphe_theme_background_light";
+    public static final String SETTINGS_KEY_DARK_CUSTOM_COLOR = "morphe_theme_background_dark_custom_color";
+    public static final String SETTINGS_KEY_LIGHT_CUSTOM_COLOR = "morphe_theme_background_light_custom_color";
 
     public static final DarkThemeBackground DEFAULT_DARK = DarkThemeBackground.PURE_BLACK;
     public static final LightThemeBackground DEFAULT_LIGHT = LightThemeBackground.WHITE;
+    public static final String DEFAULT_DARK_CUSTOM_COLOR = "#0F0F0F";
+    public static final String DEFAULT_LIGHT_CUSTOM_COLOR = "#FFFFFF";
 
     /**
      * Config value of {@code APP_DEFAULT}. No resource variant uses it, so the app colors are used.
@@ -131,6 +208,20 @@ public class ThemeBackgroundPatch {
     private static int lightConfigValue = -1;
 
     /**
+     * If a background of the user is in use and its overlay must be loaded into every context.
+     */
+    private static boolean useOverlay;
+
+    /**
+     * If a background color of the user can be applied. An overlay that an app registers for
+     * itself exists since Android 14, and no color can be added to the app on older versions.
+     */
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    public static boolean isCustomBackgroundSupported() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
+    }
+
+    /**
      * Injection point.
      * <p>
      * Called with the base context of every context of the app that attaches one.
@@ -144,16 +235,23 @@ public class ThemeBackgroundPatch {
             resolveConfigValues(base);
 
             Configuration configuration = base.getResources().getConfiguration();
+            Context context;
             if (configuration.mcc == darkConfigValue && configuration.mnc == lightConfigValue) {
                 // Context is created from a context that is already wrapped.
-                return base;
+                context = base;
+            } else {
+                Configuration override = new Configuration(configuration);
+                override.mcc = darkConfigValue;
+                override.mnc = lightConfigValue;
+
+                context = base.createConfigurationContext(override);
             }
 
-            Configuration override = new Configuration(configuration);
-            override.mcc = darkConfigValue;
-            override.mnc = lightConfigValue;
+            if (useOverlay) {
+                ThemeBackgroundOverlay.applyTo(context);
+            }
 
-            return base.createConfigurationContext(override);
+            return context;
         } catch (Exception ex) {
             Logger.printException(() -> "wrapContext failure", ex);
             return base;
@@ -177,36 +275,125 @@ public class ThemeBackgroundPatch {
             Logger.printInfo(() -> "Could not load preferences", ex);
         }
 
-        darkConfigValue = configValue(preferences, SETTINGS_KEY_DARK,
+        Background dark = selectedBackground(preferences, SETTINGS_KEY_DARK,
                 DarkThemeBackground.values(), DEFAULT_DARK);
-        lightConfigValue = configValue(preferences, SETTINGS_KEY_LIGHT,
+        Background light = selectedBackground(preferences, SETTINGS_KEY_LIGHT,
                 LightThemeBackground.values(), DEFAULT_LIGHT);
+
+        darkConfigValue = configValue(dark);
+        lightConfigValue = configValue(light);
 
         Logger.printDebug(() -> "Theme background config values: "
                 + darkConfigValue + " " + lightConfigValue);
+
+        updateOverlay(context, preferences, dark, light);
     }
 
-    private static int configValue(@Nullable SharedPreferences preferences, String key,
-                                   Background[] values, @NonNull Background defaultValue) {
-        Background selected = defaultValue;
+    private static Background selectedBackground(@Nullable SharedPreferences preferences, String key,
+                                                 Background[] values, @NonNull Background defaultValue) {
+        if (preferences == null) {
+            return defaultValue;
+        }
 
-        if (preferences != null) {
-            String name = preferences.getString(key, null);
-            if (name != null) {
-                for (Background value : values) {
-                    if (((Enum<?>) value).name().equals(name)) {
-                        selected = value;
-                        break;
-                    }
+        String name = preferences.getString(key, null);
+        if (name != null) {
+            for (Background value : values) {
+                if (((Enum<?>) value).name().equals(name)) {
+                    return value;
                 }
             }
         }
 
-        if (selected.isMaterialYou() && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+        return defaultValue;
+    }
+
+    private static int configValue(Background background) {
+        if (background.isMaterialYou() && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             // Material You colors do not exist and resolving them crashes the app.
             return APP_DEFAULT_CONFIG_VALUE;
         }
 
-        return ((Enum<?>) selected).ordinal() + 1;
+        // A custom background has no resource variant of its own,
+        // the color resources are replaced by the overlay instead.
+        return ((Enum<?>) background).ordinal() + 1;
+    }
+
+    /**
+     * Registers, updates or removes the overlay that gives the color resources of the app the
+     * color the user picked.
+     */
+    private static void updateOverlay(Context context, @Nullable SharedPreferences preferences,
+                                      Background dark, Background light) {
+        if (preferences == null || !isCustomBackgroundSupported()) {
+            return;
+        }
+
+        useOverlay = dark.isCustom() || light.isCustom();
+
+        try {
+            if (!useOverlay) {
+                ThemeBackgroundOverlay.unregisterIfRegistered(context);
+                return;
+            }
+
+            Map<String, Integer> colors = new LinkedHashMap<>();
+
+            if (dark.isCustom()) {
+                addOverlayColors(colors, darkColorResourceNames(),
+                        preferences.getString(SETTINGS_KEY_DARK_CUSTOM_COLOR, DEFAULT_DARK_CUSTOM_COLOR),
+                        DEFAULT_DARK_CUSTOM_COLOR);
+            }
+
+            if (light.isCustom()) {
+                addOverlayColors(colors, lightColorResourceNames(),
+                        preferences.getString(SETTINGS_KEY_LIGHT_CUSTOM_COLOR, DEFAULT_LIGHT_CUSTOM_COLOR),
+                        DEFAULT_LIGHT_CUSTOM_COLOR);
+            }
+
+            // The system deletes an overlay of the app when the app is installed again, so it is
+            // registered on every start and not only after the user picks another color.
+            ThemeBackgroundOverlay.register(context, colors);
+        } catch (Exception ex) {
+            // Overlays are a part of the system and a manufacturer can change how they behave.
+            Logger.printException(() -> "Could not update the overlay of the app", ex);
+        }
+    }
+
+    private static void addOverlayColors(Map<String, Integer> colors, String resourceNames,
+                                         String colorString, String defaultColor) {
+        int color;
+        try {
+            color = Color.parseColor(colorString);
+        } catch (IllegalArgumentException ex) {
+            Logger.printInfo(() -> "Using default, and ignoring invalid color: " + colorString);
+            color = Color.parseColor(defaultColor);
+        }
+
+        // A background must be opaque, otherwise the app draws over itself.
+        color |= 0xFF000000;
+
+        for (String resourceName : resourceNames.split(",")) {
+            if (!resourceName.isEmpty()) {
+                colors.put(resourceName, color);
+            }
+        }
+    }
+
+    /**
+     * Injection point.
+     * <p>
+     * Names of the dark background color resources, separated by a comma.
+     */
+    private static String darkColorResourceNames() {
+        return ""; // Modified during patching.
+    }
+
+    /**
+     * Injection point.
+     * <p>
+     * Names of the light background color resources, separated by a comma.
+     */
+    private static String lightColorResourceNames() {
+        return ""; // Modified during patching.
     }
 }

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
@@ -448,6 +448,50 @@ public class ThemeBackgroundPatch {
         }
     }
 
+    /**
+     * The color of the new content indicator, or null to keep the color of the app.
+     * <p>
+     * A Material You background does not go with the red of the app, which is why the indicator
+     * follows the same palette. Every other background keeps the app color.
+     */
+    @Nullable
+    public static Integer getIndicatorColor(Context context) {
+        try {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+                return null;
+            }
+
+            final boolean dark = Utils.isDarkModeEnabled();
+            Background background = dark
+                    ? SharedYouTubeSettings.THEME_BACKGROUND_DARK.get()
+                    : SharedYouTubeSettings.THEME_BACKGROUND_LIGHT.get();
+
+            if (!background.isMaterialYou()) {
+                return null;
+            }
+
+            return context.getColor(dark
+                    ? android.R.color.system_accent1_100
+                    : android.R.color.system_accent1_200);
+        } catch (Exception ex) {
+            Logger.printException(() -> "getIndicatorColor failure", ex);
+            return null;
+        }
+    }
+
+    /**
+     * The color of the text of the new content count, which must be readable
+     * on {@link #getIndicatorColor(Context)}.
+     */
+    public static int getIndicatorTextColor(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            return context.getColor(android.R.color.system_neutral1_900);
+        }
+
+        // Never reached, an indicator color exists only with a Material You background.
+        return Color.BLACK;
+    }
+
     private static int customColor(boolean dark) {
         String colorString = dark
                 ? SharedYouTubeSettings.THEME_BACKGROUND_DARK_CUSTOM_COLOR.get()

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
@@ -22,6 +22,9 @@ import java.util.List;
 import java.util.Map;
 
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.ResourceType;
+import app.morphe.extension.shared.ResourceUtils;
+import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.Setting;
 import app.morphe.extension.shared.settings.SharedYouTubeSettings;
 
@@ -247,7 +250,7 @@ public class ThemeBackgroundPatch {
                 context = base.createConfigurationContext(override);
             }
 
-            if (useOverlay) {
+            if (isCustomBackgroundSupported() && useOverlay) {
                 ThemeBackgroundOverlay.applyTo(context);
             }
 
@@ -380,9 +383,71 @@ public class ThemeBackgroundPatch {
     }
 
     /**
+     * The color of a background, used to show it next to the name in the app settings.
+     *
+     * @param dark  If the background is of the dark theme.
+     * @param index Index of the background, which is the ordinal of its enum value.
+     */
+    public static int getBackgroundColor(Context context, boolean dark, int index) {
+        try {
+            Background background = dark
+                    ? DarkThemeBackground.values()[index]
+                    : LightThemeBackground.values()[index];
+
+            if (background.isCustom()) {
+                return customColor(dark);
+            }
+
+            // The color of a background is the value its resource variant declares, and the
+            // variant is selected the same way the app selects the background it uses.
+            Configuration configuration = new Configuration(context.getResources().getConfiguration());
+            if (dark) {
+                configuration.mcc = configValue(background);
+            } else {
+                configuration.mnc = configValue(background);
+            }
+
+            final int identifier = ResourceUtils.getIdentifier(ResourceType.COLOR,
+                    backgroundColorResourceName(dark));
+
+            Context variant = context.createConfigurationContext(configuration);
+            if (isCustomBackgroundSupported()) {
+                ThemeBackgroundOverlay.removeFrom(variant);
+            }
+
+            return variant.getColor(identifier);
+        } catch (Exception ex) {
+            Logger.printException(() -> "getBackgroundColor failure", ex);
+            return Utils.getAppBackgroundColor();
+        }
+    }
+
+    private static int customColor(boolean dark) {
+        String colorString = dark
+                ? SharedYouTubeSettings.THEME_BACKGROUND_DARK_CUSTOM_COLOR.get()
+                : SharedYouTubeSettings.THEME_BACKGROUND_LIGHT_CUSTOM_COLOR.get();
+
+        try {
+            return Color.parseColor(colorString) | 0xFF000000;
+        } catch (IllegalArgumentException ex) {
+            Logger.printInfo(() -> "Using default, and ignoring invalid color: " + colorString);
+            return Color.parseColor(dark ? DEFAULT_DARK_CUSTOM_COLOR : DEFAULT_LIGHT_CUSTOM_COLOR);
+        }
+    }
+
+    /**
+     * The first name is the color the app uses for the background itself.
+     */
+    private static String backgroundColorResourceName(boolean dark) {
+        String resourceNames = dark ? darkColorResourceNames() : lightColorResourceNames();
+        return resourceNames.split(",")[0];
+    }
+
+    /**
      * Injection point.
      * <p>
      * Names of the dark background color resources, separated by a comma.
+     * The first name is the color the app uses for the background itself.
      */
     private static String darkColorResourceNames() {
         return ""; // Modified during patching.
@@ -392,6 +457,7 @@ public class ThemeBackgroundPatch {
      * Injection point.
      * <p>
      * Names of the light background color resources, separated by a comma.
+     * The first name is the color the app uses for the background itself.
      */
     private static String lightColorResourceNames() {
         return ""; // Modified during patching.

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
@@ -158,8 +158,7 @@ public class ThemeBackgroundPatch {
     public static final class CustomDarkBackgroundAvailability implements Setting.Availability {
         @Override
         public boolean isAvailable() {
-            return isCustomBackgroundSupported()
-                    && SharedYouTubeSettings.THEME_BACKGROUND_DARK.get().isCustom();
+            return SharedYouTubeSettings.THEME_BACKGROUND_DARK.get().isCustom();
         }
 
         @Override
@@ -174,8 +173,7 @@ public class ThemeBackgroundPatch {
     public static final class CustomLightBackgroundAvailability implements Setting.Availability {
         @Override
         public boolean isAvailable() {
-            return isCustomBackgroundSupported()
-                    && SharedYouTubeSettings.THEME_BACKGROUND_LIGHT.get().isCustom();
+            return SharedYouTubeSettings.THEME_BACKGROUND_LIGHT.get().isCustom();
         }
 
         @Override
@@ -283,8 +281,8 @@ public class ThemeBackgroundPatch {
         Background light = selectedBackground(preferences, SETTINGS_KEY_LIGHT,
                 LightThemeBackground.values(), DEFAULT_LIGHT);
 
-        darkConfigValue = configValue(dark);
-        lightConfigValue = configValue(light);
+        darkConfigValue = configValue(preferences, dark, true);
+        lightConfigValue = configValue(preferences, light, false);
 
         Logger.printDebug(() -> "Theme background config values: "
                 + darkConfigValue + " " + lightConfigValue);
@@ -310,15 +308,43 @@ public class ThemeBackgroundPatch {
         return defaultValue;
     }
 
-    private static int configValue(Background background) {
+    private static int configValue(@Nullable SharedPreferences preferences, Background background, boolean dark) {
         if (background.isMaterialYou() && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             // Material You colors do not exist and resolving them crashes the app.
             return APP_DEFAULT_CONFIG_VALUE;
         }
 
+        if (background.isCustom() && !isCustomBackgroundSupported()) {
+            String key = dark ? SETTINGS_KEY_DARK_CUSTOM_COLOR : SETTINGS_KEY_LIGHT_CUSTOM_COLOR;
+            String defaultColor = dark ? DEFAULT_DARK_CUSTOM_COLOR : DEFAULT_LIGHT_CUSTOM_COLOR;
+            String colorString = preferences != null ? preferences.getString(key, defaultColor) : defaultColor;
+
+            return 100 + get9BitColorIndex(colorString, defaultColor);
+        }
+
         // A custom background has no resource variant of its own,
         // the color resources are replaced by the overlay instead.
         return ((Enum<?>) background).ordinal() + 1;
+    }
+
+    private static int get9BitColorIndex(String colorString, String defaultColor) {
+        int color;
+        try {
+            color = Color.parseColor(colorString);
+        } catch (IllegalArgumentException ex) {
+            Logger.printException(() -> "Invalid color: " + colorString);
+            color = Color.parseColor(defaultColor);
+        }
+
+        int r = (color >> 16) & 0xFF;
+        int g = (color >> 8) & 0xFF;
+        int b = color & 0xFF;
+
+        int r3 = Math.round(r * 7f / 255f);
+        int g3 = Math.round(g * 7f / 255f);
+        int b3 = Math.round(b * 7f / 255f);
+
+        return (r3 << 6) | (g3 << 3) | b3;
     }
 
     /**
@@ -402,9 +428,9 @@ public class ThemeBackgroundPatch {
             // variant is selected the same way the app selects the background it uses.
             Configuration configuration = new Configuration(context.getResources().getConfiguration());
             if (dark) {
-                configuration.mcc = configValue(background);
+                configuration.mcc = configValue(null, background, true);
             } else {
-                configuration.mnc = configValue(background);
+                configuration.mnc = configValue(null, background, false);
             }
 
             final int identifier = ResourceUtils.getIdentifier(ResourceType.COLOR,

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
@@ -7,14 +7,17 @@
 
 package app.morphe.extension.shared.theme;
 
+import static app.morphe.extension.shared.settings.SharedYouTubeSettings.THEME_BACKGROUND_DARK;
+import static app.morphe.extension.shared.settings.SharedYouTubeSettings.THEME_BACKGROUND_DARK_CUSTOM_COLOR;
+import static app.morphe.extension.shared.settings.SharedYouTubeSettings.THEME_BACKGROUND_LIGHT;
+import static app.morphe.extension.shared.settings.SharedYouTubeSettings.THEME_BACKGROUND_LIGHT_CUSTOM_COLOR;
+
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.os.Build;
 
 import androidx.annotation.ChecksSdkIntAtLeast;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.LinkedHashMap;
@@ -25,8 +28,9 @@ import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.settings.EnumSetting;
 import app.morphe.extension.shared.settings.Setting;
-import app.morphe.extension.shared.settings.SharedYouTubeSettings;
+import app.morphe.extension.shared.settings.StringSetting;
 
 /**
  * Changes the app background color while the app runs.
@@ -158,12 +162,12 @@ public class ThemeBackgroundPatch {
     public static final class CustomDarkBackgroundAvailability implements Setting.Availability {
         @Override
         public boolean isAvailable() {
-            return SharedYouTubeSettings.THEME_BACKGROUND_DARK.get().isCustom();
+            return THEME_BACKGROUND_DARK.get().isCustom();
         }
 
         @Override
         public List<Setting<?>> getParentSettings() {
-            return List.of(SharedYouTubeSettings.THEME_BACKGROUND_DARK);
+            return List.of(THEME_BACKGROUND_DARK);
         }
     }
 
@@ -173,37 +177,19 @@ public class ThemeBackgroundPatch {
     public static final class CustomLightBackgroundAvailability implements Setting.Availability {
         @Override
         public boolean isAvailable() {
-            return SharedYouTubeSettings.THEME_BACKGROUND_LIGHT.get().isCustom();
+            return THEME_BACKGROUND_LIGHT.get().isCustom();
         }
 
         @Override
         public List<Setting<?>> getParentSettings() {
-            return List.of(SharedYouTubeSettings.THEME_BACKGROUND_LIGHT);
+            return List.of(THEME_BACKGROUND_LIGHT);
         }
     }
-
-    public static final String SETTINGS_KEY_DARK = "morphe_theme_background_dark";
-    public static final String SETTINGS_KEY_LIGHT = "morphe_theme_background_light";
-    public static final String SETTINGS_KEY_DARK_CUSTOM_COLOR = "morphe_theme_background_dark_custom_color";
-    public static final String SETTINGS_KEY_LIGHT_CUSTOM_COLOR = "morphe_theme_background_light_custom_color";
-
-    public static final DarkThemeBackground DEFAULT_DARK = DarkThemeBackground.PURE_BLACK;
-    public static final LightThemeBackground DEFAULT_LIGHT = LightThemeBackground.WHITE;
-    public static final String DEFAULT_DARK_CUSTOM_COLOR = "#0F0F0F";
-    public static final String DEFAULT_LIGHT_CUSTOM_COLOR = "#FFFFFF";
 
     /**
      * Config value of {@code APP_DEFAULT}. No resource variant uses it, so the app colors are used.
      */
     private static final int APP_DEFAULT_CONFIG_VALUE = 1;
-
-    /**
-     * Name of the shared preferences of Morphe.
-     * <p>
-     * The settings cannot be used here because the first context is wrapped before the extension
-     * has a context of its own, and reading a setting without a context crashes the app.
-     */
-    private static final String PREFERENCES_NAME = "morphe_prefs";
 
     private static int darkConfigValue = -1;
     private static int lightConfigValue = -1;
@@ -231,6 +217,11 @@ public class ThemeBackgroundPatch {
         try {
             if (base == null) {
                 return null;
+            }
+
+            if (!Utils.isContextSet()) {
+                // Context might be used before context is set.
+                Utils.setContext(base);
             }
 
             resolveConfigValues(base);
@@ -268,58 +259,42 @@ public class ThemeBackgroundPatch {
             return;
         }
 
-        SharedPreferences preferences = null;
-        try {
-            preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE);
-        } catch (Exception ex) {
-            // Preferences of the app are not available before the device is unlocked.
-            Logger.printInfo(() -> "Could not load preferences", ex);
-        }
+        Background dark = selectedBackground(THEME_BACKGROUND_DARK, DarkThemeBackground.values());
+        Background light = selectedBackground(THEME_BACKGROUND_LIGHT, LightThemeBackground.values());
 
-        Background dark = selectedBackground(preferences, SETTINGS_KEY_DARK,
-                DarkThemeBackground.values(), DEFAULT_DARK);
-        Background light = selectedBackground(preferences, SETTINGS_KEY_LIGHT,
-                LightThemeBackground.values(), DEFAULT_LIGHT);
+        darkConfigValue = configValue(dark, true);
+        lightConfigValue = configValue(light, false);
 
-        darkConfigValue = configValue(preferences, dark, true);
-        lightConfigValue = configValue(preferences, light, false);
+        Logger.printDebug(() -> "Theme background config values: " + darkConfigValue + " " + lightConfigValue);
 
-        Logger.printDebug(() -> "Theme background config values: "
-                + darkConfigValue + " " + lightConfigValue);
-
-        updateOverlay(context, preferences, dark, light);
+        updateOverlay(context, dark, light);
     }
 
-    private static Background selectedBackground(@Nullable SharedPreferences preferences, String key,
-                                                 Background[] values, @NonNull Background defaultValue) {
-        if (preferences == null) {
-            return defaultValue;
-        }
-
-        String name = preferences.getString(key, null);
-        if (name != null) {
-            for (Background value : values) {
-                if (((Enum<?>) value).name().equals(name)) {
-                    return value;
-                }
+    private static Background selectedBackground(EnumSetting<? extends Background> setting,
+                                                 Background[] values) {
+        Enum<?> name = setting.get();
+        for (Background value : values) {
+            if (value.equals(name)) {
+                return value;
             }
         }
 
-        return defaultValue;
+        return setting.defaultValue;
     }
 
-    private static int configValue(@Nullable SharedPreferences preferences, Background background, boolean dark) {
+    private static int configValue(Background background, boolean dark) {
         if (background.isMaterialYou() && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             // Material-You colors do not exist and resolving them crashes the app.
             return APP_DEFAULT_CONFIG_VALUE;
         }
 
         if (background.isCustom() && !isCustomBackgroundSupported()) {
-            String key = dark ? SETTINGS_KEY_DARK_CUSTOM_COLOR : SETTINGS_KEY_LIGHT_CUSTOM_COLOR;
-            String defaultColor = dark ? DEFAULT_DARK_CUSTOM_COLOR : DEFAULT_LIGHT_CUSTOM_COLOR;
-            String colorString = preferences != null ? preferences.getString(key, defaultColor) : defaultColor;
+            StringSetting setting = dark
+                    ? THEME_BACKGROUND_DARK_CUSTOM_COLOR
+                    : THEME_BACKGROUND_LIGHT_CUSTOM_COLOR;
+            String colorString = setting.get();
 
-            return 100 + get9BitColorIndex(colorString, defaultColor);
+            return 100 + get9BitColorIndex(colorString, setting.defaultValue);
         }
 
         // A custom background has no resource variant of its own,
@@ -351,9 +326,8 @@ public class ThemeBackgroundPatch {
      * Registers, updates or removes the overlay that gives the color resources of the app the
      * color the user picked.
      */
-    private static void updateOverlay(Context context, @Nullable SharedPreferences preferences,
-                                      Background dark, Background light) {
-        if (preferences == null || !isCustomBackgroundSupported()) {
+    private static void updateOverlay(Context context, Background dark, Background light) {
+        if (!isCustomBackgroundSupported()) {
             return;
         }
 
@@ -368,15 +342,11 @@ public class ThemeBackgroundPatch {
             Map<String, Integer> colors = new LinkedHashMap<>();
 
             if (dark.isCustom()) {
-                addOverlayColors(colors, darkColorResourceNames(),
-                        preferences.getString(SETTINGS_KEY_DARK_CUSTOM_COLOR, DEFAULT_DARK_CUSTOM_COLOR),
-                        DEFAULT_DARK_CUSTOM_COLOR);
+                addOverlayColors(colors, darkColorResourceNames(), THEME_BACKGROUND_DARK_CUSTOM_COLOR);
             }
 
             if (light.isCustom()) {
-                addOverlayColors(colors, lightColorResourceNames(),
-                        preferences.getString(SETTINGS_KEY_LIGHT_CUSTOM_COLOR, DEFAULT_LIGHT_CUSTOM_COLOR),
-                        DEFAULT_LIGHT_CUSTOM_COLOR);
+                addOverlayColors(colors, lightColorResourceNames(), THEME_BACKGROUND_LIGHT_CUSTOM_COLOR);
             }
 
             // The system deletes an overlay of the app when the app is installed again, so it is
@@ -389,13 +359,14 @@ public class ThemeBackgroundPatch {
     }
 
     private static void addOverlayColors(Map<String, Integer> colors, String resourceNames,
-                                         String colorString, String defaultColor) {
+                                         StringSetting colorSetting) {
+        String colorString = colorSetting.get();
         int color;
         try {
             color = Color.parseColor(colorString);
         } catch (IllegalArgumentException ex) {
-            Logger.printInfo(() -> "Using default, and ignoring invalid color: " + colorString);
-            color = Color.parseColor(defaultColor);
+            Logger.printException(() -> "Invalid custom color: " + colorString);
+            color = Color.parseColor(colorSetting.resetToDefault());
         }
 
         // A background must be opaque, otherwise the app draws over itself.
@@ -428,9 +399,9 @@ public class ThemeBackgroundPatch {
             // variant is selected the same way the app selects the background it uses.
             Configuration configuration = new Configuration(context.getResources().getConfiguration());
             if (dark) {
-                configuration.mcc = configValue(null, background, true);
+                configuration.mcc = configValue(background, true);
             } else {
-                configuration.mnc = configValue(null, background, false);
+                configuration.mnc = configValue(background, false);
             }
 
             final int identifier = ResourceUtils.getIdentifier(ResourceType.COLOR,
@@ -463,8 +434,8 @@ public class ThemeBackgroundPatch {
 
             final boolean dark = Utils.isDarkModeEnabled();
             Background background = dark
-                    ? SharedYouTubeSettings.THEME_BACKGROUND_DARK.get()
-                    : SharedYouTubeSettings.THEME_BACKGROUND_LIGHT.get();
+                    ? THEME_BACKGROUND_DARK.get()
+                    : THEME_BACKGROUND_LIGHT.get();
 
             if (!background.isMaterialYou()) {
                 return null;
@@ -493,15 +464,16 @@ public class ThemeBackgroundPatch {
     }
 
     private static int customColor(boolean dark) {
-        String colorString = dark
-                ? SharedYouTubeSettings.THEME_BACKGROUND_DARK_CUSTOM_COLOR.get()
-                : SharedYouTubeSettings.THEME_BACKGROUND_LIGHT_CUSTOM_COLOR.get();
+        StringSetting setting = dark
+                ? THEME_BACKGROUND_DARK_CUSTOM_COLOR
+                : THEME_BACKGROUND_LIGHT_CUSTOM_COLOR;
+        String colorString = setting.get();
 
         try {
             return Color.parseColor(colorString) | 0xFF000000;
         } catch (IllegalArgumentException ex) {
-            Logger.printInfo(() -> "Using default, and ignoring invalid color: " + colorString);
-            return Color.parseColor(dark ? DEFAULT_DARK_CUSTOM_COLOR : DEFAULT_LIGHT_CUSTOM_COLOR);
+            Logger.printException(() -> "Invalid custom color: " + colorString);
+            return Color.parseColor(setting.resetToDefault());
         }
     }
 

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
@@ -18,6 +18,7 @@ import android.graphics.Color;
 import android.os.Build;
 
 import androidx.annotation.ChecksSdkIntAtLeast;
+import androidx.annotation.ColorInt;
 import androidx.annotation.Nullable;
 
 import java.util.LinkedHashMap;
@@ -28,7 +29,6 @@ import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
-import app.morphe.extension.shared.settings.EnumSetting;
 import app.morphe.extension.shared.settings.Setting;
 import app.morphe.extension.shared.settings.StringSetting;
 
@@ -68,11 +68,6 @@ public class ThemeBackgroundPatch {
         boolean isCustom();
     }
 
-    /**
-     * Important: Existing values cannot be renamed or removed, and new values can only be appended.
-     * The ordinal of a value selects its resource variant, so changing the order of this enum
-     * changes the background of everyone who already selected one.
-     */
     public enum DarkThemeBackground implements Background {
         APP_DEFAULT,
         PURE_BLACK,
@@ -114,9 +109,6 @@ public class ThemeBackgroundPatch {
         }
     }
 
-    /**
-     * @see DarkThemeBackground
-     */
     public enum LightThemeBackground implements Background {
         APP_DEFAULT,
         WHITE,
@@ -259,31 +251,18 @@ public class ThemeBackgroundPatch {
             return;
         }
 
-        Background dark = selectedBackground(THEME_BACKGROUND_DARK, DarkThemeBackground.values());
-        Background light = selectedBackground(THEME_BACKGROUND_LIGHT, LightThemeBackground.values());
+        Background dark = THEME_BACKGROUND_DARK.get();
+        Background light = THEME_BACKGROUND_LIGHT.get();
+        Logger.printDebug(() -> "Theme dark: " + darkConfigValue + " light:" + lightConfigValue);
 
         darkConfigValue = configValue(dark, true);
         lightConfigValue = configValue(light, false);
 
-        Logger.printDebug(() -> "Theme background config values: " + darkConfigValue + " " + lightConfigValue);
-
         updateOverlay(context, dark, light);
     }
 
-    private static Background selectedBackground(EnumSetting<? extends Background> setting,
-                                                 Background[] values) {
-        Enum<?> name = setting.get();
-        for (Background value : values) {
-            if (value.equals(name)) {
-                return value;
-            }
-        }
-
-        return setting.defaultValue;
-    }
-
     private static int configValue(Background background, boolean dark) {
-        if (background.isMaterialYou() && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S && background.isMaterialYou()) {
             // Material-You colors do not exist and resolving them crashes the app.
             return APP_DEFAULT_CONFIG_VALUE;
         }
@@ -292,9 +271,7 @@ public class ThemeBackgroundPatch {
             StringSetting setting = dark
                     ? THEME_BACKGROUND_DARK_CUSTOM_COLOR
                     : THEME_BACKGROUND_LIGHT_CUSTOM_COLOR;
-            String colorString = setting.get();
-
-            return 100 + get9BitColorIndex(colorString, setting.defaultValue);
+            return 100 + get9BitColorIndex(setting);
         }
 
         // A custom background has no resource variant of its own,
@@ -302,13 +279,14 @@ public class ThemeBackgroundPatch {
         return ((Enum<?>) background).ordinal() + 1;
     }
 
-    private static int get9BitColorIndex(String colorString, String defaultColor) {
+    private static int get9BitColorIndex(StringSetting colorSetting) {
+        String colorString = colorSetting.get();
         int color;
         try {
             color = Color.parseColor(colorString);
         } catch (IllegalArgumentException ex) {
             Logger.printException(() -> "Invalid color: " + colorString);
-            color = Color.parseColor(defaultColor);
+            color = Color.parseColor(colorSetting.resetToDefault());
         }
 
         final int r = (color >> 16) & 0xFF;
@@ -359,14 +337,14 @@ public class ThemeBackgroundPatch {
     }
 
     private static void addOverlayColors(Map<String, Integer> colors, String resourceNames,
-                                         StringSetting colorSetting) {
-        String colorString = colorSetting.get();
+                                         StringSetting customColorSetting) {
+        String colorString = customColorSetting.get();
         int color;
         try {
             color = Color.parseColor(colorString);
         } catch (IllegalArgumentException ex) {
             Logger.printException(() -> "Invalid custom color: " + colorString);
-            color = Color.parseColor(colorSetting.resetToDefault());
+            color = Color.parseColor(customColorSetting.resetToDefault());
         }
 
         // A background must be opaque, otherwise the app draws over itself.
@@ -385,11 +363,12 @@ public class ThemeBackgroundPatch {
      * @param dark  If the background is of the dark theme.
      * @param index Index of the background, which is the ordinal of its enum value.
      */
+    @ColorInt
     public static int getBackgroundColor(Context context, boolean dark, int index) {
         try {
-            Background background = dark
-                    ? DarkThemeBackground.values()[index]
-                    : LightThemeBackground.values()[index];
+            Background background = (dark
+                    ? DarkThemeBackground.values()
+                    : LightThemeBackground.values())[index];
 
             if (background.isCustom()) {
                 return customColor(dark);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeBackgroundPatch.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2524
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.theme;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.Configuration;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import app.morphe.extension.shared.Logger;
+
+/**
+ * Changes the app background color while the app runs.
+ * <p>
+ * The background of the app is not painted by app code, it is resolved by the resource system from
+ * XML: the window background is {@code ?ytBaseBackground}, which resolves to a color resource.
+ * Nothing in the app can be hooked to change that, but the resource system picks a resource
+ * variant using the {@link Configuration} of the context it is resolved with.
+ * <p>
+ * The patch writes one {@code values-mccNNN/colors.xml} for every dark background and one
+ * {@code values-mncNNN/colors.xml} for every light background, and this class selects one of them
+ * by overriding {@link Configuration#mcc} and {@link Configuration#mnc} of every context the app
+ * attaches. Both qualifiers are ignored by the app itself and affect no other resource.
+ * <p>
+ * The config value of a background is its ordinal plus one, and {@link #APP_DEFAULT_CONFIG_VALUE}
+ * is used for the unpatched colors of the app. The patch relies on the same numbering.
+ */
+@SuppressWarnings("unused")
+public class ThemeBackgroundPatch {
+
+    public interface Background {
+        /**
+         * If the color of this background is a Material You system color,
+         * which only exists on Android 12 and later.
+         */
+        boolean isMaterialYou();
+    }
+
+    /**
+     * Important: Existing values cannot be renamed or removed, and new values can only be appended.
+     * The ordinal of a value selects its resource variant, so changing the order of this enum
+     * changes the background of everyone who already selected one.
+     */
+    public enum DarkThemeBackground implements Background {
+        APP_DEFAULT(false),
+        PURE_BLACK(false),
+        MATERIAL_YOU_NEUTRAL(true),
+        MATERIAL_YOU_PRIMARY(true),
+        MATERIAL_YOU_SECONDARY(true),
+        MATERIAL_YOU_TERTIARY(true),
+        MODERN_YOUTUBE(false),
+        CLASSIC_YOUTUBE(false),
+        CATPPUCCIN_MOCHA(false),
+        DARK_PINK(false),
+        DARK_BLUE(false),
+        DARK_GREEN(false),
+        DARK_YELLOW(false),
+        DARK_ORANGE(false),
+        DARK_RED(false);
+
+        private final boolean materialYou;
+
+        DarkThemeBackground(boolean materialYou) {
+            this.materialYou = materialYou;
+        }
+
+        @Override
+        public boolean isMaterialYou() {
+            return materialYou;
+        }
+    }
+
+    /**
+     * @see DarkThemeBackground
+     */
+    public enum LightThemeBackground implements Background {
+        APP_DEFAULT(false),
+        WHITE(false),
+        MATERIAL_YOU_NEUTRAL(true),
+        MATERIAL_YOU_PRIMARY(true),
+        MATERIAL_YOU_SECONDARY(true),
+        MATERIAL_YOU_TERTIARY(true),
+        CATPPUCCIN_LATTE(false),
+        LIGHT_PINK(false),
+        LIGHT_BLUE(false),
+        LIGHT_GREEN(false),
+        LIGHT_YELLOW(false),
+        LIGHT_ORANGE(false),
+        LIGHT_RED(false);
+
+        private final boolean materialYou;
+
+        LightThemeBackground(boolean materialYou) {
+            this.materialYou = materialYou;
+        }
+
+        @Override
+        public boolean isMaterialYou() {
+            return materialYou;
+        }
+    }
+
+    public static final String SETTINGS_KEY_DARK = "morphe_theme_background_dark";
+    public static final String SETTINGS_KEY_LIGHT = "morphe_theme_background_light";
+
+    public static final DarkThemeBackground DEFAULT_DARK = DarkThemeBackground.PURE_BLACK;
+    public static final LightThemeBackground DEFAULT_LIGHT = LightThemeBackground.WHITE;
+
+    /**
+     * Config value of {@code APP_DEFAULT}. No resource variant uses it, so the app colors are used.
+     */
+    private static final int APP_DEFAULT_CONFIG_VALUE = 1;
+
+    /**
+     * Name of the shared preferences of Morphe.
+     * <p>
+     * The settings cannot be used here because the first context is wrapped before the extension
+     * has a context of its own, and reading a setting without a context crashes the app.
+     */
+    private static final String PREFERENCES_NAME = "morphe_prefs";
+
+    private static int darkConfigValue = -1;
+    private static int lightConfigValue = -1;
+
+    /**
+     * Injection point.
+     * <p>
+     * Called with the base context of every context of the app that attaches one.
+     */
+    public static Context wrapContext(Context base) {
+        try {
+            if (base == null) {
+                return null;
+            }
+
+            resolveConfigValues(base);
+
+            Configuration configuration = base.getResources().getConfiguration();
+            if (configuration.mcc == darkConfigValue && configuration.mnc == lightConfigValue) {
+                // Context is created from a context that is already wrapped.
+                return base;
+            }
+
+            Configuration override = new Configuration(configuration);
+            override.mcc = darkConfigValue;
+            override.mnc = lightConfigValue;
+
+            return base.createConfigurationContext(override);
+        } catch (Exception ex) {
+            Logger.printException(() -> "wrapContext failure", ex);
+            return base;
+        }
+    }
+
+    /**
+     * The selected backgrounds require an app restart to change,
+     * so the preferences are read only once.
+     */
+    private static void resolveConfigValues(Context context) {
+        if (darkConfigValue > 0) {
+            return;
+        }
+
+        SharedPreferences preferences = null;
+        try {
+            preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE);
+        } catch (Exception ex) {
+            // Preferences of the app are not available before the device is unlocked.
+            Logger.printInfo(() -> "Could not load preferences", ex);
+        }
+
+        darkConfigValue = configValue(preferences, SETTINGS_KEY_DARK,
+                DarkThemeBackground.values(), DEFAULT_DARK);
+        lightConfigValue = configValue(preferences, SETTINGS_KEY_LIGHT,
+                LightThemeBackground.values(), DEFAULT_LIGHT);
+
+        Logger.printDebug(() -> "Theme background config values: "
+                + darkConfigValue + " " + lightConfigValue);
+    }
+
+    private static int configValue(@Nullable SharedPreferences preferences, String key,
+                                   Background[] values, @NonNull Background defaultValue) {
+        Background selected = defaultValue;
+
+        if (preferences != null) {
+            String name = preferences.getString(key, null);
+            if (name != null) {
+                for (Background value : values) {
+                    if (((Enum<?>) value).name().equals(name)) {
+                        selected = value;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (selected.isMaterialYou() && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            // Material You colors do not exist and resolving them crashes the app.
+            return APP_DEFAULT_CONFIG_VALUE;
+        }
+
+        return ((Enum<?>) selected).ordinal() + 1;
+    }
+}

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorListPreference.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorListPreference.java
@@ -21,21 +21,21 @@ import app.morphe.extension.shared.ui.ColorDot;
  * Shows the color of every background next to its name, the same way the app icons are shown.
  */
 @SuppressWarnings({"unused", "deprecation"})
-public class ThemeBackgroundListPreference extends IconListPreference {
+public class ThemeColorListPreference extends IconListPreference {
 
-    public ThemeBackgroundListPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+    public ThemeColorListPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
     }
 
-    public ThemeBackgroundListPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+    public ThemeColorListPreference(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
     }
 
-    public ThemeBackgroundListPreference(Context context, AttributeSet attrs) {
+    public ThemeColorListPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
     }
 
-    public ThemeBackgroundListPreference(Context context) {
+    public ThemeColorListPreference(Context context) {
         super(context);
     }
 
@@ -53,7 +53,7 @@ public class ThemeBackgroundListPreference extends IconListPreference {
         Drawable[] drawables = new Drawable[values.length];
         for (int i = 0, length = values.length; i < length; i++) {
             drawables[i] = ColorDot.createColorDotDrawable(
-                    ThemeBackgroundPatch.getBackgroundColor(context, dark, i));
+                    ThemeColorPatch.getBackgroundColor(context, dark, i));
         }
 
         return drawables;

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorOverlay.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorOverlay.java
@@ -36,12 +36,18 @@ import app.morphe.extension.shared.Logger;
  * Registering only creates the overlay. The system does not apply an overlay an app registers for
  * itself, and the app loads it into the resources of every context it creates.
  * <p>
+ * An overlay replaces a color in every configuration, so it cannot be qualified the way a resource
+ * variant is. Each theme is given an overlay of its own instead, and a context is only ever loaded
+ * with the overlay of the theme it shows. Otherwise, the background of one theme replaces the color
+ * the other theme uses for its text and icons.
+ * <p>
  * Kept in a class of its own so the API 34 classes are never loaded on an older device.
  */
 @RequiresApi(api = Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 final class ThemeColorOverlay {
 
-    private static final String OVERLAY_NAME = "morphe_theme_background";
+    private static final String OVERLAY_NAME_DARK = "morphe_theme_background_dark";
+    private static final String OVERLAY_NAME_LIGHT = "morphe_theme_background_light";
 
     /**
      * An overlay is rejected unless the target declares the resources it may change, so the patch
@@ -50,12 +56,14 @@ final class ThemeColorOverlay {
     private static final String OVERLAYABLE_NAME = "MorpheThemeColor";
 
     /**
-     * Gives every color resource of {@code colors} the color it is mapped to.
-     * A resource that is not included keeps the value it has in the app.
+     * Gives every color resource of {@code colors} the color it is mapped to, in the overlay of one
+     * theme. A resource that is not included keeps the value it has in the app.
+     *
+     * @param dark If the overlay of the dark theme is registered.
      */
-    static void register(Context context, Map<String, Integer> colors) {
+    static void register(Context context, boolean dark, Map<String, Integer> colors) {
         String packageName = context.getPackageName();
-        FabricatedOverlay overlay = new FabricatedOverlay(OVERLAY_NAME, packageName);
+        FabricatedOverlay overlay = new FabricatedOverlay(overlayName(dark), packageName);
         overlay.setTargetOverlayable(OVERLAYABLE_NAME);
 
         for (Map.Entry<String, Integer> entry : colors.entrySet()) {
@@ -66,56 +74,78 @@ final class ThemeColorOverlay {
         OverlayManagerTransaction transaction = OverlayManagerTransaction.newInstance();
         transaction.registerFabricatedOverlay(overlay);
         commit(context, transaction);
-        resourcesLoader = null;
+        setResourcesLoader(dark, null);
 
-        Logger.printDebug(() -> "Registered overlay of " + colors.size() + " colors");
+        Logger.printDebug(() -> "Registered " + overlayName(dark)
+                + " overlay of " + colors.size() + " colors");
     }
 
     /**
-     * Removes the overlay of the app, and does nothing if the app has none.
+     * Removes the overlay of a theme, and does nothing if the app has none.
      */
-    static void unregisterIfRegistered(Context context) {
-        if (findOverlay(context) != null) {
-            unregister(context);
+    static void unregisterIfRegistered(Context context, boolean dark) {
+        if (findOverlay(context, dark) != null) {
+            unregister(context, dark);
         }
     }
 
-    private static void unregister(Context context) {
+    private static void unregister(Context context, boolean dark) {
         // An identifier cannot be created on its own, but an overlay of the same name has the
         // identifier of the overlay that is registered.
-        FabricatedOverlay overlay = new FabricatedOverlay(OVERLAY_NAME, context.getPackageName());
+        FabricatedOverlay overlay = new FabricatedOverlay(
+                overlayName(dark), context.getPackageName());
 
         OverlayManagerTransaction transaction = OverlayManagerTransaction.newInstance();
         transaction.unregisterFabricatedOverlay(overlay.getIdentifier());
         commit(context, transaction);
-        resourcesLoader = null;
+        setResourcesLoader(dark, null);
 
-        Logger.printDebug(() -> "Unregistered overlay");
+        Logger.printDebug(() -> "Unregistered " + overlayName(dark) + " overlay");
     }
 
     /**
-     * The overlay is a file of the app, and loading it once is enough for the whole process.
+     * The overlay of a theme is a file of the app, and loading it once is enough for the
+     * whole process.
      */
     @Nullable
-    private static ResourcesLoader resourcesLoader;
+    private static ResourcesLoader darkResourcesLoader;
+    @Nullable
+    private static ResourcesLoader lightResourcesLoader;
+
+    @Nullable
+    private static ResourcesLoader resourcesLoader(boolean dark) {
+        return dark ? darkResourcesLoader : lightResourcesLoader;
+    }
+
+    private static void setResourcesLoader(boolean dark, @Nullable ResourcesLoader loader) {
+        if (dark) {
+            darkResourcesLoader = loader;
+        } else {
+            lightResourcesLoader = loader;
+        }
+    }
 
     /**
-     * Loads the overlay into the resources of {@code context}. Without this the overlay is
-     * registered but nothing of the app uses it.
+     * Loads the overlay of a theme into the resources of {@code context}. Without this the overlay
+     * is registered but nothing of the app uses it.
+     *
+     * @param dark If the app shows its dark theme. The overlay of the other theme is never loaded,
+     *             its colors are the text and the icons of this one.
      */
-    static void applyTo(Context context) {
+    static void applyTo(Context context, boolean dark) {
         try {
-            ResourcesLoader loader = resourcesLoader;
+            ResourcesLoader loader = resourcesLoader(dark);
             if (loader == null) {
-                OverlayInfo overlayInfo = findOverlay(context);
+                OverlayInfo overlayInfo = findOverlay(context, dark);
                 if (overlayInfo == null) {
-                    Logger.printException(() -> "Overlay of the app is not registered");
+                    Logger.printException(() -> "Overlay " + overlayName(dark)
+                            + " of the app is not registered");
                     return;
                 }
 
                 loader = new ResourcesLoader();
                 loader.addProvider(ResourcesProvider.loadOverlay(overlayInfo));
-                resourcesLoader = loader;
+                setResourcesLoader(dark, loader);
             }
 
             // Adding the same loader again is ignored, and every context of the app needs it
@@ -127,31 +157,38 @@ final class ThemeColorOverlay {
     }
 
     /**
-     * Removes the overlay from the resources of {@code context}, which is needed to read a color
-     * the app declares. An overlay replaces the color of every configuration, so a context that
-     * uses it cannot resolve the color of another background.
+     * Removes the overlay of both themes from the resources of {@code context}, which is needed to
+     * read a color the app declares. An overlay replaces the color of every configuration, so a
+     * context that uses one cannot resolve the color of another background.
      */
     static void removeFrom(Context context) {
         try {
-            ResourcesLoader loader = resourcesLoader;
-            if (loader != null) {
-                context.getResources().removeLoaders(loader);
+            for (ResourcesLoader loader : new ResourcesLoader[]{
+                    darkResourcesLoader, lightResourcesLoader}) {
+                if (loader != null) {
+                    context.getResources().removeLoaders(loader);
+                }
             }
         } catch (Exception ex) {
             Logger.printException(() -> "Could not remove the overlay of the app", ex);
         }
     }
 
+    private static String overlayName(boolean dark) {
+        return dark ? OVERLAY_NAME_DARK : OVERLAY_NAME_LIGHT;
+    }
+
     @Nullable
-    private static OverlayInfo findOverlay(Context context) {
+    private static OverlayInfo findOverlay(Context context, boolean dark) {
         OverlayManager overlayManager = context.getSystemService(OverlayManager.class);
         if (overlayManager == null) {
             return null;
         }
 
+        final String overlayName = overlayName(dark);
         for (OverlayInfo overlayInfo : overlayManager.getOverlayInfosForTarget(
                 context.getPackageName())) {
-            if (OVERLAY_NAME.equals(overlayInfo.getOverlayName())) {
+            if (overlayName.equals(overlayInfo.getOverlayName())) {
                 return overlayInfo;
             }
         }

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorOverlay.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorOverlay.java
@@ -39,7 +39,7 @@ import app.morphe.extension.shared.Logger;
  * Kept in a class of its own so the API 34 classes are never loaded on an older device.
  */
 @RequiresApi(api = Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
-final class ThemeBackgroundOverlay {
+final class ThemeColorOverlay {
 
     private static final String OVERLAY_NAME = "morphe_theme_background";
 
@@ -47,7 +47,7 @@ final class ThemeBackgroundOverlay {
      * An overlay is rejected unless the target declares the resources it may change, so the patch
      * adds this to {@code res/values/overlayable.xml} and both names must stay identical.
      */
-    private static final String OVERLAYABLE_NAME = "MorpheThemeBackground";
+    private static final String OVERLAYABLE_NAME = "MorpheThemeColor";
 
     /**
      * Gives every color resource of {@code colors} the color it is mapped to.
@@ -168,6 +168,6 @@ final class ThemeBackgroundOverlay {
         overlayManager.commit(transaction);
     }
 
-    private ThemeBackgroundOverlay() {
+    private ThemeColorOverlay() {
     }
 }

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
@@ -54,11 +54,11 @@ import app.morphe.extension.shared.settings.StringSetting;
  * is used for the unpatched colors of the app. The patch relies on the same numbering.
  * <p>
  * Only a color that was compiled in can be selected this way, so the {@code CUSTOM} background
- * uses {@link ThemeBackgroundOverlay} instead to give the same color resources a value of its
+ * uses {@link ThemeColorOverlay} instead to give the same color resources a value of its
  * own. That needs Android 14 or later.
  */
 @SuppressWarnings("unused")
-public class ThemeBackgroundPatch {
+public class ThemeColorPatch {
 
     public interface Background {
         /**
@@ -73,7 +73,7 @@ public class ThemeBackgroundPatch {
         boolean isCustom();
     }
 
-    public enum DarkThemeBackground implements Background {
+    public enum ThemeColorDark implements Background {
         APP_DEFAULT,
         PURE_BLACK,
         MATERIAL_YOU_NEUTRAL(true, false),
@@ -93,11 +93,11 @@ public class ThemeBackgroundPatch {
         private final boolean materialYou;
         private final boolean custom;
 
-        DarkThemeBackground() {
+        ThemeColorDark() {
             this(false, false);
         }
 
-        DarkThemeBackground(boolean materialYou, boolean custom) {
+        ThemeColorDark(boolean materialYou, boolean custom) {
             this.materialYou = materialYou;
             this.custom = custom;
         }
@@ -113,7 +113,7 @@ public class ThemeBackgroundPatch {
         }
     }
 
-    public enum LightThemeBackground implements Background {
+    public enum ThemeColorLight implements Background {
         APP_DEFAULT,
         WHITE,
         MATERIAL_YOU_NEUTRAL(true, false),
@@ -132,11 +132,11 @@ public class ThemeBackgroundPatch {
         private final boolean materialYou;
         private final boolean custom;
 
-        LightThemeBackground() {
+        ThemeColorLight() {
             this(false, false);
         }
 
-        LightThemeBackground(boolean materialYou, boolean custom) {
+        ThemeColorLight(boolean materialYou, boolean custom) {
             this.materialYou = materialYou;
             this.custom = custom;
         }
@@ -264,7 +264,7 @@ public class ThemeBackgroundPatch {
             }
 
             if (isCustomBackgroundSupported() && useOverlay) {
-                ThemeBackgroundOverlay.applyTo(context);
+                ThemeColorOverlay.applyTo(context);
             }
 
             updateMorpheColors(context);
@@ -399,7 +399,7 @@ public class ThemeBackgroundPatch {
 
         try {
             if (!useOverlay) {
-                ThemeBackgroundOverlay.unregisterIfRegistered(context);
+                ThemeColorOverlay.unregisterIfRegistered(context);
                 return;
             }
 
@@ -415,7 +415,7 @@ public class ThemeBackgroundPatch {
 
             // The system deletes an overlay of the app when the app is installed again, so it is
             // registered on every start and not only after the user picks another color.
-            ThemeBackgroundOverlay.register(context, colors);
+            ThemeColorOverlay.register(context, colors);
         } catch (Exception ex) {
             // Overlays are a part of the system and a manufacturer can change how they behave.
             Logger.printException(() -> "Could not update the overlay of the app", ex);
@@ -453,8 +453,8 @@ public class ThemeBackgroundPatch {
     public static int getBackgroundColor(Context context, boolean dark, int index) {
         try {
             Background background = (dark
-                    ? DarkThemeBackground.values()
-                    : LightThemeBackground.values())[index];
+                    ? ThemeColorDark.values()
+                    : ThemeColorLight.values())[index];
 
             if (background.isCustom()) {
                 return customColor(dark);
@@ -475,7 +475,7 @@ public class ThemeBackgroundPatch {
 
             Context variant = context.createConfigurationContext(configuration);
             if (isCustomBackgroundSupported()) {
-                ThemeBackgroundOverlay.removeFrom(variant);
+                ThemeColorOverlay.removeFrom(variant);
             }
 
             return variant.getColor(identifier);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
@@ -11,6 +11,7 @@ import static app.morphe.extension.shared.settings.SharedYouTubeSettings.THEME_B
 import static app.morphe.extension.shared.settings.SharedYouTubeSettings.THEME_BACKGROUND_DARK_CUSTOM_COLOR;
 import static app.morphe.extension.shared.settings.SharedYouTubeSettings.THEME_BACKGROUND_LIGHT;
 import static app.morphe.extension.shared.settings.SharedYouTubeSettings.THEME_BACKGROUND_LIGHT_CUSTOM_COLOR;
+import static app.morphe.extension.shared.settings.SharedYouTubeSettings.THEME_LAST_USED_DARK_MODE;
 
 import android.content.Context;
 import android.content.res.Configuration;
@@ -212,9 +213,15 @@ public class ThemeColorPatch {
     private static boolean useOverlay;
 
     /**
-     * If the colors Morphe uses for itself were resolved with the theme they belong to.
+     * The color of the background that is selected for each theme, or zero for a theme the app
+     * does not have. Resolved once, with the resource variant of the theme it belongs to.
      */
-    private static boolean morpheColorsUpdated;
+    @ColorInt
+    private static int darkBackgroundColor;
+    @ColorInt
+    private static int lightBackgroundColor;
+
+    private static boolean backgroundColorsResolved;
 
     /**
      * If a background color of the user can be applied. An overlay that an app registers for
@@ -246,10 +253,16 @@ public class ThemeColorPatch {
             Configuration configuration = base.getResources().getConfiguration();
 
             // A variant belongs to one theme only, so the background of the theme the app shows
-            // is the one to ask for. The night mode of the device says nothing about it, the app
-            // has a theme setting of its own. A theme change recreates the activity, and the
-            // index of the other theme is used from then on.
-            final int index = Utils.isDarkModeEnabled() ? darkConfigValue : lightConfigValue;
+            // is the one to ask for. A theme change recreates the activity, and the index of the
+            // other theme is used from then on.
+            final boolean dark = isDarkTheme();
+            if (THEME_LAST_USED_DARK_MODE.get() != dark) {
+                // Contexts that attach before the app resolves its theme can then select the
+                // variant of the theme the app is about to show.
+                THEME_LAST_USED_DARK_MODE.save(dark);
+            }
+
+            final int index = dark ? darkConfigValue : lightConfigValue;
 
             Context context;
             if (configuration.mcc == mobileCountryCode(index)
@@ -267,7 +280,7 @@ public class ThemeColorPatch {
                 ThemeColorOverlay.applyTo(context);
             }
 
-            updateMorpheColors(context);
+            resolveBackgroundColors(context);
 
             return context;
         } catch (Exception ex) {
@@ -287,34 +300,50 @@ public class ThemeColorPatch {
 
         Background dark = THEME_BACKGROUND_DARK.get();
         Background light = THEME_BACKGROUND_LIGHT.get();
-        Logger.printDebug(() -> "Theme dark: " + darkConfigValue + " light:" + lightConfigValue);
 
         darkConfigValue = configValue(dark, true);
         lightConfigValue = configValue(light, false);
+        Logger.printDebug(() -> "Theme dark: " + darkConfigValue + " light: " + lightConfigValue);
 
         updateOverlay(context, dark, light);
     }
 
     /**
-     * Morphe uses the background of the app for its own dialogs and settings, and it resolves
-     * the color with the context of the app. That context can be of the other theme than the one
-     * the app shows, because the app can use a theme of its own while the device uses the other,
-     * and a background belongs to one theme only. Both colors are resolved again here, with the
-     * theme each of them belongs to.
+     * Resolves the color of both selected backgrounds, and hands them to Morphe, which uses the
+     * background of the app for its own dialogs and settings.
+     * <p>
+     * A context of the app carries the resource variant of the theme the app shows, so the color
+     * of the other theme cannot be read from it: it would be the unpatched color of the app. Each
+     * color is resolved here with a configuration of the theme it belongs to, and everything that
+     * follows the background of the app uses {@link #backgroundColor(boolean)} instead of a color
+     * of whichever context is current.
      */
-    private static void updateMorpheColors(Context context) {
-        if (morpheColorsUpdated || !Utils.isContextSet()) {
+    private static void resolveBackgroundColors(Context context) {
+        if (backgroundColorsResolved || !Utils.isContextSet()) {
             return;
         }
-        morpheColorsUpdated = true;
+        backgroundColorsResolved = true;
 
         // An app without a light theme has no light colors to replace.
         if (!darkColorResourceNames().isEmpty()) {
-            ThemeUtils.setThemeDarkColor(selectedBackgroundColor(context, true));
+            darkBackgroundColor = selectedBackgroundColor(context, true);
+            ThemeUtils.setThemeDarkColor(darkBackgroundColor);
         }
         if (!lightColorResourceNames().isEmpty()) {
-            ThemeUtils.setThemeLightColor(selectedBackgroundColor(context, false));
+            lightBackgroundColor = selectedBackgroundColor(context, false);
+            ThemeUtils.setThemeLightColor(lightBackgroundColor);
         }
+    }
+
+    /**
+     * The color of the background that is selected for a theme.
+     *
+     * @param dark If the background of the dark theme is wanted.
+     * @return The color, or zero for a theme the app does not have.
+     */
+    @ColorInt
+    static int backgroundColor(boolean dark) {
+        return dark ? darkBackgroundColor : lightBackgroundColor;
     }
 
     /**
@@ -325,7 +354,7 @@ public class ThemeColorPatch {
      * the unpatched app.
      */
     public static boolean isAppDefaultBackground() {
-        final boolean dark = Utils.isDarkModeEnabled();
+        final boolean dark = isDarkTheme();
 
         // The config value is used instead of the setting because a Material-You background
         // falls back to the app default on Android 11 and earlier.
@@ -333,6 +362,26 @@ public class ThemeColorPatch {
             return darkConfigValue == (DARK_INDEX_OFFSET + APP_DEFAULT_CONFIG_VALUE);
         }
         return lightConfigValue == (LIGHT_INDEX_OFFSET + APP_DEFAULT_CONFIG_VALUE);
+    }
+
+    /**
+     * If the app shows its dark theme.
+     * <p>
+     * The theme of the app is resolved after the first contexts of the app attach, and the theme
+     * of the last run is used until then. The night mode of the device is not used for it, the app
+     * has a theme setting of its own and can show the other theme than the device does.
+     *
+     * @see Utils#isDarkModeEnabled()
+     */
+    static boolean isDarkTheme() {
+        // An app without a light theme shows the dark one, whatever the device or the app report.
+        if (lightColorResourceNames().isEmpty()) {
+            return true;
+        }
+
+        return Utils.isDarkModeStatusKnown()
+                ? Utils.isDarkModeEnabled()
+                : THEME_LAST_USED_DARK_MODE.get();
     }
 
     private static int selectedBackgroundColor(Context context, boolean dark) {

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
@@ -317,6 +317,22 @@ public class ThemeColorPatch {
         }
     }
 
+    /**
+     * If the theme the app shows uses the background of the app itself.
+     * <p>
+     * No color of the app is replaced then, and patch code that recolors app components to match
+     * a selected background must leave them untouched, otherwise the app looks different from
+     * the unpatched app.
+     */
+    public static boolean isAppDefaultBackground() {
+        final boolean dark = Utils.isDarkModeEnabled();
+
+        // The config value is used instead of the setting because a Material-You background
+        // falls back to the app default on Android 11 and earlier.
+        return (dark ? darkConfigValue : lightConfigValue)
+                == (dark ? DARK_INDEX_OFFSET : LIGHT_INDEX_OFFSET) + APP_DEFAULT_CONFIG_VALUE;
+    }
+
     private static int selectedBackgroundColor(Context context, boolean dark) {
         Background background = dark
                 ? THEME_BACKGROUND_DARK.get()
@@ -366,14 +382,7 @@ public class ThemeColorPatch {
     }
 
     private static int get9BitColorIndex(StringSetting colorSetting) {
-        String colorString = colorSetting.get();
-        int color;
-        try {
-            color = Color.parseColor(colorString);
-        } catch (IllegalArgumentException ex) {
-            Logger.printException(() -> "Invalid color: " + colorString);
-            color = Color.parseColor(colorSetting.resetToDefault());
-        }
+        final int color = customColor(colorSetting);
 
         final int r = (color >> 16) & 0xFF;
         final int g = (color >> 8) & 0xFF;
@@ -424,17 +433,7 @@ public class ThemeColorPatch {
 
     private static void addOverlayColors(Map<String, Integer> colors, String resourceNames,
                                          StringSetting customColorSetting) {
-        String colorString = customColorSetting.get();
-        int color;
-        try {
-            color = Color.parseColor(colorString);
-        } catch (IllegalArgumentException ex) {
-            Logger.printException(() -> "Invalid custom color: " + colorString);
-            color = Color.parseColor(customColorSetting.resetToDefault());
-        }
-
-        // A background must be opaque, otherwise the app draws over itself.
-        color |= 0xFF000000;
+        final int color = customColor(customColorSetting);
 
         for (String resourceName : resourceNames.split(",")) {
             if (!resourceName.isEmpty()) {
@@ -572,16 +571,26 @@ public class ThemeColorPatch {
     }
 
     private static int customColor(boolean dark) {
-        StringSetting setting = dark
+        return customColor(dark
                 ? THEME_BACKGROUND_DARK_CUSTOM_COLOR
-                : THEME_BACKGROUND_LIGHT_CUSTOM_COLOR;
+                : THEME_BACKGROUND_LIGHT_CUSTOM_COLOR);
+    }
+
+    /**
+     * The color a custom background setting holds, or the color of its default value if the
+     * user saved something that is not a color.
+     * <p>
+     * A background must be opaque, otherwise the app draws over itself.
+     */
+    @ColorInt
+    private static int customColor(StringSetting setting) {
         String colorString = setting.get();
 
         try {
             return Color.parseColor(colorString) | 0xFF000000;
         } catch (IllegalArgumentException ex) {
             Logger.printException(() -> "Invalid custom color: " + colorString);
-            return Color.parseColor(setting.resetToDefault());
+            return Color.parseColor(setting.resetToDefault()) | 0xFF000000;
         }
     }
 

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
@@ -26,6 +26,7 @@ import android.widget.TextView;
 import androidx.annotation.ChecksSdkIntAtLeast;
 import androidx.annotation.ColorInt;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -208,9 +209,11 @@ public class ThemeColorPatch {
     private static int lightConfigValue = -1;
 
     /**
-     * If a background of the user is in use and its overlay must be loaded into every context.
+     * If the background of a theme is one the user picked, and the overlay of that theme must be
+     * loaded into every context that shows it.
      */
-    private static boolean useOverlay;
+    private static boolean useDarkOverlay;
+    private static boolean useLightOverlay;
 
     /**
      * The color of the background that is selected for each theme, or zero for a theme the app
@@ -276,8 +279,8 @@ public class ThemeColorPatch {
                 context = base.createConfigurationContext(override);
             }
 
-            if (isCustomBackgroundSupported() && useOverlay) {
-                ThemeColorOverlay.applyTo(context);
+            if (isCustomBackgroundSupported() && useOverlay(dark)) {
+                ThemeColorOverlay.applyTo(context, dark);
             }
 
             resolveBackgroundColors(context);
@@ -446,51 +449,64 @@ public class ThemeColorPatch {
         return (r3 << 6) | (g3 << 3) | b3;
     }
 
+    private static boolean useOverlay(boolean dark) {
+        return dark ? useDarkOverlay : useLightOverlay;
+    }
+
     /**
-     * Registers, updates or removes the overlay that gives the color resources of the app the
-     * color the user picked.
+     * Registers, updates or removes the overlay of both themes.
      */
     private static void updateOverlay(Context context, Background dark, Background light) {
         if (!isCustomBackgroundSupported()) {
             return;
         }
 
-        useOverlay = dark.isCustom() || light.isCustom();
+        // A theme the app does not have declares no color resource, and has nothing to overlay.
+        useDarkOverlay = dark.isCustom() && !darkColorResourceNames().isEmpty();
+        useLightOverlay = light.isCustom() && !lightColorResourceNames().isEmpty();
 
+        updateOverlay(context, true, darkColorResourceNames(), THEME_BACKGROUND_DARK_CUSTOM_COLOR);
+        updateOverlay(context, false, lightColorResourceNames(), THEME_BACKGROUND_LIGHT_CUSTOM_COLOR);
+    }
+
+    /**
+     * Registers, updates or removes the overlay that gives the color resources of one theme the
+     * color the user picked.
+     */
+    @RequiresApi(api = Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private static void updateOverlay(Context context, boolean dark, String resourceNames,
+                                      StringSetting customColorSetting) {
         try {
-            if (!useOverlay) {
-                ThemeColorOverlay.unregisterIfRegistered(context);
+            if (!useOverlay(dark)) {
+                ThemeColorOverlay.unregisterIfRegistered(context, dark);
                 return;
-            }
-
-            Map<String, Integer> colors = new LinkedHashMap<>();
-
-            if (dark.isCustom()) {
-                addOverlayColors(colors, darkColorResourceNames(), THEME_BACKGROUND_DARK_CUSTOM_COLOR);
-            }
-
-            if (light.isCustom()) {
-                addOverlayColors(colors, lightColorResourceNames(), THEME_BACKGROUND_LIGHT_CUSTOM_COLOR);
             }
 
             // The system deletes an overlay of the app when the app is installed again, so it is
             // registered on every start and not only after the user picks another color.
-            ThemeColorOverlay.register(context, colors);
+            ThemeColorOverlay.register(context, dark,
+                    overlayColors(resourceNames, customColorSetting));
         } catch (Exception ex) {
             // Overlays are a part of the system and a manufacturer can change how they behave.
             Logger.printException(() -> "Could not update the overlay of the app", ex);
         }
     }
 
-    private static void addOverlayColors(Map<String, Integer> colors, String resourceNames,
-                                         StringSetting customColorSetting) {
+    /**
+     * The color the user picked, mapped to every color resource of a theme.
+     */
+    private static Map<String, Integer> overlayColors(String resourceNames,
+                                                      StringSetting customColorSetting) {
         final int color = customColor(customColorSetting);
+        Map<String, Integer> colors = new LinkedHashMap<>();
 
         for (String resourceName : resourceNames.split(",")) {
             if (!resourceName.isEmpty()) {
                 colors.put(resourceName, color);
             }
         }
+
+        return colors;
     }
 
     /**

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
@@ -329,8 +329,10 @@ public class ThemeColorPatch {
 
         // The config value is used instead of the setting because a Material-You background
         // falls back to the app default on Android 11 and earlier.
-        return (dark ? darkConfigValue : lightConfigValue)
-                == (dark ? DARK_INDEX_OFFSET : LIGHT_INDEX_OFFSET) + APP_DEFAULT_CONFIG_VALUE;
+        if (dark) {
+            return darkConfigValue == (DARK_INDEX_OFFSET + APP_DEFAULT_CONFIG_VALUE);
+        }
+        return lightConfigValue == (LIGHT_INDEX_OFFSET + APP_DEFAULT_CONFIG_VALUE);
     }
 
     private static int selectedBackgroundColor(Context context, boolean dark) {

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
@@ -310,10 +310,10 @@ public class ThemeColorPatch {
 
         // An app without a light theme has no light colors to replace.
         if (!darkColorResourceNames().isEmpty()) {
-            Utils.setThemeDarkColor(selectedBackgroundColor(context, true));
+            ThemeUtils.setThemeDarkColor(selectedBackgroundColor(context, true));
         }
         if (!lightColorResourceNames().isEmpty()) {
-            Utils.setThemeLightColor(selectedBackgroundColor(context, false));
+            ThemeUtils.setThemeLightColor(selectedBackgroundColor(context, false));
         }
     }
 
@@ -469,7 +469,7 @@ public class ThemeColorPatch {
             final String resourceName = backgroundColorResourceName(dark);
             if (resourceName.isEmpty()) {
                 // The app has no theme of this kind, and no color of it to show.
-                return Utils.getAppBackgroundColor();
+                return ThemeUtils.getAppBackgroundColor();
             }
 
             final int identifier = ResourceUtils.getIdentifier(ResourceType.COLOR, resourceName);
@@ -482,7 +482,7 @@ public class ThemeColorPatch {
             return variant.getColor(identifier);
         } catch (Exception ex) {
             Logger.printException(() -> "getBackgroundColor failure", ex);
-            return Utils.getAppBackgroundColor();
+            return ThemeUtils.getAppBackgroundColor();
         }
     }
 

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
@@ -202,6 +202,17 @@ public class ThemeColorPatch {
      * The patch uses the same numbering.
      */
     private static final int PALETTE_INDEX_OFFSET = 100;
+
+    /**
+     * The value a color channel can have in the 9 bit palette, of the dark and of the light theme.
+     * The patch generates the variants with the same values, and both must stay identical.
+     * <p>
+     * A background sits at one end of the range, so the eight values of a channel are placed where
+     * the backgrounds of that theme are instead of being spread evenly. A dark background of
+     * #0F0F0F would otherwise be shown as pure black, because the nearest even value is 36 away.
+     */
+    private static final int[] PALETTE_LEVELS_DARK = {0, 3, 15, 38, 74, 126, 187, 255};
+    private static final int[] PALETTE_LEVELS_LIGHT = {0, 68, 129, 181, 217, 240, 252, 255};
     private static final int DARK_INDEX_OFFSET = 0;
     private static final int LIGHT_INDEX_OFFSET = 700;
 
@@ -427,7 +438,7 @@ public class ThemeColorPatch {
             StringSetting setting = dark
                     ? THEME_BACKGROUND_DARK_CUSTOM_COLOR
                     : THEME_BACKGROUND_LIGHT_CUSTOM_COLOR;
-            return offset + PALETTE_INDEX_OFFSET + get9BitColorIndex(setting);
+            return offset + PALETTE_INDEX_OFFSET + get9BitColorIndex(setting, dark);
         }
 
         // A custom background has no resource variant of its own,
@@ -435,18 +446,33 @@ public class ThemeColorPatch {
         return offset + ((Enum<?>) background).ordinal() + 1;
     }
 
-    private static int get9BitColorIndex(StringSetting colorSetting) {
+    private static int get9BitColorIndex(StringSetting colorSetting, boolean dark) {
         final int color = customColor(colorSetting);
+        int[] levels = dark ? PALETTE_LEVELS_DARK : PALETTE_LEVELS_LIGHT;
 
-        final int r = (color >> 16) & 0xFF;
-        final int g = (color >> 8) & 0xFF;
-        final int b = color & 0xFF;
-
-        final int r3 = Math.round(r * 7f / 255f);
-        final int g3 = Math.round(g * 7f / 255f);
-        final int b3 = Math.round(b * 7f / 255f);
+        final int r3 = nearestPaletteLevel(levels, (color >> 16) & 0xFF);
+        final int g3 = nearestPaletteLevel(levels, (color >> 8) & 0xFF);
+        final int b3 = nearestPaletteLevel(levels, color & 0xFF);
 
         return (r3 << 6) | (g3 << 3) | b3;
+    }
+
+    /**
+     * @return The index of the palette value that is closest to a color channel.
+     */
+    private static int nearestPaletteLevel(int[] levels, int channel) {
+        int nearest = 0;
+        int smallestDistance = Integer.MAX_VALUE;
+
+        for (int i = 0, length = levels.length; i < length; i++) {
+            final int distance = Math.abs(levels[i] - channel);
+            if (distance < smallestDistance) {
+                smallestDistance = distance;
+                nearest = i;
+            }
+        }
+
+        return nearest;
     }
 
     private static boolean useOverlay(boolean dark) {

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/ColorPickerPreference.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/ColorPickerPreference.java
@@ -1,0 +1,500 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original first edition code:
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/584b00fd87f83504b8886e4f3f674f8c3943cd91
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/2e9d6959c94df7588b9e34b18770e9f437e91926
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/ece8076f7cefd752b97515014bc50fe4fd80171e
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/2b62fc2224c42da024fd64602346ff30613517c0
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/a426e2af5086367a2a1fee83abbbd2ea230bda06
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/584b00fd87f83504b8886e4f3f674f8c3943cd91
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/14a8f4fb96f5e2a4bc264a54115e0870b1a1ffa8
+ * https://github.com/MorpheApp/morphe-patches/commit/f5371ca998c019609c2b5558b3408ab1fec065c8
+ *
+ * See the included NOTICE file for §7(c) terms that apply to Morphe contributions.
+ */
+
+package app.morphe.extension.shared.settings.preference;
+
+import static app.morphe.extension.shared.StringRef.str;
+import static app.morphe.extension.shared.ResourceUtils.getIdentifierOrThrow;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.os.Build;
+import android.os.Bundle;
+import android.preference.EditTextPreference;
+import android.text.Editable;
+import android.text.InputType;
+import android.text.TextWatcher;
+import android.util.AttributeSet;
+import android.util.Pair;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.Nullable;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.ResourceType;
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.settings.Setting;
+import app.morphe.extension.shared.settings.StringSetting;
+import app.morphe.extension.shared.ui.ColorDot;
+import app.morphe.extension.shared.ui.CustomDialog;
+import app.morphe.extension.shared.ui.Dim;
+
+/**
+ * A custom preference for selecting a color via a hexadecimal code or a color picker dialog.
+ * Extends {@link EditTextPreference} to display a colored dot in the widget area,
+ * reflecting the currently selected color. The dot is dimmed when the preference is disabled.
+ */
+@SuppressWarnings({"unused", "deprecation"})
+public class ColorPickerPreference extends EditTextPreference {
+    /** Length of a valid color string of format #RRGGBB (without alpha) or #AARRGGBB (with alpha). */
+    public static final int COLOR_STRING_LENGTH_WITHOUT_ALPHA = 7;
+    public static final int COLOR_STRING_LENGTH_WITH_ALPHA = 9;
+
+    /** Matches everything that is not a hex number/letter. */
+    private static final Pattern PATTERN_NOT_HEX = Pattern.compile("[^0-9A-Fa-f]");
+
+    /** Alpha for dimming when the preference is disabled. */
+    public static final float DISABLED_ALPHA = 0.5f; // 50%
+
+    /** View displaying a colored dot in the widget area. */
+    private View widgetColorDot;
+
+    /** Dialog View displaying a colored dot for the selected color preview in the dialog. */
+    private View dialogColorDot;
+
+    /** Current color, including alpha channel if opacity slider is enabled. */
+    @ColorInt
+    private int currentColor;
+
+    /** Associated setting for storing the color value. */
+    private StringSetting colorSetting;
+
+    /** Dialog TextWatcher for the EditText to monitor color input changes. */
+    private TextWatcher colorTextWatcher;
+
+    /** Dialog color picker view. */
+    protected ColorPickerView dialogColorPickerView;
+
+    /** Listener for color changes. */
+    protected OnColorChangeListener colorChangeListener;
+
+    /** Whether the opacity slider is enabled. */
+    private boolean opacitySliderEnabled = false;
+
+    public static final int ID_MORPHE_COLOR_PICKER_VIEW =
+            getIdentifierOrThrow(ResourceType.ID, "morphe_color_picker_view");
+    public static final int ID_PREFERENCE_COLOR_DOT =
+            getIdentifierOrThrow(ResourceType.ID, "preference_color_dot");
+    public static final int LAYOUT_MORPHE_COLOR_DOT_WIDGET =
+            getIdentifierOrThrow(ResourceType.LAYOUT, "morphe_color_dot_widget");
+    public static final int LAYOUT_MORPHE_COLOR_PICKER =
+            getIdentifierOrThrow(ResourceType.LAYOUT, "morphe_color_picker");
+
+    /**
+     * Removes non-valid hex characters, converts to all uppercase,
+     * and adds # character to the start if not present.
+     */
+    public static String cleanupColorCodeString(String colorString, boolean includeAlpha) {
+        String result = "#" + PATTERN_NOT_HEX.matcher(colorString)
+                .replaceAll("").toUpperCase(Locale.ROOT);
+
+        int maxLength = includeAlpha ? COLOR_STRING_LENGTH_WITH_ALPHA : COLOR_STRING_LENGTH_WITHOUT_ALPHA;
+        if (result.length() < maxLength) {
+            return result;
+        }
+
+        return result.substring(0, maxLength);
+    }
+
+    /**
+     * @param color Color, with or without alpha channel.
+     * @param includeAlpha Whether to include the alpha channel in the output string.
+     * @return #RRGGBB or #AARRGGBB hex color string
+     */
+    public static String getColorString(@ColorInt int color, boolean includeAlpha) {
+        if (includeAlpha) {
+            return String.format("#%08X", color);
+        }
+        color = color & 0x00FFFFFF; // Mask to strip alpha.
+        return String.format("#%06X", color);
+    }
+
+    /**
+     * Interface for notifying color changes.
+     */
+    public interface OnColorChangeListener {
+        void onColorChanged(String key, int newColor);
+    }
+
+    /**
+     * Sets the listener for color changes.
+     */
+    public void setOnColorChangeListener(OnColorChangeListener listener) {
+        this.colorChangeListener = listener;
+    }
+
+    /**
+     * Enables or disables the opacity slider in the color picker dialog.
+     */
+    public void setOpacitySliderEnabled(boolean enabled) {
+        this.opacitySliderEnabled = enabled;
+    }
+
+    public ColorPickerPreference(Context context) {
+        super(context);
+        init();
+    }
+
+    public ColorPickerPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public ColorPickerPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    /**
+     * Initializes the preference by setting up the EditText, loading the color, and set the widget layout.
+     */
+    private void init() {
+        if (getKey() != null) {
+            colorSetting = (StringSetting) Setting.getSettingFromPath(getKey());
+            if (colorSetting == null) {
+                Logger.printException(() -> "Could not find color setting for: " + getKey());
+            }
+        } else {
+            Logger.printDebug(() -> "initialized without key, settings will be loaded later");
+        }
+
+        EditText editText = getEditText();
+        editText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS
+                | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            editText.setAutofillHints((String) null);
+        }
+
+        // Set the widget layout to a custom layout containing the colored dot.
+        setWidgetLayoutResource(LAYOUT_MORPHE_COLOR_DOT_WIDGET);
+    }
+
+    /**
+     * Sets the selected color and updates the UI and settings.
+     */
+    @Override
+    public void setText(String colorString) {
+        try {
+            Logger.printDebug(() -> "setText: " + colorString);
+            super.setText(colorString);
+
+            currentColor = Color.parseColor(colorString);
+            if (colorSetting != null) {
+                colorSetting.save(getColorString(currentColor, opacitySliderEnabled));
+            }
+            updateDialogColorDot();
+            updateWidgetColorDot();
+
+            // Notify the listener about the color change.
+            if (colorChangeListener != null) {
+                colorChangeListener.onColorChanged(getKey(), currentColor);
+            }
+        } catch (IllegalArgumentException ex) {
+            // This code is reached if the user pastes settings JSON with an invalid color
+            // since this preference is updated with the new setting text.
+            Logger.printDebug(() -> "Parse color error: " + colorString, ex);
+            Utils.showToastShort(str("morphe_settings_color_invalid"));
+            setText(colorSetting.resetToDefault());
+        } catch (Exception ex) {
+            Logger.printException(() -> "setText failure: " + colorString, ex);
+        }
+    }
+
+    /**
+     * Creates a TextWatcher to monitor changes in the EditText for color input.
+     */
+    private TextWatcher createColorTextWatcher(ColorPickerView colorPickerView) {
+        return new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable edit) {
+                try {
+                    String colorString = edit.toString();
+                    String sanitizedColorString = cleanupColorCodeString(colorString, opacitySliderEnabled);
+                    if (!sanitizedColorString.equals(colorString)) {
+                        edit.replace(0, colorString.length(), sanitizedColorString);
+                        return;
+                    }
+
+                    int expectedLength = opacitySliderEnabled
+                            ? COLOR_STRING_LENGTH_WITH_ALPHA
+                            : COLOR_STRING_LENGTH_WITHOUT_ALPHA;
+                    if (sanitizedColorString.length() != expectedLength) {
+                        return;
+                    }
+
+                    final int newColor = Color.parseColor(colorString);
+                    if (currentColor != newColor) {
+                        Logger.printDebug(() -> "afterTextChanged: " + sanitizedColorString);
+                        currentColor = newColor;
+                        updateDialogColorDot();
+                        updateWidgetColorDot();
+                        colorPickerView.setColor(newColor);
+                    }
+                } catch (Exception ex) {
+                    // Should never be reached since input is validated before using.
+                    Logger.printException(() -> "afterTextChanged failure", ex);
+                }
+            }
+        };
+    }
+
+    /**
+     * Hook for subclasses to add a custom view to the top of the dialog.
+     */
+    @Nullable
+    protected View createExtraDialogContentView(Context context) {
+        return null; // Default implementation returns no extra view.
+    }
+
+    /**
+     * Hook for subclasses to handle the OK button click.
+     */
+    protected void onDialogOkClicked() {
+        // Default implementation does nothing.
+    }
+
+    /**
+     * Hook for subclasses to handle the Neutral button click.
+     */
+    protected void onDialogNeutralClicked() {
+        // Default implementation.
+        try {
+            final int defaultColor = Color.parseColor(colorSetting.defaultValue);
+            dialogColorPickerView.setColor(defaultColor);
+        } catch (Exception ex) {
+            Logger.printException(() -> "Reset button failure", ex);
+        }
+    }
+
+    /**
+     * @return If the dialog uses {@link Dialog#setCanceledOnTouchOutside(boolean)}.
+     */
+    protected boolean cancelDialogOnTouchOutside() {
+        return false;
+    }
+
+    @Override
+    protected void showDialog(Bundle state) {
+        Context context = getContext();
+
+        // Create content container for all dialog views.
+        LinearLayout contentContainer = new LinearLayout(context);
+        contentContainer.setOrientation(LinearLayout.VERTICAL);
+
+        // Add extra view from subclass if it exists.
+        View extraView = createExtraDialogContentView(context);
+        if (extraView != null) {
+            contentContainer.addView(extraView);
+        }
+
+        // Inflate color picker view.
+        View colorPicker = LayoutInflater.from(context).inflate(LAYOUT_MORPHE_COLOR_PICKER, null);
+        dialogColorPickerView = colorPicker.findViewById(ID_MORPHE_COLOR_PICKER_VIEW);
+        dialogColorPickerView.setOpacitySliderEnabled(opacitySliderEnabled);
+        dialogColorPickerView.setColor(currentColor);
+        contentContainer.addView(colorPicker);
+
+        // Horizontal layout for preview and EditText.
+        LinearLayout inputLayout = new LinearLayout(context);
+        inputLayout.setOrientation(LinearLayout.HORIZONTAL);
+        inputLayout.setGravity(Gravity.CENTER_VERTICAL);
+
+        dialogColorDot = new View(context);
+        LinearLayout.LayoutParams previewParams = new LinearLayout.LayoutParams(Dim.dp20,Dim.dp20);
+        previewParams.setMargins(Dim.dp16, 0, Dim.dp10, 0);
+        dialogColorDot.setLayoutParams(previewParams);
+        inputLayout.addView(dialogColorDot);
+        updateDialogColorDot();
+
+        EditText editText = getEditText();
+        ViewParent parent = editText.getParent();
+        if (parent instanceof ViewGroup parentViewGroup) {
+            parentViewGroup.removeView(editText);
+        }
+        editText.setLayoutParams(new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+        ));
+        String currentColorString = getColorString(currentColor, opacitySliderEnabled);
+        editText.setText(currentColorString);
+        editText.setSelection(currentColorString.length());
+        editText.setTypeface(Typeface.MONOSPACE);
+        colorTextWatcher = createColorTextWatcher(dialogColorPickerView);
+        editText.addTextChangedListener(colorTextWatcher);
+        inputLayout.addView(editText);
+
+        // Add a dummy view to take up remaining horizontal space,
+        // otherwise it will show an oversize underlined text view.
+        View paddingView = new View(context);
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                0,
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                1f
+        );
+        paddingView.setLayoutParams(params);
+        inputLayout.addView(paddingView);
+
+        contentContainer.addView(inputLayout);
+
+        // Create ScrollView to wrap the content container.
+        ScrollView contentScrollView = new ScrollView(context);
+        contentScrollView.setVerticalScrollBarEnabled(false);
+        contentScrollView.setOverScrollMode(View.OVER_SCROLL_NEVER);
+        LinearLayout.LayoutParams scrollViewParams = new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                0,
+                1.0f
+        );
+        contentScrollView.setLayoutParams(scrollViewParams);
+        contentScrollView.addView(contentContainer);
+
+        final int originalColor = currentColor;
+        Pair<Dialog, LinearLayout> dialogPair = CustomDialog.create(
+                context,
+                getTitle() != null ? getTitle().toString() : str("morphe_settings_color_picker_title"),
+                null,
+                null,
+                null,
+                () -> { // OK button action.
+                    try {
+                        String colorString = editText.getText().toString();
+                        int expectedLength = opacitySliderEnabled
+                                ? COLOR_STRING_LENGTH_WITH_ALPHA
+                                : COLOR_STRING_LENGTH_WITHOUT_ALPHA;
+                        if (colorString.length() != expectedLength) {
+                            Utils.showToastShort(str("morphe_settings_color_invalid"));
+                            setText(getColorString(originalColor, opacitySliderEnabled));
+                            return;
+                        }
+                        setText(colorString);
+
+                        onDialogOkClicked();
+                    } catch (Exception ex) {
+                        // Should never happen due to a bad color string,
+                        // since the text is validated and fixed while the user types.
+                        Logger.printException(() -> "OK button failure", ex);
+                    }
+                },
+                () -> { // Cancel button action.
+                    try {
+                        setText(getColorString(originalColor, opacitySliderEnabled));
+                    } catch (Exception ex) {
+                        Logger.printException(() -> "Cancel button failure", ex);
+                    }
+                },
+                str("morphe_settings_reset_color"), // Neutral button text.
+                this::onDialogNeutralClicked, // Neutral button action.
+                false // Do not dismiss dialog.
+        );
+
+        // Add the ScrollView to the dialog's main layout.
+        LinearLayout dialogMainLayout = dialogPair.second;
+        dialogMainLayout.addView(contentScrollView, dialogMainLayout.getChildCount() - 1);
+
+        // Set up color picker listener with debouncing.
+        // Add listener last to prevent callbacks from set calls above.
+        dialogColorPickerView.setOnColorChangedListener(color -> {
+            // Check if it actually changed, since this callback
+            // can be caused by updates in afterTextChanged().
+            if (currentColor == color) {
+                return;
+            }
+
+            String updatedColorString = getColorString(color, opacitySliderEnabled);
+            Logger.printDebug(() -> "onColorChanged: " + updatedColorString);
+            currentColor = color;
+            editText.setText(updatedColorString);
+            editText.setSelection(updatedColorString.length());
+
+            updateDialogColorDot();
+            updateWidgetColorDot();
+        });
+
+        // Configure and show the dialog.
+        Dialog dialog = dialogPair.first;
+        dialog.setCanceledOnTouchOutside(cancelDialogOnTouchOutside());
+        dialog.show();
+    }
+
+    @Override
+    protected void onDialogClosed(boolean positiveResult) {
+        super.onDialogClosed(positiveResult);
+
+        if (colorTextWatcher != null) {
+            getEditText().removeTextChangedListener(colorTextWatcher);
+            colorTextWatcher = null;
+        }
+
+        dialogColorDot = null;
+        dialogColorPickerView = null;
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
+        updateWidgetColorDot();
+    }
+
+    @Override
+    protected void onBindView(View view) {
+        super.onBindView(view);
+
+        widgetColorDot = view.findViewById(ID_PREFERENCE_COLOR_DOT);
+        updateWidgetColorDot();
+    }
+
+    private void updateWidgetColorDot() {
+        if (widgetColorDot == null) return;
+
+        ColorDot.applyColorDot(
+                widgetColorDot,
+                currentColor,
+                widgetColorDot.isEnabled()
+        );
+    }
+
+    private void updateDialogColorDot() {
+        if (dialogColorDot == null) return;
+
+        ColorDot.applyColorDot(
+                dialogColorDot,
+                currentColor,
+                true
+        );
+    }
+}

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/ColorPickerView.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/ColorPickerView.java
@@ -1,0 +1,658 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original first edition code:
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/584b00fd87f83504b8886e4f3f674f8c3943cd91
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/2e9d6959c94df7588b9e34b18770e9f437e91926
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/ece8076f7cefd752b97515014bc50fe4fd80171e
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/2b62fc2224c42da024fd64602346ff30613517c0
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/a426e2af5086367a2a1fee83abbbd2ea230bda06
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/584b00fd87f83504b8886e4f3f674f8c3943cd91
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/14a8f4fb96f5e2a4bc264a54115e0870b1a1ffa8
+ * https://github.com/MorpheApp/morphe-patches/commit/f5371ca998c019609c2b5558b3408ab1fec065c8
+ *
+ * See the included NOTICE file for §7(c) terms that apply to Morphe contributions.
+ */
+
+package app.morphe.extension.shared.settings.preference;
+
+import static app.morphe.extension.shared.settings.preference.ColorPickerPreference.getColorString;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.ComposeShader;
+import android.graphics.LinearGradient;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.RectF;
+import android.graphics.Shader;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.View;
+
+import androidx.annotation.ColorInt;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.ui.Dim;
+
+/**
+ * A custom color picker view that allows the user to select a color using a hue slider, a saturation-value selector
+ * and an optional opacity slider.
+ * This implementation is density-independent and responsive across different screen sizes and DPIs.
+ * <p>
+ * This view displays three main components for color selection:
+ * <ul>
+ *     <li><b>Hue Bar:</b> A horizontal bar at the bottom that allows the user to select the hue component of the color.
+ *     <li><b>Saturation-Value Selector:</b> A rectangular area above the hue bar that allows the user to select the
+ *     saturation and value (brightness) components of the color based on the selected hue.
+ *     <li><b>Opacity Slider:</b> An optional horizontal bar below the hue bar that allows the user to adjust
+ *     the opacity (alpha channel) of the color.
+ * </ul>
+ * <p>
+ * The view uses {@link LinearGradient} and {@link ComposeShader} to create the color gradients for the hue bar,
+ * opacity slider, and the saturation-value selector. It also uses {@link Paint} to draw the selectors (draggable handles).
+ * <p>
+ * The selected color can be retrieved using {@link #getColor()} and can be set using {@link #setColor(int)}.
+ * An {@link OnColorChangedListener} can be registered to receive notifications when the selected color changes.
+ */
+@SuppressLint("DrawAllocation")
+public class ColorPickerView extends View {
+    /**
+     * Interface definition for a callback to be invoked when the selected color changes.
+     */
+    public interface OnColorChangedListener {
+        /**
+         * Called when the selected color has changed.
+         */
+        void onColorChanged(@ColorInt int color);
+    }
+
+    /** Expanded touch area for the hue and opacity bars to increase the touch-sensitive area. */
+    public static final float TOUCH_EXPANSION = Dim.dp20;
+
+    /** Margin between different areas of the view (saturation-value selector, hue bar, and opacity slider). */
+    private static final float MARGIN_BETWEEN_AREAS = Dim.dp24;
+
+    /** Padding around the view. */
+    private static final float VIEW_PADDING = Dim.dp16;
+
+    /** Height of the hue bar. */
+    private static final float HUE_BAR_HEIGHT = Dim.dp12;
+
+    /** Height of the opacity slider. */
+    private static final float OPACITY_BAR_HEIGHT = Dim.dp12;
+
+    /** Corner radius for the hue bar. */
+    private static final float HUE_CORNER_RADIUS = Dim.dp6;
+
+    /** Corner radius for the opacity slider. */
+    private static final float OPACITY_CORNER_RADIUS = Dim.dp6;
+
+    /** Radius of the selector handles. */
+    private static final float SELECTOR_RADIUS = Dim.dp12;
+
+    /** Stroke width for the selector handle outlines. */
+    private static final float SELECTOR_STROKE_WIDTH = 8;
+
+    /**
+     * Hue and opacity fill radius. Use slightly smaller radius for the selector handle fill,
+     * otherwise the antialiasing causes the fill color to bleed past the selector outline.
+     */
+    private static final float SELECTOR_FILL_RADIUS = SELECTOR_RADIUS - SELECTOR_STROKE_WIDTH / 2;
+
+    /** Thin dark outline stroke width for the selector rings. */
+    private static final float SELECTOR_EDGE_STROKE_WIDTH = 1;
+
+    /** Radius for the outer edge of the selector rings, including stroke width. */
+    public static final float SELECTOR_EDGE_RADIUS =
+            SELECTOR_RADIUS + SELECTOR_STROKE_WIDTH / 2 + SELECTOR_EDGE_STROKE_WIDTH / 2;
+
+    /** Selector outline inner color. */
+    @ColorInt
+    private static final int SELECTOR_OUTLINE_COLOR = Color.WHITE;
+
+    /** Dark edge color for the selector rings. */
+    @ColorInt
+    private static final int SELECTOR_EDGE_COLOR = Color.parseColor("#CFCFCF");
+
+    /** Precomputed array of hue colors for the hue bar (0-360 degrees). */
+    private static final int[] HUE_COLORS = new int[361];
+    static {
+        for (int i = 0; i < 361; i++) {
+            HUE_COLORS[i] = Color.HSVToColor(new float[]{i, 1, 1});
+        }
+    }
+
+    /** Paint for the hue bar. */
+    private final Paint huePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+
+    /** Paint for the opacity slider. */
+    private final Paint opacityPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+
+    /** Paint for the saturation-value selector. */
+    private final Paint saturationValuePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+
+    /** Paint for the draggable selector handles. */
+    private final Paint selectorPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    {
+        selectorPaint.setStrokeWidth(SELECTOR_STROKE_WIDTH);
+    }
+
+    /** Bounds of the hue bar. */
+    private final RectF hueRect = new RectF();
+
+    /** Bounds of the opacity slider. */
+    private final RectF opacityRect = new RectF();
+
+    /** Bounds of the saturation-value selector. */
+    private final RectF saturationValueRect = new RectF();
+
+    /** HSV color calculations to avoid allocations during drawing. */
+    private final float[] hsvArray = {1, 1, 1};
+
+    /** Current hue value (0-360). */
+    private float hue = 0f;
+
+    /** Current saturation value (0-1). */
+    private float saturation = 1f;
+
+    /** Current value (brightness) value (0-1). */
+    private float value = 1f;
+
+    /** Current opacity value (0-1). */
+    private float opacity = 1f;
+
+    /** The currently selected color, including alpha channel if opacity slider is enabled. */
+    @ColorInt
+    private int selectedColor;
+
+    /** Listener for color change events. */
+    private OnColorChangedListener colorChangedListener;
+
+    /** Tracks if the hue selector is being dragged. */
+    private boolean isDraggingHue;
+
+    /** Tracks if the saturation-value selector is being dragged. */
+    private boolean isDraggingSaturation;
+
+    /** Tracks if the opacity selector is being dragged. */
+    private boolean isDraggingOpacity;
+
+    /** Flag to enable/disable the opacity slider. */
+    private boolean opacitySliderEnabled = false;
+
+    public ColorPickerView(Context context) {
+        super(context);
+    }
+
+    public ColorPickerView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public ColorPickerView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    /**
+     * Enables or disables the opacity slider.
+     */
+    public void setOpacitySliderEnabled(boolean enabled) {
+        if (opacitySliderEnabled != enabled) {
+            opacitySliderEnabled = enabled;
+            if (!enabled) {
+                opacity = 1f; // Reset to fully opaque when disabled.
+                updateSelectedColor();
+            }
+            updateOpacityShader();
+            requestLayout(); // Trigger re-measure to account for opacity slider.
+            invalidate();
+        }
+    }
+
+    /**
+     * Measures the view, ensuring a consistent aspect ratio and minimum dimensions.
+     */
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        final float DESIRED_ASPECT_RATIO = 0.8f; // height = width * 0.8
+
+        final int minWidth = Dim.dp(250);
+        final int minHeight = (int) (minWidth * DESIRED_ASPECT_RATIO) + (int) (HUE_BAR_HEIGHT + MARGIN_BETWEEN_AREAS)
+                + (opacitySliderEnabled ? (int) (OPACITY_BAR_HEIGHT + MARGIN_BETWEEN_AREAS) : 0);
+
+        int width = resolveSize(minWidth, widthMeasureSpec);
+        int height = resolveSize(minHeight, heightMeasureSpec);
+
+        // Ensure minimum dimensions for usability.
+        width = Math.max(width, minWidth);
+        height = Math.max(height, minHeight);
+
+        // Adjust height to maintain desired aspect ratio if possible.
+        final int desiredHeight = (int) (width * DESIRED_ASPECT_RATIO) + (int) (HUE_BAR_HEIGHT + MARGIN_BETWEEN_AREAS)
+                + (opacitySliderEnabled ? (int) (OPACITY_BAR_HEIGHT + MARGIN_BETWEEN_AREAS) : 0);
+        if (MeasureSpec.getMode(heightMeasureSpec) != MeasureSpec.EXACTLY) {
+            height = desiredHeight;
+        }
+
+        setMeasuredDimension(width, height);
+    }
+
+    /**
+     * Updates the view's layout when its size changes, recalculating bounds and shaders.
+     */
+    @Override
+    protected void onSizeChanged(int width, int height, int oldWidth, int oldHeight) {
+        super.onSizeChanged(width, height, oldWidth, oldHeight);
+
+        // Calculate bounds with hue bar and optional opacity bar at the bottom.
+        final float effectiveWidth = width - (2 * VIEW_PADDING);
+        final float effectiveHeight = height - (2 * VIEW_PADDING) - HUE_BAR_HEIGHT - MARGIN_BETWEEN_AREAS
+                - (opacitySliderEnabled ? OPACITY_BAR_HEIGHT + MARGIN_BETWEEN_AREAS : 0);
+
+        // Adjust rectangles to account for padding and density-independent dimensions.
+        saturationValueRect.set(
+                VIEW_PADDING,
+                VIEW_PADDING,
+                VIEW_PADDING + effectiveWidth,
+                VIEW_PADDING + effectiveHeight
+        );
+
+        hueRect.set(
+                VIEW_PADDING,
+                height - VIEW_PADDING - HUE_BAR_HEIGHT - (opacitySliderEnabled ? OPACITY_BAR_HEIGHT + MARGIN_BETWEEN_AREAS : 0),
+                VIEW_PADDING + effectiveWidth,
+                height - VIEW_PADDING - (opacitySliderEnabled ? OPACITY_BAR_HEIGHT + MARGIN_BETWEEN_AREAS : 0)
+        );
+
+        if (opacitySliderEnabled) {
+            opacityRect.set(
+                    VIEW_PADDING,
+                    height - VIEW_PADDING - OPACITY_BAR_HEIGHT,
+                    VIEW_PADDING + effectiveWidth,
+                    height - VIEW_PADDING
+            );
+        }
+
+        // Update the shaders.
+        updateHueShader();
+        updateSaturationValueShader();
+        updateOpacityShader();
+    }
+
+    /**
+     * Updates the shader for the hue bar to reflect the color gradient.
+     */
+    private void updateHueShader() {
+        LinearGradient hueShader = new LinearGradient(
+                hueRect.left, hueRect.top,
+                hueRect.right, hueRect.top,
+                HUE_COLORS,
+                null,
+                Shader.TileMode.CLAMP
+        );
+
+        huePaint.setShader(hueShader);
+    }
+
+    /**
+     * Updates the shader for the opacity slider to reflect the current RGB color with varying opacity.
+     */
+    private void updateOpacityShader() {
+        if (!opacitySliderEnabled) {
+            opacityPaint.setShader(null);
+            return;
+        }
+
+        // Create a linear gradient for opacity from transparent to opaque, using the current RGB color.
+        int rgbColor = Color.HSVToColor(0, new float[]{hue, saturation, value});
+        LinearGradient opacityShader = new LinearGradient(
+                opacityRect.left, opacityRect.top,
+                opacityRect.right, opacityRect.top,
+                rgbColor & 0x00FFFFFF, // Fully transparent
+                rgbColor | 0xFF000000, // Fully opaque
+                Shader.TileMode.CLAMP
+        );
+
+        opacityPaint.setShader(opacityShader);
+    }
+
+    /**
+     * Updates the shader for the saturation-value selector to reflect the current hue.
+     */
+    @SuppressWarnings("ExtractMethodRecommender")
+    private void updateSaturationValueShader() {
+        // Create a saturation-value gradient based on the current hue.
+        // Calculate the start color (white with the selected hue) for the saturation gradient.
+        final int startColor = Color.HSVToColor(new float[]{hue, 0f, 1f});
+
+        // Calculate the middle color (fully saturated color with the selected hue) for the saturation gradient.
+        final int midColor = Color.HSVToColor(new float[]{hue, 1f, 1f});
+
+        // Create a linear gradient for the saturation from startColor to midColor (horizontal).
+        LinearGradient satShader = new LinearGradient(
+                saturationValueRect.left, saturationValueRect.top,
+                saturationValueRect.right, saturationValueRect.top,
+                startColor,
+                midColor,
+                Shader.TileMode.CLAMP
+        );
+
+        // Create a linear gradient for the value (brightness) from white to black (vertical).
+        LinearGradient valShader = new LinearGradient(
+                saturationValueRect.left, saturationValueRect.top,
+                saturationValueRect.left, saturationValueRect.bottom,
+                Color.WHITE,
+                Color.BLACK,
+                Shader.TileMode.CLAMP
+        );
+
+        // Combine the saturation and value shaders using PorterDuff.Mode.MULTIPLY to create the final color.
+        ComposeShader combinedShader = new ComposeShader(satShader, valShader, PorterDuff.Mode.MULTIPLY);
+
+        // Set the combined shader for the saturation-value paint.
+        saturationValuePaint.setShader(combinedShader);
+    }
+
+    /**
+     * Draws the color picker components, including the saturation-value selector, hue bar, opacity slider, and their respective handles.
+     */
+    @Override
+    protected void onDraw(Canvas canvas) {
+        // Draw the saturation-value selector rectangle.
+        canvas.drawRect(saturationValueRect, saturationValuePaint);
+
+        // Draw the hue bar.
+        canvas.drawRoundRect(hueRect, HUE_CORNER_RADIUS, HUE_CORNER_RADIUS, huePaint);
+
+        // Draw the opacity bar if enabled.
+        if (opacitySliderEnabled) {
+            canvas.drawRoundRect(opacityRect, OPACITY_CORNER_RADIUS, OPACITY_CORNER_RADIUS, opacityPaint);
+        }
+
+        final float hueSelectorX = hueRect.left + (hue / 360f) * hueRect.width();
+        final float hueSelectorY = hueRect.centerY();
+
+        final float satSelectorX = saturationValueRect.left + saturation * saturationValueRect.width();
+        final float satSelectorY = saturationValueRect.top + (1 - value) * saturationValueRect.height();
+
+        // Draw the saturation and hue selector handles filled with their respective colors (fully opaque).
+        hsvArray[0] = hue;
+        final int hueHandleColor = Color.HSVToColor(0xFF, hsvArray); // Force opaque for hue handle.
+        final int satHandleColor = Color.HSVToColor(0xFF, new float[]{hue, saturation, value}); // Force opaque for sat-val handle.
+        selectorPaint.setStyle(Paint.Style.FILL_AND_STROKE);
+
+        selectorPaint.setColor(hueHandleColor);
+        canvas.drawCircle(hueSelectorX, hueSelectorY, SELECTOR_FILL_RADIUS, selectorPaint);
+
+        selectorPaint.setColor(satHandleColor);
+        canvas.drawCircle(satSelectorX, satSelectorY, SELECTOR_FILL_RADIUS, selectorPaint);
+
+        if (opacitySliderEnabled) {
+            final float opacitySelectorX = opacityRect.left + opacity * opacityRect.width();
+            final float opacitySelectorY = opacityRect.centerY();
+            selectorPaint.setColor(selectedColor); // Use full ARGB color to show opacity.
+            canvas.drawCircle(opacitySelectorX, opacitySelectorY, SELECTOR_FILL_RADIUS, selectorPaint);
+        }
+
+        // Draw white outlines for the handles.
+        selectorPaint.setColor(SELECTOR_OUTLINE_COLOR);
+        selectorPaint.setStyle(Paint.Style.STROKE);
+        selectorPaint.setStrokeWidth(SELECTOR_STROKE_WIDTH);
+        canvas.drawCircle(hueSelectorX, hueSelectorY, SELECTOR_RADIUS, selectorPaint);
+        canvas.drawCircle(satSelectorX, satSelectorY, SELECTOR_RADIUS, selectorPaint);
+        if (opacitySliderEnabled) {
+            final float opacitySelectorX = opacityRect.left + opacity * opacityRect.width();
+            final float opacitySelectorY = opacityRect.centerY();
+            canvas.drawCircle(opacitySelectorX, opacitySelectorY, SELECTOR_RADIUS, selectorPaint);
+        }
+
+        // Draw thin dark outlines for the handles at the outer edge of the white outline.
+        selectorPaint.setColor(SELECTOR_EDGE_COLOR);
+        selectorPaint.setStrokeWidth(SELECTOR_EDGE_STROKE_WIDTH);
+        canvas.drawCircle(hueSelectorX, hueSelectorY, SELECTOR_EDGE_RADIUS, selectorPaint);
+        canvas.drawCircle(satSelectorX, satSelectorY, SELECTOR_EDGE_RADIUS, selectorPaint);
+        if (opacitySliderEnabled) {
+            final float opacitySelectorX = opacityRect.left + opacity * opacityRect.width();
+            final float opacitySelectorY = opacityRect.centerY();
+            canvas.drawCircle(opacitySelectorX, opacitySelectorY, SELECTOR_EDGE_RADIUS, selectorPaint);
+        }
+    }
+
+    /**
+     * Handles touch events to allow dragging of the hue, saturation-value, and opacity selectors.
+     *
+     * @param event The motion event.
+     * @return True if the event was handled, false otherwise.
+     */
+    @SuppressLint("ClickableViewAccessibility")
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        try {
+            final float x = event.getX();
+            final float y = event.getY();
+            final int action = event.getAction();
+            Logger.printDebug(() -> "onTouchEvent action: " + action + " x: " + x + " y: " + y);
+
+            // Define touch expansion for the hue and opacity bars.
+            RectF expandedHueRect = new RectF(
+                    hueRect.left,
+                    hueRect.top - TOUCH_EXPANSION,
+                    hueRect.right,
+                    hueRect.bottom + TOUCH_EXPANSION
+            );
+            RectF expandedOpacityRect = opacitySliderEnabled ? new RectF(
+                    opacityRect.left,
+                    opacityRect.top - TOUCH_EXPANSION,
+                    opacityRect.right,
+                    opacityRect.bottom + TOUCH_EXPANSION
+            ) : new RectF();
+
+            switch (action) {
+                case MotionEvent.ACTION_DOWN:
+                    // Calculate current handle positions.
+                    final float hueSelectorX = hueRect.left + (hue / 360f) * hueRect.width();
+                    final float hueSelectorY = hueRect.centerY();
+
+                    final float satSelectorX = saturationValueRect.left + saturation * saturationValueRect.width();
+                    final float valSelectorY = saturationValueRect.top + (1 - value) * saturationValueRect.height();
+
+                    final float opacitySelectorX = opacitySliderEnabled ? opacityRect.left + opacity * opacityRect.width() : 0;
+                    final float opacitySelectorY = opacitySliderEnabled ? opacityRect.centerY() : 0;
+
+                    // Create hit areas for all handles.
+                    RectF hueHitRect = new RectF(
+                            hueSelectorX - SELECTOR_RADIUS,
+                            hueSelectorY - SELECTOR_RADIUS,
+                            hueSelectorX + SELECTOR_RADIUS,
+                            hueSelectorY + SELECTOR_RADIUS
+                    );
+                    RectF satValHitRect = new RectF(
+                            satSelectorX - SELECTOR_RADIUS,
+                            valSelectorY - SELECTOR_RADIUS,
+                            satSelectorX + SELECTOR_RADIUS,
+                            valSelectorY + SELECTOR_RADIUS
+                    );
+                    RectF opacityHitRect = opacitySliderEnabled ? new RectF(
+                            opacitySelectorX - SELECTOR_RADIUS,
+                            opacitySelectorY - SELECTOR_RADIUS,
+                            opacitySelectorX + SELECTOR_RADIUS,
+                            opacitySelectorY + SELECTOR_RADIUS
+                    ) : new RectF();
+
+                    // Check if the touch started on a handle or within the expanded bar areas.
+                    if (hueHitRect.contains(x, y)) {
+                        isDraggingHue = true;
+                        updateHueFromTouch(x);
+                    } else if (satValHitRect.contains(x, y)) {
+                        isDraggingSaturation = true;
+                        updateSaturationValueFromTouch(x, y);
+                    } else if (opacitySliderEnabled && opacityHitRect.contains(x, y)) {
+                        isDraggingOpacity = true;
+                        updateOpacityFromTouch(x);
+                    } else if (expandedHueRect.contains(x, y)) {
+                        // Handle touch within the expanded hue bar area.
+                        isDraggingHue = true;
+                        updateHueFromTouch(x);
+                    } else if (saturationValueRect.contains(x, y)) {
+                        isDraggingSaturation = true;
+                        updateSaturationValueFromTouch(x, y);
+                    } else if (opacitySliderEnabled && expandedOpacityRect.contains(x, y)) {
+                        isDraggingOpacity = true;
+                        updateOpacityFromTouch(x);
+                    }
+                    break;
+
+                case MotionEvent.ACTION_MOVE:
+                    // Continue updating values even if touch moves outside the view.
+                    if (isDraggingHue) {
+                        updateHueFromTouch(x);
+                    } else if (isDraggingSaturation) {
+                        updateSaturationValueFromTouch(x, y);
+                    } else if (isDraggingOpacity) {
+                        updateOpacityFromTouch(x);
+                    }
+                    break;
+
+                case MotionEvent.ACTION_UP:
+                case MotionEvent.ACTION_CANCEL:
+                    isDraggingHue = false;
+                    isDraggingSaturation = false;
+                    isDraggingOpacity = false;
+                    break;
+            }
+        } catch (Exception ex) {
+            Logger.printException(() -> "onTouchEvent failure", ex);
+        }
+
+        return true;
+    }
+
+    /**
+     * Updates the hue value based on a touch event.
+     */
+    private void updateHueFromTouch(float x) {
+        // Clamp x to the hue rectangle bounds.
+        final float clampedX = Utils.clamp(x, hueRect.left, hueRect.right);
+        final float updatedHue = ((clampedX - hueRect.left) / hueRect.width()) * 360f;
+        if (hue == updatedHue) {
+            return;
+        }
+
+        hue = updatedHue;
+        updateSaturationValueShader();
+        updateOpacityShader();
+        updateSelectedColor();
+    }
+
+    /**
+     * Updates the saturation and value based on a touch event.
+     */
+    private void updateSaturationValueFromTouch(float x, float y) {
+        // Clamp x and y to the saturation-value rectangle bounds.
+        final float clampedX = Utils.clamp(x, saturationValueRect.left, saturationValueRect.right);
+        final float clampedY = Utils.clamp(y, saturationValueRect.top, saturationValueRect.bottom);
+
+        final float updatedSaturation = (clampedX - saturationValueRect.left) / saturationValueRect.width();
+        final float updatedValue = 1 - ((clampedY - saturationValueRect.top) / saturationValueRect.height());
+
+        if (saturation == updatedSaturation && value == updatedValue) {
+            return;
+        }
+        saturation = updatedSaturation;
+        value = updatedValue;
+        updateOpacityShader();
+        updateSelectedColor();
+    }
+
+    /**
+     * Updates the opacity value based on a touch event.
+     */
+    private void updateOpacityFromTouch(float x) {
+        if (!opacitySliderEnabled) {
+            return;
+        }
+        final float clampedX = Utils.clamp(x, opacityRect.left, opacityRect.right);
+        final float updatedOpacity = (clampedX - opacityRect.left) / opacityRect.width();
+        if (opacity == updatedOpacity) {
+            return;
+        }
+        opacity = updatedOpacity;
+        updateSelectedColor();
+    }
+
+    /**
+     * Updates the selected color based on the current hue, saturation, value, and opacity.
+     */
+    private void updateSelectedColor() {
+        final int rgbColor = Color.HSVToColor(0, new float[]{hue, saturation, value});
+        final int updatedColor = opacitySliderEnabled
+                ? (rgbColor & 0x00FFFFFF) | (((int) (opacity * 255)) << 24)
+                : (rgbColor & 0x00FFFFFF) | 0xFF000000;
+
+        if (selectedColor != updatedColor) {
+            selectedColor = updatedColor;
+
+            if (colorChangedListener != null) {
+                colorChangedListener.onColorChanged(updatedColor);
+            }
+        }
+
+        // Must always redraw, otherwise if saturation is pure grey or black
+        // then the hue slider cannot be changed.
+        invalidate();
+    }
+
+    /**
+     * Sets the selected color, updating the hue, saturation, value and opacity sliders accordingly.
+     */
+    public void setColor(@ColorInt int color) {
+        if (selectedColor == color) {
+            return;
+        }
+
+        // Update the selected color.
+        selectedColor = color;
+        Logger.printDebug(() -> "setColor: " + getColorString(selectedColor, opacitySliderEnabled));
+
+        // Convert the ARGB color to HSV values.
+        float[] hsv = new float[3];
+        Color.colorToHSV(color, hsv);
+
+        // Update the hue, saturation, and value.
+        hue = hsv[0];
+        saturation = hsv[1];
+        value = hsv[2];
+        opacity = opacitySliderEnabled ? ((color >> 24) & 0xFF) / 255f : 1f;
+
+        // Update the saturation-value shader based on the new hue.
+        updateSaturationValueShader();
+        updateOpacityShader();
+
+        // Notify the listener if it's set.
+        if (colorChangedListener != null) {
+            colorChangedListener.onColorChanged(selectedColor);
+        }
+
+        // Invalidate the view to trigger a redraw.
+        invalidate();
+    }
+
+    /**
+     * Gets the currently selected color.
+     */
+    @ColorInt
+    public int getColor() {
+        return selectedColor;
+    }
+
+    /**
+     * Sets a listener to be notified when the selected color changes.
+     */
+    public void setOnColorChangedListener(OnColorChangedListener listener) {
+        colorChangedListener = listener;
+    }
+}

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/CustomDialogListPreference.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/CustomDialogListPreference.java
@@ -31,6 +31,7 @@ import androidx.annotation.Nullable;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.CustomDialog;
 
 /**
@@ -153,13 +154,13 @@ public class CustomDialogListPreference extends ListPreference {
 
             CharSequence itemText = getItem(position);
             holder.itemText.setText(itemText);
-            holder.itemText.setTextColor(Utils.getAppForegroundColor());
+            holder.itemText.setTextColor(ThemeUtils.getAppForegroundColor());
 
             // Show or hide checkmark and placeholder.
             String currentValue = entryValues[position].toString();
             boolean isSelected = currentValue.equals(selectedValue);
             holder.checkIcon.setVisibility(isSelected ? View.VISIBLE : View.GONE);
-            holder.checkIcon.setColorFilter(Utils.getAppForegroundColor());
+            holder.checkIcon.setColorFilter(ThemeUtils.getAppForegroundColor());
             holder.placeholder.setVisibility(isSelected ? View.GONE : View.VISIBLE);
 
             return view;

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/IconListPreference.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/IconListPreference.java
@@ -39,6 +39,7 @@ import java.util.Objects;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.CustomDialog;
 
 /**
@@ -344,11 +345,11 @@ public class IconListPreference extends CustomDialogListPreference {
             }
 
             holder.itemText.setText(getItem(position));
-            holder.itemText.setTextColor(Utils.getAppForegroundColor());
+            holder.itemText.setTextColor(ThemeUtils.getAppForegroundColor());
 
             boolean isSelected = entryValues[position].toString().equals(selectedValue);
             holder.checkIcon.setVisibility(isSelected ? View.VISIBLE : View.GONE);
-            holder.checkIcon.setColorFilter(Utils.getAppForegroundColor());
+            holder.checkIcon.setColorFilter(ThemeUtils.getAppForegroundColor());
             holder.placeholder.setVisibility(isSelected ? View.GONE : View.VISIBLE);
 
             if (holder.itemIcon != null) {

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/NotificationIconListPreference.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/NotificationIconListPreference.java
@@ -25,7 +25,7 @@ import androidx.annotation.Nullable;
 
 import java.util.Locale;
 
-import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.theme.ThemeUtils;
 
 /**
  * An {@link IconListPreference} for notification icon selection.
@@ -70,7 +70,7 @@ public class NotificationIconListPreference extends IconListPreference {
         int sizePx = Math.round(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, ICON_SIZE_DP, dm));
         float cornerRadius = sizePx * ICON_CORNER_RADIUS_FRACTION;
 
-        int fgColor = Utils.getAppForegroundColor();
+        int fgColor = ThemeUtils.getAppForegroundColor();
         int bgColor = isLightColor(fgColor) ? 0xFF000000 : 0xFFFFFFFF;
 
         // Resolve the current app icon style so FOLLOW can mirror it.

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutDialogStyle.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutDialogStyle.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.BaseSettings;
+import app.morphe.extension.shared.theme.ThemeUtils;
 
 /**
  * HTML scaffolding shared by the About and Credits dialogs, styled to match Morphe.
@@ -140,8 +141,8 @@ final class AboutDialogStyle {
         return DOCUMENT_START
                 .replace("{dir}", Utils.isRightToLeftLocale(
                         BaseSettings.MORPHE_LANGUAGE.get().getLocale()) ? "rtl" : "ltr")
-                .replace("{bg}", Utils.getColorHexString(Utils.getDialogBackgroundColor()))
-                .replace("{fg}", Utils.getColorHexString(Utils.getAppForegroundColor()))
+                .replace("{bg}", Utils.getColorHexString(ThemeUtils.getDialogBackgroundColor()))
+                .replace("{fg}", Utils.getColorHexString(ThemeUtils.getAppForegroundColor()))
                 .replace("{accent}", accentColor())
                 .replace("{blue}", MORPHE_BLUE)
                 .replace("{teal}", MORPHE_TEAL);

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutWebViewDialog.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/AboutWebViewDialog.java
@@ -26,6 +26,7 @@ import android.widget.LinearLayout;
 import androidx.annotation.NonNull;
 
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.Dim;
 
 /**
@@ -63,7 +64,7 @@ class AboutWebViewDialog extends Dialog {
         // Set rounded rectangle background.
         ShapeDrawable mainBackground = new ShapeDrawable(new RoundRectShape(
                 Dim.roundedCorners(28), null, null));
-        mainBackground.getPaint().setColor(Utils.getDialogBackgroundColor());
+        mainBackground.getPaint().setColor(ThemeUtils.getDialogBackgroundColor());
         mainLayout.setBackground(mainBackground);
 
         // Create WebView.
@@ -85,5 +86,4 @@ class AboutWebViewDialog extends Dialog {
             Utils.setDialogWindowParameters(window, Gravity.CENTER, 0, 90, false);
         }
     }
-
 }

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/LicenseTextDialog.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/settings/preference/about/LicenseTextDialog.java
@@ -20,7 +20,7 @@ import android.webkit.WebView;
 
 import java.util.List;
 
-import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.theme.ThemeUtils;
 
 /**
  * Shows the notices of a single bundled dependency.
@@ -44,8 +44,8 @@ class LicenseTextDialog extends Dialog {
         // same color the page is, rather than whatever the device theme happens to be.
         Window window = getWindow();
         if (window != null) {
-            window.setBackgroundDrawable(new ColorDrawable(Utils.getDialogBackgroundColor()));
-            window.setNavigationBarColor(Utils.getDialogBackgroundColor());
+            window.setBackgroundDrawable(new ColorDrawable(ThemeUtils.getDialogBackgroundColor()));
+            window.setNavigationBarColor(ThemeUtils.getDialogBackgroundColor());
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 window.setNavigationBarContrastEnforced(true);
             }
@@ -62,7 +62,7 @@ class LicenseTextDialog extends Dialog {
         webView.getSettings().setBuiltInZoomControls(true);
         webView.getSettings().setDisplayZoomControls(false);
         // A WebView paints white until the page is parsed, which flashes as the dialog opens.
-        webView.setBackgroundColor(Utils.getDialogBackgroundColor());
+        webView.setBackgroundColor(ThemeUtils.getDialogBackgroundColor());
         webView.setWebViewClient(new AboutLinksWebClient(getContext(), this));
 
         webView.loadDataWithBaseURL(null, buildHtml(), "text/html", "UTF-8", null);

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/theme/ThemeUtils.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/theme/ThemeUtils.java
@@ -137,11 +137,28 @@ public class ThemeUtils {
     }
 
     /**
-     * @return The current app foreground color.
+     * The color of the text and the icons Morphe draws on the background of the app.
+     * <p>
+     * The background of the other theme is not a foreground color. It is one the user picks, and
+     * a dark theme with a red background would give the light theme red text.
+     *
+     * @return Black or white, whichever stays readable on {@link #getAppBackgroundColor()}.
      */
     @ColorInt
     public static int getAppForegroundColor() {
-        return Utils.isDarkModeEnabled() ? getThemeLightColor() : getThemeDarkColor();
+        return isBrightColor(getAppBackgroundColor()) ? Color.BLACK : Color.WHITE;
+    }
+
+    /**
+     * @return If a color is bright enough that dark text is the readable one on it.
+     */
+    private static boolean isBrightColor(@ColorInt int color) {
+        // Rec. 601 luma, which weights a channel the way the eye responds to it.
+        final int luma = (299 * Color.red(color)
+                + 587 * Color.green(color)
+                + 114 * Color.blue(color)) / 1000;
+
+        return luma >= 128;
     }
 
     @ColorInt

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/theme/ThemeUtils.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/theme/ThemeUtils.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
+package app.morphe.extension.shared.theme;
+
+import android.graphics.Color;
+
+import androidx.annotation.ColorInt;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.ResourceUtils;
+import app.morphe.extension.shared.Utils;
+
+/**
+ * The background color of both themes of the app, which Morphe uses for its own dialogs and
+ * settings so that they always match the app.
+ * <p>
+ * Each color is resolved from the app resources when it is first used, unless a patch handed one
+ * in with {@link #setThemeLightColor(int)} or {@link #setThemeDarkColor(int)}. A patch that lets
+ * the user pick the background knows the color of both themes, and only it can resolve the color
+ * of the theme the app does not currently show.
+ */
+@SuppressWarnings("unused")
+public class ThemeUtils {
+
+    @ColorInt
+    private static int lightColor = Color.WHITE;
+    @ColorInt
+    private static int darkColor = Color.BLACK;
+
+    /**
+     * If a color was handed in by a patch or read from the app resources, and must not be
+     * resolved again.
+     */
+    private static boolean lightColorResolved;
+    private static boolean darkColorResolved;
+
+    /**
+     * Injection point.
+     */
+    @SuppressWarnings("SameReturnValue")
+    private static String getThemeLightColorResourceName() {
+        // Value is changed by Settings patch.
+        return "#FFFFFFFF";
+    }
+
+    /**
+     * Injection point.
+     */
+    @SuppressWarnings("SameReturnValue")
+    private static String getThemeDarkColorResourceName() {
+        // Value is changed by Settings patch.
+        return "#FF000000";
+    }
+
+    /**
+     * Sets the theme light color used by the app.
+     */
+    public static void setThemeLightColor(@ColorInt int color) {
+        Logger.printDebug(() -> "Setting theme light color: " + Utils.getColorHexString(color));
+        lightColorResolved = true;
+        lightColor = color;
+    }
+
+    /**
+     * Sets the theme dark color used by the app.
+     */
+    public static void setThemeDarkColor(@ColorInt int color) {
+        Logger.printDebug(() -> "Setting theme dark color: " + Utils.getColorHexString(color));
+        darkColorResolved = true;
+        darkColor = color;
+    }
+
+    /**
+     * @return The background color of the light theme of the app.
+     */
+    @ColorInt
+    public static int getThemeLightColor() {
+        if (!lightColorResolved && Utils.isContextSet()) {
+            setThemeLightColor(themeColor(getThemeLightColorResourceName(), Color.WHITE));
+        }
+
+        return lightColor;
+    }
+
+    /**
+     * @return The background color of the dark theme of the app.
+     */
+    @ColorInt
+    public static int getThemeDarkColor() {
+        if (!darkColorResolved && Utils.isContextSet()) {
+            setThemeDarkColor(themeColor(getThemeDarkColorResourceName(), Color.BLACK));
+        }
+
+        return darkColor;
+    }
+
+    @ColorInt
+    private static int themeColor(String resourceName, @ColorInt int defaultColor) {
+        try {
+            return ResourceUtils.getColor(resourceName, defaultColor);
+        } catch (Exception ex) {
+            // This code can never be reached since a bad custom color will
+            // fail during resource compilation. So no localized strings are needed here.
+            Logger.printException(() -> "Invalid custom theme color: " + resourceName, ex);
+            return defaultColor;
+        }
+    }
+
+    @ColorInt
+    public static int getDialogBackgroundColor() {
+        if (Utils.isDarkModeEnabled()) {
+            final int darkColor = getThemeDarkColor();
+            return darkColor == Color.BLACK
+                    // Lighten the background a little if using AMOLED dark theme
+                    // as the dialogs are almost invisible.
+                    ? 0xFF080808 // 3%
+                    : darkColor;
+        }
+
+        return getThemeLightColor();
+    }
+
+    /**
+     * @return The current app background color.
+     */
+    @ColorInt
+    public static int getAppBackgroundColor() {
+        return Utils.isDarkModeEnabled() ? getThemeDarkColor() : getThemeLightColor();
+    }
+
+    /**
+     * @return The current app foreground color.
+     */
+    @ColorInt
+    public static int getAppForegroundColor() {
+        return Utils.isDarkModeEnabled() ? getThemeLightColor() : getThemeDarkColor();
+    }
+
+    @ColorInt
+    public static int getOkButtonBackgroundColor() {
+        return Utils.isDarkModeEnabled()
+                // Must be inverted color.
+                ? Color.WHITE
+                : Color.BLACK;
+    }
+
+    @ColorInt
+    public static int getCancelOrNeutralButtonBackgroundColor() {
+        return Utils.isDarkModeEnabled()
+                ? Utils.adjustColorBrightness(getDialogBackgroundColor(), 1.10f)
+                : Utils.adjustColorBrightness(getThemeLightColor(), 0.95f);
+    }
+
+    @ColorInt
+    public static int getEditTextBackground() {
+        return Utils.isDarkModeEnabled()
+                ? Utils.adjustColorBrightness(getDialogBackgroundColor(), 1.05f)
+                : Utils.adjustColorBrightness(getThemeLightColor(), 0.97f);
+    }
+
+    private ThemeUtils() {
+    }
+}

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/ui/ColorDot.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/ui/ColorDot.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original first edition code:
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/584b00fd87f83504b8886e4f3f674f8c3943cd91
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/2e9d6959c94df7588b9e34b18770e9f437e91926
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/ece8076f7cefd752b97515014bc50fe4fd80171e
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/2b62fc2224c42da024fd64602346ff30613517c0
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/a426e2af5086367a2a1fee83abbbd2ea230bda06
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/584b00fd87f83504b8886e4f3f674f8c3943cd91
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/14a8f4fb96f5e2a4bc264a54115e0870b1a1ffa8
+ * https://github.com/MorpheApp/morphe-patches/commit/f5371ca998c019609c2b5558b3408ab1fec065c8
+ *
+ * See the included NOTICE file for §7(c) terms that apply to Morphe contributions.
+ */
+
+package app.morphe.extension.shared.ui;
+
+import static app.morphe.extension.shared.Utils.adjustColorBrightness;
+import static app.morphe.extension.shared.Utils.isDarkModeEnabled;
+import static app.morphe.extension.shared.settings.preference.ColorPickerPreference.DISABLED_ALPHA;
+import static app.morphe.extension.shared.theme.ThemeUtils.getAppBackgroundColor;
+
+import android.graphics.Color;
+import android.graphics.drawable.GradientDrawable;
+import android.view.View;
+
+import androidx.annotation.ColorInt;
+import app.morphe.extension.shared.theme.ThemeUtils;
+
+public class ColorDot {
+    private static final int STROKE_WIDTH = Dim.dp(1.5f);
+
+    /**
+     * Creates a circular drawable with a main fill and a stroke.
+     * Stroke adapts to dark/light theme and transparency, applied only when color is transparent or matches app background.
+     */
+    public static GradientDrawable createColorDotDrawable(@ColorInt int color) {
+        final boolean isDarkTheme = isDarkModeEnabled();
+        final boolean isTransparent = Color.alpha(color) == 0;
+        final int opaqueColor = color | 0xFF000000;
+        final int appBackground = getAppBackgroundColor();
+        final int strokeColor;
+        final int strokeWidth;
+
+        // Determine stroke color.
+        if (isTransparent || (opaqueColor == appBackground)) {
+            final int baseColor = isTransparent ? appBackground : opaqueColor;
+            strokeColor = adjustColorBrightness(baseColor, isDarkTheme ? 1.2f : 0.8f);
+            strokeWidth = STROKE_WIDTH;
+        } else {
+            strokeColor = 0;
+            strokeWidth = 0;
+        }
+
+        // Create circular drawable with conditional stroke.
+        GradientDrawable circle = new GradientDrawable();
+        circle.setShape(GradientDrawable.OVAL);
+        circle.setColor(color);
+        circle.setStroke(strokeWidth, strokeColor);
+
+        return circle;
+    }
+
+    /**
+     * Applies the color dot drawable to the target view.
+     */
+    public static void applyColorDot(View targetView, @ColorInt int color, boolean enabled) {
+        if (targetView == null) return;
+        targetView.setBackground(createColorDotDrawable(color));
+        targetView.setAlpha(enabled ? 1.0f : DISABLED_ALPHA);
+        if (!isDarkModeEnabled()) {
+            targetView.setClipToOutline(true);
+            targetView.setElevation(Dim.dp2);
+        }
+    }
+}

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/ui/CustomDialog.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/ui/CustomDialog.java
@@ -1,0 +1,514 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original first edition code:
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/584b00fd87f83504b8886e4f3f674f8c3943cd91
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/2e9d6959c94df7588b9e34b18770e9f437e91926
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/ece8076f7cefd752b97515014bc50fe4fd80171e
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/2b62fc2224c42da024fd64602346ff30613517c0
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/a426e2af5086367a2a1fee83abbbd2ea230bda06
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/584b00fd87f83504b8886e4f3f674f8c3943cd91
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/14a8f4fb96f5e2a4bc264a54115e0870b1a1ffa8
+ * https://github.com/MorpheApp/morphe-patches/commit/f5371ca998c019609c2b5558b3408ab1fec065c8
+ *
+ * See the included NOTICE file for §7(c) terms that apply to Morphe contributions.
+ */
+
+package app.morphe.extension.shared.ui;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.ShapeDrawable;
+import android.graphics.drawable.shapes.RoundRectShape;
+import android.text.Spanned;
+import android.text.TextUtils;
+import android.text.method.LinkMovementMethod;
+import android.util.Pair;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.*;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.ResourceUtils;
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.settings.BaseSettings;
+import app.morphe.extension.shared.theme.ThemeUtils;
+
+/**
+ * A utility class for creating a customizable dialog with a title, message or EditText, and up to three buttons (OK, Cancel, Neutral).
+ * The dialog supports themed colors, rounded corners, and dynamic button layout based on screen width. It is dismissible by default.
+ */
+public class CustomDialog {
+    private final Context context;
+    private final Dialog dialog;
+    private final LinearLayout mainLayout;
+
+    /**
+     * Creates a custom dialog with a styled layout, including a title, message, buttons, and an optional EditText.
+     * The dialog's appearance adapts to the app's dark mode setting, with rounded corners and customizable button actions.
+     * Buttons adjust dynamically to their text content and are arranged in a single row if they fit within 80% of the
+     * screen width, with the Neutral button aligned to the left and OK/Cancel buttons centered on the right.
+     * If buttons do not fit, each is placed on a separate row, all aligned to the right.
+     *
+     * @param context                     Context used to create the dialog.
+     * @param title                       Title text of the dialog.
+     * @param message                     Message text of the dialog (supports Spanned for HTML), or null if replaced by EditText.
+     * @param editText                    EditText to include in the dialog, or null if no EditText is needed.
+     * @param okButtonText                OK button text, or null to use the default "OK" string.
+     * @param onOkClick                   Action to perform when the OK button is clicked.
+     * @param onCancelClick               Action to perform when the Cancel button is clicked, or null if no Cancel button is needed.
+     * @param neutralButtonText           Neutral button text, or null if no Neutral button is needed.
+     * @param onNeutralClick              Action to perform when the Neutral button is clicked, or null if no Neutral button is needed.
+     * @param dismissDialogOnNeutralClick If the dialog should be dismissed when the Neutral button is clicked.
+     * @return The Dialog and its main LinearLayout container.
+     */
+    public static Pair<Dialog, LinearLayout> create(Context context, CharSequence title, CharSequence message,
+                                                    @Nullable EditText editText, CharSequence okButtonText,
+                                                    Runnable onOkClick, Runnable onCancelClick,
+                                                    @Nullable CharSequence neutralButtonText,
+                                                    @Nullable Runnable onNeutralClick,
+                                                    boolean dismissDialogOnNeutralClick) {
+        return create(context, title, message, editText, okButtonText, onOkClick, onCancelClick,
+                neutralButtonText, onNeutralClick, dismissDialogOnNeutralClick, true);
+    }
+
+    public static Pair<Dialog, LinearLayout> create(Context context, CharSequence title, CharSequence message,
+                                                    @Nullable EditText editText, CharSequence okButtonText,
+                                                    Runnable onOkClick, Runnable onCancelClick,
+                                                    @Nullable CharSequence neutralButtonText,
+                                                    @Nullable Runnable onNeutralClick,
+                                                    boolean dismissDialogOnNeutralClick,
+                                                    boolean accentOkButton) {
+        Logger.printDebug(() -> "Creating custom dialog with title: " + title);
+        CustomDialog customDialog = new CustomDialog(context, title, message, editText,
+                okButtonText, onOkClick, onCancelClick,
+                neutralButtonText, onNeutralClick, dismissDialogOnNeutralClick, accentOkButton);
+        return new Pair<>(customDialog.dialog, customDialog.mainLayout);
+    }
+
+    /**
+     * Initializes a custom dialog with the specified parameters.
+     *
+     * @param context                     Context used to create the dialog.
+     * @param title                       Title text of the dialog.
+     * @param message                     Message text of the dialog, or null if replaced by EditText.
+     * @param editText                    EditText to include in the dialog, or null if no EditText is needed.
+     * @param okButtonText                OK button text, or null to use the default "OK" string.
+     * @param onOkClick                   Action to perform when the OK button is clicked.
+     * @param onCancelClick               Action to perform when the Cancel button is clicked, or null if no Cancel button is needed.
+     * @param neutralButtonText           Neutral button text, or null if no Neutral button is needed.
+     * @param onNeutralClick              Action to perform when the Neutral button is clicked, or null if no Neutral button is needed.
+     * @param dismissDialogOnNeutralClick If the dialog should be dismissed when the Neutral button is clicked.
+     */
+    private CustomDialog(Context context, CharSequence title, CharSequence message, @Nullable EditText editText,
+                         CharSequence okButtonText, Runnable onOkClick, Runnable onCancelClick,
+                         @Nullable CharSequence neutralButtonText, @Nullable Runnable onNeutralClick,
+                         boolean dismissDialogOnNeutralClick, boolean accentOkButton) {
+        this.context = context;
+        this.dialog = new Dialog(context);
+        this.dialog.requestWindowFeature(Window.FEATURE_NO_TITLE); // Remove default title bar.
+
+        // Create main layout.
+        mainLayout = createMainLayout();
+        addTitle(title);
+        addContent(message, editText);
+        addButtons(okButtonText, onOkClick, onCancelClick, neutralButtonText, onNeutralClick, dismissDialogOnNeutralClick, accentOkButton);
+
+        // Set dialog content and window attributes.
+        dialog.setContentView(mainLayout);
+        Window window = dialog.getWindow();
+        if (window != null) {
+            Utils.setDialogWindowParameters(window, Gravity.CENTER, 0, 90, false);
+        }
+    }
+
+    /**
+     * Creates the main layout for the dialog with vertical orientation and rounded corners.
+     *
+     * @return The configured LinearLayout for the dialog.
+     */
+    private LinearLayout createMainLayout() {
+        LinearLayout layout = new LinearLayout(context);
+        layout.setOrientation(LinearLayout.VERTICAL);
+        layout.setPadding(Dim.dp24, Dim.dp16, Dim.dp24, Dim.dp24);
+
+        // Set rounded rectangle background.
+        ShapeDrawable background = new ShapeDrawable(new RoundRectShape(
+                Dim.roundedCorners(28), null, null));
+        // Dialog background.
+        background.getPaint().setColor(ThemeUtils.getDialogBackgroundColor());
+        layout.setBackground(background);
+
+        return layout;
+    }
+
+    /**
+     * Adds a title to the dialog if provided.
+     *
+     * @param title The title text to display.
+     */
+    private void addTitle(CharSequence title) {
+        if (TextUtils.isEmpty(title)) return;
+
+        TextView titleView = new TextView(context);
+        titleView.setText(title);
+        titleView.setTypeface(Typeface.DEFAULT_BOLD);
+        titleView.setTextSize(18);
+        titleView.setTextColor(ThemeUtils.getAppForegroundColor());
+        titleView.setGravity(Gravity.CENTER);
+
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT);
+        params.setMargins(0, 0, 0, Dim.dp16);
+        titleView.setLayoutParams(params);
+
+        mainLayout.addView(titleView);
+    }
+
+    /**
+     * Adds a message or EditText to the dialog within a ScrollView.
+     *
+     * @param message  The message text to display (supports Spanned for HTML), or null if replaced by EditText.
+     * @param editText The EditText to include, or null if no EditText is needed.
+     */
+    private void addContent(CharSequence message, @Nullable EditText editText) {
+        // Create content container (message/EditText) inside a ScrollView only if message or editText is provided.
+        if (message == null && editText == null) return;
+
+        ScrollView scrollView = new ScrollView(context);
+        // Disable the vertical scrollbar.
+        scrollView.setVerticalScrollBarEnabled(false);
+        scrollView.setOverScrollMode(View.OVER_SCROLL_NEVER);
+
+        LinearLayout contentContainer = new LinearLayout(context);
+        contentContainer.setOrientation(LinearLayout.VERTICAL);
+        scrollView.addView(contentContainer);
+
+        // EditText (if provided).
+        if (editText != null) {
+            ShapeDrawable background = new ShapeDrawable(new RoundRectShape(
+                    Dim.roundedCorners(10), null, null));
+            background.getPaint().setColor(ThemeUtils.getEditTextBackground());
+            scrollView.setPadding(Dim.dp8, Dim.dp8, Dim.dp8, Dim.dp8);
+            scrollView.setBackground(background);
+            scrollView.setClipToOutline(true);
+
+            // Remove EditText from its current parent, if any.
+            ViewGroup parent = (ViewGroup) editText.getParent();
+            if (parent != null) parent.removeView(editText);
+            // Style the EditText to match the dialog theme.
+            editText.setTextColor(ThemeUtils.getAppForegroundColor());
+            editText.setBackgroundColor(Color.TRANSPARENT);
+            editText.setPadding(0, 0, 0, 0);
+            contentContainer.addView(editText, new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT));
+            // Message (if not replaced by EditText).
+        } else {
+            TextView messageView = new TextView(context);
+            // Supports Spanned (HTML).
+            messageView.setText(message);
+            messageView.setTextSize(16);
+            messageView.setTextColor(ThemeUtils.getAppForegroundColor());
+            // Enable HTML link clicking if the message contains links.
+            if (message instanceof Spanned) {
+                messageView.setMovementMethod(LinkMovementMethod.getInstance());
+            }
+            contentContainer.addView(messageView, new LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT));
+        }
+
+        // Weight to take available space.
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                0,
+                1.0f);
+        scrollView.setLayoutParams(params);
+        // Add ScrollView to main layout only if content exist.
+        mainLayout.addView(scrollView);
+    }
+
+    /**
+     * Adds buttons to the dialog, arranging them dynamically based on their widths.
+     *
+     * @param okButtonText                OK button text, or null to use the default "OK" string.
+     * @param onOkClick                   Action for the OK button click.
+     * @param onCancelClick               Action for the Cancel button click, or null if no Cancel button.
+     * @param neutralButtonText           Neutral button text, or null if no Neutral button.
+     * @param onNeutralClick              Action for the Neutral button click, or null if no Neutral button.
+     * @param dismissDialogOnNeutralClick If the dialog should dismiss on Neutral button click.
+     */
+    private void addButtons(CharSequence okButtonText, Runnable onOkClick, Runnable onCancelClick,
+                            @Nullable CharSequence neutralButtonText, @Nullable Runnable onNeutralClick,
+                            boolean dismissDialogOnNeutralClick, boolean accentOkButton) {
+        // Button container.
+        LinearLayout buttonContainer = new LinearLayout(context);
+        buttonContainer.setOrientation(LinearLayout.VERTICAL);
+        LinearLayout.LayoutParams buttonContainerParams = new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT);
+        buttonContainerParams.setMargins(0, Dim.dp16, 0, 0);
+        buttonContainer.setLayoutParams(buttonContainerParams);
+
+        List<Button> buttons = new ArrayList<>();
+        List<Integer> buttonWidths = new ArrayList<>();
+
+        // Create buttons in order: Neutral, Cancel, OK.
+        if (neutralButtonText != null && onNeutralClick != null) {
+            Button neutralButton = createButton(context, dialog, neutralButtonText, onNeutralClick, false, dismissDialogOnNeutralClick);
+            buttons.add(neutralButton);
+            buttonWidths.add(measureButtonWidth(neutralButton));
+        }
+        if (onCancelClick != null) {
+            String localizedCancelString = ResourceUtils.getSystemStringByLocale("cancel",
+                    BaseSettings.MORPHE_LANGUAGE.get().getLocale());
+            Button cancelButton = createButton(context, dialog, localizedCancelString,
+                    onCancelClick, false, true);
+            buttons.add(cancelButton);
+            buttonWidths.add(measureButtonWidth(cancelButton));
+        }
+        if (onOkClick != null) {
+            CharSequence localizedOkString = okButtonText != null ? okButtonText
+                    : ResourceUtils.getSystemStringByLocale("ok",
+                    BaseSettings.MORPHE_LANGUAGE.get().getLocale());
+            Button okButton = createButton(context, dialog, localizedOkString,
+                    onOkClick, accentOkButton, true);
+            buttons.add(okButton);
+            buttonWidths.add(measureButtonWidth(okButton));
+        }
+
+        // Handle button layout.
+        layoutButtons(buttonContainer, buttons, buttonWidths);
+        mainLayout.addView(buttonContainer);
+    }
+
+    /**
+     * Creates a styled button for use inside a {@link CustomDialog} layout.
+     * Can be called externally to create additional buttons that match the dialog's visual style.
+     *
+     * @param context       Context used to create the button.
+     * @param dialog        The dialog to dismiss on click, or null if no dismissal is needed.
+     * @param text          The button text to display.
+     * @param onClick       The action to perform on button click, or null for no action.
+     * @param isOkButton    If true, uses the OK button style (accent background); otherwise uses the secondary style.
+     * @param dismissDialog If true, dismisses the dialog when the button is clicked.
+     * @return The created Button.
+     */
+    public static Button createButton(Context context, @Nullable Dialog dialog,
+                                      CharSequence text, @Nullable Runnable onClick,
+                                      boolean isOkButton, boolean dismissDialog) {
+        Button button = new Button(context, null, 0);
+        button.setText(text);
+        button.setTextSize(14);
+        button.setAllCaps(false);
+        button.setSingleLine(true);
+        button.setEllipsize(TextUtils.TruncateAt.END);
+        button.setGravity(Gravity.CENTER);
+        // Set internal padding.
+        button.setPadding(Dim.dp8, 0, Dim.dp8, 0);
+        // Clear theme-imposed minimum width so text is never clipped with ellipsis.
+        button.setMinWidth(0);
+        button.setMinimumWidth(0);
+
+        // Background color for OK button (inversion) and Cancel/Neutral buttons.
+        ShapeDrawable background = new ShapeDrawable(new RoundRectShape(
+                Dim.roundedCorners(20), null, null));
+        background.getPaint().setColor(isOkButton
+                ? ThemeUtils.getOkButtonBackgroundColor()
+                : ThemeUtils.getCancelOrNeutralButtonBackgroundColor());
+        button.setBackground(background);
+
+        button.setTextColor(Utils.isDarkModeEnabled()
+                ? (isOkButton ? Color.BLACK : Color.WHITE)
+                : (isOkButton ? Color.WHITE : Color.BLACK));
+
+        ViewAnimations.applyPressEffect(button);
+
+        button.setOnClickListener(v -> {
+            if (onClick != null) onClick.run();
+            if (dismissDialog && dialog != null) dialog.dismiss();
+        });
+
+        return button;
+    }
+
+    /**
+     * Returns the usable pixel width available for buttons inside the dialog.
+     * Dialog window = 90% of screen width; mainLayout horizontal padding = dp24 * 2.
+     */
+    private int buttonAreaWidth() {
+        return (int) (Dim.getScreenWidth() * 0.9f) - Dim.dp24 * 2;
+    }
+
+    /**
+     * Measures the intrinsic width of a button, capped at the available button area.
+     */
+    private int measureButtonWidth(Button button) {
+        int widthSpec = View.MeasureSpec.makeMeasureSpec(buttonAreaWidth(), View.MeasureSpec.AT_MOST);
+        int heightSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
+        button.measure(widthSpec, heightSpec);
+        return button.getMeasuredWidth();
+    }
+
+    /**
+     * Arranges buttons in the dialog, either in a single row or multiple rows based on their total width.
+     *
+     * @param buttonContainer The container for the buttons.
+     * @param buttons         The list of buttons to arrange.
+     * @param buttonWidths    The measured widths of the buttons.
+     */
+    private void layoutButtons(LinearLayout buttonContainer, List<Button> buttons, List<Integer> buttonWidths) {
+        if (buttons.isEmpty()) return;
+
+        // Check if buttons fit in one row.
+        int totalWidth = 0;
+        for (Integer width : buttonWidths) {
+            totalWidth += width;
+        }
+        if (buttonWidths.size() > 1) {
+            // Add margins for gaps.
+            totalWidth += (buttonWidths.size() - 1) * Dim.dp8;
+        }
+
+        // Single button: stretch to full width.
+        if (buttons.size() == 1) {
+            layoutSingleButton(buttonContainer, buttons.get(0));
+        } else if (totalWidth <= buttonAreaWidth()) {
+            // Single row: Neutral, Cancel, OK.
+            layoutButtonsInRow(buttonContainer, buttons, buttonWidths);
+        } else {
+            // Multiple rows: OK, Cancel, Neutral.
+            layoutButtonsInColumns(buttonContainer, buttons);
+        }
+    }
+
+    /**
+     * Arranges a single button, stretching it to full width.
+     *
+     * @param buttonContainer The container for the button.
+     * @param button          The button to arrange.
+     */
+    private void layoutSingleButton(LinearLayout buttonContainer, Button button) {
+        LinearLayout singleContainer = new LinearLayout(context);
+        singleContainer.setOrientation(LinearLayout.HORIZONTAL);
+        singleContainer.setGravity(Gravity.CENTER);
+
+        ViewGroup parent = (ViewGroup) button.getParent();
+        if (parent != null) parent.removeView(button);
+
+        button.setLayoutParams(new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                Dim.dp36));
+        singleContainer.addView(button);
+        buttonContainer.addView(singleContainer);
+    }
+
+    /**
+     * Arranges buttons in a single horizontal row with proportional widths.
+     *
+     * @param buttonContainer The container for the buttons.
+     * @param buttons         The list of buttons to arrange.
+     * @param buttonWidths    The measured widths of the buttons.
+     */
+    private void layoutButtonsInRow(LinearLayout buttonContainer, List<Button> buttons, List<Integer> buttonWidths) {
+        LinearLayout rowContainer = new LinearLayout(context);
+        rowContainer.setOrientation(LinearLayout.HORIZONTAL);
+        rowContainer.setGravity(Gravity.CENTER);
+        rowContainer.setLayoutParams(new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT));
+
+        // Add all buttons with proportional weights and specific margins.
+        for (int i = 0; i < buttons.size(); i++) {
+            Button button = getButton(buttons, buttonWidths, i);
+            rowContainer.addView(button);
+        }
+
+        buttonContainer.addView(rowContainer);
+    }
+
+    @NonNull
+    private Button getButton(List<Button> buttons, List<Integer> buttonWidths, int i) {
+        Button button = buttons.get(i);
+        ViewGroup parent = (ViewGroup) button.getParent();
+        if (parent != null) parent.removeView(button);
+
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                0, Dim.dp36, buttonWidths.get(i));
+
+        // Set margins based on button type and combination.
+        if (buttons.size() == 2) {
+            // Neutral + OK or Cancel + OK.
+            params.setMargins(i == 0 ? 0 : Dim.dp4, 0, i == 0 ? Dim.dp4 : 0, 0);
+        } else if (buttons.size() == 3) {
+            // Neutral.
+            // Cancel.
+            // OK.
+            params.setMargins(i == 0 ? 0 : Dim.dp4, 0, i == 2 ? 0 : Dim.dp4, 0);
+        }
+
+        button.setLayoutParams(params);
+        return button;
+    }
+
+    /**
+     * Arranges buttons in separate rows, ordered OK, Cancel, Neutral.
+     *
+     * @param buttonContainer The container for the buttons.
+     * @param buttons         The list of buttons to arrange.
+     */
+    private void layoutButtonsInColumns(LinearLayout buttonContainer, List<Button> buttons) {
+        // Reorder: OK, Cancel, Neutral.
+        List<Button> reorderedButtons = new ArrayList<>();
+        if (buttons.size() == 3) {
+            reorderedButtons.add(buttons.get(2)); // OK
+            reorderedButtons.add(buttons.get(1)); // Cancel
+            reorderedButtons.add(buttons.get(0)); // Neutral
+        } else if (buttons.size() == 2) {
+            reorderedButtons.add(buttons.get(1)); // OK or Cancel
+            reorderedButtons.add(buttons.get(0)); // Neutral or Cancel
+        }
+
+        for (int i = 0; i < reorderedButtons.size(); i++) {
+            Button button = reorderedButtons.get(i);
+            LinearLayout singleContainer = new LinearLayout(context);
+            singleContainer.setOrientation(LinearLayout.HORIZONTAL);
+            singleContainer.setGravity(Gravity.CENTER);
+            singleContainer.setLayoutParams(new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    Dim.dp36));
+
+            ViewGroup parent = (ViewGroup) button.getParent();
+            if (parent != null) parent.removeView(button);
+
+            button.setLayoutParams(new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    Dim.dp36));
+            singleContainer.addView(button);
+            buttonContainer.addView(singleContainer);
+
+            // Add a spacer between the buttons (except the last one).
+            if (i < reorderedButtons.size() - 1) {
+                View spacer = new View(context);
+                LinearLayout.LayoutParams spacerParams = new LinearLayout.LayoutParams(
+                        LinearLayout.LayoutParams.MATCH_PARENT,
+                        Dim.dp8);
+                spacer.setLayoutParams(spacerParams);
+                buttonContainer.addView(spacer);
+            }
+        }
+    }
+}

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/ui/SheetBottomDialog.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/ui/SheetBottomDialog.java
@@ -1,0 +1,440 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original first edition code:
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/584b00fd87f83504b8886e4f3f674f8c3943cd91
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/2e9d6959c94df7588b9e34b18770e9f437e91926
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/ece8076f7cefd752b97515014bc50fe4fd80171e
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/2b62fc2224c42da024fd64602346ff30613517c0
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/a426e2af5086367a2a1fee83abbbd2ea230bda06
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/584b00fd87f83504b8886e4f3f674f8c3943cd91
+ * https://gitlab.com/ReVanced/revanced-patches/-/commit/14a8f4fb96f5e2a4bc264a54115e0870b1a1ffa8
+ * https://github.com/MorpheApp/morphe-patches/commit/f5371ca998c019609c2b5558b3408ab1fec065c8
+ *
+ * See the included NOTICE file for §7(c) terms that apply to Morphe contributions.
+ */
+
+package app.morphe.extension.shared.ui;
+
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.annotation.SuppressLint;
+import android.app.Dialog;
+import android.content.Context;
+import android.graphics.drawable.ShapeDrawable;
+import android.graphics.drawable.shapes.RoundRectShape;
+import android.view.Gravity;
+import android.view.MotionEvent;
+import android.view.VelocityTracker;
+import android.view.View;
+import android.view.ViewConfiguration;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.animation.DecelerateInterpolator;
+import android.widget.LinearLayout;
+import android.widget.ListView;
+import android.widget.ScrollView;
+import android.widget.Scroller;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.theme.ThemeUtils;
+
+/**
+ * A utility class for creating a bottom sheet dialog that slides up from the bottom of the screen.
+ * The dialog supports drag-to-dismiss functionality, animations, and nested scrolling for scrollable content.
+ */
+@SuppressWarnings("unused")
+public class SheetBottomDialog {
+
+    /**
+     * Creates a {@link SlideDialog} that slides up from the bottom of the screen with a specified content view.
+     * The dialog supports drag-to-dismiss functionality, allowing the user to drag it downward to close it,
+     * with proper handling of nested scrolling for scrollable content (e.g., {@link ListView}).
+     * It includes side margins, a top spacer for drag interaction, and can be dismissed by touching outside.
+     *
+     * @param context           The context used to create the dialog.
+     * @param contentView       The {@link View} to be displayed inside the dialog, such as a {@link LinearLayout}
+     *                          containing a {@link ListView}, buttons, or other UI elements.
+     * @param animationDuration The duration of the slide-in and slide-out animations in milliseconds.
+     * @return A configured {@link SlideDialog} instance ready to be shown.
+     */
+    public static SlideDialog createSlideDialog(@NonNull Context context, @NonNull View contentView, int animationDuration) {
+        SlideDialog dialog = new SlideDialog(context);
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+        dialog.setCancelable(true);
+        dialog.setCanceledOnTouchOutside(true);
+
+        LinearLayout wrapperLayout = new LinearLayout(context);
+        wrapperLayout.setOrientation(LinearLayout.VERTICAL);
+
+        // Drag container.
+        DraggableLinearLayout dragContainer = new DraggableLinearLayout(context, animationDuration);
+        dragContainer.setOrientation(LinearLayout.VERTICAL);
+        dragContainer.setDialog(dialog);
+
+        // Top spacer - drag handle and tap-to-dismiss area above the sheet content.
+        View spacer = new View(context);
+        spacer.setLayoutParams(new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT, Dim.dp40));
+        spacer.setOnClickListener(v -> dialog.cancel());
+        dragContainer.addView(spacer);
+
+        // Content view.
+        ViewGroup parent = (ViewGroup) contentView.getParent();
+        if (parent != null) parent.removeView(contentView);
+        dragContainer.addView(contentView);
+
+        wrapperLayout.addView(dragContainer);
+        dialog.setContentView(wrapperLayout);
+
+        Window window = dialog.getWindow();
+        if (window != null) {
+            window.setWindowAnimations(0);
+            Utils.setDialogWindowParameters(window, Gravity.BOTTOM, 0, 100, false);
+        }
+
+        dialog.setAnimView(dragContainer);
+        dialog.setAnimationDuration(animationDuration);
+
+        return dialog;
+    }
+
+    /**
+     * Creates a {@link DraggableLinearLayout} with a rounded background and a centered handle bar,
+     * styled for use as the main layout in a {@link SlideDialog}. The layout has vertical orientation,
+     * includes padding, and supports drag-to-dismiss functionality with proper handling of nested scrolling
+     * for scrollable content (e.g., {@link ListView}) or clickable elements (e.g., buttons, {@link android.widget.SeekBar}).
+     *
+     * @param context         The context used to create the layout.
+     * @param backgroundColor The background color for the layout as an {@link Integer}, or null to use
+     *                        the default dialog background color.
+     * @return A configured {@link DraggableLinearLayout} with a handle bar and styled background.
+     */
+    public static DraggableLinearLayout createMainLayout(@NonNull Context context, @Nullable Integer backgroundColor) {
+        DraggableLinearLayout mainLayout = new DraggableLinearLayout(context);
+        mainLayout.setOrientation(LinearLayout.VERTICAL);
+        LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+        layoutParams.setMargins(Dim.dp8, 0, Dim.dp8, Dim.dp8);
+        mainLayout.setLayoutParams(layoutParams);
+
+        ShapeDrawable background = new ShapeDrawable(new RoundRectShape(
+                Dim.roundedCorners(12), null, null));
+        int color = (backgroundColor != null) ? backgroundColor : ThemeUtils.getDialogBackgroundColor();
+        background.getPaint().setColor(color);
+        mainLayout.setBackground(background);
+
+        // Add handle bar.
+        LinearLayout handleContainer = new LinearLayout(context);
+        LinearLayout.LayoutParams containerParams = new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+        containerParams.setMargins(0, Dim.dp8, 0, 0);
+        handleContainer.setLayoutParams(containerParams);
+        handleContainer.setGravity(Gravity.CENTER_HORIZONTAL | Gravity.BOTTOM);
+        View handleBar = new View(context);
+        ShapeDrawable handleBackground = new ShapeDrawable(new RoundRectShape(
+                Dim.roundedCorners(4), null, null));
+        handleBackground.getPaint().setColor(Utils.adjustColorBrightness(color, 0.9f, 1.25f));
+        LinearLayout.LayoutParams handleParams = new LinearLayout.LayoutParams(Dim.dp40, Dim.dp4);
+        handleBar.setLayoutParams(handleParams);
+        handleBar.setBackground(handleBackground);
+
+        handleContainer.addView(handleBar);
+        mainLayout.addView(handleContainer);
+
+        return mainLayout;
+    }
+
+    /**
+     * A custom {@link LinearLayout} that provides drag-to-dismiss functionality for a {@link SlideDialog}.
+     * This layout intercepts touch events to allow dragging the dialog downward to dismiss it when the
+     * content cannot scroll upward. It ensures compatibility with scrollable content (e.g., {@link ListView},
+     * {@link ScrollView}) and clickable elements (e.g., buttons, {@link android.widget.SeekBar}) by prioritizing
+     * their touch events to prevent conflicts.
+     *
+     * <p>Dragging is enabled only after the dialog's slide-in animation completes. The dialog is dismissed
+     * if dragged beyond 50% of its height or with a downward fling velocity exceeding 800 px/s.</p>
+     */
+    public static class DraggableLinearLayout extends LinearLayout {
+        private static final int MIN_FLING_VELOCITY = 800; // px/s
+        private static final float DISMISS_HEIGHT_FRACTION = 0.5f; // 50% of height.
+
+        private float initialTouchRawY; // Raw Y on ACTION_DOWN.
+        private float dragOffset; // Current drag translation.
+        private boolean isDragging;
+        private boolean isDragEnabled;
+
+        private final int animationDuration;
+        private final Scroller scroller;
+        private final VelocityTracker velocityTracker;
+        private final Runnable settleRunnable;
+
+        private SlideDialog dialog;
+        private float dismissThreshold;
+
+        /**
+         * Constructs a new {@link DraggableLinearLayout} with the specified context.
+         */
+        public DraggableLinearLayout(@NonNull Context context) {
+            this(context, 0);
+        }
+
+        /**
+         * Constructs a new {@link DraggableLinearLayout} with the specified context and animation duration.
+         *
+         * @param context      The context used to initialize the layout.
+         * @param animDuration The duration of the drag animation in milliseconds.
+         */
+        public DraggableLinearLayout(@NonNull Context context, int animDuration) {
+            super(context);
+            scroller = new Scroller(context, new DecelerateInterpolator());
+            velocityTracker = VelocityTracker.obtain();
+            animationDuration = animDuration;
+            settleRunnable = this::runSettleAnimation;
+
+            setClickable(true);
+
+            // Enable drag only after slide-in animation finishes.
+            isDragEnabled = false;
+            postDelayed(() -> isDragEnabled = true, animationDuration + 50);
+        }
+
+        /**
+         * Sets the {@link SlideDialog} associated with this layout for dismissal.
+         */
+        public void setDialog(@NonNull SlideDialog dialog) {
+            this.dialog = dialog;
+        }
+
+        /**
+         * Updates the dismissal threshold when the layout's size changes.
+         */
+        @Override
+        protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+            super.onSizeChanged(w, h, oldw, oldh);
+            dismissThreshold = h * DISMISS_HEIGHT_FRACTION;
+        }
+
+        /**
+         * Intercepts touch events to initiate dragging when the content cannot scroll upward and the
+         * touch movement exceeds the system's touch slop.
+         */
+        @Override
+        public boolean onInterceptTouchEvent(MotionEvent ev) {
+            if (!isDragEnabled) return false;
+
+            switch (ev.getActionMasked()) {
+                case MotionEvent.ACTION_DOWN:
+                    initialTouchRawY = ev.getRawY();
+                    isDragging = false;
+                    scroller.forceFinished(true);
+                    removeCallbacks(settleRunnable);
+                    velocityTracker.clear();
+                    velocityTracker.addMovement(ev);
+                    dragOffset = getTranslationY();
+                    break;
+
+                case MotionEvent.ACTION_MOVE:
+                    float dy = ev.getRawY() - initialTouchRawY;
+                    if (dy > ViewConfiguration.get(getContext()).getScaledTouchSlop()
+                            && !canChildScrollUp()) {
+                        isDragging = true;
+                        return true; // Intercept touches for drag.
+                    }
+                    break;
+            }
+            return false;
+        }
+
+        /**
+         * Handles touch events to perform dragging or trigger dismissal/return animations based on
+         * drag distance or fling velocity.
+         */
+        @SuppressLint("ClickableViewAccessibility")
+        @Override
+        public boolean onTouchEvent(MotionEvent ev) {
+            if (!isDragEnabled) return super.onTouchEvent(ev);
+            velocityTracker.addMovement(ev);
+
+            switch (ev.getActionMasked()) {
+                case MotionEvent.ACTION_MOVE:
+                    if (isDragging) {
+                        float deltaY = ev.getRawY() - initialTouchRawY;
+                        dragOffset = Math.max(0, deltaY); // Prevent upward drag.
+                        setTranslationY(dragOffset); // 1:1 following finger.
+                    }
+                    return true;
+
+                case MotionEvent.ACTION_UP:
+                case MotionEvent.ACTION_CANCEL:
+                    velocityTracker.computeCurrentVelocity(1000);
+                    float velocityY = velocityTracker.getYVelocity();
+
+                    if (dragOffset > dismissThreshold || velocityY > MIN_FLING_VELOCITY) {
+                        startDismissAnimation();
+                    } else {
+                        startReturnAnimation();
+                    }
+                    isDragging = false;
+                    return true;
+            }
+            // Consume the touch event to prevent focus changes on child views.
+            return true;
+        }
+
+        /**
+         * Starts an animation to dismiss the dialog by sliding it downward.
+         */
+        private void startDismissAnimation() {
+            scroller.startScroll(0, (int) dragOffset,
+                    0, getHeight() - (int) dragOffset, animationDuration);
+            post(settleRunnable);
+        }
+
+        /**
+         * Starts an animation to return the dialog to its original position.
+         */
+        private void startReturnAnimation() {
+            scroller.startScroll(0, (int) dragOffset,
+                    0, -(int) dragOffset, animationDuration);
+            post(settleRunnable);
+        }
+
+        /**
+         * Runs the settle animation, updating the layout's translation until the animation completes.
+         * Dismisses the dialog if the drag offset reaches the view's height.
+         */
+        private void runSettleAnimation() {
+            if (scroller.computeScrollOffset()) {
+                dragOffset = scroller.getCurrY();
+                setTranslationY(dragOffset);
+
+                if (dragOffset >= getHeight() && dialog != null) {
+                    dialog.dismiss();
+                    scroller.forceFinished(true);
+                } else {
+                    post(settleRunnable);
+                }
+            } else {
+                dragOffset = getTranslationY();
+            }
+        }
+
+        /**
+         * Checks if any child view can scroll upward, preventing drag if scrolling is possible.
+         *
+         * @return True if a child can scroll upward, false otherwise.
+         */
+        private boolean canChildScrollUp() {
+            View target = findScrollableChild(this);
+            return target != null && target.canScrollVertically(-1);
+        }
+
+        /**
+         * Recursively searches for a scrollable child view within the given view group.
+         *
+         * @param group The view group to search.
+         * @return The scrollable child view, or null if none found.
+         */
+        private View findScrollableChild(ViewGroup group) {
+            for (int i = 0; i < group.getChildCount(); i++) {
+                View child = group.getChildAt(i);
+                if (child.canScrollVertically(-1)) return child;
+                if (child instanceof ViewGroup) {
+                    View scroll = findScrollableChild((ViewGroup) child);
+                    if (scroll != null) return scroll;
+                }
+            }
+            return null;
+        }
+    }
+
+    /**
+     * A custom dialog that slides up from the bottom of the screen with animation. It supports
+     * drag-to-dismiss functionality and ensures smooth dismissal animations without overlapping
+     * dismiss calls. The dialog animates a specified view during show and dismiss operations.
+     */
+    public static class SlideDialog extends Dialog {
+        private View animView;
+        private boolean isDismissing = false;
+        private int duration;
+        private final int screenHeight;
+
+        /**
+         * Constructs a new {@link SlideDialog} with the specified context.
+         */
+        public SlideDialog(@NonNull Context context) {
+            super(context);
+            screenHeight = context.getResources().getDisplayMetrics().heightPixels;
+        }
+
+        /**
+         * Sets the view to animate during show and dismiss operations.
+         */
+        public void setAnimView(@NonNull View view) {
+            this.animView = view;
+        }
+
+        /**
+         * Sets the duration of the slide-in and slide-out animations.
+         */
+        public void setAnimationDuration(int duration) {
+            this.duration = duration;
+        }
+
+        /**
+         * Displays the dialog with a slide-up animation for the animated view.
+         */
+        @Override
+        public void show() {
+            super.show();
+            if (animView == null) return;
+            animView.setTranslationY(screenHeight);
+            animView.animate()
+                    .translationY(0)
+                    .setDuration(duration)
+                    .setListener(null)
+                    .start();
+        }
+
+        /**
+         * Cancels the dialog, triggering a dismissal animation.
+         */
+        @Override
+        public void cancel() {
+            super.cancel();
+        }
+
+        /**
+         * Dismisses the dialog by sliding the content downward.
+         * Ensures that dismissal is not triggered multiple times concurrently.
+         */
+        @Override
+        public void dismiss() {
+            if (isDismissing) return;
+            isDismissing = true;
+
+            if (animView == null) {
+                super.dismiss();
+                isDismissing = false;
+                return;
+            }
+
+            animView.animate()
+                    .translationY(screenHeight)
+                    .setDuration(duration)
+                    .setListener(new AnimatorListenerAdapter() {
+                        @Override
+                        public void onAnimationEnd(Animator animation) {
+                            SlideDialog.super.dismiss();
+                            isDismissing = false;
+                        }
+                    })
+                    .start();
+        }
+    }
+}

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
@@ -51,6 +51,7 @@ import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.patches.components.ContextInterface;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.shared.ui.SheetBottomDialog;
 import app.morphe.extension.shared.ui.ViewAnimations;
@@ -378,7 +379,7 @@ public class CustomPlaybackSpeedPatch {
             TextView currentSpeedText = new TextView(context);
             float currentSpeed = VideoInformation.getPlaybackSpeed();
             currentSpeedText.setText(VideoInformation.formatSpeedStringX(currentSpeed));
-            currentSpeedText.setTextColor(Utils.getAppForegroundColor());
+            currentSpeedText.setTextColor(ThemeUtils.getAppForegroundColor());
             currentSpeedText.setTextSize(16);
             currentSpeedText.setTypeface(Typeface.DEFAULT_BOLD);
             currentSpeedText.setGravity(Gravity.CENTER);
@@ -406,9 +407,9 @@ public class CustomPlaybackSpeedPatch {
             speedSlider.setMax(speedToProgressValue(customPlaybackSpeedsMax));
             speedSlider.setProgress(speedToProgressValue(currentSpeed));
             speedSlider.getProgressDrawable().setColorFilter(
-                    new PorterDuffColorFilter(Utils.getAppForegroundColor(), PorterDuff.Mode.SRC_IN)); // Theme progress bar.
+                    new PorterDuffColorFilter(ThemeUtils.getAppForegroundColor(), PorterDuff.Mode.SRC_IN)); // Theme progress bar.
             speedSlider.getThumb().setColorFilter(
-                    new PorterDuffColorFilter(Utils.getAppForegroundColor(), PorterDuff.Mode.SRC_IN)); // Theme slider thumb.
+                    new PorterDuffColorFilter(ThemeUtils.getAppForegroundColor(), PorterDuff.Mode.SRC_IN)); // Theme slider thumb.
             LinearLayout.LayoutParams sliderParams = new LinearLayout.LayoutParams(
                     0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f);
             speedSlider.setLayoutParams(sliderParams);
@@ -468,7 +469,7 @@ public class CustomPlaybackSpeedPatch {
                 // Create speed button.
                 Button speedButton = new Button(context, null, 0);
                 speedButton.setText(VideoInformation.formatSpeedStringX(speed, 1));
-                speedButton.setTextColor(Utils.getAppForegroundColor());
+                speedButton.setTextColor(ThemeUtils.getAppForegroundColor());
                 speedButton.setTextSize(12);
                 speedButton.setTypeface(Utils.appIsUsingBoldIcons()
                         ? Typeface.DEFAULT_BOLD
@@ -496,7 +497,7 @@ public class CustomPlaybackSpeedPatch {
                     TextView normalLabel = new TextView(context);
                     // Use same 'Normal' string as stock YouTube.
                     normalLabel.setText(str("normal_playback_rate_label"));
-                    normalLabel.setTextColor(Utils.getAppForegroundColor());
+                    normalLabel.setTextColor(ThemeUtils.getAppForegroundColor());
                     normalLabel.setTextSize(10);
                     normalLabel.setGravity(Gravity.CENTER);
                     normalLabel.setSingleLine(true);
@@ -570,7 +571,7 @@ public class CustomPlaybackSpeedPatch {
                 TextView currentPitchText = new TextView(context);
                 float currentPitch = VideoInformation.getPlaybackAudioPitch();
                 currentPitchText.setText(VideoInformation.formatAudioPitchStringX(currentPitch));
-                currentPitchText.setTextColor(Utils.getAppForegroundColor());
+                currentPitchText.setTextColor(ThemeUtils.getAppForegroundColor());
                 currentPitchText.setTextSize(16);
                 currentPitchText.setTypeface(Typeface.DEFAULT_BOLD);
                 currentPitchText.setGravity(Gravity.CENTER);
@@ -597,9 +598,9 @@ public class CustomPlaybackSpeedPatch {
                 pitchSlider.setMax(pitchToProgressValue(customPlaybackSpeedsMax));
                 pitchSlider.setProgress(pitchToProgressValue(currentPitch));
                 pitchSlider.getProgressDrawable().setColorFilter(
-                        new PorterDuffColorFilter(Utils.getAppForegroundColor(), PorterDuff.Mode.SRC_IN));
+                        new PorterDuffColorFilter(ThemeUtils.getAppForegroundColor(), PorterDuff.Mode.SRC_IN));
                 pitchSlider.getThumb().setColorFilter(
-                        new PorterDuffColorFilter(Utils.getAppForegroundColor(), PorterDuff.Mode.SRC_IN));
+                        new PorterDuffColorFilter(ThemeUtils.getAppForegroundColor(), PorterDuff.Mode.SRC_IN));
                 LinearLayout.LayoutParams pitchSliderParams = new LinearLayout.LayoutParams(
                         0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f);
                 pitchSlider.setLayoutParams(pitchSliderParams);
@@ -656,7 +657,7 @@ public class CustomPlaybackSpeedPatch {
 
                     Button pitchPresetButton = new Button(context, null, 0);
                     pitchPresetButton.setText(pitchLabel);
-                    pitchPresetButton.setTextColor(Utils.getAppForegroundColor());
+                    pitchPresetButton.setTextColor(ThemeUtils.getAppForegroundColor());
                     pitchPresetButton.setTextSize(12);
                     pitchPresetButton.setTypeface(Utils.appIsUsingBoldIcons()
                             ? Typeface.DEFAULT_BOLD
@@ -843,7 +844,7 @@ class OutlineSymbolDrawable extends Drawable {
     OutlineSymbolDrawable(boolean isPlus) {
         this.isPlus = isPlus;
         paint = new Paint(Paint.ANTI_ALIAS_FLAG); // Enable antialiasing for smooth rendering.
-        paint.setColor(Utils.getAppForegroundColor());
+        paint.setColor(ThemeUtils.getAppForegroundColor());
         paint.setStyle(Paint.Style.STROKE);
         paint.setStrokeCap(Paint.Cap.ROUND);
         paint.setStrokeWidth(Utils.appIsUsingBoldIcons() ? Dim.dp2 : Dim.dp1);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/theme/ThemePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/theme/ThemePatch.java
@@ -1,9 +1,16 @@
 package app.morphe.extension.youtube.patches.theme;
 
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
+import android.view.View;
+import android.view.ViewStub;
+import android.widget.TextView;
+
 import androidx.annotation.Nullable;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.theme.BaseThemePatch;
+import app.morphe.extension.shared.theme.ThemeBackgroundPatch;
 import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
@@ -67,6 +74,48 @@ public class ThemePatch extends BaseThemePatch {
      */
     public static int getValue(int originalValue) {
         return processColorValue(originalValue, DARK_VALUES, WHITE_VALUES);
+    }
+
+    /**
+     * Injection point.
+     * <p>
+     * Called with the view stub of a new content indicator of the pivot bar, which is the dot
+     * of a tab and the count next to it, before either is shown.
+     */
+    public static void onNewContentIndicator(ViewStub stub) {
+        try {
+            stub.setOnInflateListener((inflatedStub, view) -> {
+                Integer color = ThemeBackgroundPatch.getIndicatorColor(view.getContext());
+                if (color == null) {
+                    return;
+                }
+
+                setIndicatorColor(view, color);
+
+                // The pivot bar can set the background of an indicator after it is inflated,
+                // and the color is applied again after the app is done with the view.
+                view.post(() -> setIndicatorColor(view, color));
+            });
+        } catch (Exception ex) {
+            Logger.printException(() -> "onNewContentIndicator failure", ex);
+        }
+    }
+
+    private static void setIndicatorColor(View view, int color) {
+        Drawable background = view.getBackground();
+
+        // Both indicators are a shape with a stroke of the app background color, and only the
+        // fill of the shape is replaced. Mutate is needed, otherwise every user of the
+        // drawable is changed as well.
+        if (background instanceof GradientDrawable) {
+            ((GradientDrawable) background.mutate()).setColor(color);
+        }
+
+        // The count is a text view, and its text must stay readable on the new color.
+        if (view instanceof TextView) {
+            ((TextView) view).setTextColor(
+                    ThemeBackgroundPatch.getIndicatorTextColor(view.getContext()));
+        }
     }
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/theme/ThemePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/theme/ThemePatch.java
@@ -1,16 +1,10 @@
 package app.morphe.extension.youtube.patches.theme;
 
-import android.graphics.drawable.Drawable;
-import android.graphics.drawable.GradientDrawable;
-import android.view.View;
-import android.view.ViewStub;
-import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.theme.BaseThemePatch;
-import app.morphe.extension.shared.theme.ThemeBackgroundPatch;
 import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
@@ -74,48 +68,6 @@ public class ThemePatch extends BaseThemePatch {
      */
     public static int getValue(int originalValue) {
         return processColorValue(originalValue, DARK_VALUES, WHITE_VALUES);
-    }
-
-    /**
-     * Injection point.
-     * <p>
-     * Called with the view stub of a new content indicator of the pivot bar, which is the dot
-     * of a tab and the count next to it, before either is shown.
-     */
-    public static void onNewContentIndicator(ViewStub stub) {
-        try {
-            stub.setOnInflateListener((inflatedStub, view) -> {
-                Integer color = ThemeBackgroundPatch.getIndicatorColor(view.getContext());
-                if (color == null) {
-                    return;
-                }
-
-                setIndicatorColor(view, color);
-
-                // The pivot bar can set the background of an indicator after it is inflated,
-                // and the color is applied again after the app is done with the view.
-                view.post(() -> setIndicatorColor(view, color));
-            });
-        } catch (Exception ex) {
-            Logger.printException(() -> "onNewContentIndicator failure", ex);
-        }
-    }
-
-    private static void setIndicatorColor(View view, int color) {
-        Drawable background = view.getBackground();
-
-        // Both indicators are a shape with a stroke of the app background color, and only the
-        // fill of the shape is replaced. Mutate is needed, otherwise every user of the
-        // drawable is changed as well.
-        if (background instanceof GradientDrawable) {
-            ((GradientDrawable) background.mutate()).setColor(color);
-        }
-
-        // The count is a text view, and its text must stay readable on the new color.
-        if (view instanceof TextView) {
-            ((TextView) view).setTextColor(
-                    ThemeBackgroundPatch.getIndicatorTextColor(view.getContext()));
-        }
     }
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/theme/ThemePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/theme/ThemePatch.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2524
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.youtube.patches.theme;
 
 import androidx.annotation.ColorInt;

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/theme/ThemePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/theme/ThemePatch.java
@@ -1,6 +1,6 @@
 package app.morphe.extension.youtube.patches.theme;
 
-
+import androidx.annotation.ColorInt;
 import androidx.annotation.Nullable;
 
 import app.morphe.extension.shared.Logger;
@@ -66,7 +66,8 @@ public class ThemePatch extends BaseThemePatch {
      * @param originalValue The original color value.
      * @return The new or original color value.
      */
-    public static int getValue(int originalValue) {
+    @ColorInt
+    public static int getValue(@ColorInt int originalValue) {
         return processColorValue(originalValue, DARK_VALUES, WHITE_VALUES);
     }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
@@ -48,6 +48,7 @@ import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.patches.components.BufferAsciiStrings;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.youtube.patches.AddToQueuePatch;
 import app.morphe.extension.youtube.patches.VideoInformation;
@@ -419,7 +420,7 @@ public final class FlyoutUtils {
 
         if (icon != null) {
             final Drawable mutableIcon = icon.mutate();
-            mutableIcon.setTint(Utils.getAppForegroundColor());
+            mutableIcon.setTint(ThemeUtils.getAppForegroundColor());
             mutableIcon.setTintMode(PorterDuff.Mode.SRC_IN);
 
             final LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(
@@ -440,7 +441,7 @@ public final class FlyoutUtils {
         textView.setText(text);
         textView.setTextSize(16);
         textView.setTypeface(null, Typeface.BOLD);
-        textView.setTextColor(Utils.getAppForegroundColor());
+        textView.setTextColor(ThemeUtils.getAppForegroundColor());
 
         customButton.addView(textView);
         customButton.setOnClickListener(clickListener);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/PlaylistPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/PlaylistPatch.java
@@ -36,6 +36,7 @@ import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.innertube.utils.AuthUtils;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.shared.ui.SheetBottomDialog;
 import app.morphe.extension.youtube.patches.LoadVideoPatch;
@@ -177,7 +178,7 @@ public class PlaylistPatch {
 
         ImageView icon = new ImageView(context);
         icon.setImageResource(iconId);
-        icon.setColorFilter(Utils.getAppForegroundColor());
+        icon.setColorFilter(ThemeUtils.getAppForegroundColor());
         LinearLayout.LayoutParams iconParams = new LinearLayout.LayoutParams(Dim.dp24, Dim.dp24);
         iconParams.setMarginEnd(Dim.dp16);
         icon.setLayoutParams(iconParams);
@@ -185,7 +186,7 @@ public class PlaylistPatch {
 
         TextView text = new TextView(context);
         text.setText(title);
-        text.setTextColor(Utils.getAppForegroundColor());
+        text.setTextColor(ThemeUtils.getAppForegroundColor());
         text.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 16);
         LinearLayout.LayoutParams textParams = new LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/voiceovertranslation/VotBottomSheet.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/voiceovertranslation/VotBottomSheet.java
@@ -54,6 +54,7 @@ import app.morphe.extension.shared.settings.IntegerSetting;
 import app.morphe.extension.shared.settings.preference.CustomDialogListPreference;
 import app.morphe.extension.shared.settings.preference.SeekBarPreference;
 import app.morphe.extension.shared.settings.preference.SeekBarPreference.SeekBarConfig;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.CustomDialog;
 import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.shared.ui.SheetBottomDialog;
@@ -83,7 +84,7 @@ public final class VotBottomSheet {
         SheetBottomDialog.DraggableLinearLayout root = SheetBottomDialog
                 .createMainLayout(context, getDialogBackgroundColor());
 
-        final int fg = Utils.getAppForegroundColor();
+        final int fg = ThemeUtils.getAppForegroundColor();
 
         String[] langEntries = context.getResources().getStringArray(ResourceUtils
                 .getIdentifierOrThrow(ResourceType.ARRAY, "morphe_vot_caption_language_entries"));
@@ -229,7 +230,7 @@ public final class VotBottomSheet {
         SheetBottomDialog.DraggableLinearLayout pickerRoot =
                 SheetBottomDialog.createMainLayout(context, getDialogBackgroundColor());
         pickerRoot.setPadding(Dim.dp16, 0, Dim.dp16, Dim.dp16);
-        final int fg = Utils.getAppForegroundColor();
+        final int fg = ThemeUtils.getAppForegroundColor();
         pickerRoot.addView(makeTitle(context, str("morphe_vot_translation_service_title"), fg));
 
         LayoutInflater inflater = LayoutInflater.from(context);
@@ -339,7 +340,7 @@ public final class VotBottomSheet {
                 ? TTS_ENGINE_SYSTEM
                 : VoiceCatalog.resolve(lang, voiceId);
 
-        final int fg = Utils.getAppForegroundColor();
+        final int fg = ThemeUtils.getAppForegroundColor();
 
         SheetBottomDialog.DraggableLinearLayout pickerRoot =
                 SheetBottomDialog.createMainLayout(context, getDialogBackgroundColor());
@@ -545,7 +546,7 @@ public final class VotBottomSheet {
         SheetBottomDialog.DraggableLinearLayout pickerRoot =
                 SheetBottomDialog.createMainLayout(context, getDialogBackgroundColor());
         pickerRoot.setPadding(Dim.dp16, 0, Dim.dp16, Dim.dp16);
-        pickerRoot.addView(makeTitle(context, title, Utils.getAppForegroundColor()));
+        pickerRoot.addView(makeTitle(context, title, ThemeUtils.getAppForegroundColor()));
 
         ListView listView = new ListView(context);
         listView.setDivider(null);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/preference/SwipeZonePreference.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/preference/SwipeZonePreference.java
@@ -39,6 +39,7 @@ import app.morphe.extension.shared.settings.Setting;
 import app.morphe.extension.shared.settings.StringSetting;
 import app.morphe.extension.shared.settings.preference.CustomDialogListPreference;
 import app.morphe.extension.shared.settings.preference.SeekBarPreference;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.youtube.settings.Settings;
 import app.morphe.extension.youtube.swipecontrols.SwipeControlsConfigurationProvider.SwipeZoneAction;
@@ -289,10 +290,10 @@ public final class SwipeZonePreference extends Preference {
             this.onZoneClick = onZoneClick;
             setClickable(true);
 
-            fgColor = Utils.getAppForegroundColor();
+            fgColor = ThemeUtils.getAppForegroundColor();
             final int separatorColor = withAlpha(fgColor, SEPARATOR_ALPHA);
 
-            final int bgColor = Utils.getAppBackgroundColor();
+            final int bgColor = ThemeUtils.getAppBackgroundColor();
             screenBgColor  = bgColor;
             edgeBgColor    = Utils.adjustColorBrightness(bgColor, Utils.isDarkModeEnabled() ? 0.90f : 0.97f);
             dimTextColor   = withAlpha(fgColor, DIM_TEXT_ALPHA);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/preference/VoiceOverTranslationModelPreference.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/preference/VoiceOverTranslationModelPreference.java
@@ -36,6 +36,7 @@ import java.util.function.Function;
 
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.preference.CustomDialogListPreference;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.CustomDialog;
 import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.youtube.patches.voiceovertranslation.VoiceOverTranslationPatch;
@@ -101,7 +102,7 @@ public class VoiceOverTranslationModelPreference extends CustomDialogListPrefere
         String currentModel = Settings.VOT_OPENROUTER_MODEL.get();
         final boolean isCustom = !isPreset(currentModel);
 
-        final int fg = Utils.getAppForegroundColor();
+        final int fg = ThemeUtils.getAppForegroundColor();
         final int secondaryFg = Color.argb(153, Color.red(fg), Color.green(fg), Color.blue(fg));
         final int checkmarkRes = Utils.appIsUsingBoldIcons() ? DRAWABLE_CHECKMARK_BOLD : DRAWABLE_CHECKMARK;
         LayoutInflater inflater = LayoutInflater.from(context);
@@ -267,7 +268,7 @@ public class VoiceOverTranslationModelPreference extends CustomDialogListPrefere
 
         ShapeDrawable background = new ShapeDrawable(new RoundRectShape(
                 Dim.roundedCorners(10), null, null));
-        background.getPaint().setColor(Utils.getEditTextBackground());
+        background.getPaint().setColor(ThemeUtils.getEditTextBackground());
         editText.setPadding(Dim.dp8, Dim.dp8, Dim.dp8, Dim.dp8);
         editText.setBackground(background);
         editText.setClipToOutline(true);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/SponsorBlockUtils.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/sponsorblock/SponsorBlockUtils.java
@@ -2,6 +2,9 @@
  * Copyright 2026 Morphe.
  * https://github.com/MorpheApp/morphe-patches
  *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
  */
 
@@ -44,6 +47,7 @@ import java.util.regex.Pattern;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.CustomDialog;
 import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.shared.ui.SheetBottomDialog;
@@ -548,7 +552,7 @@ public class SponsorBlockUtils {
             titleView.setText(str("morphe_sb_channel_whitelist_title"));
             titleView.setTextSize(18);
             titleView.setTypeface(Typeface.DEFAULT_BOLD);
-            titleView.setTextColor(Utils.getAppForegroundColor());
+            titleView.setTextColor(ThemeUtils.getAppForegroundColor());
             titleView.setGravity(Gravity.CENTER_HORIZONTAL);
             LinearLayout.LayoutParams titleParams = new LinearLayout.LayoutParams(
                     LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
@@ -581,7 +585,7 @@ public class SponsorBlockUtils {
             TextView sectionLabel = new TextView(context);
             sectionLabel.setText(str("morphe_sb_channel_whitelist_current_channel"));
             sectionLabel.setTextSize(13);
-            sectionLabel.setTextColor(Utils.getAppForegroundColor());
+            sectionLabel.setTextColor(ThemeUtils.getAppForegroundColor());
             sectionLabel.setAlpha(0.7f);
             LinearLayout.LayoutParams labelParams = new LinearLayout.LayoutParams(
                     LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
@@ -600,7 +604,7 @@ public class SponsorBlockUtils {
             TextView channelIdText = new TextView(context);
             channelIdText.setText(currentDisplayName);
             channelIdText.setTextSize(14);
-            channelIdText.setTextColor(Utils.getAppForegroundColor());
+            channelIdText.setTextColor(ThemeUtils.getAppForegroundColor());
             channelIdText.setLayoutParams(new LinearLayout.LayoutParams(
                     0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f));
             channelIdText.setEllipsize(TextUtils.TruncateAt.END);
@@ -644,7 +648,7 @@ public class SponsorBlockUtils {
         TextView channelsHeader = new TextView(context);
         channelsHeader.setText(str("morphe_sb_channel_whitelist_channels_header"));
         channelsHeader.setTextSize(13);
-        channelsHeader.setTextColor(Utils.getAppForegroundColor());
+        channelsHeader.setTextColor(ThemeUtils.getAppForegroundColor());
         channelsHeader.setAlpha(0.7f);
         LinearLayout.LayoutParams headerParams = new LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
@@ -658,7 +662,7 @@ public class SponsorBlockUtils {
             TextView emptyView = new TextView(context);
             emptyView.setText(str("morphe_sb_channel_whitelist_empty"));
             emptyView.setTextSize(14);
-            emptyView.setTextColor(Utils.getAppForegroundColor());
+            emptyView.setTextColor(ThemeUtils.getAppForegroundColor());
             emptyView.setAlpha(0.5f);
             emptyView.setGravity(Gravity.CENTER_HORIZONTAL);
             LinearLayout.LayoutParams emptyParams = new LinearLayout.LayoutParams(
@@ -701,7 +705,7 @@ public class SponsorBlockUtils {
         TextView idText = new TextView(context);
         idText.setText(displayName);
         idText.setTextSize(14);
-        idText.setTextColor(Utils.getAppForegroundColor());
+        idText.setTextColor(ThemeUtils.getAppForegroundColor());
         idText.setLayoutParams(new LinearLayout.LayoutParams(
                 0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f));
         idText.setEllipsize(TextUtils.TruncateAt.END);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LoopVideoButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/LoopVideoButton.java
@@ -34,6 +34,7 @@ import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.CustomDialog;
 import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch;
@@ -321,7 +322,7 @@ public class LoopVideoButton {
         // Override the DigitsKeyListener that TYPE_CLASS_NUMBER installs — it strips ':',
         // which breaks the TextWatcher colon auto-insertion.
         editText.setKeyListener(android.text.method.DigitsKeyListener.getInstance("0123456789:"));
-        editText.setTextColor(Utils.getAppForegroundColor());
+        editText.setTextColor(ThemeUtils.getAppForegroundColor());
         editText.setHintTextColor(Color.GRAY);
         editText.setBackgroundColor(Color.TRANSPARENT);
         editText.setPadding(0, 0, 0, 0);
@@ -393,7 +394,7 @@ public class LoopVideoButton {
         TextView labelView = new TextView(context);
         labelView.setText(label);
         labelView.setTextSize(13);
-        labelView.setTextColor(Utils.getAppForegroundColor());
+        labelView.setTextColor(ThemeUtils.getAppForegroundColor());
         LinearLayout.LayoutParams labelParams = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -402,7 +403,7 @@ public class LoopVideoButton {
 
         ShapeDrawable fieldBackground = new ShapeDrawable(new RoundRectShape(
                 Dim.roundedCorners(10), null, null));
-        fieldBackground.getPaint().setColor(Utils.getEditTextBackground());
+        fieldBackground.getPaint().setColor(ThemeUtils.getEditTextBackground());
 
         LinearLayout fieldBox = new LinearLayout(context);
         fieldBox.setBackground(fieldBackground);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/VideoQualityDialogButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/VideoQualityDialogButton.java
@@ -42,6 +42,7 @@ import java.util.List;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.shared.ui.SheetBottomDialog;
 import app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch;
@@ -254,7 +255,7 @@ public class VideoQualityDialogButton {
             // Append title part with default foreground color.
             spannableTitle.append(titlePart);
             spannableTitle.setSpan(
-                    new ForegroundColorSpan(Utils.getAppForegroundColor()),
+                    new ForegroundColorSpan(ThemeUtils.getAppForegroundColor()),
                     0,
                     titlePart.length(),
                     Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
@@ -265,7 +266,7 @@ public class VideoQualityDialogButton {
             int separatorStart = spannableTitle.length();
             spannableTitle.append(separatorPart);
             final int adjustedTitleForegroundColor = Utils.adjustColorBrightness(
-                    Utils.getAppForegroundColor(), 1.6f, 0.6f);
+                    ThemeUtils.getAppForegroundColor(), 1.6f, 0.6f);
             spannableTitle.setSpan(
                     new ForegroundColorSpan(adjustedTitleForegroundColor),
                     separatorStart,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 [versions]
 morphe-patcher = "1.8.0"
-morphe-patches-library = "1.6.1-dev.6"
+morphe-patches-library = "1.6.1-dev.8"
 # Tracking https://github.com/google/smali/issues/100.
 smali = "d92701d947"
 agp = "9.1.0"

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/Fingerprints.kt
@@ -1,0 +1,33 @@
+package app.morphe.patches.music.layout.theme
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation.MatchAfterImmediately
+import app.morphe.patcher.InstructionLocation.MatchAfterWithin
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.opcode
+import app.morphe.patches.all.misc.resources.ResourceType
+import app.morphe.patches.all.misc.resources.resourceLiteral
+import com.android.tools.smali.dexlib2.Opcode
+
+/**
+ * The top bar creates the view stub of the new content count, which is the number
+ * next to the notification icon.
+ */
+internal object TopBarNewContentCountFingerprint : Fingerprint(
+    filters = listOf(
+        resourceLiteral(ResourceType.ID, "new_content_count"),
+        // The app calls this on a view group and not on a view, so only the name is matched.
+        methodCall(
+            name = "findViewById",
+            location = MatchAfterImmediately()
+        ),
+        opcode(
+            opcode = Opcode.CHECK_CAST,
+            location = MatchAfterWithin(3)
+        ),
+        methodCall(
+            smali = "Landroid/view/ViewStub;->inflate()Landroid/view/View;",
+            location = MatchAfterWithin(8)
+        )
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/ThemePatch.kt
@@ -58,7 +58,10 @@ val themePatch = baseThemePatch(
     executeBlock = {
         PreferenceScreen.GENERAL.addPreferences(
             noTitleUnsortedPreferenceCategory(
-                ListPreference("morphe_theme_background_dark"),
+                ListPreference(
+                    "morphe_theme_background_dark",
+                    tag = "app.morphe.extension.shared.theme.ThemeBackgroundListPreference"
+                ),
                 TextPreference(
                     "morphe_theme_background_dark_custom_color",
                     tag = "app.morphe.extension.shared.settings.preference.ColorPickerPreference",

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/ThemePatch.kt
@@ -1,12 +1,25 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2524
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.patches.music.layout.theme
 
 import app.morphe.patches.music.misc.extension.sharedExtensionPatch
 import app.morphe.patches.music.misc.playservice.is_9_30_or_greater
 import app.morphe.patches.music.misc.playservice.versionCheckPatch
+import app.morphe.patches.music.misc.settings.PreferenceScreen
+import app.morphe.patches.music.misc.settings.settingsPatch
 import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
 import app.morphe.patches.shared.layout.theme.THEME_DEFAULT_DARK_COLOR_NAMES
 import app.morphe.patches.shared.layout.theme.baseThemePatch
 import app.morphe.patches.shared.layout.theme.baseThemeResourcePatch
+import app.morphe.patches.shared.misc.settings.preference.ListPreference
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/music/patches/theme/ThemePatch;"
 
@@ -19,6 +32,7 @@ val themePatch = baseThemePatch(
     block = {
         dependsOn(
             sharedExtensionPatch,
+            settingsPatch,
             versionCheckPatch,
             baseThemeResourcePatch(
                 darkColorNames = {
@@ -33,5 +47,11 @@ val themePatch = baseThemePatch(
         )
 
         compatibleWith(COMPATIBILITY_YOUTUBE_MUSIC)
+    },
+
+    executeBlock = {
+        PreferenceScreen.GENERAL.addPreferences(
+            ListPreference("morphe_theme_background_dark")
+        )
     }
 )

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/ThemePatch.kt
@@ -10,12 +10,16 @@
 
 package app.morphe.patches.music.layout.theme
 
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.patches.music.misc.extension.sharedExtensionPatch
 import app.morphe.patches.music.misc.playservice.is_9_30_or_greater
 import app.morphe.patches.music.misc.playservice.versionCheckPatch
 import app.morphe.patches.music.misc.settings.PreferenceScreen
 import app.morphe.patches.music.misc.settings.settingsPatch
 import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
+import app.morphe.patches.shared.layout.theme.THEME_BACKGROUND_EXTENSION_CLASS
 import app.morphe.patches.shared.layout.theme.THEME_DEFAULT_DARK_COLOR_NAMES
 import app.morphe.patches.shared.layout.theme.baseThemePatch
 import app.morphe.patches.shared.layout.theme.baseThemeResourcePatch
@@ -23,6 +27,7 @@ import app.morphe.patches.shared.misc.settings.preference.InputType
 import app.morphe.patches.shared.misc.settings.preference.ListPreference
 import app.morphe.patches.shared.misc.settings.preference.TextPreference
 import app.morphe.patches.shared.misc.settings.preference.noTitleUnsortedPreferenceCategory
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/music/patches/theme/ThemePatch;"
 
@@ -46,6 +51,7 @@ val themePatch = baseThemePatch(
         dependsOn(
             sharedExtensionPatch,
             settingsPatch,
+            resourceMappingPatch,
             versionCheckPatch,
             baseThemeResourcePatch(
                 darkColorNames = darkColorNames
@@ -56,6 +62,22 @@ val themePatch = baseThemePatch(
     },
 
     executeBlock = {
+        // Color of the new content count of the top bar, which is red in the app and does
+        // not go with a Material You background.
+        TopBarNewContentCountFingerprint.let {
+            it.method.apply {
+                // Not the last match, which is the call that inflates the stub.
+                val checkCastIndex = it.instructionMatches[2].index
+                val stubRegister = getInstruction<OneRegisterInstruction>(checkCastIndex).registerA
+
+                addInstruction(
+                    checkCastIndex + 1,
+                    "invoke-static { v$stubRegister }, $THEME_BACKGROUND_EXTENSION_CLASS" +
+                            "->onNewContentIndicator(Landroid/view/ViewStub;)V"
+                )
+            }
+        }
+
         PreferenceScreen.GENERAL.addPreferences(
             noTitleUnsortedPreferenceCategory(
                 ListPreference(

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/ThemePatch.kt
@@ -19,13 +19,26 @@ import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
 import app.morphe.patches.shared.layout.theme.THEME_DEFAULT_DARK_COLOR_NAMES
 import app.morphe.patches.shared.layout.theme.baseThemePatch
 import app.morphe.patches.shared.layout.theme.baseThemeResourcePatch
+import app.morphe.patches.shared.misc.settings.preference.InputType
 import app.morphe.patches.shared.misc.settings.preference.ListPreference
+import app.morphe.patches.shared.misc.settings.preference.TextPreference
+import app.morphe.patches.shared.misc.settings.preference.noTitleUnsortedPreferenceCategory
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/music/patches/theme/ThemePatch;"
+
+private val darkColorNames = {
+    THEME_DEFAULT_DARK_COLOR_NAMES + setOf(
+        "yt_black_pure",
+        "yt_black_pure_opacity80",
+        "ytm_color_grey_12",
+        "material_grey_800"
+    )
+}
 
 @Suppress("unused")
 val themePatch = baseThemePatch(
     extensionClassDescriptor = EXTENSION_CLASS,
+    darkColorNames = darkColorNames,
     useModernLithoColorHook = {
         is_9_30_or_greater
     },
@@ -35,14 +48,7 @@ val themePatch = baseThemePatch(
             settingsPatch,
             versionCheckPatch,
             baseThemeResourcePatch(
-                darkColorNames = {
-                    THEME_DEFAULT_DARK_COLOR_NAMES + setOf(
-                        "yt_black_pure",
-                        "yt_black_pure_opacity80",
-                        "ytm_color_grey_12",
-                        "material_grey_800"
-                    )
-                }
+                darkColorNames = darkColorNames
             )
         )
 
@@ -51,7 +57,14 @@ val themePatch = baseThemePatch(
 
     executeBlock = {
         PreferenceScreen.GENERAL.addPreferences(
-            ListPreference("morphe_theme_background_dark")
+            noTitleUnsortedPreferenceCategory(
+                ListPreference("morphe_theme_background_dark"),
+                TextPreference(
+                    "morphe_theme_background_dark_custom_color",
+                    tag = "app.morphe.extension.shared.settings.preference.ColorPickerPreference",
+                    inputType = InputType.TEXT_CAP_CHARACTERS
+                )
+            )
         )
     }
 )

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/ThemePatch.kt
@@ -19,8 +19,8 @@ import app.morphe.patches.music.misc.playservice.versionCheckPatch
 import app.morphe.patches.music.misc.settings.PreferenceScreen
 import app.morphe.patches.music.misc.settings.settingsPatch
 import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
-import app.morphe.patches.shared.layout.theme.THEME_BACKGROUND_EXTENSION_CLASS
-import app.morphe.patches.shared.layout.theme.THEME_DEFAULT_DARK_COLOR_NAMES
+import app.morphe.patches.shared.layout.theme.THEME_COLOR_EXTENSION_CLASS
+import app.morphe.patches.shared.layout.theme.THEME_DEFAULT_COLOR_NAMES_DARK
 import app.morphe.patches.shared.layout.theme.baseThemePatch
 import app.morphe.patches.shared.layout.theme.baseThemeResourcePatch
 import app.morphe.patches.shared.misc.settings.preference.InputType
@@ -31,8 +31,8 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/music/patches/theme/ThemePatch;"
 
-private val darkColorNames = {
-    THEME_DEFAULT_DARK_COLOR_NAMES + setOf(
+private val musicColorNamesDark = {
+    THEME_DEFAULT_COLOR_NAMES_DARK + setOf(
         "yt_black_pure",
         "yt_black_pure_opacity80",
         "ytm_color_grey_12",
@@ -43,7 +43,7 @@ private val darkColorNames = {
 @Suppress("unused")
 val themePatch = baseThemePatch(
     extensionClassDescriptor = EXTENSION_CLASS,
-    darkColorNames = darkColorNames,
+    colorNamesDark = musicColorNamesDark,
     useModernLithoColorHook = {
         is_9_30_or_greater
     },
@@ -54,7 +54,7 @@ val themePatch = baseThemePatch(
             resourceMappingPatch,
             versionCheckPatch,
             baseThemeResourcePatch(
-                darkColorNames = darkColorNames
+                colorNamesDark = musicColorNamesDark
             )
         )
 
@@ -72,7 +72,7 @@ val themePatch = baseThemePatch(
 
                 addInstruction(
                     checkCastIndex + 1,
-                    "invoke-static { v$stubRegister }, $THEME_BACKGROUND_EXTENSION_CLASS" +
+                    "invoke-static { v$stubRegister }, $THEME_COLOR_EXTENSION_CLASS" +
                             "->onNewContentIndicator(Landroid/view/ViewStub;)V"
                 )
             }
@@ -82,7 +82,7 @@ val themePatch = baseThemePatch(
             noTitleUnsortedPreferenceCategory(
                 ListPreference(
                     "morphe_theme_background_dark",
-                    tag = "app.morphe.extension.shared.theme.ThemeBackgroundListPreference"
+                    tag = "app.morphe.extension.shared.theme.ThemeColorListPreference"
                 ),
                 TextPreference(
                     "morphe_theme_background_dark_custom_color",

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -10,6 +10,7 @@
 
 package app.morphe.patches.shared.layout.theme
 
+import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.BytecodePatchBuilder
 import app.morphe.patcher.patch.BytecodePatchContext
@@ -19,8 +20,8 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.shared.misc.settings.overrideThemeColors
 import app.morphe.util.asSequence
-import app.morphe.util.findMutableMethodOf
 import app.morphe.util.returnEarly
+import com.android.tools.smali.dexlib2.AccessFlags
 import org.w3c.dom.Element
 
 internal const val THEME_BACKGROUND_EXTENSION_CLASS =
@@ -117,31 +118,20 @@ internal val THEME_DEFAULT_LIGHT_COLOR_NAMES = setOf(
  */
 private val themeBackgroundContextHookPatch = bytecodePatch {
     execute {
-        var hookedContexts = 0
-
-        classDefForEach { classDef ->
-            val mutableClass by lazy { mutableClassDefBy(classDef) }
-
-            classDef.methods.forEach { method ->
-                if (method.name != "attachBaseContext" ||
-                    method.implementation == null ||
-                    method.parameterTypes.singleOrNull()?.toString() != "Landroid/content/Context;"
-                ) return@forEach
-
-                mutableClass.findMutableMethodOf(method).addInstructions(
-                    0,
-                    """
-                        invoke-static { p1 }, $THEME_BACKGROUND_EXTENSION_CLASS->wrapContext(Landroid/content/Context;)Landroid/content/Context;
-                        move-result-object p1
-                    """
-                )
-
-                hookedContexts++
+        Fingerprint(
+            name = "attachBaseContext",
+            parameters = listOf("Landroid/content/Context;"),
+            custom = { method, _ ->
+                !AccessFlags.STATIC.isSet(method.accessFlags)
             }
-        }
-
-        if (hookedContexts == 0) {
-            throw PatchException("Could not find a context to hook")
+        ).matchAll().forEach {
+            it.method.addInstructions(
+                0,
+                """
+                    invoke-static { p1 }, $THEME_BACKGROUND_EXTENSION_CLASS->wrapContext(Landroid/content/Context;)Landroid/content/Context;
+                    move-result-object p1
+                """
+            )
         }
     }
 }
@@ -159,8 +149,7 @@ internal fun baseThemePatch(
     executeBlock: BytecodePatchContext.() -> Unit = {}
 ) = bytecodePatch(
     name = "Theme",
-    description = "Adds options for theming, and adds a setting to change the app background " +
-            "color (defaults to pure black).",
+    description = "Adds options for theming, and adds a setting to change the app background color.",
 ) {
     block()
 

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -213,9 +213,11 @@ internal fun baseThemeResourcePatch(
 ) = resourcePatch {
     execute {
         addBackgroundColorVariants("mcc", THEME_DARK_BACKGROUNDS, darkColorNames())
+        add9BitColorVariants("mcc", darkColorNames())
 
         if (includeLightBackground) {
             addBackgroundColorVariants("mnc", THEME_LIGHT_BACKGROUNDS, lightColorNames())
+            add9BitColorVariants("mnc", lightColorNames())
         }
 
         declareOverlayableColors(
@@ -281,8 +283,6 @@ private fun ResourcePatchContext.addBackgroundColorVariants(
         throw PatchException("No color to replace for the app background")
     }
 
-    val resourceDirectory = get("res")
-
     backgrounds.forEachIndexed { index, color ->
         // The app default has no variant of its own.
         if (color == null) return@forEachIndexed
@@ -290,18 +290,46 @@ private fun ResourcePatchContext.addBackgroundColorVariants(
         // The configuration value of a background is its index plus one,
         // and the extension uses the same numbering.
         val variantValue = "%03d".format(index + 1)
-        val variantDirectory = resourceDirectory.resolve("values-$qualifier$variantValue")
-        variantDirectory.mkdirs()
-
-        variantDirectory.resolve("colors.xml").writeText(
-            buildString {
-                appendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>")
-                appendLine("<resources>")
-                colorNames.forEach { name ->
-                    appendLine("    <color name=\"$name\">$color</color>")
-                }
-                appendLine("</resources>")
-            }
-        )
+        writeBackgroundColorVariant(qualifier, variantValue, color, colorNames)
     }
+}
+
+private fun ResourcePatchContext.add9BitColorVariants(
+    qualifier: String,
+    colorNames: Set<String>
+) {
+    for (index in 0 until 512) {
+        val r3 = (index shr 6) and 0x7
+        val g3 = (index shr 3) and 0x7
+        val b3 = index and 0x7
+
+        val r = Math.round(r3 * 255f / 7f)
+        val g = Math.round(g3 * 255f / 7f)
+        val b = Math.round(b3 * 255f / 7f)
+
+        val color = "#%02X%02X%02X".format(r, g, b)
+        val variantValue = "%03d".format(100 + index)
+        writeBackgroundColorVariant(qualifier, variantValue, color, colorNames)
+    }
+}
+
+private fun ResourcePatchContext.writeBackgroundColorVariant(
+    qualifier: String,
+    variantValue: String,
+    color: String,
+    colorNames: Set<String>
+) {
+    val variantDirectory = get("res").resolve("values-$qualifier$variantValue")
+    variantDirectory.mkdirs()
+
+    variantDirectory.resolve("colors.xml").writeText(
+        buildString {
+            appendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>")
+            appendLine("<resources>")
+            colorNames.forEach { name ->
+                appendLine("    <color name=\"$name\">$color</color>")
+            }
+            appendLine("</resources>")
+        }
+    )
 }

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -18,10 +18,18 @@ import app.morphe.patcher.patch.ResourcePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.shared.misc.settings.overrideThemeColors
+import app.morphe.util.asSequence
 import app.morphe.util.findMutableMethodOf
+import app.morphe.util.returnEarly
+import org.w3c.dom.Element
 
-private const val THEME_BACKGROUND_EXTENSION_CLASS =
+internal const val THEME_BACKGROUND_EXTENSION_CLASS =
     "Lapp/morphe/extension/shared/theme/ThemeBackgroundPatch;"
+
+/**
+ * Must be identical to the name the extension uses with `FabricatedOverlay#setTargetOverlayable`.
+ */
+private const val THEME_BACKGROUND_OVERLAYABLE_NAME = "MorpheThemeBackground"
 
 /**
  * Background colors that can be selected in the app settings.
@@ -49,6 +57,7 @@ private val THEME_DARK_BACKGROUNDS = listOf(
     "#282900",                              // DARK_YELLOW
     "#291800",                              // DARK_ORANGE
     "#290000",                              // DARK_RED
+    null,                                   // CUSTOM
 )
 
 /**
@@ -70,6 +79,7 @@ private val THEME_LIGHT_BACKGROUNDS = listOf(
     "#FDFFCC",                              // LIGHT_YELLOW
     "#FFE6CC",                              // LIGHT_ORANGE
     "#FFD6D6",                              // LIGHT_RED
+    null,                                   // CUSTOM
 )
 
 /**
@@ -142,6 +152,8 @@ private val themeBackgroundContextHookPatch = bytecodePatch {
 internal fun baseThemePatch(
     extensionClassDescriptor: String,
     includeLightBackground: Boolean = false,
+    darkColorNames: (() -> Set<String>) = { THEME_DEFAULT_DARK_COLOR_NAMES },
+    lightColorNames: (() -> Set<String>) = { THEME_DEFAULT_LIGHT_COLOR_NAMES },
     useModernLithoColorHook: BytecodePatchBuilder.() -> Boolean,
     block: BytecodePatchBuilder.() -> Unit,
     executeBlock: BytecodePatchContext.() -> Unit = {}
@@ -165,6 +177,13 @@ internal fun baseThemePatch(
             APP_DARK_BACKGROUND_COLOR_NAME
         )
 
+        // A custom background color has no resource variant to select,
+        // so the extension replaces the same colors with an overlay of the app.
+        DarkColorResourceNamesFingerprint.method.returnEarly(darkColorNames().joinToString(","))
+        if (includeLightBackground) {
+            LightColorResourceNamesFingerprint.method.returnEarly(lightColorNames().joinToString(","))
+        }
+
         executeBlock()
 
         lithoColorOverrideHook(extensionClassDescriptor, "getValue")
@@ -187,6 +206,58 @@ internal fun baseThemeResourcePatch(
         if (includeLightBackground) {
             addBackgroundColorVariants("mnc", THEME_LIGHT_BACKGROUNDS, lightColorNames())
         }
+
+        declareOverlayableColors(
+            if (includeLightBackground) darkColorNames() + lightColorNames() else darkColorNames()
+        )
+    }
+}
+
+/**
+ * Declares the background colors as overlayable, which an overlay the app registers for itself
+ * requires. Without this the system rejects the overlay of a custom background color.
+ */
+private fun ResourcePatchContext.declareOverlayableColors(colorNames: Set<String>) {
+    // A policy item is resolved while encoding, so a color that this app version
+    // does not have must not be declared.
+    val declaredColors = mutableSetOf<String>()
+    document("res/values/colors.xml").use { document ->
+        (document.getElementsByTagName("resources").item(0) as Element)
+            .childNodes.asSequence()
+            .filterIsInstance<Element>()
+            .forEach { declaredColors += it.getAttribute("name") }
+    }
+
+    val overlayableColors = colorNames.filter { it in declaredColors }
+    if (overlayableColors.isEmpty()) {
+        throw PatchException("Could not find any background color to declare as overlayable")
+    }
+
+    val overlayable = buildString {
+        appendLine("    <overlayable name=\"$THEME_BACKGROUND_OVERLAYABLE_NAME\">")
+        appendLine("        <policy type=\"public\">")
+        overlayableColors.forEach { name ->
+            appendLine("            <item type=\"color\" name=\"$name\" />")
+        }
+        appendLine("        </policy>")
+        appendLine("    </overlayable>")
+    }
+
+    // The app can declare overlayables of its own, and those must be kept.
+    val overlayableFile = get("res").resolve("values/overlayable.xml")
+    if (overlayableFile.exists()) {
+        overlayableFile.writeText(
+            overlayableFile.readText().replaceFirst("</resources>", "$overlayable</resources>")
+        )
+    } else {
+        overlayableFile.writeText(
+            buildString {
+                appendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>")
+                appendLine("<resources>")
+                append(overlayable)
+                appendLine("</resources>")
+            }
+        )
     }
 }
 
@@ -207,9 +278,8 @@ private fun ResourcePatchContext.addBackgroundColorVariants(
 
         // The configuration value of a background is its index plus one,
         // and the extension uses the same numbering.
-        val variantDirectory = resourceDirectory.resolve(
-            "values-$qualifier" + "%03d".format(index + 1)
-        )
+        val variantValue = "%03d".format(index + 1)
+        val variantDirectory = resourceDirectory.resolve("values-$qualifier$variantValue")
         variantDirectory.mkdirs()
 
         variantDirectory.resolve("colors.xml").writeText(

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -179,9 +179,13 @@ internal fun baseThemePatch(
 
         // A custom background color has no resource variant to select,
         // so the extension replaces the same colors with an overlay of the app.
-        DarkColorResourceNamesFingerprint.method.returnEarly(darkColorNames().joinToString(","))
+        DarkColorResourceNamesFingerprint.method.returnEarly(
+            colorResourceNames(APP_DARK_BACKGROUND_COLOR_NAME, darkColorNames())
+        )
         if (includeLightBackground) {
-            LightColorResourceNamesFingerprint.method.returnEarly(lightColorNames().joinToString(","))
+            LightColorResourceNamesFingerprint.method.returnEarly(
+                colorResourceNames(APP_LIGHT_BACKGROUND_COLOR_NAME, lightColorNames())
+            )
         }
 
         executeBlock()
@@ -189,6 +193,13 @@ internal fun baseThemePatch(
         lithoColorOverrideHook(extensionClassDescriptor, "getValue")
     }
 }
+
+/**
+ * The extension shows the color of a background in the app settings using the first name,
+ * so the color the app uses for the background itself must be first.
+ */
+private fun colorResourceNames(appBackgroundColorName: String, colorNames: Set<String>) =
+    (listOf(appBackgroundColorName) + colorNames).distinct().joinToString(",")
 
 /**
  * Adds a color variant of the app background for every value that can be selected in the app

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -1,32 +1,104 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2524
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.patches.shared.layout.theme
 
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.BytecodePatchBuilder
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.ResourcePatchContext
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.patcher.patch.colorOption
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.shared.misc.settings.overrideThemeColors
-import app.morphe.util.childElementsSequence
-import app.morphe.util.forEachChildElement
-import org.w3c.dom.Element
+import app.morphe.util.findMutableMethodOf
 import java.io.File
-import java.util.Locale
 
-internal const val THEME_COLOR_OPTION_DESCRIPTION = "Can be a hex color (#RRGGBB) or a color resource reference."
+private const val THEME_BACKGROUND_EXTENSION_CLASS =
+    "Lapp/morphe/extension/shared/theme/ThemeBackgroundPatch;"
+
+/**
+ * Background colors that can be selected in the app settings.
+ *
+ * The index of a color is the ordinal of the matching value of the extension enum
+ * `ThemeBackgroundPatch.DarkThemeBackground`, and the extension selects the color of an index
+ * using the 'mcc' resource qualifier. Existing entries cannot be reordered or removed,
+ * and new entries can only be appended.
+ *
+ * A null color is the unpatched color of the app, and has no resource variant.
+ */
+private val THEME_DARK_BACKGROUNDS = listOf(
+    null,                                   // APP_DEFAULT
+    "@android:color/black",                 // PURE_BLACK
+    "@android:color/system_neutral1_900",   // MATERIAL_YOU_NEUTRAL
+    "@android:color/system_accent1_800",    // MATERIAL_YOU_PRIMARY
+    "@android:color/system_accent2_800",    // MATERIAL_YOU_SECONDARY
+    "@android:color/system_accent3_800",    // MATERIAL_YOU_TERTIARY
+    "#0F0F0F",                              // MODERN_YOUTUBE
+    "#212121",                              // CLASSIC_YOUTUBE
+    "#181825",                              // CATPPUCCIN_MOCHA
+    "#290025",                              // DARK_PINK
+    "#001029",                              // DARK_BLUE
+    "#002905",                              // DARK_GREEN
+    "#282900",                              // DARK_YELLOW
+    "#291800",                              // DARK_ORANGE
+    "#290000",                              // DARK_RED
+)
+
+/**
+ * Selected using the 'mnc' resource qualifier.
+ *
+ * @see THEME_DARK_BACKGROUNDS
+ */
+private val THEME_LIGHT_BACKGROUNDS = listOf(
+    null,                                   // APP_DEFAULT
+    "@android:color/white",                 // WHITE
+    "@android:color/system_neutral1_100",   // MATERIAL_YOU_NEUTRAL
+    "@android:color/system_accent1_200",    // MATERIAL_YOU_PRIMARY
+    "@android:color/system_accent2_200",    // MATERIAL_YOU_SECONDARY
+    "@android:color/system_accent3_200",    // MATERIAL_YOU_TERTIARY
+    "#E6E9EF",                              // CATPPUCCIN_LATTE
+    "#FCCFF3",                              // LIGHT_PINK
+    "#D1E0FF",                              // LIGHT_BLUE
+    "#CCFFCC",                              // LIGHT_GREEN
+    "#FDFFCC",                              // LIGHT_YELLOW
+    "#FFE6CC",                              // LIGHT_ORANGE
+    "#FFD6D6",                              // LIGHT_RED
+)
+
+/**
+ * The splash screen is drawn by the system before the app can select a background,
+ * so it always uses the color of the default setting value.
+ */
+internal const val DEFAULT_DARK_THEME_BACKGROUND_COLOR = "@android:color/black"
+internal const val DEFAULT_LIGHT_THEME_BACKGROUND_COLOR = "@android:color/white"
+
+/**
+ * The color the app themes use for the 'ytBaseBackground' attribute, which is the background
+ * of the app. Morphe dialogs and settings use the same color so that both always match.
+ */
+private const val APP_DARK_BACKGROUND_COLOR_NAME = "yt_sys_color_baseline_mobile_dark_default_base_background"
+private const val APP_LIGHT_BACKGROUND_COLOR_NAME = "yt_sys_color_baseline_mobile_light_default_base_background"
 
 internal val THEME_DEFAULT_DARK_COLOR_NAMES = setOf(
     "yt_black0", "yt_black1", "yt_black2", "yt_black3", "yt_black4",
     "yt_black1_opacity95", "yt_black1_opacity98",
     "yt_status_bar_background_dark", "material_grey_850",
-    "yt_sys_color_baseline_mobile_dark_default_base_background",
+    APP_DARK_BACKGROUND_COLOR_NAME,
     "yt_sys_color_baseline_mobile_dark_default_raised_background"
 )
 
 internal val THEME_DEFAULT_LIGHT_COLOR_NAMES = setOf(
     "yt_white1", "yt_white2", "yt_white3", "yt_white4",
     "yt_white1_opacity95", "yt_white1_opacity98",
-    "yt_sys_color_baseline_mobile_light_default_base_background",
+    APP_LIGHT_BACKGROUND_COLOR_NAME,
     "yt_sys_color_baseline_mobile_light_default_raised_background",
 )
 
@@ -73,114 +145,67 @@ fun patchCountTextColor(resDir: File, color: String) {
 }
 
 /**
- * @param colorString #AARRGGBB #RRGGBB, or an Android color resource name.
+ * Hooks every context of the app so the app resources resolve
+ * with the background colors selected in the app settings.
  */
-internal fun validateColorName(colorString: String): Boolean {
-    if (colorString.startsWith("#")) {
-        // #RRGGBB or #AARRGGBB
-        val hex = colorString.substring(1).uppercase(Locale.US)
+private val themeBackgroundContextHookPatch = bytecodePatch {
+    execute {
+        var hookedContexts = 0
 
-        if (hex.length == 8) {
-            // Transparent colors will crash the app.
-            if (hex[0] != 'F' || hex[1] != 'F') {
-                return false
+        classDefForEach { classDef ->
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+
+            classDef.methods.forEach { method ->
+                if (method.name != "attachBaseContext" ||
+                    method.implementation == null ||
+                    method.parameterTypes.singleOrNull()?.toString() != "Landroid/content/Context;"
+                ) return@forEach
+
+                mutableClass.findMutableMethodOf(method).addInstructions(
+                    0,
+                    """
+                        invoke-static { p1 }, $THEME_BACKGROUND_EXTENSION_CLASS->wrapContext(Landroid/content/Context;)Landroid/content/Context;
+                        move-result-object p1
+                    """
+                )
+
+                hookedContexts++
             }
-        } else if (hex.length != 6) {
-            return false
         }
 
-        return hex.all { it.isDigit() || it in 'A'..'F' }
+        if (hookedContexts == 0) {
+            throw PatchException("Could not find a context to hook")
+        }
     }
-
-    if (colorString.startsWith("@android:color/")) {
-        // Cannot easily validate Android built-in colors, so assume it's a correct color.
-        return true
-    }
-
-    // Allow any color name, because if it's invalid it will
-    // throw an exception during resource compilation.
-    return colorString.startsWith("@color/")
 }
-
-/**
- * Dark theme color options for YouTube and YT Music Theme patch.
- */
-internal val darkThemeBackgroundColorOption = colorOption(
-    key = "darkThemeBackgroundColor",
-    default = "@android:color/black",
-    values = mapOf(
-        "Pure black" to "@android:color/black",
-        "Material You (Neutral)" to "@android:color/system_neutral1_900",
-        "Material You - Primary" to "@android:color/system_accent1_800",
-        "Material You - Secondary" to "@android:color/system_accent2_800",
-        "Material You - Tertiary" to "@android:color/system_accent3_800",
-        "Modern YouTube" to "#0F0F0F",
-        "Classic YouTube" to "#212121",
-        "Catppuccin (Mocha)" to "#181825",
-        "Dark pink" to "#290025",
-        "Dark blue" to "#001029",
-        "Dark green" to "#002905",
-        "Dark yellow" to "#282900",
-        "Dark orange" to "#291800",
-        "Dark red" to "#290000",
-    ),
-    title = "Dark theme background color",
-    description = THEME_COLOR_OPTION_DESCRIPTION
-)
-
-/**
- * Light theme color options for YouTube Theme patch.
- */
-internal val lightThemeBackgroundColorOption = colorOption(
-    key = "lightThemeBackgroundColor",
-    default = "@android:color/white",
-    values =  mapOf(
-        "White" to "@android:color/white",
-        "Material You (Neutral)" to "@android:color/system_neutral1_100",
-        "Material You - Primary" to "@android:color/system_accent1_200",
-        "Material You - Secondary" to "@android:color/system_accent2_200",
-        "Material You - Tertiary" to "@android:color/system_accent3_200",
-        "Catppuccin (Latte)" to "#E6E9EF",
-        "Light pink" to "#FCCFF3",
-        "Light blue" to "#D1E0FF",
-        "Light green" to "#CCFFCC",
-        "Light yellow" to "#FDFFCC",
-        "Light orange" to "#FFE6CC",
-        "Light red" to "#FFD6D6",
-    ),
-    title = "Light theme background color",
-    description = THEME_COLOR_OPTION_DESCRIPTION
-)
 
 /**
  * Shared theme patch for YouTube and YT Music.
  */
 internal fun baseThemePatch(
     extensionClassDescriptor: String,
-    includeLightThemeOption: Boolean = false,
+    includeLightBackground: Boolean = false,
     useModernLithoColorHook: BytecodePatchBuilder.() -> Boolean,
     block: BytecodePatchBuilder.() -> Unit,
     executeBlock: BytecodePatchContext.() -> Unit = {}
 ) = bytecodePatch(
     name = "Theme",
-    description = "Adds options for theming and applies a custom background theme " +
-            "(dark background theme defaults to pure black).",
+    description = "Adds options for theming, and adds a setting to change the app background " +
+            "color (defaults to pure black).",
 ) {
-    darkThemeBackgroundColorOption()
-
-    if (includeLightThemeOption) {
-        lightThemeBackgroundColorOption()
-    }
-
     block()
 
-    dependsOn(lithoColorHookPatch(useModernLithoColorHook))
+    dependsOn(
+        lithoColorHookPatch(useModernLithoColorHook),
+        themeBackgroundContextHookPatch
+    )
 
     execute {
+        // Morphe dialogs and settings use the background color of the app, and the color
+        // resources resolve to the background that is selected in the app settings.
         overrideThemeColors(
-            if (includeLightThemeOption)
-                lightThemeBackgroundColorOption.value!! else null,
-            darkThemeBackgroundColorOption.value!!
+            if (includeLightBackground) APP_LIGHT_BACKGROUND_COLOR_NAME else null,
+            APP_DARK_BACKGROUND_COLOR_NAME
         )
 
         executeBlock()
@@ -189,122 +214,56 @@ internal fun baseThemePatch(
     }
 }
 
+/**
+ * Adds a color variant of the app background for every value that can be selected in the app
+ * settings. The variants are qualified with 'mcc' and 'mnc' because the app itself ignores both,
+ * and the extension selects one of them by overriding the configuration of the app contexts.
+ */
 internal fun baseThemeResourcePatch(
     darkColorNames: (() -> Set<String>) = { THEME_DEFAULT_DARK_COLOR_NAMES },
     lightColorNames: (() -> Set<String>) = { THEME_DEFAULT_LIGHT_COLOR_NAMES },
-    lightColorReplacement: (() -> String)? = null
+    includeLightBackground: Boolean = false
 ) = resourcePatch {
-    darkThemeBackgroundColorOption()
-
     execute {
-        // Patch validators don't work here for unknown reason.
-        // This should be changed to a patch option validator.
-        val darkThemeBackgroundColor = darkThemeBackgroundColorOption.value!!
-        if (!validateColorName(darkThemeBackgroundColor)) {
-            throw PatchException("Invalid dark theme color: $darkThemeBackgroundColor")
+        addBackgroundColorVariants("mcc", THEME_DARK_BACKGROUNDS, darkColorNames())
+
+        if (includeLightBackground) {
+            addBackgroundColorVariants("mnc", THEME_LIGHT_BACKGROUNDS, lightColorNames())
         }
+    }
+}
 
-        val lightThemeBackgroundColor = lightColorReplacement?.invoke()
-        if (lightThemeBackgroundColor != null && !validateColorName(lightThemeBackgroundColor)) {
-            throw PatchException("Invalid light theme color: $lightThemeBackgroundColor")
-        }
+private fun ResourcePatchContext.addBackgroundColorVariants(
+    qualifier: String,
+    backgrounds: List<String?>,
+    colorNames: Set<String>
+) {
+    if (colorNames.isEmpty()) {
+        throw PatchException("No color to replace for the app background")
+    }
 
-        document("res/values/colors.xml").use { document ->
-            val resourcesNode = document.getElementsByTagName("resources").item(0) as Element
-            val resolvedDarkNames = darkColorNames()
-            val resolvedLightNames = lightColorNames()
+    val resourceDirectory = get("res")
 
-            resourcesNode.childElementsSequence().forEach { node ->
-                val name = node.getAttribute("name")
-                when {
-                    name in resolvedDarkNames -> node.textContent = darkThemeBackgroundColor
-                    lightThemeBackgroundColor != null && name in resolvedLightNames -> node.textContent = lightThemeBackgroundColor
+    backgrounds.forEachIndexed { index, color ->
+        // The app default has no variant of its own.
+        if (color == null) return@forEachIndexed
+
+        // The configuration value of a background is its index plus one,
+        // and the extension uses the same numbering.
+        val variantDirectory = resourceDirectory.resolve(
+            "values-$qualifier" + "%03d".format(index + 1)
+        )
+        variantDirectory.mkdirs()
+
+        variantDirectory.resolve("colors.xml").writeText(
+            buildString {
+                appendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>")
+                appendLine("<resources>")
+                colorNames.forEach { name ->
+                    appendLine("    <color name=\"$name\">$color</color>")
                 }
+                appendLine("</resources>")
             }
-        }
-
-        val isMaterialYouDark = darkThemeBackgroundColor.startsWith("@android:color/system_")
-
-        if (isMaterialYouDark) {
-            val resDir = get("res")
-            val darkDotColor = "@android:color/system_accent1_100"
-            val darkCountBgColor = "@android:color/system_accent1_100"
-            val darkCountTextColor = "@android:color/system_neutral1_900"
-
-            createNotifDrawable(resDir, "drawable/morphe_notif_dot_dark.xml", darkDotColor, "oval")
-            createNotifDrawable(resDir, "drawable/morphe_notif_count_dark.xml", darkCountBgColor, "rectangle", hasCorners = true)
-            patchCountTextColor(resDir, darkCountTextColor)
-
-            val ytmDrawables = listOf(
-                "new_content_dot_background.xml",
-                "new_content_dot_background_cairo.xml",
-                "new_content_count_background.xml",
-                "new_content_count_background_cairo.xml"
-            )
-            val ytmDrawableDirs = listOf("drawable", "drawable-anydpi-v26", "drawable-anydpi", "drawable-v24", "drawable-v31")
-
-            ytmDrawables.forEach { fileName ->
-                ytmDrawableDirs.forEach { dirName ->
-                    val file = resDir.resolve("$dirName/$fileName")
-                    if (file.exists()) {
-                        val patchedXml = file.readText().replace(
-                            Regex("""<solid\s+android:color="[^"]+""""),
-                            """<solid android:color="$darkDotColor""""
-                        )
-                        file.writeText(patchedXml)
-                    }
-                }
-            }
-
-            val ytmLayoutDirs = listOf("layout", "layout-v26", "layout-v31")
-            ytmLayoutDirs.forEach { dirName ->
-                val file = resDir.resolve("$dirName/new_content_count.xml")
-                if (file.exists()) {
-                    val patchedXml = file.readText().replace(
-                        Regex("""android:textColor="[^"]+""""),
-                        """android:textColor="$darkCountTextColor""""
-                    )
-                    file.writeText(patchedXml)
-                }
-            }
-
-            val stylesFile = "res/values/styles.xml"
-            if (get(stylesFile).exists()) {
-                document(stylesFile).use { document ->
-                    val resources = document.getElementsByTagName("resources").item(0) as? Element ?: return@use
-
-                    resources.forEachChildElement { style ->
-                        if (style.nodeName != "style") return@forEachChildElement
-
-                        val overrides: Map<String, String> = when (style.getAttribute("name")) {
-                            "PivotBar.Dark" -> mapOf(
-                                "dotBackground" to "@drawable/morphe_notif_dot_dark",
-                                "countBackground" to "@drawable/morphe_notif_count_dark"
-                            )
-                            "CairoDarkThemeUpdates" -> mapOf(
-                                "ytRedIndicator" to darkDotColor
-                            )
-                            else -> return@forEachChildElement
-                        }
-
-                        overrides.forEach { (attrName, attrValue) ->
-                            var found = false
-                            style.forEachChildElement { item ->
-                                if (item.nodeName == "item" && item.getAttribute("name") == attrName) {
-                                    item.textContent = attrValue
-                                    found = true
-                                }
-                            }
-                            if (!found) {
-                                style.appendChild(document.createElement("item").apply {
-                                    setAttribute("name", attrName)
-                                    textContent = attrValue
-                                })
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        )
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -19,7 +19,6 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.shared.misc.settings.overrideThemeColors
 import app.morphe.util.findMutableMethodOf
-import java.io.File
 
 private const val THEME_BACKGROUND_EXTENSION_CLASS =
     "Lapp/morphe/extension/shared/theme/ThemeBackgroundPatch;"
@@ -101,48 +100,6 @@ internal val THEME_DEFAULT_LIGHT_COLOR_NAMES = setOf(
     APP_LIGHT_BACKGROUND_COLOR_NAME,
     "yt_sys_color_baseline_mobile_light_default_raised_background",
 )
-
-/**
- * Common utility to generate a notification shape drawable.
- */
-fun createNotifDrawable(
-    resDir: File,
-    resPath: String,
-    color: String,
-    shape: String,
-    hasCorners: Boolean = false,
-) {
-    val file = resDir.resolve(resPath)
-    file.parentFile?.mkdirs()
-    val cornersLine = if (hasCorners)
-        "\n    <corners android:radius=\"@dimen/new_content_count_radius\" />"
-    else ""
-    file.writeText(
-        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-                "<shape android:shape=\"$shape\"\n" +
-                "  xmlns:android=\"http://schemas.android.com/apk/res/android\">\n" +
-                "    <solid android:color=\"$color\" />$cornersLine\n" +
-                "</shape>"
-    )
-}
-
-/**
- * Common utility to patch the notification count text color across all API levels.
- */
-fun patchCountTextColor(resDir: File, color: String) {
-    val targetFolders = listOf("layout-v31", "layout-v26", "layout")
-
-    targetFolders.forEach { folder ->
-        val file = resDir.resolve("$folder/new_content_count.xml")
-        if (file.exists()) {
-            val patchedXml = file.readText().replace(
-                Regex("""android:textColor="[^"]+""""),
-                """android:textColor="$color""""
-            )
-            file.writeText(patchedXml)
-        }
-    }
-}
 
 /**
  * Hooks every context of the app so the app resources resolve

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -23,6 +23,7 @@ import app.morphe.util.asSequence
 import app.morphe.util.returnEarly
 import com.android.tools.smali.dexlib2.AccessFlags
 import org.w3c.dom.Element
+import kotlin.math.roundToInt
 
 internal const val THEME_BACKGROUND_EXTENSION_CLASS =
     "Lapp/morphe/extension/shared/theme/ThemeBackgroundPatch;"
@@ -292,9 +293,9 @@ private fun ResourcePatchContext.add9BitColorVariants(
         val g3 = (index shr 3) and 0x7
         val b3 = index and 0x7
 
-        val r = Math.round(r3 * 255f / 7f)
-        val g = Math.round(g3 * 255f / 7f)
-        val b = Math.round(b3 * 255f / 7f)
+        val r = (r3 * 255f / 7f).roundToInt()
+        val g = (g3 * 255f / 7f).roundToInt()
+        val b = (b3 * 255f / 7f).roundToInt()
 
         val color = "#%02X%02X%02X".format(r, g, b)
         val variantValue = "%03d".format(100 + index)

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -23,7 +23,6 @@ import app.morphe.util.forEachChildElement
 import app.morphe.util.getNode
 import app.morphe.util.returnEarly
 import com.android.tools.smali.dexlib2.AccessFlags
-import kotlin.math.roundToInt
 
 internal const val THEME_COLOR_EXTENSION_CLASS = "Lapp/morphe/extension/shared/theme/ThemeColorPatch;"
 
@@ -42,12 +41,23 @@ private const val UNUSED_MOBILE_COUNTRY_CODE = 100
 private const val PALETTE_INDEX_OFFSET = 100
 
 /**
+ * The value a color channel can have in the 9 bit palette, of the dark and of the light theme.
+ * The extension picks an index with the same values, and both must stay identical.
+ *
+ * A background sits at one end of the range, so the eight values of a channel are placed where the
+ * backgrounds of that theme are instead of being spread evenly. A dark background of #0F0F0F would
+ * otherwise be shown as pure black, because the nearest even value is 36 away.
+ */
+private val PALETTE_LEVELS_DARK = intArrayOf(0, 3, 15, 38, 74, 126, 187, 255)
+private val PALETTE_LEVELS_LIGHT = intArrayOf(0, 68, 129, 181, 217, 240, 252, 255)
+
+/**
  * A background must only be used by the theme it belongs to. The app uses the light colors as
  * its foreground while it is dark, and the other way around. A light background would otherwise
  * replace the color of the text and the icons of the dark theme.
  *
  * The theme of the app is not the night mode of the device, the app has a setting of its own,
- * so a variant cannot be qualified with 'night'. Instead the extension asks for the variant of
+ * so a variant cannot be qualified with 'night'. Instead, the extension asks for the variant of
  * the theme the app shows, and the indices of the two themes never overlap.
  */
 private const val THEME_INDEX_OFFSET_DARK = 0
@@ -227,11 +237,11 @@ internal fun baseThemeResourcePatch(
 ) = resourcePatch {
     execute {
         addBackgroundColorVariants(THEME_INDEX_OFFSET_DARK, THEME_COLORS_DARK, colorNamesDark())
-        add9BitColorVariants(THEME_INDEX_OFFSET_DARK, colorNamesDark())
+        add9BitColorVariants(THEME_INDEX_OFFSET_DARK, PALETTE_LEVELS_DARK, colorNamesDark())
 
         if (includeLightBackground) {
             addBackgroundColorVariants(THEME_INDEX_OFFSET_LIGHT, THEME_COLORS_LIGHT, colorNamesLight())
-            add9BitColorVariants(THEME_INDEX_OFFSET_LIGHT, colorNamesLight())
+            add9BitColorVariants(THEME_INDEX_OFFSET_LIGHT, PALETTE_LEVELS_LIGHT, colorNamesLight())
         }
 
         declareOverlayableColors(
@@ -308,16 +318,13 @@ private fun ResourcePatchContext.addBackgroundColorVariants(
 
 private fun ResourcePatchContext.add9BitColorVariants(
     indexOffset: Int,
+    levels: IntArray,
     colorNames: Set<String>
 ) {
     for (index in 0 until 512) {
-        val r3 = (index shr 6) and 0x7
-        val g3 = (index shr 3) and 0x7
-        val b3 = index and 0x7
-
-        val r = (r3 * 255f / 7f).roundToInt()
-        val g = (g3 * 255f / 7f).roundToInt()
-        val b = (b3 * 255f / 7f).roundToInt()
+        val r = levels[(index shr 6) and 0x7]
+        val g = levels[(index shr 3) and 0x7]
+        val b = levels[index and 0x7]
 
         val color = "#%02X%02X%02X".format(r, g, b)
         writeBackgroundColorVariant(indexOffset + PALETTE_INDEX_OFFSET + index, color, colorNames)

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -25,8 +25,7 @@ import com.android.tools.smali.dexlib2.AccessFlags
 import org.w3c.dom.Element
 import kotlin.math.roundToInt
 
-internal const val THEME_BACKGROUND_EXTENSION_CLASS =
-    "Lapp/morphe/extension/shared/theme/ThemeBackgroundPatch;"
+internal const val THEME_COLOR_EXTENSION_CLASS = "Lapp/morphe/extension/shared/theme/ThemeColorPatch;"
 
 /**
  * Mobile country codes of 100 to 199 are not assigned to any country, so a device never reports
@@ -51,25 +50,25 @@ private const val PALETTE_INDEX_OFFSET = 100
  * so a variant cannot be qualified with 'night'. Instead the extension asks for the variant of
  * the theme the app shows, and the indices of the two themes never overlap.
  */
-private const val DARK_INDEX_OFFSET = 0
-private const val LIGHT_INDEX_OFFSET = 700
+private const val THEME_INDEX_OFFSET_DARK = 0
+private const val THEME_INDEX_OFFSET_LIGHT = 700
 
 /**
  * Must be identical to the name the extension uses with `FabricatedOverlay#setTargetOverlayable`.
  */
-private const val THEME_BACKGROUND_OVERLAYABLE_NAME = "MorpheThemeBackground"
+private const val THEME_BACKGROUND_OVERLAYABLE_NAME = "MorpheThemeColor"
 
 /**
  * Background colors that can be selected in the app settings.
  *
  * The index of a color is the ordinal of the matching value of the extension enum
- * `ThemeBackgroundPatch.DarkThemeBackground`, and the extension selects the color of an index
+ * `ThemeColorPatch.ThemeColorDark`, and the extension selects the color of an index
  * using the 'mcc' resource qualifier. Existing entries cannot be reordered or removed,
  * and new entries can only be appended.
  *
  * A null color is the unpatched color of the app, and has no resource variant.
  */
-private val THEME_DARK_BACKGROUNDS = listOf(
+private val THEME_COLORS_DARK = listOf(
     null,                                   // APP_DEFAULT
     "@android:color/black",                 // PURE_BLACK
     "@android:color/system_neutral1_900",   // MATERIAL_YOU_NEUTRAL
@@ -90,9 +89,9 @@ private val THEME_DARK_BACKGROUNDS = listOf(
 /**
  * Selected using the 'mnc' resource qualifier.
  *
- * @see THEME_DARK_BACKGROUNDS
+ * @see THEME_COLORS_DARK
  */
-private val THEME_LIGHT_BACKGROUNDS = listOf(
+private val THEME_COLORS_LIGHT = listOf(
     null,                                   // APP_DEFAULT
     "@android:color/white",                 // WHITE
     "@android:color/system_neutral1_100",   // MATERIAL_YOU_NEUTRAL
@@ -113,28 +112,28 @@ private val THEME_LIGHT_BACKGROUNDS = listOf(
  * The splash screen is drawn by the system before the app can select a background,
  * so it always uses the color of the default setting value.
  */
-internal const val DEFAULT_DARK_THEME_BACKGROUND_COLOR = "@android:color/black"
-internal const val DEFAULT_LIGHT_THEME_BACKGROUND_COLOR = "@android:color/white"
+internal const val DEFAULT_THEME_COLOR_DARK = "@android:color/black"
+internal const val DEFAULT_THEME_COLOR_LIGHT = "@android:color/white"
 
 /**
  * The color the app themes use for the 'ytBaseBackground' attribute, which is the background
  * of the app. Morphe dialogs and settings use the same color so that both always match.
  */
-private const val APP_DARK_BACKGROUND_COLOR_NAME = "yt_sys_color_baseline_mobile_dark_default_base_background"
-private const val APP_LIGHT_BACKGROUND_COLOR_NAME = "yt_sys_color_baseline_mobile_light_default_base_background"
+private const val APP_COLOR_NAME_DARK = "yt_sys_color_baseline_mobile_dark_default_base_background"
+private const val APP_COLOR_NAME_LIGHT = "yt_sys_color_baseline_mobile_light_default_base_background"
 
-internal val THEME_DEFAULT_DARK_COLOR_NAMES = setOf(
+internal val THEME_DEFAULT_COLOR_NAMES_DARK = setOf(
     "yt_black0", "yt_black1", "yt_black2", "yt_black3", "yt_black4",
     "yt_black1_opacity95", "yt_black1_opacity98",
     "yt_status_bar_background_dark", "material_grey_850",
-    APP_DARK_BACKGROUND_COLOR_NAME,
+    APP_COLOR_NAME_DARK,
     "yt_sys_color_baseline_mobile_dark_default_raised_background"
 )
 
-internal val THEME_DEFAULT_LIGHT_COLOR_NAMES = setOf(
+internal val THEME_DEFAULT_COLOR_NAMES_LIGHT = setOf(
     "yt_white1", "yt_white2", "yt_white3", "yt_white4",
     "yt_white1_opacity95", "yt_white1_opacity98",
-    APP_LIGHT_BACKGROUND_COLOR_NAME,
+    APP_COLOR_NAME_LIGHT,
     "yt_sys_color_baseline_mobile_light_default_raised_background",
 )
 
@@ -142,7 +141,7 @@ internal val THEME_DEFAULT_LIGHT_COLOR_NAMES = setOf(
  * Hooks every context of the app so the app resources resolve
  * with the background colors selected in the app settings.
  */
-private val themeBackgroundContextHookPatch = bytecodePatch {
+private val themeColorContextHookPatch = bytecodePatch {
     execute {
         Fingerprint(
             name = "attachBaseContext",
@@ -154,7 +153,7 @@ private val themeBackgroundContextHookPatch = bytecodePatch {
             it.method.addInstructions(
                 0,
                 """
-                    invoke-static { p1 }, $THEME_BACKGROUND_EXTENSION_CLASS->wrapContext(Landroid/content/Context;)Landroid/content/Context;
+                    invoke-static { p1 }, $THEME_COLOR_EXTENSION_CLASS->wrapContext(Landroid/content/Context;)Landroid/content/Context;
                     move-result-object p1
                 """
             )
@@ -168,8 +167,8 @@ private val themeBackgroundContextHookPatch = bytecodePatch {
 internal fun baseThemePatch(
     extensionClassDescriptor: String,
     includeLightBackground: Boolean = false,
-    darkColorNames: (() -> Set<String>) = { THEME_DEFAULT_DARK_COLOR_NAMES },
-    lightColorNames: (() -> Set<String>) = { THEME_DEFAULT_LIGHT_COLOR_NAMES },
+    colorNamesDark: (() -> Set<String>) = { THEME_DEFAULT_COLOR_NAMES_DARK },
+    colorNamesLight: (() -> Set<String>) = { THEME_DEFAULT_COLOR_NAMES_LIGHT },
     useModernLithoColorHook: BytecodePatchBuilder.() -> Boolean,
     block: BytecodePatchBuilder.() -> Unit,
     executeBlock: BytecodePatchContext.() -> Unit = {}
@@ -181,25 +180,25 @@ internal fun baseThemePatch(
 
     dependsOn(
         lithoColorHookPatch(useModernLithoColorHook),
-        themeBackgroundContextHookPatch
+        themeColorContextHookPatch
     )
 
     execute {
         // Morphe dialogs and settings use the background color of the app, and the color
         // resources resolve to the background that is selected in the app settings.
         overrideThemeColors(
-            if (includeLightBackground) APP_LIGHT_BACKGROUND_COLOR_NAME else null,
-            APP_DARK_BACKGROUND_COLOR_NAME
+            if (includeLightBackground) APP_COLOR_NAME_LIGHT else null,
+            APP_COLOR_NAME_DARK
         )
 
         // A custom background color has no resource variant to select,
         // so the extension replaces the same colors with an overlay of the app.
         DarkColorResourceNamesFingerprint.method.returnEarly(
-            colorResourceNames(APP_DARK_BACKGROUND_COLOR_NAME, darkColorNames())
+            colorResourceNames(APP_COLOR_NAME_DARK, colorNamesDark())
         )
         if (includeLightBackground) {
             LightColorResourceNamesFingerprint.method.returnEarly(
-                colorResourceNames(APP_LIGHT_BACKGROUND_COLOR_NAME, lightColorNames())
+                colorResourceNames(APP_COLOR_NAME_LIGHT, colorNamesLight())
             )
         }
 
@@ -222,21 +221,21 @@ private fun colorResourceNames(appBackgroundColorName: String, colorNames: Set<S
  * and the extension selects one of them by overriding the configuration of the app contexts.
  */
 internal fun baseThemeResourcePatch(
-    darkColorNames: (() -> Set<String>) = { THEME_DEFAULT_DARK_COLOR_NAMES },
-    lightColorNames: (() -> Set<String>) = { THEME_DEFAULT_LIGHT_COLOR_NAMES },
+    colorNamesDark: (() -> Set<String>) = { THEME_DEFAULT_COLOR_NAMES_DARK },
+    colorNamesLight: (() -> Set<String>) = { THEME_DEFAULT_COLOR_NAMES_LIGHT },
     includeLightBackground: Boolean = false
 ) = resourcePatch {
     execute {
-        addBackgroundColorVariants(DARK_INDEX_OFFSET, THEME_DARK_BACKGROUNDS, darkColorNames())
-        add9BitColorVariants(DARK_INDEX_OFFSET, darkColorNames())
+        addBackgroundColorVariants(THEME_INDEX_OFFSET_DARK, THEME_COLORS_DARK, colorNamesDark())
+        add9BitColorVariants(THEME_INDEX_OFFSET_DARK, colorNamesDark())
 
         if (includeLightBackground) {
-            addBackgroundColorVariants(LIGHT_INDEX_OFFSET, THEME_LIGHT_BACKGROUNDS, lightColorNames())
-            add9BitColorVariants(LIGHT_INDEX_OFFSET, lightColorNames())
+            addBackgroundColorVariants(THEME_INDEX_OFFSET_LIGHT, THEME_COLORS_LIGHT, colorNamesLight())
+            add9BitColorVariants(THEME_INDEX_OFFSET_LIGHT, colorNamesLight())
         }
 
         declareOverlayableColors(
-            if (includeLightBackground) darkColorNames() + lightColorNames() else darkColorNames()
+            if (includeLightBackground) colorNamesDark() + colorNamesLight() else colorNamesDark()
         )
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -29,6 +29,32 @@ internal const val THEME_BACKGROUND_EXTENSION_CLASS =
     "Lapp/morphe/extension/shared/theme/ThemeBackgroundPatch;"
 
 /**
+ * Mobile country codes of 100 to 199 are not assigned to any country, so a device never reports
+ * one. Every generated variant uses a code of that range, which is the only way the system can
+ * be kept from using a variant of its own accord: the splash screen and anything else the system
+ * draws is resolved with the configuration of the device and not with the one the app asks for.
+ */
+private const val UNUSED_MOBILE_COUNTRY_CODE = 100
+
+/**
+ * Index of the first color of the 9 bit palette. The indices below it belong to the backgrounds
+ * that can be selected by name.
+ */
+private const val PALETTE_INDEX_OFFSET = 100
+
+/**
+ * A background must only be used by the theme it belongs to, otherwise a light background
+ * replaces the color of the text and the icons of the dark theme, because the app uses the
+ * light colors as its foreground while it is dark, and the other way around.
+ *
+ * The theme of the app is not the night mode of the device, the app has a setting of its own,
+ * so a variant cannot be qualified with 'night'. Instead the extension asks for the variant of
+ * the theme the app shows, and the indices of the two themes never overlap.
+ */
+private const val DARK_INDEX_OFFSET = 0
+private const val LIGHT_INDEX_OFFSET = 700
+
+/**
  * Must be identical to the name the extension uses with `FabricatedOverlay#setTargetOverlayable`.
  */
 private const val THEME_BACKGROUND_OVERLAYABLE_NAME = "MorpheThemeBackground"
@@ -50,7 +76,6 @@ private val THEME_DARK_BACKGROUNDS = listOf(
     "@android:color/system_accent1_800",    // MATERIAL_YOU_PRIMARY
     "@android:color/system_accent2_800",    // MATERIAL_YOU_SECONDARY
     "@android:color/system_accent3_800",    // MATERIAL_YOU_TERTIARY
-    "#0F0F0F",                              // MODERN_YOUTUBE
     "#212121",                              // CLASSIC_YOUTUBE
     "#181825",                              // CATPPUCCIN_MOCHA
     "#290025",                              // DARK_PINK
@@ -202,12 +227,12 @@ internal fun baseThemeResourcePatch(
     includeLightBackground: Boolean = false
 ) = resourcePatch {
     execute {
-        addBackgroundColorVariants("mcc", THEME_DARK_BACKGROUNDS, darkColorNames())
-        add9BitColorVariants("mcc", darkColorNames())
+        addBackgroundColorVariants(DARK_INDEX_OFFSET, THEME_DARK_BACKGROUNDS, darkColorNames())
+        add9BitColorVariants(DARK_INDEX_OFFSET, darkColorNames())
 
         if (includeLightBackground) {
-            addBackgroundColorVariants("mnc", THEME_LIGHT_BACKGROUNDS, lightColorNames())
-            add9BitColorVariants("mnc", lightColorNames())
+            addBackgroundColorVariants(LIGHT_INDEX_OFFSET, THEME_LIGHT_BACKGROUNDS, lightColorNames())
+            add9BitColorVariants(LIGHT_INDEX_OFFSET, lightColorNames())
         }
 
         declareOverlayableColors(
@@ -265,7 +290,7 @@ private fun ResourcePatchContext.declareOverlayableColors(colorNames: Set<String
 }
 
 private fun ResourcePatchContext.addBackgroundColorVariants(
-    qualifier: String,
+    indexOffset: Int,
     backgrounds: List<String?>,
     colorNames: Set<String>
 ) {
@@ -279,13 +304,12 @@ private fun ResourcePatchContext.addBackgroundColorVariants(
 
         // The configuration value of a background is its index plus one,
         // and the extension uses the same numbering.
-        val variantValue = "%03d".format(index + 1)
-        writeBackgroundColorVariant(qualifier, variantValue, color, colorNames)
+        writeBackgroundColorVariant(indexOffset + index + 1, color, colorNames)
     }
 }
 
 private fun ResourcePatchContext.add9BitColorVariants(
-    qualifier: String,
+    indexOffset: Int,
     colorNames: Set<String>
 ) {
     for (index in 0 until 512) {
@@ -298,18 +322,21 @@ private fun ResourcePatchContext.add9BitColorVariants(
         val b = (b3 * 255f / 7f).roundToInt()
 
         val color = "#%02X%02X%02X".format(r, g, b)
-        val variantValue = "%03d".format(100 + index)
-        writeBackgroundColorVariant(qualifier, variantValue, color, colorNames)
+        writeBackgroundColorVariant(indexOffset + PALETTE_INDEX_OFFSET + index, color, colorNames)
     }
 }
 
 private fun ResourcePatchContext.writeBackgroundColorVariant(
-    qualifier: String,
-    variantValue: String,
+    index: Int,
     color: String,
     colorNames: Set<String>
 ) {
-    val variantDirectory = get("res").resolve("values-$qualifier$variantValue")
+    // The mobile country code of a variant is never one a device can have, so the resource
+    // system uses a variant only when the app asks for it. The extension uses the same encoding.
+    val mcc = "%03d".format(UNUSED_MOBILE_COUNTRY_CODE + (index shr 5))
+    val mnc = "%03d".format(1 + (index and 31))
+
+    val variantDirectory = get("res").resolve("values-mcc$mcc-mnc$mnc")
     variantDirectory.mkdirs()
 
     variantDirectory.resolve("colors.xml").writeText(

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -19,19 +19,19 @@ import app.morphe.patcher.patch.ResourcePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.shared.misc.settings.overrideThemeColors
-import app.morphe.util.asSequence
+import app.morphe.util.forEachChildElement
+import app.morphe.util.getNode
 import app.morphe.util.returnEarly
 import com.android.tools.smali.dexlib2.AccessFlags
-import org.w3c.dom.Element
 import kotlin.math.roundToInt
 
 internal const val THEME_COLOR_EXTENSION_CLASS = "Lapp/morphe/extension/shared/theme/ThemeColorPatch;"
 
 /**
  * Mobile country codes of 100 to 199 are not assigned to any country, so a device never reports
- * one. Every generated variant uses a code of that range, which is the only way the system can
- * be kept from using a variant of its own accord: the splash screen and anything else the system
- * draws is resolved with the configuration of the device and not with the one the app asks for.
+ * one. Every generated variant uses a code of that range. That is the only way the system can be
+ * kept from using a variant of its own accord. Anything the system draws, such as the splash
+ * screen, is resolved with the configuration of the device and not with the one the app asks for.
  */
 private const val UNUSED_MOBILE_COUNTRY_CODE = 100
 
@@ -42,9 +42,9 @@ private const val UNUSED_MOBILE_COUNTRY_CODE = 100
 private const val PALETTE_INDEX_OFFSET = 100
 
 /**
- * A background must only be used by the theme it belongs to, otherwise a light background
- * replaces the color of the text and the icons of the dark theme, because the app uses the
- * light colors as its foreground while it is dark, and the other way around.
+ * A background must only be used by the theme it belongs to. The app uses the light colors as
+ * its foreground while it is dark, and the other way around. A light background would otherwise
+ * replace the color of the text and the icons of the dark theme.
  *
  * The theme of the app is not the night mode of the device, the app has a setting of its own,
  * so a variant cannot be qualified with 'night'. Instead the extension asks for the variant of
@@ -249,10 +249,9 @@ private fun ResourcePatchContext.declareOverlayableColors(colorNames: Set<String
     // does not have must not be declared.
     val declaredColors = mutableSetOf<String>()
     document("res/values/colors.xml").use { document ->
-        (document.getElementsByTagName("resources").item(0) as Element)
-            .childNodes.asSequence()
-            .filterIsInstance<Element>()
-            .forEach { declaredColors += it.getAttribute("name") }
+        document.getNode("resources").forEachChildElement {
+            declaredColors += it.getAttribute("name")
+        }
     }
 
     val overlayableColors = colorNames.filter { it in declaredColors }

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/Fingerprints.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.patches.shared.layout.theme
 
 import app.morphe.patcher.Fingerprint

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/Fingerprints.kt
@@ -65,3 +65,19 @@ internal object LithoOnBoundsChangeLegacyFingerprint : Fingerprint(
         )
     )
 )
+
+internal object DarkColorResourceNamesFingerprint : Fingerprint(
+    definingClass = THEME_BACKGROUND_EXTENSION_CLASS,
+    name = "darkColorResourceNames",
+    accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.STATIC),
+    returnType = "Ljava/lang/String;",
+    parameters = listOf()
+)
+
+internal object LightColorResourceNamesFingerprint : Fingerprint(
+    definingClass = THEME_BACKGROUND_EXTENSION_CLASS,
+    name = "lightColorResourceNames",
+    accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.STATIC),
+    returnType = "Ljava/lang/String;",
+    parameters = listOf()
+)

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/Fingerprints.kt
@@ -67,7 +67,7 @@ internal object LithoOnBoundsChangeLegacyFingerprint : Fingerprint(
 )
 
 internal object DarkColorResourceNamesFingerprint : Fingerprint(
-    definingClass = THEME_BACKGROUND_EXTENSION_CLASS,
+    definingClass = THEME_COLOR_EXTENSION_CLASS,
     name = "darkColorResourceNames",
     accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.STATIC),
     returnType = "Ljava/lang/String;",
@@ -75,7 +75,7 @@ internal object DarkColorResourceNamesFingerprint : Fingerprint(
 )
 
 internal object LightColorResourceNamesFingerprint : Fingerprint(
-    definingClass = THEME_BACKGROUND_EXTENSION_CLASS,
+    definingClass = THEME_COLOR_EXTENSION_CLASS,
     name = "lightColorResourceNames",
     accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.STATIC),
     returnType = "Ljava/lang/String;",

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/settings/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/settings/Fingerprints.kt
@@ -1,11 +1,23 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.patches.shared.misc.settings
 
 import app.morphe.patcher.Fingerprint
 import app.morphe.patches.all.misc.extension.SHARED_UTILS_EXTENSION_CLASS
 import com.android.tools.smali.dexlib2.AccessFlags
 
+private const val THEME_UTILS_EXTENSION_CLASS = "Lapp/morphe/extension/shared/theme/ThemeUtils;"
+
 internal object ThemeLightColorResourceNameFingerprint : Fingerprint(
-    definingClass = SHARED_UTILS_EXTENSION_CLASS,
+    definingClass = THEME_UTILS_EXTENSION_CLASS,
     name = "getThemeLightColorResourceName",
     accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.STATIC),
     returnType = "Ljava/lang/String;",
@@ -13,7 +25,7 @@ internal object ThemeLightColorResourceNameFingerprint : Fingerprint(
 )
 
 internal object ThemeDarkColorResourceNameFingerprint : Fingerprint(
-    definingClass = SHARED_UTILS_EXTENSION_CLASS,
+    definingClass = THEME_UTILS_EXTENSION_CLASS,
     name = "getThemeDarkColorResourceName",
     accessFlags = listOf(AccessFlags.PRIVATE, AccessFlags.STATIC),
     returnType = "Ljava/lang/String;",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
@@ -93,7 +93,7 @@ internal object PivotBarNewContentDotFingerprint : Fingerprint(
     filters = listOf(
         resourceLiteral(ResourceType.ID, "new_content_dot"),
         methodCall(
-            smali = "Landroid/view/View;->findViewById(I)Landroid/view/View;",
+            name = "findViewById",
             location = MatchAfterImmediately()
         ),
         opcode(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
@@ -17,6 +17,8 @@ import app.morphe.patcher.anyInstruction
 import app.morphe.patcher.literal
 import app.morphe.patcher.methodCall
 import app.morphe.patcher.opcode
+import app.morphe.patches.all.misc.resources.ResourceType
+import app.morphe.patches.all.misc.resources.resourceLiteral
 import app.morphe.patches.youtube.shared.YOUTUBE_MAIN_ACTIVITY_CLASS_TYPE
 import com.android.tools.smali.dexlib2.Opcode
 
@@ -79,6 +81,29 @@ internal object ShowSplashScreenFingerprint : Fingerprint(
         opcode(
             opcode = Opcode.IF_NE,
             location = MatchAfterImmediately()
+        )
+    )
+)
+
+/**
+ * The pivot bar creates the view stub of the new content dot, and of the count next to it.
+ * The count is matched as well because the effects picker uses the same dot id.
+ */
+internal object PivotBarNewContentDotFingerprint : Fingerprint(
+    filters = listOf(
+        resourceLiteral(ResourceType.ID, "new_content_dot"),
+        methodCall(
+            smali = "Landroid/view/View;->findViewById(I)Landroid/view/View;",
+            location = MatchAfterImmediately()
+        ),
+        opcode(
+            opcode = Opcode.CHECK_CAST,
+            location = MatchAfterWithin(3)
+        ),
+        resourceLiteral(
+            ResourceType.ID,
+            "new_content_count",
+            location = MatchAfterWithin(30)
         )
     )
 )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
@@ -104,6 +104,7 @@ internal object PivotBarNewContentDotFingerprint : Fingerprint(
             ResourceType.ID,
             "new_content_count",
             location = MatchAfterWithin(30)
-        )
+        ),
+        opcode(opcode = Opcode.CHECK_CAST)
     )
 )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -16,11 +16,11 @@ import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
-import app.morphe.patches.shared.layout.theme.DEFAULT_DARK_THEME_BACKGROUND_COLOR
-import app.morphe.patches.shared.layout.theme.DEFAULT_LIGHT_THEME_BACKGROUND_COLOR
-import app.morphe.patches.shared.layout.theme.THEME_BACKGROUND_EXTENSION_CLASS
-import app.morphe.patches.shared.layout.theme.THEME_DEFAULT_DARK_COLOR_NAMES
-import app.morphe.patches.shared.layout.theme.THEME_DEFAULT_LIGHT_COLOR_NAMES
+import app.morphe.patches.shared.layout.theme.DEFAULT_THEME_COLOR_DARK
+import app.morphe.patches.shared.layout.theme.DEFAULT_THEME_COLOR_LIGHT
+import app.morphe.patches.shared.layout.theme.THEME_COLOR_EXTENSION_CLASS
+import app.morphe.patches.shared.layout.theme.THEME_DEFAULT_COLOR_NAMES_DARK
+import app.morphe.patches.shared.layout.theme.THEME_DEFAULT_COLOR_NAMES_LIGHT
 import app.morphe.patches.shared.layout.theme.baseThemePatch
 import app.morphe.patches.shared.layout.theme.baseThemeResourcePatch
 import app.morphe.patches.shared.misc.settings.preference.InputType
@@ -38,17 +38,15 @@ import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import app.morphe.util.forEachChildElement
-import app.morphe.util.indexOfFirstInstructionOrThrow
 import app.morphe.util.insertLiteralOverride
-import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import org.w3c.dom.Element
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/theme/ThemePatch;"
 
-private val darkColorNames = {
-    THEME_DEFAULT_DARK_COLOR_NAMES + if (is_21_06_or_greater)
+private val youTubeColorNamesDark = {
+    THEME_DEFAULT_COLOR_NAMES_DARK + if (is_21_06_or_greater)
         setOf(
             // yt_ref_color_constants_baseline_black_black0
             // yt_ref_color_constants_baseline_black_black1
@@ -62,20 +60,22 @@ private val darkColorNames = {
         ) else emptySet()
 }
 
-private val lightColorNames = {
-    THEME_DEFAULT_LIGHT_COLOR_NAMES + if (is_21_06_or_greater)
+private val youTubeColorNamesLight = {
+    THEME_DEFAULT_COLOR_NAMES_LIGHT + if (is_21_06_or_greater) {
         setOf(
             "yt_sys_color_baseline_light_base_background",
             "yt_sys_color_baseline_light_raised_background"
         )
-    else emptySet()
+    } else {
+        emptySet()
+    }
 }
 
 val themePatch = baseThemePatch(
     extensionClassDescriptor = EXTENSION_CLASS,
     includeLightBackground = true,
-    darkColorNames = darkColorNames,
-    lightColorNames = lightColorNames,
+    colorNamesDark = youTubeColorNamesDark,
+    colorNamesLight = youTubeColorNamesLight,
     useModernLithoColorHook = {
         is_21_30_or_greater
     },
@@ -84,9 +84,6 @@ val themePatch = baseThemePatch(
             dependsOn(resourceMappingPatch)
 
             execute {
-                val lightThemeBackgroundColor = DEFAULT_LIGHT_THEME_BACKGROUND_COLOR
-                val darkThemeBackgroundColor = DEFAULT_DARK_THEME_BACKGROUND_COLOR
-
                 fun addColorResource(
                     resourceFile: String,
                     colorName: String,
@@ -110,12 +107,12 @@ val themePatch = baseThemePatch(
                 addColorResource(
                     "res/values/colors.xml",
                     splashBackgroundColorKey,
-                    lightThemeBackgroundColor
+                    DEFAULT_THEME_COLOR_LIGHT
                 )
                 addColorResource(
                     "res/values-night/colors.xml",
                     splashBackgroundColorKey,
-                    darkThemeBackgroundColor
+                    DEFAULT_THEME_COLOR_DARK
                 )
 
                 // Edit splash screen files and change the background color.
@@ -206,6 +203,7 @@ val themePatch = baseThemePatch(
                             }
                         }
                     } catch (_: Exception) {
+                        // Ignore?
                     }
                 }
             }
@@ -219,8 +217,8 @@ val themePatch = baseThemePatch(
             versionCheckPatch,
             baseThemeResourcePatch(
                 includeLightBackground = true,
-                darkColorNames = darkColorNames,
-                lightColorNames = lightColorNames
+                colorNamesDark = youTubeColorNamesDark,
+                colorNamesLight = youTubeColorNamesLight
             ),
             themeResourcePatch
         )
@@ -233,7 +231,7 @@ val themePatch = baseThemePatch(
             noTitleUnsortedPreferenceCategory(
                 ListPreference(
                     "morphe_theme_background_dark",
-                    tag = "app.morphe.extension.shared.theme.ThemeBackgroundListPreference"
+                    tag = "app.morphe.extension.shared.theme.ThemeColorListPreference"
                 ),
                 TextPreference(
                     "morphe_theme_background_dark_custom_color",
@@ -242,7 +240,7 @@ val themePatch = baseThemePatch(
                 ),
                 ListPreference(
                     "morphe_theme_background_light",
-                    tag = "app.morphe.extension.shared.theme.ThemeBackgroundListPreference"
+                    tag = "app.morphe.extension.shared.theme.ThemeColorListPreference"
                 ),
                 TextPreference(
                     "morphe_theme_background_light_custom_color",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -18,6 +18,7 @@ import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.patches.shared.layout.theme.DEFAULT_DARK_THEME_BACKGROUND_COLOR
 import app.morphe.patches.shared.layout.theme.DEFAULT_LIGHT_THEME_BACKGROUND_COLOR
+import app.morphe.patches.shared.layout.theme.THEME_BACKGROUND_EXTENSION_CLASS
 import app.morphe.patches.shared.layout.theme.THEME_DEFAULT_DARK_COLOR_NAMES
 import app.morphe.patches.shared.layout.theme.THEME_DEFAULT_LIGHT_COLOR_NAMES
 import app.morphe.patches.shared.layout.theme.baseThemePatch
@@ -289,7 +290,7 @@ val themePatch = baseThemePatch(
 
                     addInstruction(
                         checkCastIndex + 1,
-                        "invoke-static { v$stubRegister }, $EXTENSION_CLASS" +
+                        "invoke-static { v$stubRegister }, $THEME_BACKGROUND_EXTENSION_CLASS" +
                                 "->onNewContentIndicator(Landroid/view/ViewStub;)V"
                     )
                 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -281,16 +281,16 @@ val themePatch = baseThemePatch(
             it.method.apply {
                 // Both the dot of a tab and the count next to it, and the count is hooked
                 // first so the index of the dot is still valid.
-                val countIndex = indexOfFirstInstructionOrThrow(it.instructionMatches[3].index) {
-                    opcode == Opcode.CHECK_CAST
-                }
 
-                arrayOf(countIndex, it.instructionMatches[2].index).forEach { checkCastIndex ->
+                arrayOf(
+                    it.instructionMatches.last().index,
+                    it.instructionMatches[2].index
+                ).forEach { checkCastIndex ->
                     val stubRegister = getInstruction<OneRegisterInstruction>(checkCastIndex).registerA
 
                     addInstruction(
                         checkCastIndex + 1,
-                        "invoke-static { v$stubRegister }, $THEME_BACKGROUND_EXTENSION_CLASS" +
+                        "invoke-static { v$stubRegister }, $THEME_COLOR_EXTENSION_CLASS" +
                                 "->onNewContentIndicator(Landroid/view/ViewStub;)V"
                     )
                 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -43,9 +43,35 @@ import org.w3c.dom.Element
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/theme/ThemePatch;"
 
+private val darkColorNames = {
+    THEME_DEFAULT_DARK_COLOR_NAMES + if (is_21_06_or_greater)
+        setOf(
+            // yt_ref_color_constants_baseline_black_black0
+            // yt_ref_color_constants_baseline_black_black1
+            // yt_ref_color_constants_baseline_black_black3
+            "yt_sys_color_baseline_dark_menu_background",
+            "yt_sys_color_baseline_dark_static_black",
+            "yt_sys_color_baseline_dark_raised_background",
+            "yt_sys_color_baseline_dark_base_background",
+            "yt_sys_color_baseline_light_inverted_background",
+            "yt_sys_color_baseline_light_static_black"
+        ) else emptySet()
+}
+
+private val lightColorNames = {
+    THEME_DEFAULT_LIGHT_COLOR_NAMES + if (is_21_06_or_greater)
+        setOf(
+            "yt_sys_color_baseline_light_base_background",
+            "yt_sys_color_baseline_light_raised_background"
+        )
+    else emptySet()
+}
+
 val themePatch = baseThemePatch(
     extensionClassDescriptor = EXTENSION_CLASS,
     includeLightBackground = true,
+    darkColorNames = darkColorNames,
+    lightColorNames = lightColorNames,
     useModernLithoColorHook = {
         is_21_30_or_greater
     },
@@ -188,28 +214,8 @@ val themePatch = baseThemePatch(
             versionCheckPatch,
             baseThemeResourcePatch(
                 includeLightBackground = true,
-                darkColorNames = {
-                    THEME_DEFAULT_DARK_COLOR_NAMES + if (is_21_06_or_greater)
-                        setOf(
-                            // yt_ref_color_constants_baseline_black_black0
-                            // yt_ref_color_constants_baseline_black_black1
-                            // yt_ref_color_constants_baseline_black_black3
-                            "yt_sys_color_baseline_dark_menu_background",
-                            "yt_sys_color_baseline_dark_static_black",
-                            "yt_sys_color_baseline_dark_raised_background",
-                            "yt_sys_color_baseline_dark_base_background",
-                            "yt_sys_color_baseline_light_inverted_background",
-                            "yt_sys_color_baseline_light_static_black"
-                        ) else emptySet()
-                },
-                lightColorNames = {
-                    THEME_DEFAULT_LIGHT_COLOR_NAMES + if (is_21_06_or_greater)
-                        setOf(
-                            "yt_sys_color_baseline_light_base_background",
-                            "yt_sys_color_baseline_light_raised_background"
-                        )
-                    else emptySet()
-                }
+                darkColorNames = darkColorNames,
+                lightColorNames = lightColorNames
             ),
             themeResourcePatch
         )
@@ -221,7 +227,17 @@ val themePatch = baseThemePatch(
         PreferenceScreen.GENERAL.addPreferences(
             noTitleUnsortedPreferenceCategory(
                 ListPreference("morphe_theme_background_dark"),
-                ListPreference("morphe_theme_background_light")
+                TextPreference(
+                    "morphe_theme_background_dark_custom_color",
+                    tag = "app.morphe.extension.shared.settings.preference.ColorPickerPreference",
+                    inputType = InputType.TEXT_CAP_CHARACTERS
+                ),
+                ListPreference("morphe_theme_background_light"),
+                TextPreference(
+                    "morphe_theme_background_light_custom_color",
+                    tag = "app.morphe.extension.shared.settings.preference.ColorPickerPreference",
+                    inputType = InputType.TEXT_CAP_CHARACTERS
+                )
             ),
             SwitchPreference("morphe_gradient_loading_screen", summary = true)
         )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -10,6 +10,7 @@
 
 package app.morphe.patches.youtube.layout.theme
 
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.PatchException
@@ -36,7 +37,9 @@ import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import app.morphe.util.forEachChildElement
+import app.morphe.util.indexOfFirstInstructionOrThrow
 import app.morphe.util.insertLiteralOverride
+import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import org.w3c.dom.Element
@@ -210,6 +213,7 @@ val themePatch = baseThemePatch(
         dependsOn(
             sharedExtensionPatch,
             settingsPatch,
+            resourceMappingPatch,
             seekbarColorPatch,
             versionCheckPatch,
             baseThemeResourcePatch(
@@ -269,6 +273,28 @@ val themePatch = baseThemePatch(
         PreferenceScreen.GENERAL.addPreferences(
             ListPreference("morphe_splash_screen_animation_style")
         )
+
+        // Color of the new content indicator of the pivot bar, which is red in the app and does
+        // not go with a Material You background.
+        PivotBarNewContentDotFingerprint.let {
+            it.method.apply {
+                // Both the dot of a tab and the count next to it, and the count is hooked
+                // first so the index of the dot is still valid.
+                val countIndex = indexOfFirstInstructionOrThrow(it.instructionMatches[3].index) {
+                    opcode == Opcode.CHECK_CAST
+                }
+
+                arrayOf(countIndex, it.instructionMatches[2].index).forEach { checkCastIndex ->
+                    val stubRegister = getInstruction<OneRegisterInstruction>(checkCastIndex).registerA
+
+                    addInstruction(
+                        checkCastIndex + 1,
+                        "invoke-static { v$stubRegister }, $EXTENSION_CLASS" +
+                                "->onNewContentIndicator(Landroid/view/ViewStub;)V"
+                    )
+                }
+            }
+        }
 
         UseGradientLoadingScreenFingerprint.matchAll().forEach {
             it.method.insertLiteralOverride(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -226,13 +226,19 @@ val themePatch = baseThemePatch(
     executeBlock = {
         PreferenceScreen.GENERAL.addPreferences(
             noTitleUnsortedPreferenceCategory(
-                ListPreference("morphe_theme_background_dark"),
+                ListPreference(
+                    "morphe_theme_background_dark",
+                    tag = "app.morphe.extension.shared.theme.ThemeBackgroundListPreference"
+                ),
                 TextPreference(
                     "morphe_theme_background_dark_custom_color",
                     tag = "app.morphe.extension.shared.settings.preference.ColorPickerPreference",
                     inputType = InputType.TEXT_CAP_CHARACTERS
                 ),
-                ListPreference("morphe_theme_background_light"),
+                ListPreference(
+                    "morphe_theme_background_light",
+                    tag = "app.morphe.extension.shared.theme.ThemeBackgroundListPreference"
+                ),
                 TextPreference(
                     "morphe_theme_background_light_custom_color",
                     tag = "app.morphe.extension.shared.settings.preference.ColorPickerPreference",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2524
  *
  * Original hard forked code:
  * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
@@ -15,14 +15,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
+import app.morphe.patches.shared.layout.theme.DEFAULT_DARK_THEME_BACKGROUND_COLOR
+import app.morphe.patches.shared.layout.theme.DEFAULT_LIGHT_THEME_BACKGROUND_COLOR
 import app.morphe.patches.shared.layout.theme.THEME_DEFAULT_DARK_COLOR_NAMES
 import app.morphe.patches.shared.layout.theme.THEME_DEFAULT_LIGHT_COLOR_NAMES
 import app.morphe.patches.shared.layout.theme.baseThemePatch
 import app.morphe.patches.shared.layout.theme.baseThemeResourcePatch
-import app.morphe.patches.shared.layout.theme.createNotifDrawable
-import app.morphe.patches.shared.layout.theme.darkThemeBackgroundColorOption
-import app.morphe.patches.shared.layout.theme.lightThemeBackgroundColorOption
-import app.morphe.patches.shared.layout.theme.patchCountTextColor
 import app.morphe.patches.shared.misc.settings.preference.InputType
 import app.morphe.patches.shared.misc.settings.preference.ListPreference
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
@@ -47,19 +45,17 @@ private const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/theme
 
 val themePatch = baseThemePatch(
     extensionClassDescriptor = EXTENSION_CLASS,
-    includeLightThemeOption = true,
+    includeLightBackground = true,
     useModernLithoColorHook = {
         is_21_30_or_greater
     },
     block = {
         val themeResourcePatch = resourcePatch {
-            lightThemeBackgroundColorOption()
-            darkThemeBackgroundColorOption()
             dependsOn(resourceMappingPatch)
 
             execute {
-                val lightThemeBackgroundColor = lightThemeBackgroundColorOption.value!!
-                val darkThemeBackgroundColor = darkThemeBackgroundColorOption.value!!
+                val lightThemeBackgroundColor = DEFAULT_LIGHT_THEME_BACKGROUND_COLOR
+                val darkThemeBackgroundColor = DEFAULT_DARK_THEME_BACKGROUND_COLOR
 
                 fun addColorResource(
                     resourceFile: String,
@@ -182,57 +178,6 @@ val themePatch = baseThemePatch(
                     } catch (_: Exception) {
                     }
                 }
-
-                val isMaterialYouLight = lightThemeBackgroundColor.startsWith("@android:color/system_")
-
-                if (isMaterialYouLight) {
-                    val resDir = get("res")
-                    val lightDotColor = "@android:color/system_accent1_200"
-                    val lightCountBgColor = "@android:color/system_accent1_100"
-                    val lightCountTextColor = "@android:color/system_neutral1_900"
-
-                    createNotifDrawable(resDir, "drawable/morphe_notif_dot_light.xml", lightDotColor, "oval")
-                    createNotifDrawable(resDir, "drawable/morphe_notif_count_light.xml", lightCountBgColor, "rectangle", hasCorners = true)
-                    patchCountTextColor(resDir, lightCountTextColor)
-
-                    val stylesFile = "res/values/styles.xml"
-                    if (get(stylesFile).exists()) {
-                        document(stylesFile).use { document ->
-                            val resources = document.getElementsByTagName("resources").item(0) as? Element ?: return@use
-
-                            resources.forEachChildElement { style ->
-                                if (style.nodeName != "style") return@forEachChildElement
-
-                                val overrides: Map<String, String> = when (style.getAttribute("name")) {
-                                    "PivotBar.Default" -> mapOf(
-                                        "dotBackground" to "@drawable/morphe_notif_dot_light",
-                                        "countBackground" to "@drawable/morphe_notif_count_light"
-                                    )
-                                    "CairoLightThemeUpdates" -> mapOf(
-                                        "ytRedIndicator" to lightDotColor
-                                    )
-                                    else -> return@forEachChildElement
-                                }
-
-                                overrides.forEach { (attrName, attrValue) ->
-                                    var found = false
-                                    style.forEachChildElement { item ->
-                                        if (item.nodeName == "item" && item.getAttribute("name") == attrName) {
-                                            item.textContent = attrValue
-                                            found = true
-                                        }
-                                    }
-                                    if (!found) {
-                                        style.appendChild(document.createElement("item").apply {
-                                            setAttribute("name", attrName)
-                                            textContent = attrValue
-                                        })
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
             }
         }
 
@@ -242,7 +187,7 @@ val themePatch = baseThemePatch(
             seekbarColorPatch,
             versionCheckPatch,
             baseThemeResourcePatch(
-                lightColorReplacement = { lightThemeBackgroundColorOption.value!! },
+                includeLightBackground = true,
                 darkColorNames = {
                     THEME_DEFAULT_DARK_COLOR_NAMES + if (is_21_06_or_greater)
                         setOf(
@@ -274,6 +219,10 @@ val themePatch = baseThemePatch(
 
     executeBlock = {
         PreferenceScreen.GENERAL.addPreferences(
+            noTitleUnsortedPreferenceCategory(
+                ListPreference("morphe_theme_background_dark"),
+                ListPreference("morphe_theme_background_light")
+            ),
             SwitchPreference("morphe_gradient_loading_screen", summary = true)
         )
 

--- a/patches/src/main/resources/addresources/values/shared-youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/arrays.xml
@@ -78,6 +78,7 @@
         <item>@string/morphe_theme_background_dark_entry_13</item>
         <item>@string/morphe_theme_background_dark_entry_14</item>
         <item>@string/morphe_theme_background_dark_entry_15</item>
+        <item>@string/morphe_theme_background_dark_entry_16</item>
     </string-array>
     <string-array name="morphe_theme_background_dark_entry_values">
         <item>APP_DEFAULT</item>
@@ -95,5 +96,6 @@
         <item>DARK_YELLOW</item>
         <item>DARK_ORANGE</item>
         <item>DARK_RED</item>
+        <item>CUSTOM</item>
     </string-array>
 </resources>

--- a/patches/src/main/resources/addresources/values/shared-youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/arrays.xml
@@ -61,4 +61,39 @@
         <item>PLAY</item>
         <item>CUSTOM</item>
     </string-array>
+    <!-- layout.theme.baseThemePatch -->
+    <string-array name="morphe_theme_background_dark_entries">
+        <item>@string/morphe_theme_background_dark_entry_1</item>
+        <item>@string/morphe_theme_background_dark_entry_2</item>
+        <item>@string/morphe_theme_background_dark_entry_3</item>
+        <item>@string/morphe_theme_background_dark_entry_4</item>
+        <item>@string/morphe_theme_background_dark_entry_5</item>
+        <item>@string/morphe_theme_background_dark_entry_6</item>
+        <item>@string/morphe_theme_background_dark_entry_7</item>
+        <item>@string/morphe_theme_background_dark_entry_8</item>
+        <item>@string/morphe_theme_background_dark_entry_9</item>
+        <item>@string/morphe_theme_background_dark_entry_10</item>
+        <item>@string/morphe_theme_background_dark_entry_11</item>
+        <item>@string/morphe_theme_background_dark_entry_12</item>
+        <item>@string/morphe_theme_background_dark_entry_13</item>
+        <item>@string/morphe_theme_background_dark_entry_14</item>
+        <item>@string/morphe_theme_background_dark_entry_15</item>
+    </string-array>
+    <string-array name="morphe_theme_background_dark_entry_values">
+        <item>APP_DEFAULT</item>
+        <item>PURE_BLACK</item>
+        <item>MATERIAL_YOU_NEUTRAL</item>
+        <item>MATERIAL_YOU_PRIMARY</item>
+        <item>MATERIAL_YOU_SECONDARY</item>
+        <item>MATERIAL_YOU_TERTIARY</item>
+        <item>MODERN_YOUTUBE</item>
+        <item>CLASSIC_YOUTUBE</item>
+        <item>CATPPUCCIN_MOCHA</item>
+        <item>DARK_PINK</item>
+        <item>DARK_BLUE</item>
+        <item>DARK_GREEN</item>
+        <item>DARK_YELLOW</item>
+        <item>DARK_ORANGE</item>
+        <item>DARK_RED</item>
+    </string-array>
 </resources>

--- a/patches/src/main/resources/addresources/values/shared-youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/arrays.xml
@@ -78,7 +78,6 @@
         <item>@string/morphe_theme_background_dark_entry_13</item>
         <item>@string/morphe_theme_background_dark_entry_14</item>
         <item>@string/morphe_theme_background_dark_entry_15</item>
-        <item>@string/morphe_theme_background_dark_entry_16</item>
     </string-array>
     <string-array name="morphe_theme_background_dark_entry_values">
         <item>APP_DEFAULT</item>
@@ -87,7 +86,6 @@
         <item>MATERIAL_YOU_PRIMARY</item>
         <item>MATERIAL_YOU_SECONDARY</item>
         <item>MATERIAL_YOU_TERTIARY</item>
-        <item>MODERN_YOUTUBE</item>
         <item>CLASSIC_YOUTUBE</item>
         <item>CATPPUCCIN_MOCHA</item>
         <item>DARK_PINK</item>

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -22,6 +22,24 @@ Second \"item\" text"</string>
     <!-- layout.branding.baseCustomBrandingPatch -->
     <string name="morphe_custom_branding_name_title">App name</string>
 
+    <!-- layout.theme.baseThemePatch -->
+    <string name="morphe_theme_background_dark_title">Dark theme background</string>
+    <string name="morphe_theme_background_dark_entry_1">App default</string>
+    <string name="morphe_theme_background_dark_entry_2">Pure black</string>
+    <string name="morphe_theme_background_dark_entry_3">Material You (Neutral)</string>
+    <string name="morphe_theme_background_dark_entry_4">Material You (Primary)</string>
+    <string name="morphe_theme_background_dark_entry_5">Material You (Secondary)</string>
+    <string name="morphe_theme_background_dark_entry_6">Material You (Tertiary)</string>
+    <string name="morphe_theme_background_dark_entry_7">Modern YouTube</string>
+    <string name="morphe_theme_background_dark_entry_8">Classic YouTube</string>
+    <string name="morphe_theme_background_dark_entry_9">Catppuccin (Mocha)</string>
+    <string name="morphe_theme_background_dark_entry_10">Dark pink</string>
+    <string name="morphe_theme_background_dark_entry_11">Dark blue</string>
+    <string name="morphe_theme_background_dark_entry_12">Dark green</string>
+    <string name="morphe_theme_background_dark_entry_13">Dark yellow</string>
+    <string name="morphe_theme_background_dark_entry_14">Dark orange</string>
+    <string name="morphe_theme_background_dark_entry_15">Dark red</string>
+
     <!-- interaction.downloads.downloadsPatch -->
     <string name="morphe_external_downloader_screen_title">External downloads</string>
     <string name="morphe_external_downloader_name_title">Downloader package name</string>

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -39,6 +39,9 @@ Second \"item\" text"</string>
     <string name="morphe_theme_background_dark_entry_13">Dark yellow</string>
     <string name="morphe_theme_background_dark_entry_14">Dark orange</string>
     <string name="morphe_theme_background_dark_entry_15">Dark red</string>
+    <string name="morphe_theme_background_dark_entry_16">Custom</string>
+    <string name="morphe_theme_background_dark_custom_color_title">Custom dark background</string>
+    <string name="morphe_theme_background_dark_custom_color_summary">Set the background color of the dark theme</string>
 
     <!-- interaction.downloads.downloadsPatch -->
     <string name="morphe_external_downloader_screen_title">External downloads</string>

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -30,16 +30,15 @@ Second \"item\" text"</string>
     <string name="morphe_theme_background_dark_entry_4">Material You (Primary)</string>
     <string name="morphe_theme_background_dark_entry_5">Material You (Secondary)</string>
     <string name="morphe_theme_background_dark_entry_6">Material You (Tertiary)</string>
-    <string name="morphe_theme_background_dark_entry_7">Modern YouTube</string>
-    <string name="morphe_theme_background_dark_entry_8">Classic YouTube</string>
-    <string name="morphe_theme_background_dark_entry_9">Catppuccin (Mocha)</string>
-    <string name="morphe_theme_background_dark_entry_10">Dark pink</string>
-    <string name="morphe_theme_background_dark_entry_11">Dark blue</string>
-    <string name="morphe_theme_background_dark_entry_12">Dark green</string>
-    <string name="morphe_theme_background_dark_entry_13">Dark yellow</string>
-    <string name="morphe_theme_background_dark_entry_14">Dark orange</string>
-    <string name="morphe_theme_background_dark_entry_15">Dark red</string>
-    <string name="morphe_theme_background_dark_entry_16">Custom</string>
+    <string name="morphe_theme_background_dark_entry_7">Classic YouTube</string>
+    <string name="morphe_theme_background_dark_entry_8">Catppuccin (Mocha)</string>
+    <string name="morphe_theme_background_dark_entry_9">Dark pink</string>
+    <string name="morphe_theme_background_dark_entry_10">Dark blue</string>
+    <string name="morphe_theme_background_dark_entry_11">Dark green</string>
+    <string name="morphe_theme_background_dark_entry_12">Dark yellow</string>
+    <string name="morphe_theme_background_dark_entry_13">Dark orange</string>
+    <string name="morphe_theme_background_dark_entry_14">Dark red</string>
+    <string name="morphe_theme_background_dark_entry_15">Custom</string>
     <string name="morphe_theme_background_dark_custom_color_title">Custom dark background</string>
     <string name="morphe_theme_background_dark_custom_color_summary">Set the background color of the dark theme</string>
 

--- a/patches/src/main/resources/addresources/values/youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/youtube/arrays.xml
@@ -236,6 +236,7 @@
         <item>@string/morphe_theme_background_light_entry_11</item>
         <item>@string/morphe_theme_background_light_entry_12</item>
         <item>@string/morphe_theme_background_light_entry_13</item>
+        <item>@string/morphe_theme_background_light_entry_14</item>
     </string-array>
     <string-array name="morphe_theme_background_light_entry_values">
         <item>APP_DEFAULT</item>
@@ -251,6 +252,7 @@
         <item>LIGHT_YELLOW</item>
         <item>LIGHT_ORANGE</item>
         <item>LIGHT_RED</item>
+        <item>CUSTOM</item>
     </string-array>
 
     <!-- Since the 30fps looks bad, and the 2/5 second styles are not useful

--- a/patches/src/main/resources/addresources/values/youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/youtube/arrays.xml
@@ -222,6 +222,37 @@
     </string-array>
 
     <!-- layout.theme.themePatch -->
+    <string-array name="morphe_theme_background_light_entries">
+        <item>@string/morphe_theme_background_light_entry_1</item>
+        <item>@string/morphe_theme_background_light_entry_2</item>
+        <item>@string/morphe_theme_background_light_entry_3</item>
+        <item>@string/morphe_theme_background_light_entry_4</item>
+        <item>@string/morphe_theme_background_light_entry_5</item>
+        <item>@string/morphe_theme_background_light_entry_6</item>
+        <item>@string/morphe_theme_background_light_entry_7</item>
+        <item>@string/morphe_theme_background_light_entry_8</item>
+        <item>@string/morphe_theme_background_light_entry_9</item>
+        <item>@string/morphe_theme_background_light_entry_10</item>
+        <item>@string/morphe_theme_background_light_entry_11</item>
+        <item>@string/morphe_theme_background_light_entry_12</item>
+        <item>@string/morphe_theme_background_light_entry_13</item>
+    </string-array>
+    <string-array name="morphe_theme_background_light_entry_values">
+        <item>APP_DEFAULT</item>
+        <item>WHITE</item>
+        <item>MATERIAL_YOU_NEUTRAL</item>
+        <item>MATERIAL_YOU_PRIMARY</item>
+        <item>MATERIAL_YOU_SECONDARY</item>
+        <item>MATERIAL_YOU_TERTIARY</item>
+        <item>CATPPUCCIN_LATTE</item>
+        <item>LIGHT_PINK</item>
+        <item>LIGHT_BLUE</item>
+        <item>LIGHT_GREEN</item>
+        <item>LIGHT_YELLOW</item>
+        <item>LIGHT_ORANGE</item>
+        <item>LIGHT_RED</item>
+    </string-array>
+
     <!-- Since the 30fps looks bad, and the 2/5 second styles are not useful
          (YouTube closes the animation as soon as the feed is loaded),
          only the 60fps 1 second styles are exposed in the settings.

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1085,6 +1085,9 @@ Limitation: If \'Restore old video action bar\' is turned off, \'More videos\' o
     <string name="morphe_theme_background_light_entry_11">Light yellow</string>
     <string name="morphe_theme_background_light_entry_12">Light orange</string>
     <string name="morphe_theme_background_light_entry_13">Light red</string>
+    <string name="morphe_theme_background_light_entry_14">Custom</string>
+    <string name="morphe_theme_background_light_custom_color_title">Custom light background</string>
+    <string name="morphe_theme_background_light_custom_color_summary">Set the background color of the light theme</string>
     <string name="morphe_gradient_loading_screen_title">Enable gradient loading screen</string>
     <string name="morphe_gradient_loading_screen_summary">Shows a gradient background on the loading screen instead of a solid color</string>
     <string name="morphe_splash_screen_animation_style_title">Splash screen style</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1039,7 +1039,7 @@ Limitation: If \'Restore old video action bar\' is turned off, \'More videos\' o
     <string name="morphe_miniplayer_disable_resuming_summary">Disables the \'Continue watching\' miniplayer, a YouTube Premium feature that appears on app startup</string>
     <string name="morphe_miniplayer_screen_title">Miniplayer</string>
     <string name="morphe_miniplayer_screen_summary">Customize the appearance and behavior of the minimized video player</string>
-    <string name="morphe_miniplayer_not_available_summary">YouTube removed all additional miniplayers. To change the miniplayer type then patch YouTube 21.28.207 or older</string>
+    <string name="morphe_miniplayer_not_available_summary">YouTube removed all additional miniplayers. To change the miniplayer type then patch YouTube 21.28.208 or older</string>
     <string name="morphe_miniplayer_type_title">Miniplayer type</string>
     <string name="morphe_miniplayer_type_entry_0">Disabled</string>
     <string name="morphe_miniplayer_type_entry_1">Default</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1071,6 +1071,20 @@ Limitation: If \'Restore old video action bar\' is turned off, \'More videos\' o
     <string name="morphe_back_button_always_exits_feed_summary">Pressing back always exits the app instead of scrolling to the top of the feed</string>
 
     <!-- layout.theme.themePatch -->
+    <string name="morphe_theme_background_light_title">Light theme background</string>
+    <string name="morphe_theme_background_light_entry_1">App default</string>
+    <string name="morphe_theme_background_light_entry_2">White</string>
+    <string name="morphe_theme_background_light_entry_3">Material You (Neutral)</string>
+    <string name="morphe_theme_background_light_entry_4">Material You (Primary)</string>
+    <string name="morphe_theme_background_light_entry_5">Material You (Secondary)</string>
+    <string name="morphe_theme_background_light_entry_6">Material You (Tertiary)</string>
+    <string name="morphe_theme_background_light_entry_7">Catppuccin (Latte)</string>
+    <string name="morphe_theme_background_light_entry_8">Light pink</string>
+    <string name="morphe_theme_background_light_entry_9">Light blue</string>
+    <string name="morphe_theme_background_light_entry_10">Light green</string>
+    <string name="morphe_theme_background_light_entry_11">Light yellow</string>
+    <string name="morphe_theme_background_light_entry_12">Light orange</string>
+    <string name="morphe_theme_background_light_entry_13">Light red</string>
     <string name="morphe_gradient_loading_screen_title">Enable gradient loading screen</string>
     <string name="morphe_gradient_loading_screen_summary">Shows a gradient background on the loading screen instead of a solid color</string>
     <string name="morphe_splash_screen_animation_style_title">Splash screen style</string>


### PR DESCRIPTION
### Description

Both the dark and the light background are now settings inside the app and can be changed at any time.

The app does not paint its background itself, it is resolved by the resource system from XML, so the patch writes one color variant per background and the extension asks for one of them by overriding the configuration of every context the app attaches. The qualifiers it uses are ignored by the app and affect nothing else.

- New settings `Dark theme background` and `Light theme background` under General, with the same choices the patch options had, apart from the one that was identical to the app default. Changing one asks to restart the app. YT Music has the dark background only.
- Every background shows its color next to the name, the same way the app icons are shown. The color is read from the variant that entry would apply, so a preview can never disagree with the result, and `App default` shows the color of the app version being patched.
- `Custom` lets you pick any color. On Android 14 and later the color is exact, because the app registers an overlay for itself, and the patch declares the background colors in `res/values/overlayable.xml` since the system rejects an overlay the target does not allow. On Android 8 to 13 nothing can be added to the resources at runtime, so the closest of 512 colors that were compiled in is used instead.
- Material You backgrounds fall back to the app default on Android 11 and older.
- The new content indicator, the dot of a tab and the count next to it, follows a Material You background. It is now done with a hook that colors the view, instead of replacing drawables, styles and layouts while patching, and it works in both apps.

Depends on:
- https://github.com/MorpheApp/morphe-patches-library/pull/47
- https://github.com/MorpheApp/morphe-patcher/pull/180

___
![Screenshot_2026-08-20-16-33-10-415_com.google.android.apps.youtube.music.test-edit.jpg](https://github.com/user-attachments/assets/fe3b1c19-fe0f-4e9f-a9f6-5e7cd6158f35)

