### PR TITLE
feat(YouTube - Disable fullscreen gestures): Add option to disable pinch-to-zoom

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableFullscreenGesturesPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableFullscreenGesturesPatch.java
@@ -38,4 +38,11 @@ public class DisableFullscreenGesturesPatch {
         }
         return false;
     }
+
+    /**
+     * Injection point.
+     */
+    public static boolean disableZoomGesture() {
+        return Settings.DISABLE_FULLSCREEN_ZOOM_GESTURE.get();
+    }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -211,6 +211,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting DISABLE_FULLSCREEN_PULLED_UP_GESTURE = new BooleanSetting("morphe_disable_fullscreen_pulled_up_gesture", FALSE);
     public static final BooleanSetting DISABLE_FULLSCREEN_SLIDING_GESTURE = new BooleanSetting("morphe_disable_fullscreen_sliding_down_gesture", FALSE);
     public static final BooleanSetting DISABLE_FULLSCREEN_DRAGGED_DOWN_GESTURE = new BooleanSetting("morphe_disable_fullscreen_dragged_down_gesture", FALSE);
+    public static final BooleanSetting DISABLE_FULLSCREEN_ZOOM_GESTURE = new BooleanSetting("morphe_disable_fullscreen_zoom_gesture", FALSE);
     public static final BooleanSetting DISABLE_ROLLING_NUMBER_ANIMATIONS = new BooleanSetting("morphe_disable_rolling_number_animations", FALSE);
     public static final EnumSetting<FullscreenMode> EXIT_FULLSCREEN = new EnumSetting<>("morphe_exit_fullscreen", FullscreenMode.DISABLED);
     public static final EnumSetting<VideoScaleMode> FULLSCREEN_VIDEO_SCALE = new EnumSetting<>("morphe_fullscreen_video_scale", VideoScaleMode.DEFAULT);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/DisableFullscreenGesturesPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/DisableFullscreenGesturesPatch.kt
