### PR TITLE
fix(Theme): Apply theme color to foreground text

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorOverlay.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorOverlay.java
@@ -128,32 +128,32 @@ final class ThemeColorOverlay {
     /**
      * Loads the overlay of a theme into the resources of {@code context}. Without this the overlay
      * is registered but nothing of the app uses it.
-     *
-     * @param dark If the app shows its dark theme. The overlay of the other theme is never loaded,
-     *             its colors are the text and the icons of this one.
      */
-    static void applyTo(Context context, boolean dark) {
+    static void applyTo(Context context) {
         try {
-            ResourcesLoader loader = resourcesLoader(dark);
-            if (loader == null) {
-                OverlayInfo overlayInfo = findOverlay(context, dark);
-                if (overlayInfo == null) {
-                    Logger.printException(() -> "Overlay " + overlayName(dark)
-                            + " of the app is not registered");
-                    return;
-                }
-
-                loader = new ResourcesLoader();
-                loader.addProvider(ResourcesProvider.loadOverlay(overlayInfo));
-                setResourcesLoader(dark, loader);
-            }
-
-            // Adding the same loader again is ignored, and every context of the app needs it
-            // because the loaders of a context are not inherited.
-            context.getResources().addLoaders(loader);
+            applyTo(context, true);
+            applyTo(context, false);
         } catch (Exception ex) {
             Logger.printException(() -> "Could not apply the overlay of the app", ex);
         }
+    }
+
+    private static void applyTo(Context context, boolean dark) throws Exception {
+        ResourcesLoader loader = resourcesLoader(dark);
+        if (loader == null) {
+            OverlayInfo overlayInfo = findOverlay(context, dark);
+            if (overlayInfo == null) {
+                return;
+            }
+
+            loader = new ResourcesLoader();
+            loader.addProvider(ResourcesProvider.loadOverlay(overlayInfo));
+            setResourcesLoader(dark, loader);
+        }
+
+        // Adding the same loader again is ignored, and every context of the app needs it
+        // because the loaders of a context are not inherited.
+        context.getResources().addLoaders(loader);
     }
 
     /**

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
@@ -161,7 +161,7 @@ public class ThemeColorPatch {
     /**
      * Availability of the custom dark background color.
      */
-    public static final class CustomDarkBackgroundAvailability implements Setting.Availability {
+    public static class CustomDarkBackgroundAvailability implements Setting.Availability {
         @Override
         public boolean isAvailable() {
             return THEME_BACKGROUND_DARK.get().isCustom();
@@ -176,7 +176,7 @@ public class ThemeColorPatch {
     /**
      * Availability of the custom light background color.
      */
-    public static final class CustomLightBackgroundAvailability implements Setting.Availability {
+    public static class CustomLightBackgroundAvailability implements Setting.Availability {
         @Override
         public boolean isAvailable() {
             return THEME_BACKGROUND_LIGHT.get().isCustom();
@@ -288,22 +288,23 @@ public class ThemeColorPatch {
                 THEME_LAST_USED_DARK_MODE.save(dark);
             }
 
-            final int index = dark ? darkConfigValue : lightConfigValue;
+            final int darkIndex = darkConfigValue;
+            final int lightIndex = lightConfigValue;
 
             Context context;
-            if (configuration.mcc == mobileCountryCode(index)
-                    && configuration.mnc == mobileNetworkCode(index)) {
+            if (configuration.mcc == mobileCountryCode(darkIndex)
+                    && configuration.mnc == mobileNetworkCode(lightIndex)) {
                 // Context is created from a context that is already wrapped.
                 context = base;
             } else {
                 Configuration override = new Configuration(configuration);
-                setVariantOf(override, index);
+                setVariantOf(override, darkIndex, lightIndex);
 
                 context = base.createConfigurationContext(override);
             }
 
-            if (isCustomBackgroundSupported() && useOverlay(dark)) {
-                ThemeColorOverlay.applyTo(context, dark);
+            if (isCustomBackgroundSupported()) {
+                ThemeColorOverlay.applyTo(context);
             }
 
             resolveBackgroundColors(context);
@@ -473,20 +474,18 @@ public class ThemeColorPatch {
 
     /**
      * Asks for the variant of a background, using a configuration a device never has.
-     *
-     * @param index Index of the background, which the patch uses with the same encoding.
      */
-    private static void setVariantOf(Configuration configuration, int index) {
-        configuration.mcc = mobileCountryCode(index);
-        configuration.mnc = mobileNetworkCode(index);
+    private static void setVariantOf(Configuration configuration, int darkIndex, int lightIndex) {
+        configuration.mcc = mobileCountryCode(darkIndex);
+        configuration.mnc = mobileNetworkCode(lightIndex);
     }
 
     private static int mobileCountryCode(int index) {
-        return UNUSED_MOBILE_COUNTRY_CODE + (index >> 5);
+        return UNUSED_MOBILE_COUNTRY_CODE + (index - DARK_INDEX_OFFSET);
     }
 
     private static int mobileNetworkCode(int index) {
-        return 1 + (index & 31);
+        return 1 + (index - LIGHT_INDEX_OFFSET);
     }
 
     private static int configValue(Background background, boolean dark) {
@@ -609,6 +608,8 @@ public class ThemeColorPatch {
     @ColorInt
     public static int getBackgroundColor(Context context, boolean dark, int index) {
         try {
+            resolveConfigValues(context);
+
             Background background = (dark
                     ? ThemeColorDark.values()
                     : ThemeColorLight.values())[index];
@@ -620,9 +621,12 @@ public class ThemeColorPatch {
             // The color of a background is the value its resource variant declares, and the
             // variant is selected the same way the app selects the background it uses.
             Configuration configuration = new Configuration(context.getResources().getConfiguration());
-            setVariantOf(configuration, configValue(background, dark));
+            final int configValue = configValue(background, dark);
+            setVariantOf(configuration,
+                    dark ? configValue : darkConfigValue,
+                    dark ? lightConfigValue : configValue);
 
-            final String resourceName = backgroundColorResourceName(dark);
+            String resourceName = backgroundColorResourceName(dark);
             if (resourceName.isEmpty()) {
                 // The app has no theme of this kind, and no color of it to show.
                 return ThemeUtils.getAppBackgroundColor();

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -290,12 +290,12 @@ internal fun baseThemeResourcePatch(
             emptyList()
         }
 
-        addBackgroundColorVariants(THEME_INDEX_OFFSET_DARK, THEME_COLORS_DARK, darkColorNames)
-        add9BitColorVariants(THEME_INDEX_OFFSET_DARK, PALETTE_LEVELS_DARK, darkColorNames)
+        addBackgroundColorVariants(THEME_INDEX_OFFSET_DARK, THEME_COLORS_DARK, darkColorNames, true)
+        add9BitColorVariants(THEME_INDEX_OFFSET_DARK, PALETTE_LEVELS_DARK, darkColorNames, true)
 
         if (includeLightBackground) {
-            addBackgroundColorVariants(THEME_INDEX_OFFSET_LIGHT, THEME_COLORS_LIGHT, lightColorNames)
-            add9BitColorVariants(THEME_INDEX_OFFSET_LIGHT, PALETTE_LEVELS_LIGHT, lightColorNames)
+            addBackgroundColorVariants(THEME_INDEX_OFFSET_LIGHT, THEME_COLORS_LIGHT, lightColorNames, false)
+            add9BitColorVariants(THEME_INDEX_OFFSET_LIGHT, PALETTE_LEVELS_LIGHT, lightColorNames, false)
         }
 
         declareOverlayableColors(darkColorNames + lightColorNames)
@@ -422,7 +422,8 @@ private fun ResourcePatchContext.declareOverlayableColors(colorNames: List<Strin
 private fun ResourcePatchContext.addBackgroundColorVariants(
     indexOffset: Int,
     backgrounds: List<String?>,
-    colorNames: List<String>
+    colorNames: List<String>,
+    isDark: Boolean
 ) {
     if (colorNames.isEmpty()) {
         throw PatchException("No color to replace for the app background")
@@ -434,18 +435,19 @@ private fun ResourcePatchContext.addBackgroundColorVariants(
 
         // The configuration value of a background is its index plus one,
         // and the extension uses the same numbering.
-        writeBackgroundColorVariant(indexOffset + index + 1, color, colorNames)
+        writeBackgroundColorVariant(indexOffset + index + 1, color, colorNames, isDark)
     }
 }
 
 private fun ResourcePatchContext.add9BitColorVariants(
     indexOffset: Int,
     levels: IntArray,
-    colorNames: List<String>
+    colorNames: List<String>,
+    isDark: Boolean
 ) {
     for (index in 0 until 512) {
         writeBackgroundColorVariant(
-            indexOffset + PALETTE_INDEX_OFFSET + index, paletteColor(levels, index), colorNames
+            indexOffset + PALETTE_INDEX_OFFSET + index, paletteColor(levels, index), colorNames, isDark
         )
     }
 }
@@ -462,14 +464,18 @@ private fun paletteColor(levels: IntArray, index: Int) = "#%02X%02X%02X".format(
 private fun ResourcePatchContext.writeBackgroundColorVariant(
     index: Int,
     color: String,
-    colorNames: List<String>
+    colorNames: List<String>,
+    isDark: Boolean
 ) {
     // The mobile country code of a variant is never one a device can have, so the resource
     // system uses a variant only when the app asks for it. The extension uses the same encoding.
-    val mcc = "%03d".format(UNUSED_MOBILE_COUNTRY_CODE + (index shr 5))
-    val mnc = "%03d".format(1 + (index and 31))
+    val qualifier = if (isDark) {
+        "mcc%03d".format(UNUSED_MOBILE_COUNTRY_CODE + (index - THEME_INDEX_OFFSET_DARK))
+    } else {
+        "mnc%03d".format(1 + (index - THEME_INDEX_OFFSET_LIGHT))
+    }
 
-    val variantDirectory = get("res").resolve("values-mcc$mcc-mnc$mnc")
+    val variantDirectory = get("res").resolve("values-$qualifier")
     variantDirectory.mkdirs()
 
     variantDirectory.resolve("colors.xml").writeText(


### PR DESCRIPTION
### Description

Applies theme colors to foreground elements.

This preserves the existing prior behavior of the theme patch before the in-app settings were added.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
