### PR TITLE
feat: Add `PoToken provider` patch

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/PoTokenProviderPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/patches/PoTokenProviderPatch.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2618
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.patches;
+
+import android.content.pm.PackageManager;
+import android.net.Uri;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.settings.Setting;
+import app.morphe.extension.shared.settings.SharedYouTubeSettings;
+import app.morphe.extension.shared.spoof.SpoofVideoStreamsPatch;
+
+@SuppressWarnings("unused")
+public class PoTokenProviderPatch {
+    public static final class PoTokenProviderAvailability implements Setting.Availability {
+        @Override
+        public boolean isAvailable() {
+            return isPoTokenProviderAvailable();
+        }
+    }
+
+    private static final String PO_TOKEN_SERVICE_SUFFIX = ".potokens.service.START";
+    private static final String PO_TOKEN_HELPER_PACKAGE_NAME = "app.morphe.pot.helper";
+    private static final String PO_TOKEN_HELPER_SERVICE_ACTION = PO_TOKEN_HELPER_PACKAGE_NAME + PO_TOKEN_SERVICE_SUFFIX;
+    private static final Uri PO_TOKEN_HELPER_CONTENT_AUTHORITIES;
+
+    static {
+        Uri.Builder builder = new Uri.Builder();
+        builder.scheme("content");
+        builder.authority(PO_TOKEN_HELPER_PACKAGE_NAME + ".chimera");
+        PO_TOKEN_HELPER_CONTENT_AUTHORITIES = builder.build();
+    }
+
+    /**
+     * Injection point.
+     */
+    public static Uri overrideAuthorities(String serviceAction, Uri uri) {
+        return useExternalPoTokenProvider(serviceAction)
+                ? PO_TOKEN_HELPER_CONTENT_AUTHORITIES
+                : uri;
+    }
+
+    /**
+     * Injection point.
+     */
+    public static String overrideServiceAction(String serviceAction) {
+        return useExternalPoTokenProvider(serviceAction)
+                ? PO_TOKEN_HELPER_SERVICE_ACTION
+                : serviceAction;
+    }
+
+    private static boolean useExternalPoTokenProvider(String serviceAction) {
+        return serviceAction != null
+                && serviceAction.endsWith(PO_TOKEN_SERVICE_SUFFIX)
+                && SharedYouTubeSettings.EXTERNAL_POTOKEN_PROVIDER.get()
+                && isPoTokenProviderAvailable();
+    }
+
+    private static boolean isPoTokenProviderAvailable() {
+        // To minimize confusion, it works only when 'Spoof video streams' is turned off.
+        if (!SpoofVideoStreamsPatch.isSpoofingEnabled()) {
+            try {
+                if (Utils.getContext().getPackageManager().getApplicationInfo(PO_TOKEN_HELPER_PACKAGE_NAME, 0).enabled) {
+                    Logger.printDebug(() -> "App installed: " + PO_TOKEN_HELPER_PACKAGE_NAME);
+                    return true;
+                }
+            } catch (PackageManager.NameNotFoundException error) {
+                Logger.printDebug(() -> "App not installed: " + PO_TOKEN_HELPER_PACKAGE_NAME);
+            }
+        }
+        return false;
+    }
+}

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/SharedYouTubeSettings.java
@@ -10,6 +10,7 @@ import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.patches.CustomBrandingPatch;
 import app.morphe.extension.shared.patches.CustomBrandingPatch.BrandingTheme;
 import app.morphe.extension.shared.patches.CustomBrandingPatch.NotificationIconTheme;
+import app.morphe.extension.shared.patches.PoTokenProviderPatch.PoTokenProviderAvailability;
 import app.morphe.extension.shared.spoof.SpoofVideoStreamsPatch.JavaScriptClientAvailability;
 import app.morphe.extension.shared.spoof.js.JavaScriptVariant;
 import app.morphe.extension.shared.theme.ThemeColorPatch.ThemeColorChangeForegroundAvailability;