@@ -11,8 +11,10 @@
 package app.morphe.patches.youtube.layout.player.fullscreen
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.smali.ExternalLabel
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference.Sorting
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
@@ -30,7 +32,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 @Suppress("unused")
 val disableFullscreenGesturesPatch = bytecodePatch(
     name = "Disable fullscreen gestures",
-    description = "Adds options to selectively disable gestures for entering and exiting fullscreen mode.",
+    description = "Adds options to selectively disable gestures for entering and exiting fullscreen mode, and to disable pinch-to-zoom.",
 ) {
     dependsOn(
         sharedExtensionPatch,
@@ -53,7 +55,8 @@ val disableFullscreenGesturesPatch = bytecodePatch(
                 preferences = setOf(
                     SwitchPreference("morphe_disable_fullscreen_pulled_up_gesture"),
                     SwitchPreference("morphe_disable_fullscreen_dragged_down_gesture"),
-                    SwitchPreference("morphe_disable_fullscreen_sliding_down_gesture")
+                    SwitchPreference("morphe_disable_fullscreen_sliding_down_gesture"),
+                    SwitchPreference("morphe_disable_fullscreen_zoom_gesture")
                 )
             )
         )
@@ -91,6 +94,20 @@ val disableFullscreenGesturesPatch = bytecodePatch(
                     """
                 )
             }
+        }
+
+        VideoZoomScaleBeginFingerprint.method.apply {
+            addInstructionsWithLabels(
+                0,
+                """
+                    invoke-static { }, $EXTENSION_CLASS->disableZoomGesture()Z
+                    move-result v0
+                    if-eqz v0, :allow_zoom
+                    const/4 v0, 0x0
+                    return v0
+                """,
+                ExternalLabel("allow_zoom", getInstruction(0)),
+            )
         }
 
         if (is_20_40_or_greater) {

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/DisableFullscreenGesturesPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/DisableFullscreenGesturesPatch.kt
@@ -96,19 +96,18 @@ val disableFullscreenGesturesPatch = bytecodePatch(
             }
         }
 
-        VideoZoomScaleBeginFingerprint.method.apply {
-            addInstructionsWithLabels(
-                0,
-                """
-                    invoke-static { }, $EXTENSION_CLASS->disableZoomGesture()Z
-                    move-result v0
-                    if-eqz v0, :allow_zoom
-                    const/4 v0, 0x0
-                    return v0
-                """,
-                ExternalLabel("allow_zoom", getInstruction(0)),
-            )
-        }
+        VideoZoomScaleBeginFingerprint.method.addInstructionsWithLabels(
+            0,
+            """
+                invoke-static { }, $EXTENSION_CLASS->disableZoomGesture()Z
+                move-result v0
+                if-eqz v0, :allow_zoom
+                const/4 v0, 0x0
+                return v0
+                :allow_zoom
+                nop
+            """
+        )
 
         if (is_20_40_or_greater) {
             FullscreenGestureZoomFingerprint.apply {

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/Fingerprints.kt
@@ -121,3 +121,22 @@ internal object FullscreenGestureZoomFingerprint : Fingerprint (
         methodCall(opcode = Opcode.INVOKE_VIRTUAL, returnType = "Z", location = MatchAfterWithin(12)),
     )
 )
+
+/**
+ * YouTube player pinch-to-zoom listener.
+ *
+ * Unique among other ScaleGestureDetector listeners (photo picker, creation, etc.):
+ * it implements only OnScaleGestureListener and has both ScaleGestureDetector and GestureDetector fields.
+ */
+internal object VideoZoomScaleBeginFingerprint : Fingerprint(
+    name = "onScaleBegin",
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "Z",
+    parameters = listOf("Landroid/view/ScaleGestureDetector;"),
+    custom = { _, classDef ->
+        classDef.interfaces.size == 1 &&
+            classDef.interfaces.contains($$"Landroid/view/ScaleGestureDetector$OnScaleGestureListener;") &&
+            classDef.fields.any { it.type == "Landroid/view/ScaleGestureDetector;" } &&
+            classDef.fields.any { it.type == "Landroid/view/GestureDetector;" }
+    }
+)

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -929,10 +929,11 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
 
     <!-- layout.player.fullscreen.disableFullscreenGesturesPatch -->
     <string name="morphe_disable_fullscreen_gestures_title">Fullscreen gestures</string>
-    <string name="morphe_disable_fullscreen_gestures_summary">Player gestures to enter or exit from fullscreen mode</string>
+    <string name="morphe_disable_fullscreen_gestures_summary">Player gestures in fullscreen mode, including pinch-to-zoom</string>
     <string name="morphe_disable_fullscreen_pulled_up_gesture_title">Disable portrait swipe-up gesture</string>
     <string name="morphe_disable_fullscreen_sliding_down_gesture_title">Disable portrait swipe-down gesture</string>
     <string name="morphe_disable_fullscreen_dragged_down_gesture_title">Disable landscape swipe-down gesture</string>
+    <string name="morphe_disable_fullscreen_zoom_gesture_title">Disable pinch-to-zoom gesture</string>
 
     <!-- layout.player.fullscreen.openVideosFullscreenPatch -->
     <string name="morphe_open_videos_fullscreen_title">Open videos in fullscreen mode</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -929,7 +929,7 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
 
     <!-- layout.player.fullscreen.disableFullscreenGesturesPatch -->
     <string name="morphe_disable_fullscreen_gestures_title">Fullscreen gestures</string>
-    <string name="morphe_disable_fullscreen_gestures_summary">Player gestures in fullscreen mode, including pinch-to-zoom</string>
+    <string name="morphe_disable_fullscreen_gestures_summary">Player gestures in fullscreen mode</string>
     <string name="morphe_disable_fullscreen_pulled_up_gesture_title">Disable portrait swipe-up gesture</string>
     <string name="morphe_disable_fullscreen_sliding_down_gesture_title">Disable portrait swipe-down gesture</string>
     <string name="morphe_disable_fullscreen_dragged_down_gesture_title">Disable landscape swipe-down gesture</string>


### PR DESCRIPTION
### Description

Adds a Morphe setting to disable YouTube's native pinch-to-zoom in the fullscreen player, so holding the phone with two hands does not accidentally zoom.

The option lives under **Player → Fullscreen gestures → Disable pinch-to-zoom gesture** (off by default). When enabled, `onScaleBegin` on the player `ScaleGestureDetector.OnScaleGestureListener` returns false so the scale gesture never starts.

The existing restore-zoom flag hook (`45698813`) is unchanged.

Closes #2478

### Additional context

The pinch listener is identified as the class that implements only `OnScaleGestureListener` and has both `ScaleGestureDetector` and `GestureDetector` fields. That uniquely matches the player zoom controller on 20.21.37 and 21.04.223.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)

Device-tested with the full default patch set:

- Minimum: YouTube **20.21.37**
- Maximum (recommended): YouTube **21.04.223**
- Experimental: YouTube **21.34.243**