### PR TITLE
chore(YouTube - Playback speed): Restore original speed toggle behavior

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlaybackSpeedDialogButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlaybackSpeedDialogButton.java
@@ -94,7 +94,7 @@ public class PlaybackSpeedDialogButton {
                         VideoInformation.getPlaybackSpeed() == defaultSpeed)
                         ? 1.0f
                         : defaultSpeed;
-                VideoInformation.setPlaybackSpeed(speed);
+                VideoInformation.changePlaybackSpeed(speed);
                 if (speed == 1.0f) {
                     VideoInformation.setAudioPitch(1.0f);
                 }


### PR DESCRIPTION
Fixes https://github.com/MorpheApp/morphe-patches/issues/2603

Restores the original speed toggle behavior that existed before `v1.40.0-dev.6`, where pressing and holding the playback-speed overlay button changes the current video speed without changing `PLAYBACK_SPEED_DEFAULT`.

See comment:
https://github.com/MorpheApp/morphe-patches/issues/2603#issuecomment-5426618884