### PR TITLE
feat(YouTube - Wide search bar): Replace the toggle with Disabled, Wide and Extra wide options

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/WideSearchBarLegacyPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/WideSearchBarLegacyPatch.java
@@ -20,7 +20,8 @@ import app.morphe.extension.youtube.settings.Settings;
 @SuppressWarnings("unused")
 public class WideSearchBarLegacyPatch {
 
-    private static final Boolean WIDE_SEARCHBAR_ENABLED = Settings.WIDE_SEARCHBAR.get();
+    // These targets only have the app's own wide search bar, which always replaces the logo.
+    private static final boolean WIDE_SEARCHBAR_ENABLED = Settings.SEARCHBAR_TYPE.get().isEnabled();
 
     /**
      * Injection point.
@@ -37,17 +38,12 @@ public class WideSearchBarLegacyPatch {
             try {
                 View searchBarView = Utils.getChildViewByResourceName(view, "search_bar");
 
-                final int paddingLeft = searchBarView.getPaddingLeft();
-                final int paddingRight = searchBarView.getPaddingRight();
-                final int paddingTop = searchBarView.getPaddingTop();
-                final int paddingBottom = searchBarView.getPaddingBottom();
-                final int paddingStart = Dim.dp8;
-
-                if (Utils.isRightToLeftLocale()) {
-                    searchBarView.setPadding(paddingLeft, paddingTop, paddingStart, paddingBottom);
-                } else {
-                    searchBarView.setPadding(paddingStart, paddingTop, paddingRight, paddingBottom);
-                }
+                searchBarView.setPaddingRelative(
+                        Dim.dp8,
+                        searchBarView.getPaddingTop(),
+                        searchBarView.getPaddingEnd(),
+                        searchBarView.getPaddingBottom()
+                );
             } catch (Exception ex) {
                 Logger.printException(() -> "setActionBar failure", ex);
             }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/WideSearchBarPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/WideSearchBarPatch.java
@@ -37,7 +37,20 @@ import app.morphe.extension.youtube.shared.NavigationBar.NavigationButton;
 @SuppressWarnings("unused")
 public class WideSearchBarPatch {
 
-    private static final Boolean WIDE_SEARCHBAR_ENABLED = Settings.WIDE_SEARCHBAR.get();
+    public enum SearchbarType {
+        DISABLED,
+        /** Search bar is shown beside the header logo. */
+        WIDE,
+        /** Search bar replaces the header logo and spans the entire toolbar. */
+        EXTRA_WIDE;
+
+        public boolean isEnabled() {
+            return this != DISABLED;
+        }
+    }
+
+    private static final SearchbarType SEARCHBAR_TYPE = Settings.SEARCHBAR_TYPE.get();
+    private static final boolean WIDE_SEARCHBAR_ENABLED = SEARCHBAR_TYPE.isEnabled();
     private static final int ID_YOUTUBE_LOGO =
             ResourceUtils.getIdentifier(ResourceType.ID, "youtube_logo");
     private static final int ID_SEARCH_ICON =
@@ -100,8 +113,6 @@ public class WideSearchBarPatch {
                 return;
             }
 
-            final boolean rightToLeftLocale = Utils.isRightToLeftLocale();
-
             final int backgroundColor = ThemeUtils.getEditTextBackground();
             final int textColor = Utils.adjustColorBrightness(
                     ThemeUtils.getAppForegroundColor(), 1.60f, 0.67f);
@@ -128,15 +139,13 @@ public class WideSearchBarPatch {
                 searchIcon = searchIcon.mutate();
                 searchIcon.setTint(textColor);
 
-                if (rightToLeftLocale) {
-                    wideSearchBox.setCompoundDrawablesWithIntrinsicBounds(searchIcon, null, null, null);
-                } else {
-                    wideSearchBox.setCompoundDrawablesWithIntrinsicBounds(null, null, searchIcon, null);
-                }
+                wideSearchBox.setCompoundDrawablesRelativeWithIntrinsicBounds(
+                        null, null, searchIcon, null);
                 wideSearchBox.setCompoundDrawablePadding(Dim.dp8);
             }
 
             View logoView = toolbarViewGroup.findViewById(ID_YOUTUBE_LOGO);
+            final boolean extraWide = SEARCHBAR_TYPE == SearchbarType.EXTRA_WIDE;
             final int sideMargin = Dim.dp10;
             final int searchBarHeight = Dim.dp32;
 
