### PR TITLE
feat(Spoof video streams): Makes `TV Simply` available in signed-out or incognito mode by generating a PoToken

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/spoof/SpoofVideoStreamsPatch.java
@@ -13,7 +13,7 @@ public class SpoofVideoStreamsPatch {
      */
     public static void setClientOrderToUse() {
         List<ClientType> availableClients = List.of(
-                ClientType.TV_SABR,
+                ClientType.TV_SIMPLY,
                 ClientType.VISIONOS_1_02,
                 ClientType.ANDROID_MUSIC_NO_SDK,
                 ClientType.ANDROID_MUSIC_REEL

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/ClientType.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/ClientType.java
@@ -63,6 +63,7 @@ public enum ClientType {
             false,
             false,
             false,
+            false,
             "Android Music No SDK"
     ),
     /**
@@ -207,6 +208,7 @@ public enum ClientType {
             true,
             false,
             true,
+            false,
             true,
             "TV"
     ),
@@ -229,6 +231,7 @@ public enum ClientType {
             TV_SABR.supportsMultiAudioTracks,
             TV_SABR.supportsVRImmersiveMode,
             TV_SABR.requireJS,
+            TV_SABR.requirePoToken,
             false,
             "TV Downgraded"
     ),
@@ -248,11 +251,11 @@ public enum ClientType {
             TV_SABR.userAgent,
             true,
             // This client requires a PoToken for logout.
-            // Use as a login-only client.
-            true,
+            false,
             TV_SABR.supportsMultiAudioTracks,
             TV_SABR.supportsVRImmersiveMode,
             TV_SABR.requireJS,
+            true,
             false,
             "TV Simply"
     ),
@@ -277,6 +280,7 @@ public enum ClientType {
             true,
             false,
             false,
+            false,
             "visionOS 1.03"
     ),
     /**
@@ -299,6 +303,7 @@ public enum ClientType {
             VISIONOS_1_03.supportsMultiAudioTracks,
             VISIONOS_1_03.supportsVRImmersiveMode,
             VISIONOS_1_03.requireJS,
+            VISIONOS_1_03.requirePoToken,
             VISIONOS_1_03.requireSABR,
             "visionOS 1.02"
     );
@@ -397,6 +402,11 @@ public enum ClientType {
     public final boolean requireJS;
 
     /**
+     * If the client requires PoToken.
+     */
+    public final boolean requirePoToken;
+
+    /**
      * If the client require SABR.
      */
     public final boolean requireSABR;
@@ -466,6 +476,7 @@ public enum ClientType {
         Logger.printDebug(() -> "userAgent: " + this.userAgent);
 
         requireJS = false;
+        requirePoToken = false;
     }
 
     ClientType(int id,
@@ -482,6 +493,7 @@ public enum ClientType {
                boolean supportsMultiAudioTracks,
                boolean supportsVRImmersiveMode,
                boolean requireJS,
+               boolean requirePoToken,
                boolean requireSABR,
                String friendlyName) {
         this.id = id;
@@ -498,6 +510,7 @@ public enum ClientType {
         this.supportsMultiAudioTracks = supportsMultiAudioTracks;
         this.supportsVRImmersiveMode = supportsVRImmersiveMode;
         this.requireJS = requireJS;
+        this.requirePoToken = requirePoToken;
         this.requireSABR = requireSABR;
         this.friendlyName = friendlyName;
 

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/js/JavaScriptManager.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/js/JavaScriptManager.java
@@ -338,7 +338,9 @@ public final class JavaScriptManager {
      * @return              StreamingData builder containing deobfuscated parameters.
      */
     @Nullable
-    public static StreamingData.Builder getDeobfuscatedStreamingData(StreamingData streamingData, boolean requireSABR) {
+    public static StreamingData.Builder getDeobfuscatedStreamingData(StreamingData streamingData,
+                                                                     String poToken,
+                                                                     boolean requireSABR) {
         StreamingData.Builder streamingDataBuilder = streamingData.toBuilder();
         String serverAbrStreamingUrl = streamingData.getServerAbrStreamingUrl();
 
@@ -363,6 +365,7 @@ public final class JavaScriptManager {
                 formats,
                 serverAbrStreamingUrl,
                 fallbackParam,
+                poToken,
                 false,
                 requireSABR
         );
@@ -376,6 +379,7 @@ public final class JavaScriptManager {
                 streamingData.getAdaptiveFormatsList(),
                 serverAbrStreamingUrl,
                 fallbackParam,
+                poToken,
                 true,
                 requireSABR
         );
@@ -391,6 +395,7 @@ public final class JavaScriptManager {
                                              List<Format> formats,
                                              String serverAbrStreamingUrl,
                                              String fallbackParam,
+                                             String poToken,
                                              boolean isAdaptiveFormats,
                                              boolean requireSABR) {
         PlayerDataExtractor playerDataExtractor = getPlayerDataExtractor();
@@ -475,6 +480,9 @@ public final class JavaScriptManager {
                                 ? obfuscatedUrlParameters.get(i) + "&sig=" + deobfuscatedSParameters.get(i)
                                 : format.getUrl();
                         String deobfuscatedUrl = obfuscatedUrl.replace(obfuscatedNParameter, deobfuscatedNParameter);
+                        if (isNotEmpty(poToken)) {
+                            deobfuscatedUrl = deobfuscatedUrl + "&pot=" + poToken;
+                        }
                         formatBuilder.setUrl(deobfuscatedUrl);
                         formatBuilder.clearSignatureCipher();
                     }
@@ -486,6 +494,10 @@ public final class JavaScriptManager {
                 String deobfuscatedServerAbrStreamingUrl = "";
                 if (isNotEmpty(serverAbrStreamingUrl)) {
                     deobfuscatedServerAbrStreamingUrl = serverAbrStreamingUrl.replace(obfuscatedNParameter, deobfuscatedNParameter);
+
+                    if (isNotEmpty(poToken)) {
+                        deobfuscatedServerAbrStreamingUrl = deobfuscatedServerAbrStreamingUrl + "&pot=" + poToken;
+                    }
                 }
 
                 streamingDataBuilder.setServerAbrStreamingUrl(deobfuscatedServerAbrStreamingUrl);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/BotGuardManager.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/BotGuardManager.java
@@ -35,7 +35,7 @@ public final class BotGuardManager {
     private static final String BOT_GUARD_REQUEST_KEY = "O43z0dpjhgX20SCx4KAo";
     private static final String YOUTUBE_CONFIG_URL = "https://www.youtube.com/tv_config?action_get_config=true";
     private static final String YOUTUBE_URL = "https://www.youtube.com/";
-    private static final String YOUTUBE_TV_URL = YOUTUBE_URL + "tv";
+    private static final String YOUTUBE_TV_URL = "https://www.youtube.com/tv";
     private static final String USER_AGENT = "Mozilla/5.0 (SMART-TV; Linux; Tizen 8.0) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.0 Chrome/108.0.5359.1 TV Safari/537.36";
     /**
      * TCP connection and HTTP read timeout.
@@ -47,19 +47,26 @@ public final class BotGuardManager {
      */
     private static final int MAX_MILLISECONDS_TO_WAIT_FOR_FETCH = 10 * 1000;
 
-    private static final long CHALLENGE_DATA_EXPIRATION_MS = 6 * 60 * 60 * 1000L; // 6 hours.
+    /**
+     * 5 hours 55 mins.
+     * Leave 5 minutes of margin just to be sure.
+     */
+    private static final long CHALLENGE_DATA_EXPIRATION_MS = 6 * 60 * 60 * 1000L - 5 * 60 * 1000L;
 
     @Nullable
     private volatile static String challengeData = null;
+    @NonNull
+    private volatile static String challengeRequestKey = BOT_GUARD_REQUEST_KEY;
 
-    private volatile static long challengeDataFetchedTime = -1L;
+    private volatile static long challengeFetchedTime = -1L;
 
-    private static final CompletableFuture<String> challengeDataFuture = CompletableFuture.supplyAsync(() -> downloadUrl(YOUTUBE_CONFIG_URL))
+    private static final CompletableFuture<Challenge> challengeFuture = CompletableFuture.supplyAsync(() -> downloadUrl(YOUTUBE_CONFIG_URL))
             .thenApplyAsync(jsonString -> {
                 if (jsonString != null && jsonString.startsWith(")]}'")) {
                     try {
-                        JSONObject jsonObject = new JSONObject(jsonString.substring(4));
-                        String rawData = jsonObject.getJSONObject("challengeParams").getString("R");
+                        JSONObject json = new JSONObject(jsonString.substring(4));
+                        String challengeRequestKey = json.getString("challengeRequestKey");
+                        String rawData = json.getJSONObject("challengeParams").getString("R");
                         JSONObject scrambled = new JSONObject(rawData);
                         JSONObject bgChallenge = scrambled.getJSONObject("bgChallenge");
                         String interpreterHash = bgChallenge.getString("interpreterHash");
@@ -83,7 +90,7 @@ public final class BotGuardManager {
                         challengeData.put("globalName", globalName);
                         challengeData.put("clientExperimentsStateBlob", clientExperimentsStateBlob);
 
-                        return challengeData.toString();
+                        return new Challenge(challengeRequestKey, challengeData.toString());
                     } catch (Exception ex) {
                         Logger.printException(() -> "Failed to parse challenge data", ex);
                     }
@@ -100,13 +107,23 @@ public final class BotGuardManager {
         if (isChallengeDataNotExpired()) {
             return challengeData;
         }
-        challengeData = downloadChallengeData();
-        challengeDataFetchedTime = System.currentTimeMillis();
+        Challenge challenge = downloadChallenge();
+        if (challenge != null) {
+            challengeData = challenge.data;
+            String requestKey = challenge.key;
+            if (Utils.isNotEmpty(requestKey)) {
+                challengeRequestKey = requestKey;
+            }
+            challengeFetchedTime = System.currentTimeMillis();
+        }
         return challengeData;
     }
 
     public static String getUserAgent() {
         return USER_AGENT;
+    }
+
+    public record Challenge(String key, String data) {
     }
 
     public record IntegrityToken(String token, long expirationMs) {
@@ -138,7 +155,6 @@ public final class BotGuardManager {
 
                     return null;
                 });
-
         try {
             return integrityTokenFuture.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {
@@ -159,21 +175,21 @@ public final class BotGuardManager {
 
     private static boolean isChallengeDataNotExpired() {
         return Utils.isNotEmpty(challengeData) && System.currentTimeMillis()
-                - challengeDataFetchedTime < CHALLENGE_DATA_EXPIRATION_MS;
+                - challengeFetchedTime < CHALLENGE_DATA_EXPIRATION_MS;
     }
 
     @Nullable
-    private static String downloadChallengeData() {
+    private static Challenge downloadChallenge() {
         try {
-            return challengeDataFuture.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
+            return challengeFuture.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {
             Logger.printInfo(() -> "downloadChallengeData timed out", ex);
-            challengeDataFuture.cancel(true);
+            challengeFuture.cancel(true);
         } catch (CancellationException ex) {
             Logger.printInfo(() -> "downloadChallengeData was previously cancelled");
         } catch (InterruptedException ex) {
             Logger.printException(() -> "downloadChallengeData interrupted", ex);
-            challengeDataFuture.cancel(true);
+            challengeFuture.cancel(true);
             Thread.currentThread().interrupt(); // Restore interrupt status flag.
         } catch (ExecutionException ex) {
             Logger.printException(() -> "downloadChallengeData failure", ex);
@@ -253,7 +269,7 @@ public final class BotGuardManager {
             connection.setRequestProperty("x-user-agent", "grpc-web-javascript/0.1");
             connection.setConnectTimeout(HTTP_TIMEOUT_MILLISECONDS);
             connection.setReadTimeout(HTTP_TIMEOUT_MILLISECONDS);
-            JSONArray body = new JSONArray(List.of(BOT_GUARD_REQUEST_KEY, botGuardResult));
+            JSONArray body = new JSONArray(List.of(challengeRequestKey, botGuardResult));
             byte[] requestBody = body.toString().getBytes(StandardCharsets.UTF_8);
             connection.setFixedLengthStreamingMode(requestBody.length);
             connection.getOutputStream().write(requestBody);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/BotGuardManager.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/BotGuardManager.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.spoof.potoken;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.requests.Requester;
+import app.morphe.extension.shared.settings.SharedYouTubeSettings;
+
+public final class BotGuardManager {
+    private static final String BOT_GUARD_URL = "https://www.youtube.com/api/jnn/v1/GenerateIT";
+    private static final String BOT_GUARD_REQUEST_KEY = "O43z0dpjhgX20SCx4KAo";
+    private static final String YOUTUBE_CONFIG_URL = "https://www.youtube.com/tv_config?action_get_config=true";
+    private static final String YOUTUBE_URL = "https://www.youtube.com/";
+    private static final String YOUTUBE_TV_URL = YOUTUBE_URL + "tv";
+    private static final String USER_AGENT = "Mozilla/5.0 (SMART-TV; Linux; Tizen 8.0) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.0 Chrome/108.0.5359.1 TV Safari/537.36";
+    /**
+     * TCP connection and HTTP read timeout.
+     */
+    private static final int HTTP_TIMEOUT_MILLISECONDS = 5 * 1000;
+
+    /**
+     * Any arbitrarily large value, but must be at least twice {@link #HTTP_TIMEOUT_MILLISECONDS}
+     */
+    private static final int MAX_MILLISECONDS_TO_WAIT_FOR_FETCH = 10 * 1000;
+
+    private static final long CHALLENGE_DATA_EXPIRATION_MS = 6 * 60 * 60 * 1000L; // 6 hours.
+
+    @Nullable
+    private volatile static String challengeData = null;
+
+    private volatile static long challengeDataFetchedTime = -1L;
+
+    private static final CompletableFuture<String> challengeDataFuture = CompletableFuture.supplyAsync(() -> downloadUrl(YOUTUBE_CONFIG_URL))
+            .thenApplyAsync(jsonString -> {
+                if (jsonString != null && jsonString.startsWith(")]}'")) {
+                    try {
+                        JSONObject jsonObject = new JSONObject(jsonString.substring(4));
+                        String rawData = jsonObject.getJSONObject("challengeParams").getString("R");
+                        JSONObject scrambled = new JSONObject(rawData);
+                        JSONObject bgChallenge = scrambled.getJSONObject("bgChallenge");
+                        String interpreterHash = bgChallenge.getString("interpreterHash");
+                        String program = bgChallenge.getString("program");
+                        String globalName = bgChallenge.getString("globalName");
+                        String clientExperimentsStateBlob = bgChallenge.getString("clientExperimentsStateBlob");
+                        String privateDoNotAccessOrElseTrustedResourceUrlWrappedValue = bgChallenge
+                                .getJSONObject("interpreterUrl")
+                                .getString("privateDoNotAccessOrElseTrustedResourceUrlWrappedValue");
+                        String privateDoNotAccessOrElseSafeScriptWrappedValue =
+                                downloadUrl("https:" + privateDoNotAccessOrElseTrustedResourceUrlWrappedValue);
+
+                        JSONObject interpreterJavascript = new JSONObject();
+                        interpreterJavascript.put("privateDoNotAccessOrElseSafeScriptWrappedValue", privateDoNotAccessOrElseSafeScriptWrappedValue);
+                        interpreterJavascript.put("privateDoNotAccessOrElseTrustedResourceUrlWrappedValue", privateDoNotAccessOrElseTrustedResourceUrlWrappedValue);
+
+                        JSONObject challengeData = new JSONObject();
+                        challengeData.put("interpreterJavascript", interpreterJavascript);
+                        challengeData.put("interpreterHash", interpreterHash);
+                        challengeData.put("program", program);
+                        challengeData.put("globalName", globalName);
+                        challengeData.put("clientExperimentsStateBlob", clientExperimentsStateBlob);
+
+                        return challengeData.toString();
+                    } catch (Exception ex) {
+                        Logger.printException(() -> "Failed to parse challenge data", ex);
+                    }
+                }
+
+                return null;
+            });
+
+    private BotGuardManager() {
+    }
+
+    @Nullable
+    public static String getChallengeData() {
+        if (isChallengeDataNotExpired()) {
+            return challengeData;
+        }
+        challengeData = downloadChallengeData();
+        challengeDataFetchedTime = System.currentTimeMillis();
+        return challengeData;
+    }
+
+    public static String getUserAgent() {
+        return USER_AGENT;
+    }
+
+    public record IntegrityToken(String token, long expirationMs) {
+    }
+
+    @Nullable
+    public static IntegrityToken getIntegrityToken(@Nullable String botGuardResult) {
+        CompletableFuture<IntegrityToken> integrityTokenFuture = CompletableFuture.supplyAsync(() -> fetchIntegrityToken(botGuardResult))
+                .thenApply(botGuardResponse -> {
+                    if (botGuardResponse != null) {
+                        try {
+                            long expirationSecond = -1L;
+                            int length = botGuardResponse.length();
+                            if (length > 1) {
+                                expirationSecond = Math.max(botGuardResponse.getLong(1), 7200L);
+                            }
+                            long expirationMs = System.currentTimeMillis() + ((expirationSecond - 300L) * 1000);
+
+                            for (int i = length - 1; i >= 0; i--) {
+                                if (botGuardResponse.get(i) instanceof String rawValue) {
+                                    String token = BotGuardUtil.base64ToU8(rawValue);
+                                    return new IntegrityToken(token, expirationMs);
+                                }
+                            }
+                        } catch (Exception ex) {
+                            Logger.printException(() -> "Failed to parse BotGuard response", ex);
+                        }
+                    }
+
+                    return null;
+                });
+
+        try {
+            return integrityTokenFuture.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException ex) {
+            Logger.printInfo(() -> "getIntegrityToken timed out", ex);
+            integrityTokenFuture.cancel(true);
+        } catch (CancellationException ex) {
+            Logger.printInfo(() -> "getIntegrityToken was previously cancelled");
+        } catch (InterruptedException ex) {
+            Logger.printException(() -> "getIntegrityToken interrupted", ex);
+            integrityTokenFuture.cancel(true);
+            Thread.currentThread().interrupt(); // Restore interrupt status flag.
+        } catch (ExecutionException ex) {
+            Logger.printException(() -> "getIntegrityToken failure", ex);
+        }
+
+        return null;
+    }
+
+    private static boolean isChallengeDataNotExpired() {
+        return Utils.isNotEmpty(challengeData) && System.currentTimeMillis()
+                - challengeDataFetchedTime < CHALLENGE_DATA_EXPIRATION_MS;
+    }
+
+    @Nullable
+    private static String downloadChallengeData() {
+        try {
+            return challengeDataFuture.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException ex) {
+            Logger.printInfo(() -> "downloadChallengeData timed out", ex);
+            challengeDataFuture.cancel(true);
+        } catch (CancellationException ex) {
+            Logger.printInfo(() -> "downloadChallengeData was previously cancelled");
+        } catch (InterruptedException ex) {
+            Logger.printException(() -> "downloadChallengeData interrupted", ex);
+            challengeDataFuture.cancel(true);
+            Thread.currentThread().interrupt(); // Restore interrupt status flag.
+        } catch (ExecutionException ex) {
+            Logger.printException(() -> "downloadChallengeData failure", ex);
+        }
+
+        return null;
+    }
+
+    private static void handleConnectionError(String toastMessage, @Nullable Exception ex) {
+        if (SharedYouTubeSettings.DEBUG.get()) {
+            Utils.showToastShort(toastMessage);
+        }
+        Logger.printInfo(() -> toastMessage, ex);
+    }
+
+    @Nullable
+    private static String downloadUrl(@NonNull String url) {
+        if (Utils.isNetworkConnected()) {
+            try {
+                Logger.printDebug(() -> "Starting download of: " + url);
+
+                final long start = System.currentTimeMillis();
+                HttpURLConnection connection = Requester.openConnection(url);
+                connection.setFixedLengthStreamingMode(0);
+                connection.setRequestMethod("GET");
+                connection.setRequestProperty("Referer", YOUTUBE_TV_URL);
+                connection.setRequestProperty("User-Agent", USER_AGENT);
+                connection.setConnectTimeout(HTTP_TIMEOUT_MILLISECONDS);
+                connection.setReadTimeout(HTTP_TIMEOUT_MILLISECONDS);
+                final int responseCode = connection.getResponseCode();
+
+                final String content;
+                if (responseCode == HttpURLConnection.HTTP_OK) {
+                    content = Requester.parseString(connection);
+                } else {
+                    handleConnectionError("Ignoring response code: " + responseCode, null);
+                    content = null;
+                }
+                connection.disconnect();
+
+                Logger.printDebug(() -> "Download took: " + (System.currentTimeMillis() - start) + "ms for URL: " + url);
+                return content;
+            } catch (SocketTimeoutException ex) {
+                handleConnectionError("Connection timeout", ex);
+            } catch (IOException ex) {
+                handleConnectionError("Network error", ex);
+            }
+        } else {
+            handleConnectionError("No internet connection: " + url, null);
+        }
+
+        return null;
+    }
+
+    @Nullable
+    private static JSONArray fetchIntegrityToken(@Nullable String botGuardResult) {
+        if (!Utils.isNotEmpty(botGuardResult)) {
+            handleConnectionError("BotGuardResult is null", null);
+            return null;
+        }
+        if (!Utils.isNetworkConnected()) {
+            handleConnectionError("No internet connection", null);
+            return null;
+        }
+        try {
+            Logger.printDebug(() -> "Starting fetching integrity token");
+
+            final long start = System.currentTimeMillis();
+            HttpURLConnection connection = Requester.openConnection(BOT_GUARD_URL);
+            connection.setDoOutput(true);
+            connection.setRequestMethod("POST");
+            connection.setRequestProperty("Referer", YOUTUBE_URL);
+            connection.setRequestProperty("User-Agent", USER_AGENT);
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setRequestProperty("Content-Type", "application/json+protobuf");
+            connection.setRequestProperty("x-goog-api-key", "AIzaSyDyT5W0Jh49F30Pqqtyfdf7pDLFKLJoAnw");
+            connection.setRequestProperty("x-user-agent", "grpc-web-javascript/0.1");
+            connection.setConnectTimeout(HTTP_TIMEOUT_MILLISECONDS);
+            connection.setReadTimeout(HTTP_TIMEOUT_MILLISECONDS);
+            JSONArray body = new JSONArray(List.of(BOT_GUARD_REQUEST_KEY, botGuardResult));
+            byte[] requestBody = body.toString().getBytes(StandardCharsets.UTF_8);
+            connection.setFixedLengthStreamingMode(requestBody.length);
+            connection.getOutputStream().write(requestBody);
+            final int responseCode = connection.getResponseCode();
+
+            final JSONArray result;
+            if (responseCode == HttpURLConnection.HTTP_OK) {
+                result = Requester.parseJSONArray(connection);
+            } else {
+                Logger.printDebug(() -> "Ignoring response code: " + responseCode);
+                result = null;
+            }
+            connection.disconnect();
+
+            Logger.printDebug(() -> "Fetched integrity token, took: " + (System.currentTimeMillis() - start) + "ms");
+            return result;
+        } catch (JSONException | SocketTimeoutException ex) {
+            handleConnectionError("Connection timeout", ex);
+        } catch (IOException ex) {
+            handleConnectionError("Network error", ex);
+        }
+
+        return null;
+    }
+
+}

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/BotGuardManager.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/BotGuardManager.java
@@ -183,16 +183,16 @@ public final class BotGuardManager {
         try {
             return challengeFuture.get(MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {
-            Logger.printInfo(() -> "downloadChallengeData timed out", ex);
+            Logger.printInfo(() -> "downloadChallenge timed out", ex);
             challengeFuture.cancel(true);
         } catch (CancellationException ex) {
-            Logger.printInfo(() -> "downloadChallengeData was previously cancelled");
+            Logger.printInfo(() -> "downloadChallenge was previously cancelled");
         } catch (InterruptedException ex) {
-            Logger.printException(() -> "downloadChallengeData interrupted", ex);
+            Logger.printException(() -> "downloadChallenge interrupted", ex);
             challengeFuture.cancel(true);
             Thread.currentThread().interrupt(); // Restore interrupt status flag.
         } catch (ExecutionException ex) {
-            Logger.printException(() -> "downloadChallengeData failure", ex);
+            Logger.printException(() -> "downloadChallenge failure", ex);
         }
 
         return null;

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/BotGuardManager.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/BotGuardManager.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2533
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/BotGuardUtil.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/BotGuardUtil.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2533
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
@@ -25,7 +25,7 @@ public final class BotGuardUtil {
             String[] parts = poToken.split(",");
             byte[] bytes = new byte[parts.length];
 
-            for (int i = 0; i < parts.length; i++) {
+            for (int i = 0, length = parts.length; i < length; i++) {
                 try {
                     int val = Integer.parseInt(parts[i].trim());
                     bytes[i] = (byte) val;
@@ -36,8 +36,8 @@ public final class BotGuardUtil {
             }
 
             return Base64.encodeToString(bytes, Base64.NO_WRAP)
-                    .replace("+", "-")
-                    .replace("/", "_");
+                    .replace('+', '-')
+                    .replace('/', '_');
         }
 
         return null;
@@ -50,8 +50,8 @@ public final class BotGuardUtil {
     private static String newUint8Array(byte[] contents) {
         StringBuilder sb = new StringBuilder();
         sb.append("new Uint8Array([");
-        for (int i = 0; i < contents.length; i++) {
-            if (i > 0) sb.append(",");
+        for (int i = 0, length = contents.length; i < length; i++) {
+            if (i > 0) sb.append(',');
             sb.append(Byte.toUnsignedInt(contents[i]));
         }
         sb.append("])");

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/BotGuardUtil.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/BotGuardUtil.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.spoof.potoken;
+
+import android.util.Base64;
+
+import java.nio.charset.StandardCharsets;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
+
+public final class BotGuardUtil {
+
+    public static String stringToU8(String identifier) {
+        return newUint8Array(identifier.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static String u8ToBase64(String poToken) {
+        if (Utils.isNotEmpty(poToken)) {
+            String[] parts = poToken.split(",");
+            byte[] bytes = new byte[parts.length];
+
+            for (int i = 0; i < parts.length; i++) {
+                try {
+                    int val = Integer.parseInt(parts[i].trim());
+                    bytes[i] = (byte) val;
+                } catch (NumberFormatException ignored) {
+                    // Ignore or handle error
+                    bytes[i] = 0;
+                }
+            }
+
+            return Base64.encodeToString(bytes, Base64.NO_WRAP)
+                    .replace("+", "-")
+                    .replace("/", "_");
+        }
+
+        return null;
+    }
+
+    public static String base64ToU8(String base64) {
+        return newUint8Array(base64ToByteString(base64));
+    }
+
+    private static String newUint8Array(byte[] contents) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("new Uint8Array([");
+        for (int i = 0; i < contents.length; i++) {
+            if (i > 0) sb.append(",");
+            sb.append(Byte.toUnsignedInt(contents[i]));
+        }
+        sb.append("])");
+        return sb.toString();
+    }
+
+    private static byte[] base64ToByteString(String base64) {
+        String base64Mod = base64
+                .replace('-', '+')
+                .replace('_', '/')
+                .replace('.', '=');
+        try {
+            return Base64.decode(base64Mod, Base64.DEFAULT);
+        } catch (IllegalArgumentException ex) {
+            Logger.printException(() -> "Cannot base64 decode", ex);
+        }
+
+        return new byte[0];
+    }
+}

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenException.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenException.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2533
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
@@ -21,8 +21,7 @@ public class PoTokenException extends Exception {
     public static Exception buildExceptionForJsError(String error) {
         if (error != null && error.contains("SyntaxError")) {
             return new BadWebViewException(error);
-        } else {
-            return new PoTokenException(error);
         }
+        return new PoTokenException(error);
     }
 }

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenException.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.spoof.potoken;
+
+public class PoTokenException extends Exception {
+    public PoTokenException(String message) {
+        super(message);
+    }
+
+    public static class BadWebViewException extends Exception {
+        public BadWebViewException(String message) {
+            super(message);
+        }
+    }
+
+    public static Exception buildExceptionForJsError(String error) {
+        if (error != null && error.contains("SyntaxError")) {
+            return new BadWebViewException(error);
+        } else {
+            return new PoTokenException(error);
+        }
+    }
+}

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenGenerator.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenGenerator.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.spoof.potoken;
+
+import android.annotation.SuppressLint;
+import android.webkit.CookieManager;
+
+import java.text.SimpleDateFormat;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.locks.ReentrantLock;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
+
+public class PoTokenGenerator {
+    @SuppressLint("SimpleDateFormat")
+    private final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+
+    private final ReentrantLock webPoTokenGenLock = new ReentrantLock();
+    private String webPoTokenSessionIdentifier = null;
+    private String webPoTokenStreamingPot = null;
+    private long webPoTokenExpirationMS = -1L;
+    private PoTokenWebView webPoTokenGenerator = null;
+
+    private boolean webViewBadImpl = false;
+
+    private record GeneratorState(PoTokenWebView generator, String sessionIdentifier,
+                                  String streamingPot, long expirationMs,
+                                  boolean hasBeenRecreated) {
+    }
+
+    public PoTokenResult getWebClientPoToken(String videoId, String visitorId) throws Exception {
+        if (!isWebViewSupported() || webViewBadImpl) {
+            return null;
+        }
+
+        try {
+            return getWebClientPoToken(videoId, visitorId, false);
+        } catch (Exception ex) {
+            if (ex instanceof PoTokenException.BadWebViewException) {
+                Logger.printException(() -> "Could not obtain poToken because WebView is broken", ex);
+                webViewBadImpl = true;
+                return null;
+            } else {
+                throw ex;
+            }
+        }
+    }
+
+    private boolean isWebViewSupported() {
+        try {
+            CookieManager.getInstance();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private PoTokenResult getWebClientPoToken(String videoId, String visitorId, boolean forceRecreate) throws Exception {
+        GeneratorState state;
+
+        webPoTokenGenLock.lock();
+        try {
+            if (visitorId.isEmpty()) {
+                throw new PoTokenException("Session identifier is null");
+            }
+
+            boolean shouldRecreate = webPoTokenGenerator == null
+                                     || forceRecreate 
+                                     || webPoTokenGenerator.isExpired();
+
+            if (shouldRecreate) {
+                webPoTokenSessionIdentifier = visitorId;
+                if (webPoTokenGenerator != null) {
+                    final PoTokenWebView oldGen = webPoTokenGenerator;
+                    Utils.runOnMainThread(oldGen::close);
+                }
+
+                try {
+                    // Blocks until initialized
+                    webPoTokenGenerator = PoTokenWebView.newPoTokenGenerator().get();
+                    
+                    // Blocks until token generated
+                    webPoTokenStreamingPot = webPoTokenGenerator.generatePoToken(webPoTokenSessionIdentifier).get();
+                    webPoTokenExpirationMS = webPoTokenGenerator.getExpirationMs();
+
+                } catch (ExecutionException e) {
+                    Throwable cause = e.getCause();
+                    if (cause instanceof Exception) throw (Exception) cause;
+                    throw new RuntimeException(cause);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Interrupted while creating PoTokenGenerator", e);
+                }
+            }
+            
+            state = new GeneratorState(
+                    webPoTokenGenerator,
+                    webPoTokenSessionIdentifier,
+                    webPoTokenStreamingPot,
+                    webPoTokenExpirationMS,
+                    shouldRecreate
+            );
+        } finally {
+            webPoTokenGenLock.unlock();
+        }
+
+        try {
+            String playerPot = state.generator.generatePoToken(videoId).get();
+            String streamingPot = state.streamingPot;
+            long expirationMs = state.expirationMs;
+            String expirationDate = sdf.format(expirationMs);
+            Logger.printDebug(() -> "poToken for " + videoId + ": playerPot=" + playerPot +
+                    ", streamingPot=" + streamingPot + ", sessionIdentifier=" + webPoTokenSessionIdentifier +
+                    ", expirationDate=" + expirationDate
+            );
+            return new PoTokenResult(playerPot, streamingPot, expirationMs);
+        } catch (Throwable throwable) {
+            if (state.hasBeenRecreated) {
+                throw throwable;
+            } else {
+                Logger.printException(() -> "Failed to obtain poToken, retrying");
+                return getWebClientPoToken(videoId, visitorId, true);
+            }
+        }
+    }
+}

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenGenerator.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenGenerator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2533
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
@@ -22,12 +22,12 @@ public class PoTokenGenerator {
     private final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 
     private final ReentrantLock webPoTokenGenLock = new ReentrantLock();
-    private String webPoTokenSessionIdentifier = null;
-    private String webPoTokenStreamingPot = null;
+    private String webPoTokenSessionIdentifier;
+    private String webPoTokenStreamingPot;
+    private PoTokenWebView webPoTokenGenerator;
     private long webPoTokenExpirationMS = -1L;
-    private PoTokenWebView webPoTokenGenerator = null;
 
-    private boolean webViewBadImpl = false;
+    private volatile boolean webViewBadImpl;
 
     private record GeneratorState(PoTokenWebView generator, String sessionIdentifier,
                                   String streamingPot, long expirationMs,
@@ -41,14 +41,10 @@ public class PoTokenGenerator {
 
         try {
             return getWebClientPoToken(videoId, visitorId, false);
-        } catch (Exception ex) {
-            if (ex instanceof PoTokenException.BadWebViewException) {
-                Logger.printException(() -> "Could not obtain poToken because WebView is broken", ex);
-                webViewBadImpl = true;
-                return null;
-            } else {
-                throw ex;
-            }
+        } catch (PoTokenException.BadWebViewException ex) {
+            Logger.printException(() -> "Could not obtain poToken because WebView is broken", ex);
+            webViewBadImpl = true;
+            return null;
         }
     }
 
@@ -70,14 +66,14 @@ public class PoTokenGenerator {
                 throw new PoTokenException("Session identifier is null");
             }
 
-            boolean shouldRecreate = webPoTokenGenerator == null
+            PoTokenWebView oldGen = webPoTokenGenerator;
+            boolean shouldRecreate = oldGen == null
                                      || forceRecreate 
-                                     || webPoTokenGenerator.isExpired();
+                                     || oldGen.isExpired();
 
             if (shouldRecreate) {
                 webPoTokenSessionIdentifier = visitorId;
-                if (webPoTokenGenerator != null) {
-                    final PoTokenWebView oldGen = webPoTokenGenerator;
+                if (oldGen != null) {
                     Utils.runOnMainThread(oldGen::close);
                 }
 
@@ -89,13 +85,13 @@ public class PoTokenGenerator {
                     webPoTokenStreamingPot = webPoTokenGenerator.generatePoToken(webPoTokenSessionIdentifier).get();
                     webPoTokenExpirationMS = webPoTokenGenerator.getExpirationMs();
 
-                } catch (ExecutionException e) {
-                    Throwable cause = e.getCause();
+                } catch (ExecutionException ex) {
+                    Throwable cause = ex.getCause();
                     if (cause instanceof Exception) throw (Exception) cause;
                     throw new RuntimeException(cause);
-                } catch (InterruptedException e) {
+                } catch (InterruptedException ex) {
                     Thread.currentThread().interrupt();
-                    throw new RuntimeException("Interrupted while creating PoTokenGenerator", e);
+                    throw new RuntimeException("Interrupted while creating PoTokenGenerator", ex);
                 }
             }
             
@@ -113,20 +109,18 @@ public class PoTokenGenerator {
         try {
             String playerPot = state.generator.generatePoToken(videoId).get();
             String streamingPot = state.streamingPot;
-            long expirationMs = state.expirationMs;
-            String expirationDate = sdf.format(expirationMs);
+            final long expirationMs = state.expirationMs;
             Logger.printDebug(() -> "poToken for " + videoId + ": playerPot=" + playerPot +
                     ", streamingPot=" + streamingPot + ", sessionIdentifier=" + webPoTokenSessionIdentifier +
-                    ", expirationDate=" + expirationDate
+                    ", expirationDate=" + sdf.format(expirationMs)
             );
             return new PoTokenResult(playerPot, streamingPot, expirationMs);
         } catch (Throwable throwable) {
             if (state.hasBeenRecreated) {
                 throw throwable;
-            } else {
-                Logger.printException(() -> "Failed to obtain poToken, retrying");
-                return getWebClientPoToken(videoId, visitorId, true);
             }
+            Logger.printException(() -> "Failed to obtain poToken, retrying");
+            return getWebClientPoToken(videoId, visitorId, true);
         }
     }
 }

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenManager.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenManager.java
@@ -1,16 +1,13 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2533
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
 
 package app.morphe.extension.shared.spoof.potoken;
 
-import java.util.concurrent.ExecutionException;
-
 import app.morphe.extension.shared.Logger;
-import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.spoof.ClientType;
 import app.morphe.extension.shared.spoof.requests.VisitorIdRequester;
 
@@ -32,15 +29,10 @@ public final class PoTokenManager {
         String visitorId = VisitorIdRequester.getVisitorId(clientType);
 
         try {
-            poTokenResult = Utils.submitOnBackgroundThread(() -> {
-                PoTokenGenerator poTokenGenerator = new PoTokenGenerator();
-                return poTokenGenerator.getWebClientPoToken(videoId, visitorId);
-            }).get();
-            return poTokenResult;
-        } catch (ExecutionException | InterruptedException ex) {
-            Logger.printException(() -> "Failed to launch PoTokenGenerator", ex);
+            PoTokenGenerator poTokenGenerator = new PoTokenGenerator();
+            return poTokenResult = poTokenGenerator.getWebClientPoToken(videoId, visitorId);
         } catch (Exception ex) {
-            Logger.printException(() -> "Failed to generate PoToken");
+            Logger.printException(() -> "Failed to generate PoToken", ex);
         }
 
         return null;
@@ -49,7 +41,7 @@ public final class PoTokenManager {
     public static String getPlayerPoToken(ClientType clientType, String videoId) {
         PoTokenResult result = getAndUpdatePoTokenIfNeeded(clientType, videoId);
         if (result != null) {
-            return result.getPlayerRequestPoToken();
+            return result.playerRequestPoToken;
         }
         return null;
     }
@@ -57,7 +49,7 @@ public final class PoTokenManager {
     public static String getStreamingPoToken(ClientType clientType, String videoId) {
         PoTokenResult result = getAndUpdatePoTokenIfNeeded(clientType, videoId);
         if (result != null) {
-            return result.getStreamingDataPoToken();
+            return result.streamingDataPoToken;
         }
         return null;
     }

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenManager.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenManager.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.spoof.potoken;
+
+import java.util.concurrent.ExecutionException;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.spoof.ClientType;
+import app.morphe.extension.shared.spoof.requests.VisitorIdRequester;
+
+public final class PoTokenManager {
+    private static volatile PoTokenResult poTokenResult;
+
+    private PoTokenManager() {
+    }
+
+    public static void reset() {
+        poTokenResult = null;
+    }
+
+    public static PoTokenResult getAndUpdatePoTokenIfNeeded(ClientType clientType, String videoId) {
+        if (poTokenResult != null && !poTokenResult.isExpired()) {
+            return poTokenResult;
+        }
+
+        String visitorId = VisitorIdRequester.getVisitorId(clientType);
+
+        try {
+            poTokenResult = Utils.submitOnBackgroundThread(() -> {
+                PoTokenGenerator poTokenGenerator = new PoTokenGenerator();
+                return poTokenGenerator.getWebClientPoToken(videoId, visitorId);
+            }).get();
+            return poTokenResult;
+        } catch (ExecutionException | InterruptedException ex) {
+            Logger.printException(() -> "Failed to launch PoTokenGenerator", ex);
+        } catch (Exception ex) {
+            Logger.printException(() -> "Failed to generate PoToken");
+        }
+
+        return null;
+    }
+
+    public static String getPlayerPoToken(ClientType clientType, String videoId) {
+        PoTokenResult result = getAndUpdatePoTokenIfNeeded(clientType, videoId);
+        if (result != null) {
+            return result.getPlayerRequestPoToken();
+        }
+        return null;
+    }
+
+    public static String getStreamingPoToken(ClientType clientType, String videoId) {
+        PoTokenResult result = getAndUpdatePoTokenIfNeeded(clientType, videoId);
+        if (result != null) {
+            return result.getStreamingDataPoToken();
+        }
+        return null;
+    }
+}

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenResult.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenResult.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.spoof.potoken;
+
+public class PoTokenResult {
+    private final String playerRequestPoToken;
+    private final String streamingDataPoToken;
+    private final long expirationMs;
+
+    public PoTokenResult(String playerRequestPoToken,
+                         String streamingDataPoToken,
+                         long expirationMs) {
+        this.playerRequestPoToken = playerRequestPoToken;
+        this.streamingDataPoToken = streamingDataPoToken;
+        this.expirationMs = expirationMs;
+    }
+
+    public String getPlayerRequestPoToken() {
+        return playerRequestPoToken;
+    }
+
+    public String getStreamingDataPoToken() {
+        return streamingDataPoToken;
+    }
+
+    public boolean isExpired() {
+        return System.currentTimeMillis() > expirationMs;
+    }
+}

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenResult.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenResult.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2533
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
@@ -8,27 +8,17 @@
 package app.morphe.extension.shared.spoof.potoken;
 
 public class PoTokenResult {
-    private final String playerRequestPoToken;
-    private final String streamingDataPoToken;
+    public final String playerRequestPoToken;
+    public final String streamingDataPoToken;
     private final long expirationMs;
 
-    public PoTokenResult(String playerRequestPoToken,
-                         String streamingDataPoToken,
-                         long expirationMs) {
+    public PoTokenResult(String playerRequestPoToken, String streamingDataPoToken, long expirationMs) {
         this.playerRequestPoToken = playerRequestPoToken;
         this.streamingDataPoToken = streamingDataPoToken;
         this.expirationMs = expirationMs;
     }
 
-    public String getPlayerRequestPoToken() {
-        return playerRequestPoToken;
-    }
-
-    public String getStreamingDataPoToken() {
-        return streamingDataPoToken;
-    }
-
     public boolean isExpired() {
-        return System.currentTimeMillis() > expirationMs;
+        return System.currentTimeMillis() >= expirationMs;
     }
 }

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenWebView.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenWebView.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2533
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
@@ -95,19 +95,19 @@ public class PoTokenWebView {
 
     @JavascriptInterface
     public void launchBotGuard() {
-        String js = String.join("\n",
-                "try {",
-                "data = " + BotGuardManager.getChallengeData(),
-                "runBotGuard(data).then(function (result) {",
-                "this.webPoSignalOutput = result.webPoSignalOutput",
-                JS_INTERFACE + ".onRunBotGuardResult(result.botGuardResult)",
-                "}, function (error) {",
-                JS_INTERFACE + ".onJsInitializationError()",
-                "})",
-                "} catch (error) {",
-                JS_INTERFACE + ".onJsInitializationError()",
-                "}"
-        );
+        String js = String.format("""
+            try {
+                data = %s;
+                runBotGuard(data).then(function (result) {
+                    this.webPoSignalOutput = result.webPoSignalOutput;
+                    %s.onRunBotGuardResult(result.botGuardResult);
+                }, function (error) {
+                    %s.onJsInitializationError();
+                });
+            } catch (error) {
+                %s.onJsInitializationError();
+            }
+            """, BotGuardManager.getChallengeData(), JS_INTERFACE, JS_INTERFACE, JS_INTERFACE);
         mainHandler.post(() -> webView.evaluateJavascript(js, null));
     }
 
@@ -140,21 +140,21 @@ public class PoTokenWebView {
         poTokenContinuations.put(identifier, future);
 
         String u8Identifier = BotGuardUtil.stringToU8(identifier);
-        String js = String.join("\n",
-                "try {",
-                "identifier = \"" + identifier + "\"",
-                "u8Identifier = " + u8Identifier,
-                "poTokenU8 = obtainPoToken(webPoSignalOutput, integrityToken, u8Identifier)",
-                "poTokenU8String = \"\"",
-                "for (i = 0; i < poTokenU8.length; i++) {",
-                "if (i != 0) poTokenU8String += \",\"",
-                "poTokenU8String += poTokenU8[i]",
-                "}",
-                JS_INTERFACE + ".onObtainPoTokenResult(identifier, poTokenU8String)",
-                "} catch (error) {",
-                JS_INTERFACE + ".onObtainPoTokenError(identifier)",
-                "}"
-        );
+        String js = String.format("""
+            try {
+                identifier = "%s";
+                u8Identifier = %s;
+                poTokenU8 = obtainPoToken(webPoSignalOutput, integrityToken, u8Identifier);
+                poTokenU8String = "";
+                for (i = 0; i < poTokenU8.length; i++) {
+                    if (i != 0) poTokenU8String += ",";
+                    poTokenU8String += poTokenU8[i];
+                }
+                %s.onObtainPoTokenResult(identifier, poTokenU8String);
+            } catch (error) {
+                %s.onObtainPoTokenError(identifier);
+            }
+            """, identifier, u8Identifier, JS_INTERFACE, JS_INTERFACE);
 
         mainHandler.post(() -> webView.evaluateJavascript(js, null));
 

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenWebView.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenWebView.java
@@ -16,6 +16,7 @@ import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -95,7 +96,8 @@ public class PoTokenWebView {
 
     @JavascriptInterface
     public void launchBotGuard() {
-        String js = String.format("""
+        String js = String.format(Locale.US,
+            """
             try {
                 data = %s;
                 runBotGuard(data).then(function (result) {
@@ -140,7 +142,8 @@ public class PoTokenWebView {
         poTokenContinuations.put(identifier, future);
 
         String u8Identifier = BotGuardUtil.stringToU8(identifier);
-        String js = String.format("""
+        String js = String.format(Locale.US,
+            """
             try {
                 identifier = "%s";
                 u8Identifier = %s;

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenWebView.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/potoken/PoTokenWebView.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.spoof.potoken;
+
+import android.annotation.SuppressLint;
+import android.os.Handler;
+import android.os.Looper;
+import android.webkit.ConsoleMessage;
+import android.webkit.JavascriptInterface;
+import android.webkit.WebChromeClient;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+import app.morphe.extension.shared.ResourceUtils;
+import app.morphe.extension.shared.Utils;
+
+@SuppressWarnings("unused")
+public class PoTokenWebView {
+    private static final String JS_INTERFACE = "PoTokenWebView";
+
+    private final WebView webView;
+    private final Handler mainHandler;
+    private final String modifiedHtml = Objects.requireNonNull(ResourceUtils.getRawResource("po_token"))
+            .replaceFirst(
+            "</script>",
+            "\n" + JS_INTERFACE + ".launchBotGuard()</script>"
+            );
+    
+    private final Map<String, CompletableFuture<String>> poTokenContinuations = new ConcurrentHashMap<>();
+    private final CompletableFuture<PoTokenWebView> initializationFuture;
+
+    private long expirationMs = -1L;
+
+    @SuppressLint({"SetJavaScriptEnabled", "AddJavascriptInterface"})
+    private PoTokenWebView(CompletableFuture<PoTokenWebView> initFuture) {
+        this.mainHandler = new Handler(Looper.getMainLooper());
+        this.initializationFuture = initFuture;
+        
+        // Initialize WebView on Main Thread
+        this.webView = new WebView(Utils.getContext());
+        WebSettings webViewSettings = webView.getSettings();
+        webViewSettings.setJavaScriptEnabled(true);
+        webViewSettings.setDomStorageEnabled(true);
+        webViewSettings.setSafeBrowsingEnabled(false);
+        webViewSettings.setUserAgentString(BotGuardManager.getUserAgent());
+        webViewSettings.setBlockNetworkLoads(true); // No internet for WebView
+
+        webView.addJavascriptInterface(this, JS_INTERFACE);
+
+        webView.setWebChromeClient(new WebChromeClient() {
+            @Override
+            public boolean onConsoleMessage(ConsoleMessage m) {
+                if (m.message().contains("Uncaught")) {
+                    String fmt = "\"" + m.message() + "\", source: " + m.sourceId() + " (" + m.lineNumber() + ")";
+                    onInitializationErrorCloseAndCancel(new PoTokenException.BadWebViewException(fmt));
+                }
+                return super.onConsoleMessage(m);
+            }
+        });
+    }
+
+    public static CompletableFuture<PoTokenWebView> newPoTokenGenerator() {
+        CompletableFuture<PoTokenWebView> future = new CompletableFuture<>();
+        Utils.runOnMainThread(() -> {
+            try {
+                PoTokenWebView instance = new PoTokenWebView(future);
+                instance.loadHtmlAndObtainBotGuard();
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+        
+        return future;
+    }
+
+    private void loadHtmlAndObtainBotGuard() {
+        mainHandler.post(() -> webView.loadDataWithBaseURL(
+                "https://www.youtube.com",
+                modifiedHtml,
+                "text/html",
+                "utf-8",
+                null
+        ));
+    }
+
+    @JavascriptInterface
+    public void launchBotGuard() {
+        String js = String.join("\n",
+                "try {",
+                "data = " + BotGuardManager.getChallengeData(),
+                "runBotGuard(data).then(function (result) {",
+                "this.webPoSignalOutput = result.webPoSignalOutput",
+                JS_INTERFACE + ".onRunBotGuardResult(result.botGuardResult)",
+                "}, function (error) {",
+                JS_INTERFACE + ".onJsInitializationError()",
+                "})",
+                "} catch (error) {",
+                JS_INTERFACE + ".onJsInitializationError()",
+                "}"
+        );
+        mainHandler.post(() -> webView.evaluateJavascript(js, null));
+    }
+
+    @JavascriptInterface
+    public void onJsInitializationError() {
+        onJsInitializationError("");
+    }
+
+    @JavascriptInterface
+    public void onJsInitializationError(String error) {
+        onInitializationErrorCloseAndCancel(PoTokenException.buildExceptionForJsError(error));
+    }
+
+    @JavascriptInterface
+    public void onRunBotGuardResult(String botGuardResult) {
+        BotGuardManager.IntegrityToken integrityToken = BotGuardManager.getIntegrityToken(botGuardResult);
+        if (integrityToken != null) {
+            expirationMs = integrityToken.expirationMs();
+            mainHandler.post(() -> webView.evaluateJavascript(
+                    "this.integrityToken = " + integrityToken.token(),
+                    value -> initializationFuture.complete(this)
+            ));
+        } else {
+            onInitializationErrorCloseAndCancel(new PoTokenException("Null integrity token"));
+        }
+    }
+
+    public CompletableFuture<String> generatePoToken(String identifier) {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        poTokenContinuations.put(identifier, future);
+
+        String u8Identifier = BotGuardUtil.stringToU8(identifier);
+        String js = String.join("\n",
+                "try {",
+                "identifier = \"" + identifier + "\"",
+                "u8Identifier = " + u8Identifier,
+                "poTokenU8 = obtainPoToken(webPoSignalOutput, integrityToken, u8Identifier)",
+                "poTokenU8String = \"\"",
+                "for (i = 0; i < poTokenU8.length; i++) {",
+                "if (i != 0) poTokenU8String += \",\"",
+                "poTokenU8String += poTokenU8[i]",
+                "}",
+                JS_INTERFACE + ".onObtainPoTokenResult(identifier, poTokenU8String)",
+                "} catch (error) {",
+                JS_INTERFACE + ".onObtainPoTokenError(identifier)",
+                "}"
+        );
+
+        mainHandler.post(() -> webView.evaluateJavascript(js, null));
+
+        return future;
+    }
+
+    @JavascriptInterface
+    public void onObtainPoTokenError(String identifier) {
+        onObtainPoTokenError(identifier, "");
+    }
+
+    @JavascriptInterface
+    public void onObtainPoTokenError(String identifier, String error) {
+        CompletableFuture<String> future = poTokenContinuations.remove(identifier);
+        if (future != null) {
+            future.completeExceptionally(PoTokenException.buildExceptionForJsError(error));
+        }
+    }
+
+    @JavascriptInterface
+    public void onObtainPoTokenResult(String identifier, String poTokenU8) {
+        CompletableFuture<String> future = poTokenContinuations.remove(identifier);
+        if (future != null) {
+            try {
+                String poToken = BotGuardUtil.u8ToBase64(poTokenU8);
+                future.complete(poToken);
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        }
+    }
+
+    public long getExpirationMs() {
+        return expirationMs;
+    }
+
+    public boolean isExpired() {
+        return System.currentTimeMillis() > expirationMs;
+    }
+
+    private void onInitializationErrorCloseAndCancel(Throwable error) {
+        mainHandler.post(() -> {
+            close();
+            if (!initializationFuture.isDone()) {
+                initializationFuture.completeExceptionally(error);
+            }
+        });
+    }
+
+    public void close() {
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            mainHandler.post(this::close);
+            return;
+        }
+
+        webView.clearHistory();
+        webView.clearCache(true);
+        webView.loadUrl("about:blank");
+        webView.onPause();
+        webView.removeAllViews();
+        webView.destroy();
+    }
+}

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/requests/PlayerRoutes.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/requests/PlayerRoutes.java
@@ -25,6 +25,7 @@ import app.morphe.extension.shared.requests.Route;
 import app.morphe.extension.shared.spoof.ClientType;
 import app.morphe.extension.shared.spoof.SpoofVideoStreamsPatch;
 import app.morphe.extension.shared.spoof.js.JavaScriptManager;
+import app.morphe.extension.shared.spoof.potoken.PoTokenManager;
 
 public final class PlayerRoutes {
 
@@ -47,7 +48,9 @@ public final class PlayerRoutes {
     private PlayerRoutes() {
     }
 
-    static String createInnertubeBody(ClientType clientType, String videoId, String visitorId) {
+    static String createInnertubeBody(ClientType clientType,
+                                      String videoId,
+                                      String visitorId) {
         JSONObject innerTubeBody = new JSONObject();
 
         try {
@@ -122,6 +125,15 @@ public final class PlayerRoutes {
                 playbackContext.put("devicePlaybackCapabilities", devicePlaybackCapabilities);
 
                 innerTubeBody.put("playbackContext", playbackContext);
+            }
+
+            if (clientType.requirePoToken) {
+                String poToken = PoTokenManager.getPlayerPoToken(clientType, videoId);
+                if (!TextUtils.isEmpty(poToken)) {
+                    JSONObject serviceIntegrityDimensions = new JSONObject();
+                    serviceIntegrityDimensions.put("poToken", poToken);
+                    innerTubeBody.put("serviceIntegrityDimensions", serviceIntegrityDimensions);
+                }
             }
 
             innerTubeBody.put("context", context);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/requests/StreamingDataRequest.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/requests/StreamingDataRequest.java
@@ -42,6 +42,7 @@ import app.morphe.extension.shared.settings.SharedYouTubeSettings;
 import app.morphe.extension.shared.spoof.ClientType;
 import app.morphe.extension.shared.spoof.js.JavaScriptEngineSupport;
 import app.morphe.extension.shared.spoof.js.JavaScriptManager;
+import app.morphe.extension.shared.spoof.potoken.PoTokenManager;
 
 /**
  * Video streaming data. Fetching is tied to the behavior YT uses,
@@ -187,7 +188,7 @@ public class StreamingDataRequest {
             boolean authHeadersIncludes = Utils.isNotEmpty(authorization);
 
             // Auth header is required, but the user is not logged in. These clients are skipped:
-            // ANDROID_CREATOR, TV_SIMPLY, ANDROID_MUSIC_REEL, ANDROID_MUSIC_NO_SDK.
+            // ANDROID_CREATOR, ANDROID_MUSIC_REEL, ANDROID_MUSIC_NO_SDK.
             if (clientType.canLogin && clientType.requireLogin && !authHeadersIncludes) {
                 Logger.printDebug(() -> "Skipping client since user is not logged in: " + clientType
                         + ", videoId: " + videoId);
@@ -217,7 +218,7 @@ public class StreamingDataRequest {
                 }
             }
             // These clients can play videos without the auth header:
-            // TV_SABR, VISIONOS_1_02 (VISIONOS_1_03).
+            // TV_SABR, TV_SIMPLY, VISIONOS_1_02 (VISIONOS_1_03).
             else {
                 Logger.printDebug(() -> "Do not set auth header: " + clientType + ", videoId: " + videoId);
             }
@@ -268,6 +269,7 @@ public class StreamingDataRequest {
     @Nullable
     private static StreamData buildPlayerResponseBuffer(ClientType clientType,
                                                         HttpURLConnection connection,
+                                                        String videoId,
                                                         boolean isInline) {
         if (connection == null) {
             return null;
@@ -333,8 +335,13 @@ public class StreamingDataRequest {
             }
 
             if (clientType.requireJS) {
+                // Use PoToken only when not logged in.
+                String poToken = clientType.requirePoToken
+                        ? PoTokenManager.getStreamingPoToken(clientType, videoId)
+                        : "";
+
                 StreamingData.Builder deobfuscatedStreamingDataBuilder =
-                        JavaScriptManager.getDeobfuscatedStreamingData(streamingData, clientType.requireSABR);
+                        JavaScriptManager.getDeobfuscatedStreamingData(streamingData, poToken, clientType.requireSABR);
                 if (deobfuscatedStreamingDataBuilder == null) {
                     handleDebugToast("Debug: Ignoring obfuscated streamingData (%s)", clientType);
                     return null;
@@ -408,13 +415,13 @@ public class StreamingDataRequest {
             final boolean showErrorToast = (++i == clientOrderToUse.length) || debugEnabled;
 
             HttpURLConnection connection = send(clientType, videoId, playerHeaders, showErrorToast);
-            StreamData streamingData = buildPlayerResponseBuffer(clientType, connection, isInline);
+            StreamData streamingData = buildPlayerResponseBuffer(clientType, connection, videoId, isInline);
 
             if (clientType == ClientType.TV_SABR && fallbackWithTVDash) {
                 fallbackWithTVDash = false;
                 clientType = ClientType.TV_DASH;
                 HttpURLConnection fallBackConnection = send(clientType, videoId, playerHeaders, showErrorToast);
-                streamingData = buildPlayerResponseBuffer(clientType, fallBackConnection, isInline);
+                streamingData = buildPlayerResponseBuffer(clientType, fallBackConnection, videoId, isInline);
             }
 
             if (streamingData != null) {

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/requests/StreamingDataRequest.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/requests/StreamingDataRequest.java
@@ -335,7 +335,6 @@ public class StreamingDataRequest {
             }
 
             if (clientType.requireJS) {
-                // Use PoToken only when not logged in.
                 String poToken = clientType.requirePoToken
                         ? PoTokenManager.getStreamingPoToken(clientType, videoId)
                         : "";

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/spoof/SpoofVideoStreamsPatch.java
@@ -43,7 +43,7 @@ public class SpoofVideoStreamsPatch {
         }
 
         List<ClientType> availableClients = List.of(
-                ClientType.TV_SABR,
+                ClientType.TV_SIMPLY,
                 ClientType.VISIONOS_1_02,
                 ClientType.ANDROID_CREATOR
                 // If not signed in to Android VR, there may be playback issues.

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/SpoofVideoStreamsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/SpoofVideoStreamsPatch.kt
@@ -64,6 +64,7 @@ private val spoofVideoStreamsResourcePatch = resourcePatch {
                 "polyfill.js",
                 "yt.solver.core.js", // yt-dlp-ejs 0.8.0: https://github.com/yt-dlp/ejs/releases/tag/0.8.0
                 "yt.solver.wrapper.js",
+                "po_token.html",
             )
         )
 

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -548,13 +548,13 @@ Info: May not work on live streams"</string>
     <!-- 'Spoof video streams' should be the same translation used for 'morphe_spoof_video_streams_screen_title'. -->
     <string name="morphe_livestream_dvr_not_available">"\'Enable livestream DVR\' may not be available
 
-To fix this, turn on \'Spoof video streams\' and change the \'Default client\' to \'TV\' or \'visionOS\'"</string>
+To fix this, turn on \'Spoof video streams\' and change the \'Default client\' to \'TV Simply\' or \'visionOS\'"</string>
     <string name="morphe_expand_livestream_dvr_duration_title">Expand livestream DVR duration</string>
     <string name="morphe_expand_livestream_dvr_duration_summary">Allows you to rewind live broadcasts up to 7 days into the past</string>
     <!-- 'Spoof video streams' should be the same translation used for 'morphe_spoof_video_streams_screen_title'. -->
     <string name="morphe_expand_livestream_dvr_duration_not_available">"\'Expand livestream DVR duration\' may not be available
 
-To fix this, turn on \'Spoof video streams\' and change the \'Default client\' to \'TV\' or \'visionOS\'"</string>
+To fix this, turn on \'Spoof video streams\' and change the \'Default client\' to \'TV Simply\' or \'visionOS\'"</string>
 
     <!-- interaction.seekbar.enableSlideToSeekPatch -->
     <string name="morphe_slide_to_seek_title">Enable slide to seek</string>

--- a/patches/src/main/resources/spoof/raw/po_token.html
+++ b/patches/src/main/resources/spoof/raw/po_token.html
@@ -1,4 +1,8 @@
 <!DOCTYPE html>
+<!--
+    Copyright 2026 Morphe.
+    https://github.com/MorpheApp/morphe-patches/pull/2533
+-->
 <html lang="en"><head><title></title><script>
     /**
      * Factory method to create and load a BotGuardClient instance.

--- a/patches/src/main/resources/spoof/raw/po_token.html
+++ b/patches/src/main/resources/spoof/raw/po_token.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en"><head><title></title><script>
+    /**
+     * Factory method to create and load a BotGuardClient instance.
+     * @param options - Configuration options for the BotGuardClient.
+     * @returns A promise that resolves to a loaded BotGuardClient instance.
+     */
+    function loadBotGuard(challengeData) {
+      this.vm = this[challengeData.globalName];
+      this.program = challengeData.program;
+      this.vmFunctions = {};
+      this.syncSnapshotFunction = null;
+
+      if (!this.vm)
+        throw new Error('[BotGuardClient]: VM not found in the global object');
+
+      if (!this.vm.a)
+        throw new Error('[BotGuardClient]: Could not load program');
+
+      const vmFunctionsCallback = function (
+        asyncSnapshotFunction,
+        shutdownFunction,
+        passEventFunction,
+        checkCameraFunction
+      ) {
+        this.vmFunctions = {
+          asyncSnapshotFunction: asyncSnapshotFunction,
+          shutdownFunction: shutdownFunction,
+          passEventFunction: passEventFunction,
+          checkCameraFunction: checkCameraFunction
+        };
+      };
+
+      this.syncSnapshotFunction = this.vm.a(this.program, vmFunctionsCallback, true, this.userInteractionElement, function () {/** no-op */ }, [ [], [] ])[0]
+
+      // an asynchronous function runs in the background and it will eventually call
+      // `vmFunctionsCallback`, however we need to manually tell JavaScript to pass
+      // control to the things running in the background by interrupting this async
+      // function in any way, e.g. with a delay of 1ms. The loop is most probably not
+      // needed but is there just because.
+      return new Promise(function (resolve, reject) {
+        i = 0
+        refreshIntervalId = setInterval(function () {
+          if (!!this.vmFunctions.asyncSnapshotFunction) {
+            resolve(this)
+            clearInterval(refreshIntervalId);
+          }
+          if (i >= 10000) {
+            reject("asyncSnapshotFunction is null even after 10 seconds")
+            clearInterval(refreshIntervalId);
+          }
+          i += 1;
+        }, 1);
+      })
+    }
+
+    /**
+     * Takes a snapshot asynchronously.
+     * @returns The snapshot result.
+     * @example
+     * ```ts
+     * const result = await botguard.snapshot({
+     *   contentBinding: {
+     *     c: "a=6&a2=10&b=SZWDwKVIuixOp7Y4euGTgwckbJA&c=1729143849&d=1&t=7200&c1a=1&c6a=1&c6b=1&hh=HrMb5mRWTyxGJphDr0nW2Oxonh0_wl2BDqWuLHyeKLo",
+     *     e: "ENGAGEMENT_TYPE_VIDEO_LIKE",
+     *     encryptedVideoId: "P-vC09ZJcnM"
+     *    }
+     * });
+     *
+     * console.log(result);
+     * ```
+     */
+    function snapshot(args) {
+      return new Promise(function (resolve, reject) {
+        if (!this.vmFunctions.asyncSnapshotFunction)
+          return reject(new Error('[BotGuardClient]: Async snapshot function not found'));
+
+        this.vmFunctions.asyncSnapshotFunction(function (response) { resolve(response) }, [
+          args.contentBinding,
+          args.signedTimestamp,
+          args.webPoSignalOutput,
+          args.skipPrivacyBuffer
+        ]);
+      });
+    }
+
+    function runBotGuard(challengeData) {
+      const interpreterJavascript = challengeData.interpreterJavascript.privateDoNotAccessOrElseSafeScriptWrappedValue;
+
+      if (interpreterJavascript) {
+        new Function(interpreterJavascript)();
+      } else throw new Error('Could not load VM');
+
+      const webPoSignalOutput = [];
+      return loadBotGuard({
+        globalName: challengeData.globalName,
+        globalObj: this,
+        program: challengeData.program
+      }).then(function (botguard) {
+        return botguard.snapshot({ webPoSignalOutput: webPoSignalOutput })
+      }).then(function (botGuardResult) {
+        return { webPoSignalOutput: webPoSignalOutput, botGuardResult: botGuardResult }
+      })
+    }
+
+    function obtainPoToken(webPoSignalOutput, integrityToken, identifier) {
+      const getMinter = webPoSignalOutput[0];
+
+      if (!getMinter)
+        throw new Error('PMD:Undefined');
+
+      const mintCallback = getMinter(integrityToken);
+
+      if (!(mintCallback instanceof Function))
+        throw new Error('APF:Failed');
+
+      const result = mintCallback(identifier);
+
+      if (!result)
+        throw new Error('YNJ:Undefined');
+
+      if (!(result instanceof Uint8Array))
+        throw new Error('ODM:Invalid');
+
+      return result;
+    }
+</script></head><body></body></html>


### PR DESCRIPTION
### Description

Until now, `TV Simply` is not available when signed out or incognito mode.

Since playback fails without a PoToken in signed out or incognito mode, `TV Simply` was used as a signed in client.

This issue was resolved by generating `VisitorId bind PoToken`.

### Additional context

Cold start challenge data is fetched from the `/tv_config` endpoint, and this method seems to be valid only on `TV Simply`.

`TV Simply` is now used as a fallback client.

### Build artifact

https://github.com/MorpheApp/morphe-patches/actions/runs/32478705504/artifacts/9445298228

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
