### PR TITLE
feat(YouTube): Add `Disable playlist autoplay` patch

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisablePlaylistAutoplayPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisablePlaylistAutoplayPatch.java
@@ -7,9 +7,6 @@
 
 package app.morphe.extension.youtube.patches;
 
-import java.lang.reflect.Field;
-
-import app.morphe.extension.shared.Logger;
 import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
@@ -18,24 +15,7 @@ public class DisablePlaylistAutoplayPatch {
     /**
      * Injection point.
      */
-    public static boolean shouldSkipPlaylistAutoplay(Object navigationIntent) {
-        if (!Settings.DISABLE_PLAYLIST_AUTOPLAY.get()) {
-            return false;
-        }
-        try {
-            for (Field field : navigationIntent.getClass().getDeclaredFields()) {
-                if (!Enum.class.isAssignableFrom(field.getType())) {
-                    continue;
-                }
-                field.setAccessible(true);
-                Object value = field.get(navigationIntent);
-                if (value instanceof Enum<?> && "AUTOPLAY".equals(((Enum<?>) value).name())) {
-                    return true;
-                }
-            }
-        } catch (Exception ex) {
-            Logger.printException(() -> "shouldSkipPlaylistAutoplay failure", ex);
-        }
-        return false;
+    public static boolean shouldSkipPlaylistAutoplay(Enum<?> navigationIntent) {
+        return Settings.DISABLE_PLAYLIST_AUTOPLAY.get() && "AUTOPLAY".equals(navigationIntent.name());
     }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisablePlaylistAutoplayPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisablePlaylistAutoplayPatch.java
@@ -1,0 +1,34 @@
+package app.morphe.extension.youtube.patches;
+
+import java.lang.reflect.Field;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.youtube.settings.Settings;
+
+@SuppressWarnings("unused")
+public class DisablePlaylistAutoplayPatch {
+
+    /**
+     * Injection point.
+     */
+    public static boolean shouldSkipPlaylistAutoplay(Object navigationIntent) {
+        if (!Settings.DISABLE_PLAYLIST_AUTOPLAY.get()) {
+            return false;
+        }
+        try {
+            for (Field field : navigationIntent.getClass().getDeclaredFields()) {
+                if (!Enum.class.isAssignableFrom(field.getType())) {
+                    continue;
+                }
+                field.setAccessible(true);
+                Object value = field.get(navigationIntent);
+                if (value instanceof Enum<?> && "AUTOPLAY".equals(((Enum<?>) value).name())) {
+                    return true;
+                }
+            }
+        } catch (Exception ex) {
+            Logger.printException(() -> "shouldSkipPlaylistAutoplay failure", ex);
+        }
+        return false;
+    }
+}

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisablePlaylistAutoplayPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisablePlaylistAutoplayPatch.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2628
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
 package app.morphe.extension.youtube.patches;
 
 import java.lang.reflect.Field;

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -208,6 +208,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting DISABLE_HAPTIC_FEEDBACK_TAP_AND_HOLD = new BooleanSetting("morphe_disable_haptic_feedback_tap_and_hold", FALSE);
     public static final BooleanSetting DISABLE_HAPTIC_FEEDBACK_ZOOM = new BooleanSetting("morphe_disable_haptic_feedback_zoom", FALSE);
     public static final BooleanSetting DISABLE_PLAYER_POPUP_PANELS = new BooleanSetting("morphe_disable_player_popup_panels", FALSE);
+    public static final BooleanSetting DISABLE_PLAYLIST_AUTOPLAY = new BooleanSetting("morphe_disable_playlist_autoplay", FALSE);
     public static final BooleanSetting DISABLE_FULLSCREEN_PULLED_UP_GESTURE = new BooleanSetting("morphe_disable_fullscreen_pulled_up_gesture", FALSE);
     public static final BooleanSetting DISABLE_FULLSCREEN_SLIDING_GESTURE = new BooleanSetting("morphe_disable_fullscreen_sliding_down_gesture", FALSE);
     public static final BooleanSetting DISABLE_FULLSCREEN_DRAGGED_DOWN_GESTURE = new BooleanSetting("morphe_disable_fullscreen_dragged_down_gesture", FALSE);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/playlistautoplay/DisablePlaylistAutoplayPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/playlistautoplay/DisablePlaylistAutoplayPatch.kt
@@ -44,7 +44,7 @@ val disablePlaylistAutoplayPatch = bytecodePatch(
 
         val wrapperClassDef = Fingerprint(
             accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
-            parameters = listOf(enumType, "L", "L"),
+            parameters = listOf(enumType, "L", "L")
         ).originalClassDef
         val wrapperType = wrapperClassDef.type
         val enumField = wrapperClassDef.fields.first { it.type == enumType }
@@ -58,7 +58,7 @@ val disablePlaylistAutoplayPatch = bytecodePatch(
                             sibling.returnType == "I" &&
                             sibling.parameterTypes.singleOrNull() == wrapperType
                 }
-            },
+            }
         ).matchAll().forEach { match ->
             val method = match.method
             val freeRegister = method.findFreeRegister(0)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/playlistautoplay/DisablePlaylistAutoplayPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/playlistautoplay/DisablePlaylistAutoplayPatch.kt
@@ -7,6 +7,7 @@
 
 package app.morphe.patches.youtube.layout.playlistautoplay
 
+import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
@@ -16,20 +17,11 @@ import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import app.morphe.util.findFreeRegister
-import app.morphe.util.getMutableMethod
-import com.android.tools.smali.dexlib2.iface.Method
+import com.android.tools.smali.dexlib2.AccessFlags
 
 private const val EXTENSION_CLASS =
     "Lapp/morphe/extension/youtube/patches/DisablePlaylistAutoplayPatch;"
 
-/**
- * Video-ended navigation shares one dispatch object carrying an enum: an
- * AUTOPLAY value means "continue the active playlist/queue" and fires
- * unconditionally, while AUTONAV ("play a suggested video") is the one
- * already gated by the existing Settings toggle. Every class exposing a
- * matching navigate/has-next method pair is patched, since which one handles
- * the main watch flow isn't stable across builds.
- */
 @Suppress("unused")
 val disablePlaylistAutoplayPatch = bytecodePatch(
     name = "Disable playlist autoplay",
@@ -50,47 +42,32 @@ val disablePlaylistAutoplayPatch = bytecodePatch(
 
         val enumType = NavigationIntentEnumFingerprint.originalClassDef.type
 
-        // Resolve the dispatch object's own class from its 3-arg constructor.
-        var wrapperType: String? = null
-        classDefForEach { classDef ->
-            if (wrapperType != null) return@classDefForEach
-            for (method in classDef.methods) {
-                val params = method.parameterTypes
-                if (method.name == "<init>" && params.size == 3 && params.firstOrNull() == enumType) {
-                    wrapperType = classDef.type
-                    return@classDefForEach
+        val wrapperClassDef = Fingerprint(
+            accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
+            parameters = listOf(enumType, "L", "L"),
+        ).originalClassDef
+        val wrapperType = wrapperClassDef.type
+        val enumField = wrapperClassDef.fields.first { it.type == enumType }
+
+        Fingerprint(
+            returnType = "V",
+            parameters = listOf(wrapperType),
+            custom = { method, classDef ->
+                method.implementation != null && classDef.methods.any { sibling ->
+                    sibling.implementation != null &&
+                            sibling.returnType == "I" &&
+                            sibling.parameterTypes.singleOrNull() == wrapperType
                 }
-            }
-        }
-        val resolvedWrapperType = wrapperType ?: return@execute
+            },
+        ).matchAll().forEach { match ->
+            val method = match.method
+            val freeRegister = method.findFreeRegister(0)
 
-        // Patch every class with a matching navigate/has-next method pair
-        // rather than the one exact concrete class - harmless if unused.
-        val navigateMethods = mutableListOf<Method>()
-        classDefForEach { classDef ->
-            var vMethod: Method? = null
-            var iMethod: Method? = null
-            for (method in classDef.methods) {
-                if (method.implementation == null) continue
-                val params = method.parameterTypes
-                if (params.size == 1 && params.firstOrNull() == resolvedWrapperType) {
-                    if (method.returnType == "V") vMethod = method
-                    if (method.returnType == "I") iMethod = method
-                }
-            }
-            if (vMethod != null && iMethod != null) {
-                navigateMethods += vMethod
-            }
-        }
-
-        navigateMethods.forEach { method ->
-            val mutableMethod = method.getMutableMethod()
-            val freeRegister = mutableMethod.findFreeRegister(0)
-
-            mutableMethod.addInstructionsWithLabels(
+            method.addInstructionsWithLabels(
                 0,
                 """
-                    invoke-static { p1 }, $EXTENSION_CLASS->shouldSkipPlaylistAutoplay(Ljava/lang/Object;)Z
+                    iget-object v$freeRegister, p1, $enumField
+                    invoke-static { v$freeRegister }, $EXTENSION_CLASS->shouldSkipPlaylistAutoplay(Ljava/lang/Enum;)Z
                     move-result v$freeRegister
                     if-eqz v$freeRegister, :continue
                     return-void

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/playlistautoplay/DisablePlaylistAutoplayPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/playlistautoplay/DisablePlaylistAutoplayPatch.kt
@@ -1,0 +1,96 @@
+package app.morphe.patches.youtube.layout.playlistautoplay
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.all.misc.resources.resourceMappingPatch
+import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
+import app.morphe.patches.youtube.misc.settings.PreferenceScreen
+import app.morphe.patches.youtube.misc.settings.settingsPatch
+import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
+import app.morphe.util.findFreeRegister
+import app.morphe.util.getMutableMethod
+import com.android.tools.smali.dexlib2.iface.Method
+
+private const val EXTENSION_CLASS =
+    "Lapp/morphe/extension/youtube/patches/DisablePlaylistAutoplayPatch;"
+
+/**
+ * Video-ended navigation shares one dispatch object carrying an enum: an
+ * AUTOPLAY value means "continue the active playlist/queue" and fires
+ * unconditionally, while AUTONAV ("play a suggested video") is the one
+ * already gated by the existing Settings toggle. Every class exposing a
+ * matching navigate/has-next method pair is patched, since which one handles
+ * the main watch flow isn't stable across builds.
+ */
+@Suppress("unused")
+val disablePlaylistAutoplayPatch = bytecodePatch(
+    name = "Disable playlist autoplay",
+    description = "Adds an option to stop a playlist from automatically advancing to the next video.",
+) {
+    dependsOn(
+        sharedExtensionPatch,
+        settingsPatch,
+        resourceMappingPatch,
+    )
+
+    compatibleWith(COMPATIBILITY_YOUTUBE)
+
+    execute {
+        PreferenceScreen.PLAYER.addPreferences(
+            SwitchPreference("morphe_disable_playlist_autoplay", summary = true)
+        )
+
+        val enumType = NavigationIntentEnumFingerprint.originalClassDef.type
+
+        // Resolve the dispatch object's own class from its 3-arg constructor.
+        var wrapperType: String? = null
+        classDefForEach { classDef ->
+            if (wrapperType != null) return@classDefForEach
+            for (method in classDef.methods) {
+                val params = method.parameterTypes
+                if (method.name == "<init>" && params.size == 3 && params.firstOrNull() == enumType) {
+                    wrapperType = classDef.type
+                    return@classDefForEach
+                }
+            }
+        }
+        val resolvedWrapperType = wrapperType ?: return@execute
+
+        // Patch every class with a matching navigate/has-next method pair
+        // rather than the one exact concrete class - harmless if unused.
+        val navigateMethods = mutableListOf<Method>()
+        classDefForEach { classDef ->
+            var vMethod: Method? = null
+            var iMethod: Method? = null
+            for (method in classDef.methods) {
+                if (method.implementation == null) continue
+                val params = method.parameterTypes
+                if (params.size == 1 && params.firstOrNull() == resolvedWrapperType) {
+                    if (method.returnType == "V") vMethod = method
+                    if (method.returnType == "I") iMethod = method
+                }
+            }
+            if (vMethod != null && iMethod != null) {
+                navigateMethods += vMethod
+            }
+        }
+
+        navigateMethods.forEach { method ->
+            val mutableMethod = method.getMutableMethod()
+            val freeRegister = mutableMethod.findFreeRegister(0)
+
+            mutableMethod.addInstructionsWithLabels(
+                0,
+                """
+                    invoke-static { p1 }, $EXTENSION_CLASS->shouldSkipPlaylistAutoplay(Ljava/lang/Object;)Z
+                    move-result v$freeRegister
+                    if-eqz v$freeRegister, :continue
+                    return-void
+                    :continue
+                    nop
+                """
+            )
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/playlistautoplay/DisablePlaylistAutoplayPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/playlistautoplay/DisablePlaylistAutoplayPatch.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2628
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
 package app.morphe.patches.youtube.layout.playlistautoplay
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/playlistautoplay/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/playlistautoplay/Fingerprints.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2628
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
 package app.morphe.patches.youtube.layout.playlistautoplay
 
 import app.morphe.patcher.Fingerprint
@@ -6,14 +13,6 @@ import app.morphe.patcher.string
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 
-/**
- * R8 keeps enum constant names for Enum#name()/#toString(), so this enum's
- * static constructor is findable by its constant names as string literals.
- * A lower-level token enum shares the same constant names in its own
- * `<clinit>`, so the string filter alone is ambiguous; requiring an extra
- * constructor parameter (this enum wraps a token value, the other doesn't)
- * selects it uniquely.
- */
 internal object NavigationIntentEnumFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.STATIC, AccessFlags.CONSTRUCTOR),
     filters = listOf(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/playlistautoplay/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/playlistautoplay/Fingerprints.kt
@@ -1,0 +1,30 @@
+package app.morphe.patches.youtube.layout.playlistautoplay
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.opcode
+import app.morphe.patcher.string
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+/**
+ * R8 keeps enum constant names for Enum#name()/#toString(), so this enum's
+ * static constructor is findable by its constant names as string literals.
+ * A lower-level token enum shares the same constant names in its own
+ * `<clinit>`, so the string filter alone is ambiguous; requiring an extra
+ * constructor parameter (this enum wraps a token value, the other doesn't)
+ * selects it uniquely.
+ */
+internal object NavigationIntentEnumFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.STATIC, AccessFlags.CONSTRUCTOR),
+    filters = listOf(
+        string("NEXT"),
+        string("PREVIOUS"),
+        string("AUTOPLAY"),
+        string("AUTONAV"),
+        string("JUMP"),
+        opcode(Opcode.RETURN_VOID),
+    ),
+    custom = { _, classDef ->
+        classDef.methods.any { it.name == "<init>" && it.parameterTypes.size > 2 }
+    },
+)

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -920,6 +920,10 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
     <string name="morphe_disable_player_popup_panels_title">Disable player popup panels</string>
     <string name="morphe_disable_player_popup_panels_summary">Disables playlist and live chat panels from opening automatically</string>
 
+    <!-- layout.playlistautoplay.disablePlaylistAutoplayPatch -->
+    <string name="morphe_disable_playlist_autoplay_title">Disable playlist autoplay</string>
+    <string name="morphe_disable_playlist_autoplay_summary">Stops a playlist from automatically advancing to the next video</string>
+
     <!-- layout.player.fullscreen.exitFullscreenPatch -->
     <string name="morphe_exit_fullscreen_title">Exit fullscreen mode on video end</string>
     <string name="morphe_exit_fullscreen_entry_1">Disabled</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -922,7 +922,7 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
 
     <!-- layout.playlistautoplay.disablePlaylistAutoplayPatch -->
     <string name="morphe_disable_playlist_autoplay_title">Disable playlist autoplay</string>
-    <string name="morphe_disable_playlist_autoplay_summary">Stops a playlist from automatically advancing to the next video</string>
+    <string name="morphe_disable_playlist_autoplay_summary">Prevents playlists from automatically advancing to the next video</string>
 
     <!-- layout.player.fullscreen.exitFullscreenPatch -->
     <string name="morphe_exit_fullscreen_title">Exit fullscreen mode on video end</string>


### PR DESCRIPTION
### Description

Adds an opt-in "Disable playlist autoplay" setting (Player screen) that stops a playlist from automatically advancing to the next video. This is separate from YouTube's own "Autoplay next video" setting, which only governs suggested-video autoplay outside of a playlist context.

Closes #805

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)

Had help from Claude writing this patch.