### PR TITLE
feat(YouTube - Theme): Draw the splash screen with the selected background color

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/SplashScreenTheme.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/SplashScreenTheme.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/issues/2542
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.theme;
+
+import android.app.Activity;
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+import androidx.annotation.StyleRes;
+
+/**
+ * Hands the system the theme it draws the splash screen of the app with.
+ * <p>
+ * The system draws the splash screen before the app runs, and it resolves the resources of the app
+ * with the configuration of the device, so the resource variant of the selected background can
+ * never be used for it. This is the way the system takes a theme instead, and it uses the one it
+ * was given for every launch that follows.
+ * <p>
+ * Kept in a class of its own so the API 31 classes are never loaded on an older device.
+ */
+@RequiresApi(api = Build.VERSION_CODES.S)
+final class SplashScreenTheme {
+
+    /**
+     * @param themeId The theme of the selected background, or zero to let the system draw the
+     *                splash screen of the app again.
+     */
+    static void apply(Activity activity, @StyleRes int themeId) {
+        activity.getSplashScreen().setSplashScreenTheme(themeId);
+    }
+
+    private SplashScreenTheme() {
+    }
+}

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
@@ -13,6 +13,7 @@ import static app.morphe.extension.shared.settings.SharedYouTubeSettings.THEME_B
 import static app.morphe.extension.shared.settings.SharedYouTubeSettings.THEME_BACKGROUND_LIGHT_CUSTOM_COLOR;
 import static app.morphe.extension.shared.settings.SharedYouTubeSettings.THEME_LAST_USED_DARK_MODE;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Color;
