### PR TITLE
fix(Theme): Change the color of the new content indicator of the top bar

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
@@ -642,8 +642,9 @@ public class ThemeColorPatch {
     /**
      * Injection point.
      * <p>
-     * Called with the view stub of a new content indicator of the pivot bar, which is the dot
-     * of a tab and the count next to it, before either is shown.
+     * Called with the view stub of a new content indicator, which is the dot of a pivot bar tab
+     * or of the notification button of the top bar, and the count next to it, before either
+     * is shown.
      */
     public static void onNewContentIndicator(ViewStub stub) {
         try {
@@ -659,6 +660,29 @@ public class ThemeColorPatch {
                 // and the color is applied again after the app is done with the view.
                 view.post(() -> setIndicatorColor(view, color));
             });
+        } catch (Exception ex) {
+            Logger.printException(() -> "onNewContentIndicator failure", ex);
+        }
+    }
+
+    /**
+     * Injection point.
+     * <p>
+     * Called with a new content indicator that the layout declares as a view of its own and not
+     * as a stub, which is the dot of the notification button of the Music top bar.
+     */
+    public static void onNewContentIndicator(View indicator) {
+        try {
+            Integer color = getIndicatorColor(indicator.getContext());
+            if (color == null) {
+                return;
+            }
+
+            setIndicatorColor(indicator, color);
+
+            // The top bar can set the background of the indicator after the layout is created,
+            // and the color is applied again after the app is done with the view.
+            indicator.post(() -> setIndicatorColor(indicator, color));
         } catch (Exception ex) {
             Logger.printException(() -> "onNewContentIndicator failure", ex);
         }

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/Fingerprints.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.patches.music.layout.theme
 
 import app.morphe.patcher.Fingerprint
@@ -28,6 +38,29 @@ internal object TopBarNewContentCountFingerprint : Fingerprint(
         methodCall(
             smali = "Landroid/view/ViewStub;->inflate()Landroid/view/View;",
             location = MatchAfterWithin(8)
+        )
+    )
+)
+
+/**
+ * The dot the same button shows when there is no count, which the layout declares as a view of
+ * its own and not as a stub. It is created right before the stub of the count.
+ */
+internal object TopBarNewContentDotFingerprint : Fingerprint(
+    filters = listOf(
+        resourceLiteral(ResourceType.ID, "new_content_dot"),
+        methodCall(
+            name = "findViewById",
+            location = MatchAfterImmediately()
+        ),
+        opcode(
+            opcode = Opcode.MOVE_RESULT_OBJECT,
+            location = MatchAfterImmediately()
+        ),
+        resourceLiteral(
+            ResourceType.ID,
+            "new_content_count",
+            location = MatchAfterWithin(5)
         )
     )
 )

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/ThemePatch.kt
@@ -89,6 +89,21 @@ val themePatch = baseThemePatch(
             }
         }
 
+        // The same button shows a dot when there is no count, and the dot is a view of the
+        // layout instead of a stub, so it is colored as soon as the top bar creates it.
+        TopBarNewContentDotFingerprint.let {
+            it.method.apply {
+                val moveResultIndex = it.instructionMatches[2].index
+                val dotRegister = getInstruction<OneRegisterInstruction>(moveResultIndex).registerA
+
+                addInstruction(
+                    moveResultIndex + 1,
+                    "invoke-static { v$dotRegister }, $THEME_COLOR_EXTENSION_CLASS" +
+                            "->onNewContentIndicator(Landroid/view/View;)V"
+                )
+            }
+        }
+
         PreferenceScreen.GENERAL.addPreferences(
             noTitleUnsortedPreferenceCategory(
                 ListPreference(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
@@ -119,3 +119,35 @@ internal object PivotBarNewContentDotFingerprint : Fingerprint(
         opcode(opcode = Opcode.CHECK_CAST)
     )
 )
+
+/**
+ * The top bar creates the view stub of the new content count of the notification button, and of
+ * the dot next to it. The count comes first, which is the other way around than the pivot bar,
+ * and that is what keeps both fingerprints from matching the same method.
+ */
+internal object TopBarNewContentCountFingerprint : Fingerprint(
+    filters = listOf(
+        resourceLiteral(ResourceType.ID, "new_content_count"),
+        methodCall(
+            name = "findViewById",
+            location = MatchAfterImmediately()
+        ),
+        opcode(
+            opcode = Opcode.CHECK_CAST,
+            location = MatchAfterWithin(3)
+        ),
+        resourceLiteral(
+            ResourceType.ID,
+            "new_content_dot",
+            location = MatchAfterWithin(30)
+        ),
+        methodCall(
+            name = "findViewById",
+            location = MatchAfterImmediately()
+        ),
+        opcode(
+            opcode = Opcode.CHECK_CAST,
+            location = MatchAfterWithin(3)
+        )
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -304,6 +304,28 @@ val themePatch = baseThemePatch(
             }
         }
 
+        // The notification button of the top bar has an indicator of its own, which is created
+        // by a different class than the one of the pivot bar.
+        TopBarNewContentCountFingerprint.let {
+            it.method.apply {
+                // Both the count of the button and the dot shown without one, and the dot is
+                // hooked first so the index of the count is still valid.
+
+                arrayOf(
+                    it.instructionMatches.last().index,
+                    it.instructionMatches[2].index
+                ).forEach { checkCastIndex ->
+                    val stubRegister = getInstruction<OneRegisterInstruction>(checkCastIndex).registerA
+
+                    addInstruction(
+                        checkCastIndex + 1,
+                        "invoke-static { v$stubRegister }, $THEME_COLOR_EXTENSION_CLASS" +
+                                "->onNewContentIndicator(Landroid/view/ViewStub;)V"
+                    )
+                }
+            }
+        }
+
         UseGradientLoadingScreenFingerprint.matchAll().forEach {
             it.method.insertLiteralOverride(
                 it.instructionMatches.first().index,


### PR DESCRIPTION
### Description

The new content indicator on the notification button in the top action bar now follows the selected `Material You` background color, in both `YouTube` and `YouTube Music`. 

Closes #2548

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
