### PR TITLE
fix(YouTube - Theme): Apply custom theme to drop-down menus

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/theme/ThemePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/theme/ThemePatch.java
@@ -10,11 +10,16 @@
 
 package app.morphe.extension.youtube.patches.theme;
 
+import android.graphics.drawable.ColorDrawable;
+import android.view.View;
+import android.widget.Spinner;
+
 import androidx.annotation.ColorInt;
 import androidx.annotation.Nullable;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.theme.BaseThemePatch;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
@@ -125,5 +130,19 @@ public class ThemePatch extends BaseThemePatch {
         }
 
         return replacement;
+    }
+
+    /**
+     * Injection point.
+     */
+    public static void overrideSpinnerPopupBackground(View view) {
+        try {
+            if (view instanceof Spinner spinner) {
+                int backgroundColor = ThemeUtils.getAppBackgroundColor();
+                spinner.setPopupBackgroundDrawable(new ColorDrawable(backgroundColor));
+            }
+        } catch (Exception ex) {
+            Logger.printException(() -> "Overriding spinner popup background failed", ex);
+        }
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
@@ -151,3 +151,17 @@ internal object TopBarNewContentCountFingerprint : Fingerprint(
         )
     )
 )
+
+internal object SpinnerThemeHookFingerprint : Fingerprint(
+    filters = listOf(
+        resourceLiteral(ResourceType.ID, "spinner"),
+        methodCall(
+            name = "findViewById",
+            location = MatchAfterWithin(2)
+        ),
+        opcode(
+            opcode = Opcode.CHECK_CAST,
+            location = MatchAfterWithin(3)
+        )
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -287,7 +287,7 @@ val themePatch = baseThemePatch(
             ListPreference("morphe_splash_screen_animation_style")
         )
 
-        // The splash screen is drawn by the system with the theme of the launcher activity, so
+        // Splash screen is drawn by the system with the theme of the launcher activity, so
         // the activity is handed over as soon as it exists. A patched theme color is
         // already a part of that theme, and no theme is generated to hand over.
         if (!usePatchedThemeColor) {
@@ -396,6 +396,19 @@ val themePatch = baseThemePatch(
                     """
                 )
             }
+        }
+
+        // Popup background of drop-down menus (Spinners) falls back to the Android OS
+        // default, which remains gray and does not go with a custom theme color.
+        SpinnerThemeHookFingerprint.matchAll().forEach { match ->
+            val checkCastIndex = match.instructionMatches.last().index
+            val spinnerRegister = match.method.getInstruction<OneRegisterInstruction>(checkCastIndex).registerA
+
+            match.method.addInstruction(
+                checkCastIndex + 1,
+                "invoke-static { v$spinnerRegister }, " +
+                        "$EXTENSION_CLASS->overrideSpinnerPopupBackground(Landroid/view/View;)V"
+            )
         }
     }
 )


### PR DESCRIPTION
### Description

| Before | After |
|--------|--------|
| <img width="844" height="370" alt="image" src="https://github.com/user-attachments/assets/f415b1c8-a9e7-4c5b-81d8-10f802fd2fea" /> | <img width="837" height="388" alt="Screenshot_20260825_154423_YouTube" src="https://github.com/user-attachments/assets/4fdf6a03-bc8a-4bbc-b868-e1581f334ee7" /> | 

### Additional context

<!-- ADD ADDITIONAL CONTEXT HERE -->

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
