### PR TITLE
fix(YouTube - Video quality): Combine `Fullscreen video scale` into `Video quality` patch

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/FullscreenVideoScalePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/FullscreenVideoScalePatch.java
@@ -121,7 +121,9 @@ public class FullscreenVideoScalePatch {
      */
     public static void setVideoSize(int width, int height) {
         if (width > 0 && height > 0) {
-            videoAspectRatio = width / (float) height;
+            final float aspectRation = width / (float) height;
+            videoAspectRatio = aspectRation;
+            Logger.printDebug(() -> "Video aspect ratio: " + aspectRation);
         }
     }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/quality/PrioritizeVideoQualityPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/playback/quality/PrioritizeVideoQualityPatch.java
@@ -19,6 +19,7 @@ import app.morphe.extension.shared.Utils;
 import app.morphe.extension.youtube.innertube.FormatOuterClass.Format;
 import app.morphe.extension.youtube.patches.FullscreenVideoScalePatch;
 import app.morphe.extension.youtube.settings.Settings;
+import app.morphe.extension.youtube.shared.ShortsPlayerState;
 
 @SuppressWarnings("unused")
 public final class PrioritizeVideoQualityPatch {
@@ -96,6 +97,11 @@ public final class PrioritizeVideoQualityPatch {
 
     private static void captureVideoAspect(List<MessageLite> adaptiveFormats) {
         try {
+            if (ShortsPlayerState.isOpen()) {
+                Logger.printDebug(() -> "Ignoring shorts video aspect ration");
+                return;
+            }
+
             for (MessageLite messageLite : adaptiveFormats) {
                 Format format = Format.parseFrom(messageLite.toByteArray());
                 if (format == null) {

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/FullscreenVideoScalePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/FullscreenVideoScalePatch.kt
@@ -25,7 +25,6 @@ import app.morphe.patches.youtube.misc.playertype.PlayerTypeEnumFingerprint
 import app.morphe.patches.youtube.misc.playertype.playerTypeHookPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
-import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import app.morphe.util.ResourceGroup
 import app.morphe.util.addInstructionsAtControlFlowLabel
 import app.morphe.util.copyResources
@@ -60,11 +59,7 @@ private val fullscreenVideoScaleResourcePatch = resourcePatch {
     }
 }
 
-@Suppress("unused")
-val fullscreenVideoScalePatch = bytecodePatch(
-    name = "Fullscreen video scale",
-    description = "Adds options to stretch or zoom videos to fill the screen in fullscreen mode.",
-) {
+val fullscreenVideoScalePatch = bytecodePatch {
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,
@@ -74,8 +69,6 @@ val fullscreenVideoScalePatch = bytecodePatch(
         legacyPlayerControlsPatch,
         fullscreenVideoScaleResourcePatch
     )
-
-    compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {
         PreferenceScreen.VIDEO.addPreferences(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/quality/VideoQualityPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/quality/VideoQualityPatch.kt
@@ -4,6 +4,7 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.shared.misc.settings.preference.BasePreference
 import app.morphe.patches.shared.misc.settings.preference.PreferenceCategory
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference.Sorting
+import app.morphe.patches.youtube.layout.player.fullscreen.fullscreenVideoScalePatch
 import app.morphe.patches.youtube.misc.playservice.is_20_40_or_greater
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
@@ -17,14 +18,16 @@ internal val settingsMenuVideoQualityGroup = mutableSetOf<BasePreference>()
 @Suppress("unused")
 val videoQualityPatch = bytecodePatch(
     name = "Video quality",
-    description = "Adds options to set default video qualities and always use the advanced video quality menu."
+    description = "Adds options to set default video qualities, always use the advanced video quality menu, " +
+            "and to stretch or zoom videos to fill the screen in fullscreen mode. "
 ) {
     dependsOn(
         rememberVideoQualityPatch,
         advancedVideoQualityMenuPatch,
         hidePremiumVideoQualityPatch,
         prioritizeVideoQualityPatch,
-        videoQualityDialogButtonPatch
+        videoQualityDialogButtonPatch,
+        fullscreenVideoScalePatch
     )
 
     compatibleWith(COMPATIBILITY_YOUTUBE)


### PR DESCRIPTION
- Simplifies the patches by merging the two together (required because video scale currently depends on other code in video quality)
- Fixes an screen scale issue where opening a regular video, then opening a Short (without closing the regular video), then closing the Short and returning to the regular video has the wrong aspect ratio.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