@@ -152,7 +161,19 @@ public class WideSearchBarPatch {
                 currentViewGroupParams = new ViewGroup.MarginLayoutParams(
                         ViewGroup.LayoutParams.MATCH_PARENT, searchBarHeight
                 );
-                currentViewGroupParams.setMargins(Dim.dp12, 0, Dim.dp12, 0);
+
+                int startMargin = extraWide ? Dim.dp12 : sideMargin;
+                final int endMargin = extraWide ? Dim.dp12 : sideMargin;
+
+                // Search bar fills the toolbar, so it must not overlap the logo that stays visible.
+                if (!extraWide && logoView != null) {
+                    final int measuredWidth = logoView.getMeasuredWidth();
+                    final int logoWidth = measuredWidth > 0 ? measuredWidth : DP115;
+                    startMargin = logoWidth + Dim.dp16;
+                }
+
+                currentViewGroupParams.setMarginStart(startMargin);
+                currentViewGroupParams.setMarginEnd(endMargin);
 
                 if (toolbarViewGroup instanceof FrameLayout) {
                     FrameLayout.LayoutParams frameParams = new FrameLayout.LayoutParams(
@@ -184,7 +205,9 @@ public class WideSearchBarPatch {
                     targetIndex = logoIndex + 1;
                 }
 
-                logoView.setVisibility(View.GONE);
+                if (extraWide) {
+                    logoView.setVisibility(View.GONE);
+                }
             }
 
             toolbarViewGroup.addView(wideSearchBox, targetIndex);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -47,6 +47,7 @@ import app.morphe.extension.youtube.patches.OpenShortsInRegularPlayerPatch.Short
 import app.morphe.extension.youtube.patches.OpenVideosFullscreenHookPatch.OpenFullscreenMode;
 import app.morphe.extension.youtube.patches.PlaybackInFeedsPatch;
 import app.morphe.extension.youtube.patches.VersionCheckPatch;
+import app.morphe.extension.youtube.patches.WideSearchBarPatch.SearchbarType;
 import app.morphe.extension.youtube.patches.components.LayoutComponentsFilter.ExpandableCardStyle;
 import app.morphe.extension.youtube.patches.components.PlayerFlyoutMenuComponentsFilter.HideAudioFlyoutMenuAvailability;
 import app.morphe.extension.youtube.patches.spoof.SpoofVideoStreamsPatch.SpoofClientAv1Availability;
@@ -468,7 +469,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting SHOW_TOOLBAR_SETTINGS_BUTTON = new BooleanSetting("morphe_show_toolbar_settings_button", FALSE, true);
     public static final IntegerSetting SHOW_TOOLBAR_SETTINGS_BUTTON_INDEX = new IntegerSetting("morphe_show_toolbar_settings_button_index", 3, true, parent(SHOW_TOOLBAR_SETTINGS_BUTTON));
     public static final BooleanSetting SHOW_TOOLBAR_SETTINGS_BUTTON_TYPE = new BooleanSetting("morphe_show_toolbar_settings_button_type", FALSE, true, parent(SHOW_TOOLBAR_SETTINGS_BUTTON));
-    public static final BooleanSetting WIDE_SEARCHBAR = new BooleanSetting("morphe_wide_searchbar", FALSE, true);
+    public static final EnumSetting<SearchbarType> SEARCHBAR_TYPE = new EnumSetting<>("morphe_searchbar_type", SearchbarType.DISABLED, true);
 
     // Shorts
     public static final BooleanSetting DISABLE_SHORTS_RESUMING_ON_STARTUP = new BooleanSetting("morphe_disable_shorts_resuming_on_startup", FALSE);
@@ -667,6 +668,7 @@ public class Settings extends SharedYouTubeSettings {
     private static final BooleanSetting DEPRECATED_SWIPE_BRIGHTNESS = new BooleanSetting("morphe_swipe_brightness", FALSE);
     private static final BooleanSetting DEPRECATED_SWIPE_VOLUME = new BooleanSetting("morphe_swipe_volume", FALSE);
     private static final BooleanSetting DEPRECATED_SWIPE_SPEED = new BooleanSetting("morphe_swipe_speed", FALSE);
+    private static final BooleanSetting DEPRECATED_WIDE_SEARCHBAR = new BooleanSetting("morphe_wide_searchbar", FALSE, true);
 
     // Unified SponsorBlock keys under the morphe_sb_* namespace (previously raw sb_*).
     private static final BooleanSetting DEPRECATED_SB_ENABLED = new BooleanSetting("sb_enabled", TRUE, false, false);
@@ -742,6 +744,8 @@ public class Settings extends SharedYouTubeSettings {
         migrateSwipeGestureToZone(DEPRECATED_SWIPE_BRIGHTNESS, SWIPE_LEFT_ZONE, SwipeZoneAction.BRIGHTNESS);
         migrateSwipeGestureToZone(DEPRECATED_SWIPE_VOLUME, SWIPE_RIGHT_ZONE, SwipeZoneAction.VOLUME);
         migrateSwipeGestureToZone(DEPRECATED_SWIPE_SPEED, SWIPE_TOP_ZONE, SwipeZoneAction.SPEED);
+
+        migrateWideSearchbarToType();
 
         // SponsorBlock key namespace unification (sb_* -> morphe_sb_*).
         migrateOldSettingToNew(DEPRECATED_SB_ENABLED, SB_ENABLED);
@@ -825,6 +829,21 @@ public class Settings extends SharedYouTubeSettings {
 
         // Must run before any code reads a SegmentCategory setting.
         YouTubeSponsorBlockConfig.install();
+    }
+
+    /**
+     * Older targets have no wide search bar of their own and always replace the logo with it.
+     */
+    private static void migrateWideSearchbarToType() {
+        if (DEPRECATED_WIDE_SEARCHBAR.isSetToDefault()) {
+            return;
+        }
+        if (SEARCHBAR_TYPE.isSetToDefault()) {
+            SEARCHBAR_TYPE.save(VersionCheckPatch.IS_20_31_OR_GREATER
+                    ? SearchbarType.WIDE
+                    : SearchbarType.EXTRA_WIDE);
+        }
+        DEPRECATED_WIDE_SEARCHBAR.resetToDefault();
     }
 
     /**

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/widesearchbar/WideSearchBarPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/widesearchbar/WideSearchBarPatch.kt
@@ -9,7 +9,7 @@ package app.morphe.patches.youtube.layout.widesearchbar
 
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
-import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import app.morphe.patches.shared.misc.settings.preference.ListPreference
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.playservice.is_20_31_or_greater
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
@@ -39,14 +39,23 @@ val wideSearchBarPatch = bytecodePatch(
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {
-        PreferenceScreen.GENERAL.addPreferences(
-            SwitchPreference("morphe_wide_searchbar")
-        )
-
         if (!is_20_31_or_greater) {
+            // Legacy targets use the app's own wide search bar, which always replaces the logo.
+            PreferenceScreen.GENERAL.addPreferences(
+                ListPreference(
+                    key = "morphe_searchbar_type",
+                    entriesKey = "morphe_searchbar_type_legacy_entries",
+                    entryValuesKey = "morphe_searchbar_type_legacy_entry_values"
+                )
+            )
+
             applyLegacyWideSearchBar()
             return@execute
         }
+
+        PreferenceScreen.GENERAL.addPreferences(
+            ListPreference("morphe_searchbar_type")
+        )
 
         hookToolBar("$EXTENSION_CLASS->setSearchButtonView")
 

--- a/patches/src/main/resources/addresources/values/youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/youtube/arrays.xml
@@ -474,6 +474,27 @@
         <item>YOUR_CLIPS</item>
     </string-array>
 
+    <!-- layout.searchbar.wideSearchbarPatch -->
+    <string-array name="morphe_searchbar_type_entries">
+        <item>@string/morphe_searchbar_type_entry_disabled</item>
+        <item>@string/morphe_searchbar_type_entry_wide</item>
+        <item>@string/morphe_searchbar_type_entry_extra_wide</item>
+    </string-array>
+    <string-array name="morphe_searchbar_type_entry_values">
+        <item>DISABLED</item>
+        <item>WIDE</item>
+        <item>EXTRA_WIDE</item>
+    </string-array>
+    <!-- Older targets have no wide search bar of their own and always replace the logo with it. -->
+    <string-array name="morphe_searchbar_type_legacy_entries">
+        <item>@string/morphe_searchbar_type_entry_disabled</item>
+        <item>@string/morphe_searchbar_type_entry_extra_wide</item>
+    </string-array>
+    <string-array name="morphe_searchbar_type_legacy_entry_values">
+        <item>DISABLED</item>
+        <item>EXTRA_WIDE</item>
+    </string-array>
+
     <!-- layout.shortsplayer.shortsPlayerTypePatch -->
     <string-array name="morphe_shorts_player_type_entries">
         <item>@string/morphe_shorts_player_type_shorts</item>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -943,7 +943,10 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
     <string name="morphe_player_overlay_opacity_invalid_toast">Player overlay opacity must be between 0-100</string>
 
     <!-- layout.searchbar.wideSearchbarPatch -->
-    <string name="morphe_wide_searchbar_title">Enable wide search bar</string>
+    <string name="morphe_searchbar_type_title">Search bar</string>
+    <string name="morphe_searchbar_type_entry_disabled">Disabled</string>
+    <string name="morphe_searchbar_type_entry_wide">Wide</string>
+    <string name="morphe_searchbar_type_entry_extra_wide">Extra wide</string>
 
     <!-- layout.sponsorblock.sponsorBlockPatch -->
     <string name="morphe_settings_screen_10_sponsorblock_title" translatable="false">SponsorBlock</string>


### PR DESCRIPTION
### Description

Replaces the `Wide search bar` toggle with a `Search bar` list preference offering `Disabled`, `Wide` and `Extra wide`.

`Wide` keeps the header logo visible beside the search bar, `Extra wide` hides the logo and spans the whole toolbar, and targets older than 20.31 only offer `Disabled` and `Extra wide` because they use the app's own wide search bar.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
