### PR TITLE
fix(YouTube Music - Theme): Fade the page header into the background color

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/theme/HeaderFadeLayout.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/theme/HeaderFadeLayout.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2636
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.music.patches.theme;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.theme.ThemeColorPatch;
+import app.morphe.extension.shared.theme.ThemeUtils;
+
+/**
+ * Container of the header of a playlist, album or artist page.
+ * <p>
+ * The app ends the artwork of the header in a translucent black, which only blends into a pure
+ * black background. With any other background the header ends in a hard edge against the page,
+ * so a fade into the background color is drawn over the lower part of the artwork.
+ */
+@SuppressWarnings("unused")
+public class HeaderFadeLayout extends FrameLayout {
+
+    /**
+     * Tells a fade of this class apart from a foreground of the app.
+     */
+    private static class HeaderFadeDrawable extends GradientDrawable {
+        HeaderFadeDrawable(@ColorInt int backgroundColor) {
+            // The fade starts at the middle of the artwork, which the app has darkened
+            // to almost nothing by then.
+            super(Orientation.TOP_BOTTOM, new int[]{
+                    // Not a transparent black, which would darken the middle of the fade.
+                    backgroundColor & 0x00FFFFFF,
+                    backgroundColor & 0x00FFFFFF,
+                    backgroundColor
+            });
+        }
+    }
+
+    public HeaderFadeLayout(Context context) {
+        super(context);
+    }
+
+    public HeaderFadeLayout(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public HeaderFadeLayout(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    // The fade is created once for a view and not for every layout pass.
+    @SuppressLint("DrawAllocation")
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+
+        try {
+            // The app colors are left alone, otherwise the header of an unpatched app changes.
+            if (ThemeColorPatch.isAppDefaultColor()) {
+                return;
+            }
+
+            ImageView artwork = findArtwork(this, 0, 0);
+            if (artwork == null || artwork.getForeground() instanceof HeaderFadeDrawable) {
+                return;
+            }
+
+            // The app always shows its dark theme, while the shared background color
+            // follows the night mode of the device.
+            @ColorInt final int backgroundColor = ThemeUtils.getThemeDarkColor();
+            artwork.setForeground(new HeaderFadeDrawable(backgroundColor));
+
+            // Litho reuses the views of its components, and a fade left behind shows up
+            // on whatever the view is used for next.
+            artwork.addOnAttachStateChangeListener(new OnAttachStateChangeListener() {
+                @Override
+                public void onViewAttachedToWindow(@NonNull View view) {
+                }
+
+                @Override
+                public void onViewDetachedFromWindow(@NonNull View view) {
+                    view.removeOnAttachStateChangeListener(this);
+
+                    Drawable foreground = view.getForeground();
+                    if (foreground instanceof HeaderFadeDrawable) {
+                        view.setForeground(null);
+                    }
+                }
+            });
+
+            Logger.printDebug(() -> "Header fade applied: "
+                    + Utils.getColorHexString(backgroundColor));
+        } catch (Exception ex) {
+            Logger.printException(() -> "onLayout failure", ex);
+        }
+    }
+
+    /**
+     * The artwork of the header, which is the view that covers the top of the header.
+     *
+     * @param offsetX Position of the group in this container.
+     * @param offsetY Position of the group in this container.
+     */
+    @Nullable
+    private ImageView findArtwork(ViewGroup group, int offsetX, int offsetY) {
+        for (int i = 0, count = group.getChildCount(); i < count; i++) {
+            View child = group.getChildAt(i);
+            final int childX = offsetX + child.getLeft();
+            final int childY = offsetY + child.getTop();
+
+            if (child instanceof ImageView) {
+                if (childX == 0 && childY == 0
+                        && child.getWidth() == getWidth()
+                        && child.getHeight() > 0
+                        && child.getHeight() < getHeight()) {
+                    return (ImageView) child;
+                }
+            } else if (child instanceof ViewGroup) {
+                ImageView artwork = findArtwork((ViewGroup) child, childX, childY);
+                if (artwork != null) {
+                    return artwork;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/theme/ThemePatch.kt
@@ -12,6 +12,7 @@ package app.morphe.patches.music.layout.theme
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.patches.music.misc.extension.sharedExtensionPatch
 import app.morphe.patches.music.misc.playservice.is_9_30_or_greater
@@ -29,9 +30,16 @@ import app.morphe.patches.shared.misc.settings.preference.InputType
 import app.morphe.patches.shared.misc.settings.preference.ListPreference
 import app.morphe.patches.shared.misc.settings.preference.TextPreference
 import app.morphe.patches.shared.misc.settings.preference.noTitleUnsortedPreferenceCategory
+import app.morphe.util.doRecursively
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import org.w3c.dom.Element
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/music/patches/theme/ThemePatch;"
+
+private const val HEADER_FADE_LAYOUT_CLASS =
+    "app.morphe.extension.music.patches.theme.HeaderFadeLayout"
+
+private const val DETAIL_PAGE_HEADER_LAYOUT = "res/layout/music_element_header.xml"
 
 private val musicColorNamesDark = {
     THEME_DEFAULT_COLOR_NAMES_DARK + setOf(
@@ -41,6 +49,47 @@ private val musicColorNamesDark = {
         "ytm_color_grey_12",
         "material_grey_800"
     )
+}
+
+/**
+ * The header of a playlist, album or artist page ends in a translucent black, which is only
+ * invisible while the app background is pure black.
+ * https://github.com/MorpheApp/morphe-patches/issues/200
+ */
+private val headerFadeResourcePatch = resourcePatch(
+    description = "Fades the header of a detail page into the app background."
+) {
+    execute {
+        if (!get(DETAIL_PAGE_HEADER_LAYOUT).exists()) {
+            return@execute
+        }
+
+        document(DETAIL_PAGE_HEADER_LAYOUT).use { document ->
+            // Replaced after the walk, which would otherwise lose the node it is on.
+            val containers = mutableListOf<Element>()
+
+            document.doRecursively loop@{ node ->
+                if (node !is Element) return@loop
+
+                val idAttribute = node.getAttributeNode("android:id") ?: return@loop
+                if (idAttribute.textContent == "@id/elements_container") {
+                    containers += node
+                }
+            }
+
+            containers.forEach { container ->
+                val fadeLayout = container.ownerDocument.createElement(HEADER_FADE_LAYOUT_CLASS)
+
+                val attributes = container.attributes
+                for (index in 0 until attributes.length) {
+                    val attribute = attributes.item(index)
+                    fadeLayout.setAttribute(attribute.nodeName, attribute.nodeValue)
+                }
+
+                container.parentNode.replaceChild(fadeLayout, container)
+            }
+        }
+    }
 }
 
 @Suppress("unused")
@@ -59,7 +108,8 @@ val themePatch = baseThemePatch(
                 colorNamesDark = musicColorNamesDark,
                 // The theme of the launcher activity, which the system draws the splash with.
                 splashScreenThemeParent = "@style/Theme.YouTubeMusic.Home"
-            )
+            ),
+            headerFadeResourcePatch
         )
 
         compatibleWith(COMPATIBILITY_YOUTUBE_MUSIC)


### PR DESCRIPTION
### Description

The header of a playlist, album or artist page ends in a translucent black, which only blends into a pure black background, so with any other theme color the header meets the page in a hard edge. The header artwork now fades into the background color instead, whatever color it is.

| Before | After |
| :---: | :---: |
| ![Screenshot_2026-08-28-10-38-58-588_app.morphe.android.apps.youtube.music-edit.jpg](https://github.com/user-attachments/assets/6fa2594a-bddc-476c-aa21-5a04d0e29e69) | ![Screenshot_2026-08-28-10-39-12-521_com.google.android.apps.youtube.music.test-edit.jpg](https://github.com/user-attachments/assets/124cf413-46d2-46b4-afc7-e24d0eb8dac4) |
| ![Screenshot_2026-08-28-10-39-37-106_app.morphe.android.apps.youtube.music-edit.jpg](https://github.com/user-attachments/assets/3bcde734-1410-48f4-8ce9-ddeb07bf6301) | ![Screenshot_2026-08-28-10-39-50-399_com.google.android.apps.youtube.music.test-edit.jpg](https://github.com/user-attachments/assets/6bf6822b-b8d0-4629-8c5e-f51835dac38d) |

Closes #200

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