@@ -238,6 +239,14 @@ public class ThemeColorPatch {
     private static boolean backgroundColorsResolved;
 
     /**
+     * Name of the theme that draws the splash screen of a background. The patch generates one for
+     * every background it has a color of, and uses the same numbering.
+     */
+    private static final String SPLASH_THEME_NAME = "morphe_splash_theme_";
+
+    private static boolean splashScreenThemeApplied;
+
+    /**
      * If a background color of the user can be applied. An overlay that an app registers for
      * itself exists since Android 14, and no color can be added to the app on older versions.
      */
@@ -346,6 +355,36 @@ public class ThemeColorPatch {
         if (!lightColorResourceNames().isEmpty()) {
             lightBackgroundColor = selectedBackgroundColor(context, false);
             ThemeUtils.setThemeLightColor(lightBackgroundColor);
+        }
+    }
+
+    /**
+     * Injection point.
+     * <p>
+     * Gives the system the theme it draws the splash screen of the app with, which it uses for
+     * every launch that follows.
+     * <p>
+     * The splash screen is drawn before the app runs, with the configuration of the device, so the
+     * resource variant of the selected background is never used for it. A background of the app
+     * itself and a color the user picked have no theme, and the system is given none, which brings
+     * the splash screen of the app back.
+     */
+    public static void setSplashScreenTheme(Activity activity) {
+        try {
+            if (splashScreenThemeApplied || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+                return;
+            }
+            splashScreenThemeApplied = true;
+
+            final int index = isDarkTheme() ? darkConfigValue : lightConfigValue;
+            final int themeId = ResourceUtils.getIdentifier(
+                    ResourceType.STYLE, SPLASH_THEME_NAME + index);
+
+            Logger.printDebug(() -> "Splash screen theme: " + SPLASH_THEME_NAME + index
+                    + " id: " + themeId);
+            SplashScreenTheme.apply(activity, themeId);
+        } catch (Exception ex) {
+            Logger.printException(() -> "setSplashScreenTheme failure", ex);
         }
     }
 

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
@@ -376,7 +376,7 @@ public class ThemeColorPatch {
             }
             splashScreenThemeApplied = true;
 
-            final int index = isDarkTheme() ? darkConfigValue : lightConfigValue;
+            final int index = splashScreenThemeIndex(isDarkTheme());
             final int themeId = ResourceUtils.getIdentifier(
                     ResourceType.STYLE, SPLASH_THEME_NAME + index);
 
@@ -386,6 +386,29 @@ public class ThemeColorPatch {
         } catch (Exception ex) {
             Logger.printException(() -> "setSplashScreenTheme failure", ex);
         }
+    }
+
+    /**
+     * The index of the theme that draws the splash screen of the selected background.
+     * <p>
+     * A color the user picked is not known while patching and has no theme of its own, so the
+     * palette is used for it, which has one for every value it can be quantized to.
+     */
+    private static int splashScreenThemeIndex(boolean dark) {
+        Background background = dark
+                ? THEME_BACKGROUND_DARK.get()
+                : THEME_BACKGROUND_LIGHT.get();
+
+        if (!background.isCustom()) {
+            return dark ? darkConfigValue : lightConfigValue;
+        }
+
+        StringSetting setting = dark
+                ? THEME_BACKGROUND_DARK_CUSTOM_COLOR
+                : THEME_BACKGROUND_LIGHT_CUSTOM_COLOR;
+
+        return (dark ? DARK_INDEX_OFFSET : LIGHT_INDEX_OFFSET)
+                + PALETTE_INDEX_OFFSET + get9BitColorIndex(setting, dark);
     }
 
     /**

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/ThemePatch.kt
@@ -22,6 +22,7 @@ import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
 import app.morphe.patches.shared.layout.theme.THEME_COLOR_EXTENSION_CLASS
 import app.morphe.patches.shared.layout.theme.THEME_DEFAULT_COLOR_NAMES_DARK
 import app.morphe.patches.shared.layout.theme.baseThemePatch
+import app.morphe.patches.music.shared.MusicActivityOnCreateFingerprint
 import app.morphe.patches.shared.layout.theme.baseThemeResourcePatch
 import app.morphe.patches.shared.misc.settings.preference.InputType
 import app.morphe.patches.shared.misc.settings.preference.ListPreference
@@ -53,7 +54,9 @@ val themePatch = baseThemePatch(
             resourceMappingPatch,
             versionCheckPatch,
             baseThemeResourcePatch(
-                colorNamesDark = musicColorNamesDark
+                colorNamesDark = musicColorNamesDark,
+                // The theme of the launcher activity, which the system draws the splash with.
+                splashScreenThemeParent = "@style/Theme.YouTubeMusic.Home"
             )
         )
 
@@ -61,6 +64,15 @@ val themePatch = baseThemePatch(
     },
 
     executeBlock = {
+        // The splash screen is drawn by the system with the theme of the launcher activity,
+        // so the activity is handed over as soon as it exists.
+        MusicActivityOnCreateFingerprint.method.addInstruction(
+            0,
+            // The register of 'this' can be above v15, so the range format is needed.
+            "invoke-static/range { p0 .. p0 }, $THEME_COLOR_EXTENSION_CLASS" +
+                    "->setSplashScreenTheme(Landroid/app/Activity;)V"
+        )
+
         // Color of the new content count of the top bar, which is red in the app and does
         // not go with a Material You background.
         TopBarNewContentCountFingerprint.let {

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -69,6 +69,12 @@ private const val THEME_INDEX_OFFSET_LIGHT = 700
 private const val THEME_BACKGROUND_OVERLAYABLE_NAME = "MorpheThemeColor"
 
 /**
+ * Name of the theme that draws the splash screen of a background, which the extension asks for
+ * with the same numbering.
+ */
+private const val SPLASH_THEME_NAME = "morphe_splash_theme_"
+
+/**
  * Background colors that can be selected in the app settings.
  *
  * The index of a color is the ordinal of the matching value of the extension enum
@@ -272,7 +278,8 @@ private fun ResourcePatchContext.declaredColorNames(): Set<String> {
 internal fun baseThemeResourcePatch(
     colorNamesDark: (() -> Set<String>) = { THEME_DEFAULT_COLOR_NAMES_DARK },
     colorNamesLight: (() -> Set<String>) = { THEME_DEFAULT_COLOR_NAMES_LIGHT },
-    includeLightBackground: Boolean = false
+    includeLightBackground: Boolean = false,
+    splashScreenThemeParent: String? = null
 ) = resourcePatch {
     execute {
         val declaredColors = declaredColorNames()
@@ -292,6 +299,60 @@ internal fun baseThemeResourcePatch(
         }
 
         declareOverlayableColors(darkColorNames + lightColorNames)
+
+        // An app without a launcher theme keeps the splash screen it draws itself.
+        if (splashScreenThemeParent != null) {
+            addSplashScreenThemes(splashScreenThemeParent, includeLightBackground)
+        }
+    }
+}
+
+/**
+ * Adds a theme for every background, which the system can draw the splash screen of the app with.
+ *
+ * The splash screen is drawn before the app runs and with the configuration of the device, so the
+ * resource variant of the selected background is never used for it. The extension hands one of
+ * these themes to the system instead, and the system draws the splash screen with it from then on.
+ *
+ * @param parentStyle The theme of the launcher activity, so that only the color of it differs.
+ */
+private fun ResourcePatchContext.addSplashScreenThemes(
+    parentStyle: String,
+    includeLightBackground: Boolean
+) {
+    document("res/values/styles.xml").use { document ->
+        val resources = document.getNode("resources")
+
+        buildList {
+            add(THEME_INDEX_OFFSET_DARK to THEME_COLORS_DARK)
+            if (includeLightBackground) add(THEME_INDEX_OFFSET_LIGHT to THEME_COLORS_LIGHT)
+        }.forEach { (indexOffset, backgrounds) ->
+            backgrounds.forEachIndexed { index, color ->
+                // The background of the app itself and a color the user picks have no theme of
+                // their own, and the splash screen of the app is used for both.
+                if (color == null) return@forEachIndexed
+
+                val style = document.createElement("style")
+                style.setAttribute("name", SPLASH_THEME_NAME + (indexOffset + index + 1))
+                style.setAttribute("parent", parentStyle)
+
+                // The first is used since Android 12, and the second by everything the app draws
+                // until the splash screen is gone.
+                arrayOf(
+                    "android:windowSplashScreenBackground",
+                    "android:windowBackground"
+                ).forEach { name ->
+                    style.appendChild(
+                        document.createElement("item").apply {
+                            setAttribute("name", name)
+                            textContent = color
+                        }
+                    )
+                }
+
+                resources.appendChild(style)
+            }
+        }
     }
 }
 

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -323,35 +323,60 @@ private fun ResourcePatchContext.addSplashScreenThemes(
     document("res/values/styles.xml").use { document ->
         val resources = document.getNode("resources")
 
-        buildList {
-            add(THEME_INDEX_OFFSET_DARK to THEME_COLORS_DARK)
-            if (includeLightBackground) add(THEME_INDEX_OFFSET_LIGHT to THEME_COLORS_LIGHT)
-        }.forEach { (indexOffset, backgrounds) ->
-            backgrounds.forEachIndexed { index, color ->
-                // The background of the app itself and a color the user picks have no theme of
-                // their own, and the splash screen of the app is used for both.
-                if (color == null) return@forEachIndexed
+        fun addTheme(index: Int, color: String) {
+            val style = document.createElement("style")
+            style.setAttribute("name", SPLASH_THEME_NAME + index)
+            style.setAttribute("parent", parentStyle)
 
-                val style = document.createElement("style")
-                style.setAttribute("name", SPLASH_THEME_NAME + (indexOffset + index + 1))
-                style.setAttribute("parent", parentStyle)
-
-                // The first is used since Android 12, and the second by everything the app draws
-                // until the splash screen is gone.
-                arrayOf(
-                    "android:windowSplashScreenBackground",
-                    "android:windowBackground"
-                ).forEach { name ->
-                    style.appendChild(
-                        document.createElement("item").apply {
-                            setAttribute("name", name)
-                            textContent = color
-                        }
-                    )
-                }
-
-                resources.appendChild(style)
+            // The first is used since Android 12, and the second by everything the app draws
+            // until the splash screen is gone.
+            arrayOf(
+                "android:windowSplashScreenBackground",
+                "android:windowBackground"
+            ).forEach { name ->
+                style.appendChild(
+                    document.createElement("item").apply {
+                        setAttribute("name", name)
+                        textContent = color
+                    }
+                )
             }
+
+            resources.appendChild(style)
+        }
+
+        fun addThemes(
+            indexOffset: Int,
+            backgrounds: List<String?>,
+            levels: IntArray,
+            colorNames: List<String>
+        ) {
+            backgrounds.forEachIndexed { index, color ->
+                if (color != null) {
+                    addTheme(indexOffset + index + 1, color)
+                } else if (index == 0) {
+                    // The background of the app itself, which keeps the color the app declares.
+                    // The system resolves the theme with the configuration of the device, where
+                    // no variant of a background applies, so this is the unpatched color.
+                    addTheme(indexOffset + index + 1, "@color/" + colorNames.first())
+                }
+                // A color the user picks is not known while patching, and the palette below is
+                // used for it instead.
+            }
+
+            for (index in 0 until 512) {
+                addTheme(
+                    indexOffset + PALETTE_INDEX_OFFSET + index,
+                    paletteColor(levels, index)
+                )
+            }
+        }
+
+        addThemes(THEME_INDEX_OFFSET_DARK, THEME_COLORS_DARK, PALETTE_LEVELS_DARK, darkColorNames)
+        if (includeLightBackground) {
+            addThemes(
+                THEME_INDEX_OFFSET_LIGHT, THEME_COLORS_LIGHT, PALETTE_LEVELS_LIGHT, lightColorNames
+            )
         }
     }
 }
@@ -419,14 +444,20 @@ private fun ResourcePatchContext.add9BitColorVariants(
     colorNames: List<String>
 ) {
     for (index in 0 until 512) {
-        val r = levels[(index shr 6) and 0x7]
-        val g = levels[(index shr 3) and 0x7]
-        val b = levels[index and 0x7]
-
-        val color = "#%02X%02X%02X".format(r, g, b)
-        writeBackgroundColorVariant(indexOffset + PALETTE_INDEX_OFFSET + index, color, colorNames)
+        writeBackgroundColorVariant(
+            indexOffset + PALETTE_INDEX_OFFSET + index, paletteColor(levels, index), colorNames
+        )
     }
 }
+
+/**
+ * The color of a value of the 9 bit palette, which the extension picks the index of.
+ */
+private fun paletteColor(levels: IntArray, index: Int) = "#%02X%02X%02X".format(
+    levels[(index shr 6) and 0x7],
+    levels[(index shr 3) and 0x7],
+    levels[index and 0x7]
+)
 
 private fun ResourcePatchContext.writeBackgroundColorVariant(
     index: Int,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
@@ -86,6 +86,17 @@ internal object ShowSplashScreenFingerprint : Fingerprint(
 )
 
 /**
+ * The system draws the splash screen with the theme of the launcher activity, so the extension is
+ * given the activity as soon as it is created.
+ */
+internal object MainActivityOnCreateFingerprint : Fingerprint(
+    definingClass = YOUTUBE_MAIN_ACTIVITY_CLASS_TYPE,
+    name = "onCreate",
+    returnType = "V",
+    parameters = listOf("Landroid/os/Bundle;")
+)
+
+/**
  * The pivot bar creates the view stub of the new content dot, and of the count next to it.
  * The count is matched as well because the effects picker uses the same dot id.
  */

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -216,7 +216,9 @@ val themePatch = baseThemePatch(
             baseThemeResourcePatch(
                 includeLightBackground = true,
                 colorNamesDark = youTubeColorNamesDark,
-                colorNamesLight = youTubeColorNamesLight
+                colorNamesLight = youTubeColorNamesLight,
+                // The theme of the launcher activity, which the system draws the splash with.
+                splashScreenThemeParent = "@style/Theme.YouTube.Home"
             ),
             themeResourcePatch
         )
@@ -269,6 +271,15 @@ val themePatch = baseThemePatch(
 
         PreferenceScreen.GENERAL.addPreferences(
             ListPreference("morphe_splash_screen_animation_style")
+        )
+
+        // The splash screen is drawn by the system with the theme of the launcher activity,
+        // so the activity is handed over as soon as it exists.
+        MainActivityOnCreateFingerprint.method.addInstruction(
+            0,
+            // The register of 'this' is above v15 in this method, so the range format is needed.
+            "invoke-static/range { p0 .. p0 }, $THEME_COLOR_EXTENSION_CLASS" +
+                    "->setSplashScreenTheme(Landroid/app/Activity;)V"
         )
 
         // Color of the new content indicator of the pivot bar, which is red in the app and does


### PR DESCRIPTION
The splash screen Android draws while the app starts now uses the background colorselected in the settings, instead of always being white or black.

Android draws it before the app runs, so the color variants of this patch never reach it. Instead the extension hands the system a theme with `SplashScreen.setSplashScreenTheme()`, and the patch generates one theme per color.

Side effects:

- Android 12 and later only, below that nothing changes.
- The new color shows from the second launch, because the system is told which theme to use for the launches that follow.
- A custom color is not known while patching, so the closest color of the 9 bit palette is used (`#FF3300` is drawn as `#FF2600`). The app background stays exact.
- "App default" is now the color of the app (`#0F0F0F`) instead of pure black.

Closes #2542
