### PR TITLE
feat(YouTube - Disable video codecs): Add "Force HDR video" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableVideoCodecsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableVideoCodecsPatch.java
@@ -18,12 +18,67 @@ import app.morphe.extension.youtube.settings.Settings;
 public class DisableVideoCodecsPatch {
 
     /**
+     * HDR types YouTube checks via {@link Display.HdrCapabilities#getSupportedHdrTypes()}.
+     * HLG is the type HyperOS often omits even when the decoder can play YouTube HDR.
+     */
+    private static final int[] FORCED_HDR_TYPES = {
+            Display.HdrCapabilities.HDR_TYPE_HLG,
+            Display.HdrCapabilities.HDR_TYPE_HDR10,
+            Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS,
+            Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION
+    };
+
+    /**
      * Injection point.
      */
-    public static int[] disableHdrVideo(Display.HdrCapabilities capabilities) {
-        return Settings.DISABLE_HDR_VIDEO.get()
+    public static int[] overrideSupportedHdrTypes(Display.HdrCapabilities capabilities) {
+        if (Settings.DISABLE_HDR_VIDEO.get()) {
+            return new int[0];
+        }
+
+        int[] original = capabilities == null
                 ? new int[0]
                 : capabilities.getSupportedHdrTypes();
+        if (!Settings.FORCE_HDR_VIDEO.get()) {
+            return original;
+        }
+
+        return unionHdrTypes(original);
+    }
+
+    private static int[] unionHdrTypes(int[] original) {
+        if (original == null || original.length == 0) {
+            return FORCED_HDR_TYPES.clone();
+        }
+
+        int missingCount = 0;
+        for (int forced : FORCED_HDR_TYPES) {
+            if (!containsHdrType(original, forced)) {
+                missingCount++;
+            }
+        }
+        if (missingCount == 0) {
+            return original;
+        }
+
+        int[] result = new int[original.length + missingCount];
+        System.arraycopy(original, 0, result, 0, original.length);
+        int index = original.length;
+        for (int forced : FORCED_HDR_TYPES) {
+            if (!containsHdrType(original, forced)) {
+                result[index++] = forced;
+            }
+        }
+        return result;
+    }
+
+    private static boolean containsHdrType(int[] types, int type) {
+        for (int existing : types) {
+            if (existing == type) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableVideoCodecsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableVideoCodecsPatch.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2634
  *
  * Original hard forked code:
  * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
@@ -10,6 +10,7 @@
 
 package app.morphe.extension.youtube.patches;
 
+import android.os.Build;
 import android.view.Display;
 
 import app.morphe.extension.youtube.settings.Settings;
@@ -17,27 +18,44 @@ import app.morphe.extension.youtube.settings.Settings;
 @SuppressWarnings({"unused", "deprecation", "RedundantSuppression"})
 public class DisableVideoCodecsPatch {
 
+    private static final int[] EMPTY_ARRAY_INT = new int[0];
+
     /**
      * HDR types YouTube checks via {@link Display.HdrCapabilities#getSupportedHdrTypes()}.
      * HLG is the type HyperOS often omits even when the decoder can play YouTube HDR.
      */
-    private static final int[] FORCED_HDR_TYPES = {
-            Display.HdrCapabilities.HDR_TYPE_HLG,
-            Display.HdrCapabilities.HDR_TYPE_HDR10,
-            Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS,
-            Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION
-    };
+    private static final int[] HDR_TYPES = getHdrTypes();
+
+    /**
+     * @return Equivalent of Display.HdrCapabilities.HDR_TYPES
+     */
+    private static int[] getHdrTypes() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            return new int[]{
+                    Display.HdrCapabilities.HDR_TYPE_HLG,
+                    Display.HdrCapabilities.HDR_TYPE_HDR10,
+                    Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS,
+                    Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION
+            };
+        }
+
+        return new int[]{
+                Display.HdrCapabilities.HDR_TYPE_HLG,
+                Display.HdrCapabilities.HDR_TYPE_HDR10,
+                Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION
+        };
+    }
 
     /**
      * Injection point.
      */
     public static int[] overrideSupportedHdrTypes(Display.HdrCapabilities capabilities) {
         if (Settings.DISABLE_HDR_VIDEO.get()) {
-            return new int[0];
+            return EMPTY_ARRAY_INT;
         }
 
         int[] original = capabilities == null
-                ? new int[0]
+                ? EMPTY_ARRAY_INT
                 : capabilities.getSupportedHdrTypes();
         if (!Settings.FORCE_HDR_VIDEO.get()) {
             return original;
@@ -47,12 +65,12 @@ public class DisableVideoCodecsPatch {
     }
 
     private static int[] unionHdrTypes(int[] original) {
-        if (original == null || original.length == 0) {
-            return FORCED_HDR_TYPES.clone();
+        if (original.length == 0) {
+            return HDR_TYPES.clone();
         }
 
         int missingCount = 0;
-        for (int forced : FORCED_HDR_TYPES) {
+        for (int forced : HDR_TYPES) {
             if (!containsHdrType(original, forced)) {
                 missingCount++;
             }
@@ -64,7 +82,7 @@ public class DisableVideoCodecsPatch {
         int[] result = new int[original.length + missingCount];
         System.arraycopy(original, 0, result, 0, original.length);
         int index = original.length;
-        for (int forced : FORCED_HDR_TYPES) {
+        for (int forced : HDR_TYPES) {
             if (!containsHdrType(original, forced)) {
                 result[index++] = forced;
             }
@@ -72,6 +90,7 @@ public class DisableVideoCodecsPatch {
         return result;
     }
 
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     private static boolean containsHdrType(int[] types, int type) {
         for (int existing : types) {
             if (existing == type) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -71,6 +71,8 @@ public class Settings extends SharedYouTubeSettings {
     // Video
     public static final BooleanSetting ADVANCED_VIDEO_QUALITY_MENU = new BooleanSetting("morphe_advanced_video_quality_menu", TRUE);
     public static final BooleanSetting DISABLE_HDR_VIDEO = new BooleanSetting("morphe_disable_hdr_video", FALSE);
+    public static final BooleanSetting FORCE_HDR_VIDEO = new BooleanSetting("morphe_force_hdr_video", FALSE, true,
+            "morphe_force_hdr_video_user_dialog_message", parentNot(DISABLE_HDR_VIDEO));
     public static final BooleanSetting FORCE_AVC_CODEC = new BooleanSetting("morphe_force_avc_codec", FALSE, true, "morphe_force_avc_codec_user_dialog_message");
     public static final BooleanSetting HIDE_PREMIUM_VIDEO_QUALITY = new BooleanSetting("morphe_hide_premium_video_quality", TRUE, true);
     public static final BooleanSetting VIDEO_QUALITY_PRIORITIZE = new BooleanSetting("morphe_video_quality_prioritize", TRUE, true, "morphe_video_quality_prioritize_dialog");

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/codecs/DisableVideoCodecsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/codecs/DisableVideoCodecsPatch.kt
@@ -28,7 +28,7 @@ private const val EXTENSION_CLASS =
 @Suppress("unused")
 val disableVideoCodecsPatch = bytecodePatch(
     name = "Disable video codecs",
-    description = "Adds options to disable HDR and VP9 codecs.",
+    description = "Adds options to disable or force HDR, and to disable VP9 codecs.",
 ) {
     dependsOn(
         sharedExtensionPatch,
@@ -40,6 +40,7 @@ val disableVideoCodecsPatch = bytecodePatch(
     execute {
         PreferenceScreen.VIDEO.addPreferences(
             SwitchPreference("morphe_disable_hdr_video"),
+            SwitchPreference("morphe_force_hdr_video", summary = true),
             SwitchPreference(
                 key = "morphe_force_avc_codec",
                 tag = "app.morphe.extension.youtube.settings.preference.ForceAVCSwitchPreference"
@@ -64,7 +65,7 @@ val disableVideoCodecsPatch = bytecodePatch(
 
             replaceInstruction(
                 index,
-                "invoke-static/range { v$register .. v$register }, $EXTENSION_CLASS->disableHdrVideo(Landroid/view/Display\$HdrCapabilities;)[I"
+                "invoke-static/range { v$register .. v$register }, $EXTENSION_CLASS->overrideSupportedHdrTypes(Landroid/view/Display\$HdrCapabilities;)[I"
             )
         }
     }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/codecs/DisableVideoCodecsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/codecs/DisableVideoCodecsPatch.kt
@@ -15,6 +15,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import app.morphe.patches.shared.misc.settings.preference.noTitleUnsortedPreferenceCategory
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
@@ -39,8 +40,10 @@ val disableVideoCodecsPatch = bytecodePatch(
 
     execute {
         PreferenceScreen.VIDEO.addPreferences(
-            SwitchPreference("morphe_disable_hdr_video"),
-            SwitchPreference("morphe_force_hdr_video", summary = true),
+            noTitleUnsortedPreferenceCategory(
+                SwitchPreference("morphe_disable_hdr_video"),
+                SwitchPreference("morphe_force_hdr_video", summary = true),
+            ),
             SwitchPreference(
                 key = "morphe_force_avc_codec",
                 tag = "app.morphe.extension.youtube.settings.preference.ForceAVCSwitchPreference"

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1265,6 +1265,14 @@ Tap here to open DeArrow.ajay.app"</string>
 
     <!-- video.codecs.disableVideoCodecsPatch -->
     <string name="morphe_disable_hdr_video_title">Disable HDR video</string>
+    <string name="morphe_force_hdr_video_title">Force HDR video</string>
+    <string name="morphe_force_hdr_video_summary">Makes YouTube treat this display as HDR-capable, including when the OS hides HLG</string>
+    <string name="morphe_force_hdr_video_user_dialog_message">"Use this if HDR decoding works but YouTube does not offer HDR, such as some HyperOS devices that hide HLG.
+
+Limitations:
+• Colors may look wrong if the display cannot actually show HDR
+• Playback may fail if the decoder cannot handle HDR
+• HDR still depends on the spoof video streams client"</string>
     <string name="morphe_force_avc_codec_title">Force AVC (H.264) codec</string>
     <string name="morphe_force_avc_codec_user_dialog_message">"Benefits:
 • Can improve battery life

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1266,7 +1266,7 @@ Tap here to open DeArrow.ajay.app"</string>
     <!-- video.codecs.disableVideoCodecsPatch -->
     <string name="morphe_disable_hdr_video_title">Disable HDR video</string>
     <string name="morphe_force_hdr_video_title">Force HDR video</string>
-    <string name="morphe_force_hdr_video_summary">Makes YouTube treat this display as HDR-capable, including when the OS hides HLG</string>
+    <string name="morphe_force_hdr_video_summary">Forces app to recognize this device as HDR‑capable</string>
     <string name="morphe_force_hdr_video_user_dialog_message">"Use this if HDR decoding works but YouTube does not offer HDR, such as some HyperOS devices that hide HLG.
 
 Limitations:


### PR DESCRIPTION
### Description

Adds a **Force HDR video** setting to the existing Disable video codecs patch.

YouTube decides whether to offer HDR from `Display.HdrCapabilities.getSupportedHdrTypes()`. Some HyperOS builds omit HLG even when VP9 Profile 2 HDR decoding works, so streaming never shows HDR (while downloads still can). This reuses the existing hook: if Force HDR is on, the type list is unioned with HLG, HDR10, HDR10+, and Dolby Vision.

Default is off. Disable HDR still wins if both are on.

Closes #2631

### Additional context

Confirmed by the issue reporter on HyperOS (YouTube `21.04.223`): HDR qualities appear with VisionOS 1.02, TV SABR, and Android VR Downgraded. Android VR (SABR) still has no HDR because that client does not serve HDR formats.

How to test:
1. Patch YouTube with these patches (Disable video codecs included).
2. YouTube → Settings → Morphe → **Video**
3. Leave **Disable HDR video** off.
4. Enable **Force HDR video**, confirm, force-stop / reopen YouTube (restart required).
5. Leave **Force AVC** off. Avoid the Android Studio spoof client (no HDR). Android VR (SABR) also has no HDR streams.
6. Open an HDR test video. Success is HDR rows in the quality list and an HDR codec in Stats for nerds (`vp9.2` / AV1 HDR).

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)

Issue reporter confirmed on HyperOS with YouTube `21.04.223`. Local compile of `:extensions:youtube:compileDebugJavaWithJavac` and `:patches:compileKotlin` succeeded.