@@ -29,6 +30,17 @@ public class SharedYouTubeSettings extends BaseSettings {
 
     public static final BooleanSetting SETTINGS_SEARCH_HISTORY = new BooleanSetting("morphe_settings_search_history", TRUE, true);
     public static final StringSetting SETTINGS_SEARCH_ENTRIES = new StringSetting("morphe_settings_search_entries", "");
+
+    // Network proxy
+    // There are multiple endpoint calls due to the spoof video streams patch. Place the proxy settings first.
+    public static final BooleanSetting PROXY_ENABLED = new BooleanSetting("morphe_proxy_enabled", FALSE, true);
+    public static final StringSetting PROXY_HOST = new StringSetting("morphe_proxy_host", "", true, parent(PROXY_ENABLED));
+    public static final IntegerSetting PROXY_PORT = new IntegerSetting("morphe_proxy_port", 8080, true, parent(PROXY_ENABLED));
+    public static final BooleanSetting PROXY_HTTPS = new BooleanSetting("morphe_proxy_https", FALSE, true, parent(PROXY_ENABLED));
+    public static final BooleanSetting PROXY_AUTH_ENABLED = new BooleanSetting("morphe_proxy_auth_enabled", FALSE, true, parent(PROXY_ENABLED));
+    public static final StringSetting PROXY_AUTH_USERNAME = new StringSetting("morphe_proxy_auth_username", "", true, parent(PROXY_AUTH_ENABLED));
+    public static final StringSetting PROXY_AUTH_PASSWORD = new StringSetting("morphe_proxy_auth_password", "", true, false, null, parent(PROXY_AUTH_ENABLED));
+    public static final BooleanSetting PROXY_ALLOW_DIRECT_FALLBACK = new BooleanSetting("morphe_proxy_allow_direct_fallback", FALSE, true, parent(PROXY_ENABLED));
 
     public static final BooleanSetting DISABLE_DRC_AUDIO = new BooleanSetting("morphe_disable_drc_audio", FALSE, true);
     public static final BooleanSetting FORCE_ORIGINAL_AUDIO = new BooleanSetting("morphe_force_original_audio", TRUE, true);
@@ -71,15 +83,8 @@ public class SharedYouTubeSettings extends BaseSettings {
     public static final StringSetting OAUTH2_REFRESH_TOKEN = new StringSetting("morphe_oauth2_refresh_token", "", false, false);
     public static final StringSetting SPOOF_VIDEO_STREAMS_CLIENT_IDS = new StringSetting("morphe_spoof_video_streams_clent_id", "", false, false);
 
-    // Network proxy
-    public static final BooleanSetting PROXY_ENABLED = new BooleanSetting("morphe_proxy_enabled", FALSE, true);
-    public static final StringSetting PROXY_HOST = new StringSetting("morphe_proxy_host", "", true, parent(PROXY_ENABLED));
-    public static final IntegerSetting PROXY_PORT = new IntegerSetting("morphe_proxy_port", 8080, true, parent(PROXY_ENABLED));
-    public static final BooleanSetting PROXY_HTTPS = new BooleanSetting("morphe_proxy_https", FALSE, true, parent(PROXY_ENABLED));
-    public static final BooleanSetting PROXY_AUTH_ENABLED = new BooleanSetting("morphe_proxy_auth_enabled", FALSE, true, parent(PROXY_ENABLED));
-    public static final StringSetting PROXY_AUTH_USERNAME = new StringSetting("morphe_proxy_auth_username", "", true, parent(PROXY_AUTH_ENABLED));
-    public static final StringSetting PROXY_AUTH_PASSWORD = new StringSetting("morphe_proxy_auth_password", "", true, false, null, parent(PROXY_AUTH_ENABLED));
-    public static final BooleanSetting PROXY_ALLOW_DIRECT_FALLBACK = new BooleanSetting("morphe_proxy_allow_direct_fallback", FALSE, true, parent(PROXY_ENABLED));
+    // PoToken provider
+    public static final BooleanSetting EXTERNAL_POTOKEN_PROVIDER = new BooleanSetting("morphe_external_potoken_provider", FALSE, true, "morphe_external_potoken_provider_user_dialog_message", new PoTokenProviderAvailability());
 
     // External downloads
     public static final BooleanSetting EXTERNAL_DOWNLOADER = new BooleanSetting("morphe_external_downloader", FALSE);

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/preference/ExternalPoTokenProviderAboutPreference.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/settings/preference/ExternalPoTokenProviderAboutPreference.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2618
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.shared.settings.preference;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+@SuppressWarnings("unused")
+public class ExternalPoTokenProviderAboutPreference extends URLLinkPreference {
+    {
+        externalURL = "https://github.com/MorpheApp/PotHelper/releases/latest";
+    }
+
+    public ExternalPoTokenProviderAboutPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+    public ExternalPoTokenProviderAboutPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+    public ExternalPoTokenProviderAboutPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+    public ExternalPoTokenProviderAboutPreference(Context context) {
+        super(context);
+    }
+}
+

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/potoken/PoTokenProviderPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/potoken/PoTokenProviderPatch.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2618
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.patches.music.misc.potoken
+
+import app.morphe.patches.music.misc.extension.sharedExtensionPatch
+import app.morphe.patches.music.misc.settings.PreferenceScreen
+import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
+import app.morphe.patches.shared.misc.potoken.poTokenProviderPatch
+
+@Suppress("unused")
+val poTokenProviderPatch = poTokenProviderPatch(
+    originalAppPackageName = COMPATIBILITY_YOUTUBE_MUSIC.packageName!!,
+    preferenceScreen = PreferenceScreen.MISC,
+    block = {
+        compatibleWith(COMPATIBILITY_YOUTUBE_MUSIC)
+
+        dependsOn(sharedExtensionPatch)
+    }
+)

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/potoken/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/potoken/Fingerprints.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2618
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.patches.shared.misc.potoken
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation.MatchAfterWithin
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.string
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+internal object ServiceBindIntentUtilsFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    filters = listOf(
+        string("ServiceBindIntentUtils"),
+        string("serviceActionBundleKey"),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            smali = "Landroid/os/Bundle;->putString(Ljava/lang/String;Ljava/lang/String;)V",
+            location = MatchAfterWithin(5)
+        ),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            smali = "Landroid/content/ContentResolver;->acquireUnstableContentProviderClient(Landroid/net/Uri;)Landroid/content/ContentProviderClient;",
+            location = MatchAfterWithin(10)
+        )
+    )
+)
+

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/potoken/PoTokenProviderPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/potoken/PoTokenProviderPatch.kt
@@ -14,6 +14,7 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.all.misc.clone.setOrGetFallbackPackageName
 import app.morphe.patches.shared.misc.settings.preference.BasePreferenceScreen
+import app.morphe.patches.shared.misc.settings.preference.IntentPreference
 import app.morphe.patches.shared.misc.settings.preference.NonInteractivePreference
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
@@ -95,6 +96,13 @@ internal fun poTokenProviderPatch(
                 sorting = PreferenceScreenPreference.Sorting.UNSORTED,
                 preferences = setOf(
                     SwitchPreference("morphe_external_potoken_provider", summary = true),
+                    IntentPreference(
+                        key = "morphe_external_potoken_provider_settings",
+                        titleKey = "morphe_external_potoken_provider_about_title",
+                        intent = IntentPreference.Intent("", "app.morphe.pot.helper.MainActivity") {
+                            "app.morphe.pot.helper"
+                        }
+                    ),
                     NonInteractivePreference(
                         key = "morphe_external_potoken_provider_about",
                         tag = "app.morphe.extension.shared.settings.preference.ExternalPoTokenProviderAboutPreference",

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/potoken/PoTokenProviderPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/potoken/PoTokenProviderPatch.kt
@@ -9,6 +9,8 @@ package app.morphe.patches.shared.misc.potoken
 
 import app.morphe.patcher.patch.BytecodePatchBuilder
 import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.InstallerType
+import app.morphe.patcher.patch.PatchAvailability
 import app.morphe.patcher.patch.ResourcePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
@@ -42,6 +44,14 @@ internal fun poTokenProviderPatch(
     description = "Adds option to get PoToken using an external PoToken minter app.",
     default = false
 ) {
+    // The execute block still has to check the package name, because the CLI does not report one.
+    availability { installer, _ ->
+        when (installer) {
+            InstallerType.MOUNT -> PatchAvailability.UNAVAILABLE
+            InstallerType.STANDARD, InstallerType.SHIZUKU -> PatchAvailability.DISABLED
+        }
+    }
+
     block()
 
     dependsOn(poTokenProviderResourcePatch)

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/potoken/PoTokenProviderPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/potoken/PoTokenProviderPatch.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2618
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.patches.shared.misc.potoken
+
+import app.morphe.patcher.patch.BytecodePatchBuilder
+import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.ResourcePatchContext
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patches.all.misc.clone.setOrGetFallbackPackageName
+import app.morphe.patches.shared.misc.settings.preference.BasePreferenceScreen
+import app.morphe.patches.shared.misc.settings.preference.NonInteractivePreference
+import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
+import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import app.morphe.util.addInstructionsAtControlFlowLabel
+import app.morphe.util.registersUsed
+import java.util.logging.Logger
+
+private const val EXTENSION_CLASS = "Lapp/morphe/extension/shared/patches/PoTokenProviderPatch;"
+
+private lateinit var resourceContext: ResourcePatchContext
+
+private val poTokenProviderResourcePatch = resourcePatch {
+    execute {
+        resourceContext = this
+    }
+}
+
+internal fun poTokenProviderPatch(
+    originalAppPackageName: String,
+    preferenceScreen: BasePreferenceScreen.Screen,
+    block: BytecodePatchBuilder.() -> Unit,
+    executeBlock: BytecodePatchContext.() -> Unit = {},
+) = bytecodePatch(
+    name = "PoToken provider",
+    description = "Adds option to get PoToken using an external PoToken minter app.",
+    default = false
+) {
+    block()
+
+    dependsOn(poTokenProviderResourcePatch)
+
+    execute {
+        // TODO: Migrate to GmsCore support patch.
+        val isRootInstall = setOrGetFallbackPackageName(originalAppPackageName) == originalAppPackageName
+        if (isRootInstall) {
+            return@execute Logger.getLogger(this::class.java.name).info(
+                "PoToken provider is not required for root installation. No changes applied."
+            )
+        }
+
+        resourceContext.document("AndroidManifest.xml").use { document ->
+            val packageNode = document.createElement("package")
+            packageNode.setAttribute("android:name", "app.morphe.pot.helper")
+
+            document.getElementsByTagName("queries").item(0).appendChild(packageNode)
+        }
+
+        ServiceBindIntentUtilsFingerprint.let {
+            it.method.apply {
+                val serviceActionMatch = it.instructionMatches[2]
+                val serviceActionIndex = serviceActionMatch.index
+                val serviceActionRegister = serviceActionMatch.instruction.registersUsed[2]
+
+                val authoritiesMatch = it.instructionMatches[3]
+                val authoritiesIndex = authoritiesMatch.index
+                val authoritiesRegister = authoritiesMatch.instruction.registersUsed[1]
+
+                addInstructionsAtControlFlowLabel(
+                    authoritiesIndex,
+                    """
+                        invoke-static { v$serviceActionRegister, v$authoritiesRegister }, $EXTENSION_CLASS->overrideAuthorities(Ljava/lang/String;Landroid/net/Uri;)Landroid/net/Uri;
+                        move-result-object v$authoritiesRegister
+                    """
+                )
+
+                addInstructionsAtControlFlowLabel(
+                    serviceActionIndex,
+                    """
+                        invoke-static { v$serviceActionRegister }, $EXTENSION_CLASS->overrideServiceAction(Ljava/lang/String;)Ljava/lang/String;
+                        move-result-object v$serviceActionRegister
+                    """
+                )
+            }
+        }
+
+        preferenceScreen.addPreferences(
+            PreferenceScreenPreference(
+                key = "morphe_potoken_provider_screen",
+                sorting = PreferenceScreenPreference.Sorting.UNSORTED,
+                preferences = setOf(
+                    SwitchPreference("morphe_external_potoken_provider", summary = true),
+                    NonInteractivePreference(
+                        key = "morphe_external_potoken_provider_about",
+                        tag = "app.morphe.extension.shared.settings.preference.ExternalPoTokenProviderAboutPreference",
+                        selectable = true,
+                    )
+                )
+            )
+        )
+
+        executeBlock()
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/potoken/PoTokenProviderPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/potoken/PoTokenProviderPatch.kt
@@ -41,14 +41,13 @@ internal fun poTokenProviderPatch(
     executeBlock: BytecodePatchContext.() -> Unit = {},
 ) = bytecodePatch(
     name = "PoToken provider",
-    description = "Adds option to get PoToken using an external PoToken minter app.",
-    default = false
+    description = "Adds option to get PoToken using an external PoToken minter app."
 ) {
     // The execute block still has to check the package name, because the CLI does not report one.
     availability { installer, _ ->
         when (installer) {
             InstallerType.MOUNT -> PatchAvailability.UNAVAILABLE
-            InstallerType.STANDARD, InstallerType.SHIZUKU -> PatchAvailability.DISABLED
+            InstallerType.STANDARD, InstallerType.SHIZUKU -> PatchAvailability.ENABLED
         }
     }
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/potoken/PoTokenProviderPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/potoken/PoTokenProviderPatch.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2618
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.patches.youtube.misc.potoken
+
+import app.morphe.patches.shared.misc.potoken.poTokenProviderPatch
+import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
+import app.morphe.patches.youtube.misc.settings.PreferenceScreen
+import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
+
+@Suppress("unused")
+val poTokenProviderPatch = poTokenProviderPatch(
+    originalAppPackageName = COMPATIBILITY_YOUTUBE.packageName!!,
+    preferenceScreen = PreferenceScreen.MISC,
+    block = {
+        compatibleWith(COMPATIBILITY_YOUTUBE)
+
+        dependsOn(sharedExtensionPatch)
+    }
+)

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -204,6 +204,19 @@ However, enabling this will also log some user data such as your IP address."</s
     <string name="morphe_remove_viewer_discretion_dialog_title">Remove viewer discretion dialog</string>
     <string name="morphe_remove_viewer_discretion_dialog_summary">This does not bypass the age restriction. It just accepts it automatically</string>
 
+    <!-- misc.potoken.poTokenProviderPatch -->
+    <string name="morphe_potoken_provider_screen_title">PoToken provider</string>
+    <string name="morphe_potoken_provider_screen_summary">Configure PoToken provider to prevent playback issues</string>
+    <string name="morphe_external_potoken_provider_title">External PoToken provider</string>
+    <string name="morphe_external_potoken_provider_summary">"Fixes playback issues using an external PoToken minter (Experimental)
+
+If you are a YouTube Premium user, this setting may not be required"</string>
+    <string name="morphe_external_potoken_provider_user_dialog_message">If it does not work, try force-closing the MicroG.</string>
+    <string name="morphe_external_potoken_provider_about_title" translatable="false">PotHelper</string>
+    <string name="morphe_external_potoken_provider_about_summary">"This is currently under development and may not work
+
+Tap here to download PotHelper"</string>
+
     <!-- misc.spoof.appversion.spoofAppVersionPatch -->
     <string name="morphe_spoof_app_version_title">Spoof app version</string>
     <string name="morphe_spoof_app_version_summary">Tricks the server into thinking you are using an older app version to restore legacy UI features</string>

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -211,7 +211,8 @@ However, enabling this will also log some user data such as your IP address."</s
     <string name="morphe_external_potoken_provider_summary">"Fixes playback issues using an external PoToken minter (Experimental)
 
 If you are a YouTube Premium user, this setting may not be required"</string>
-    <string name="morphe_external_potoken_provider_user_dialog_message">If it does not work, try force-closing the MicroG.</string>
+    <string name="morphe_external_potoken_provider_user_dialog_message">If it does not work, try force-closing the MicroG</string>
+    <string name="morphe_external_potoken_provider_settings_summary">Open the PotHelper settings</string>
     <string name="morphe_external_potoken_provider_about_title" translatable="false">PotHelper</string>
     <string name="morphe_external_potoken_provider_about_summary">"This is currently under development and may not work
 

--- a/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/shared-youtube/strings.xml
@@ -211,10 +211,10 @@ However, enabling this will also log some user data such as your IP address."</s
     <string name="morphe_external_potoken_provider_summary">"Fixes playback issues using an external PoToken minter (Experimental)
 
 If you are a YouTube Premium user, this setting may not be required"</string>
-    <string name="morphe_external_potoken_provider_user_dialog_message">If it does not work, try force-closing the MicroG</string>
-    <string name="morphe_external_potoken_provider_settings_summary">Open the PotHelper settings</string>
+    <string name="morphe_external_potoken_provider_user_dialog_message">If it does not work, try force-closing MicroG</string>
+    <string name="morphe_external_potoken_provider_settings_summary">Open PotHelper settings</string>
     <string name="morphe_external_potoken_provider_about_title" translatable="false">PotHelper</string>
-    <string name="morphe_external_potoken_provider_about_summary">"This is currently under development and may not work
+    <string name="morphe_external_potoken_provider_about_summary">"This feature is currently under development and may not work
 
 Tap here to download PotHelper"</string>
 


### PR DESCRIPTION
### Description

Fixes the playback issue by issuing a valid PoToken through an external PoToken minter.

If this patch is used, the `Spoof video streams` patch is no longer needed.

This patch is experimental and requires the installation of an external app. ~Therefore, it has been excluded by default.~

### Step for testing

> [!CAUTION]
> This feature is experimental and may stop working at any time. **Use at your own risk.**

> [!TIP]
> 
> 1. Download the [build artifact](https://github.com/MorpheApp/morphe-patches/actions/runs/33062092114/artifacts/9642191972) and import it in the manager.
> 
> 2. Include `PoToken provider` patch
> 
> 3. Download [PotHelper](https://github.com/MorpheApp/PotHelper/releases/latest) and install it on your device.
> 
> 4. Turn off: **Morphe > Miscellaneous > Spoof video streams > Spoof video streams**
> 
> 5. Turn on: **Morphe > Miscellaneous > PoToken provider > External PoToken provider**
> 
> 6. Restart the app and check for playback issues.

### Addtional context

MicroG's PoToken service no longer works due to changes in the DroidGuard VM approximately 2.5 years ago.

Valid PoTokens are no longer issued on MicroG forks (or the [original MicroG](https://github.com/microg/GmsCore) installed on devices that do not pass the Play Integrity API).

To obtain a valid PoToken on the LineageOS microG edition, root modules such as `PlayIntegrityFix` or `TrickyStore (keybox)` are required.

By partially mimicking the operation of these keybox modules, I have released an experimental app called [PotHelper](https://github.com/MorpheApp/PotHelper).

> [!NOTE]
> 
> 1. `PoToken provider` patch intercepts the PoToken IPC service and passes it to `PotHelper`.
> 
> 2. `PotHelper` mints the integrity token using the droidguard result passed through the unrevoked keybox and passes it to YouTube (or YouTube Music).
> 
> 3. YouTube (or YouTube Music) mints the po token using an in-app native library.

### Build Artifacts

https://github.com/MorpheApp/morphe-patches/actions/runs/33062092114/artifacts/9642191972

### Test results

- [X] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
