### PR TITLE
fix(Reddit): Preserve font weights with system and custom fonts

### DIFF
--- a/extensions/reddit/src/main/java/app/morphe/extension/reddit/patches/CustomFontPatch.java
+++ b/extensions/reddit/src/main/java/app/morphe/extension/reddit/patches/CustomFontPatch.java
@@ -103,8 +103,6 @@ public final class CustomFontPatch {
     }
 
     private static Typeface build(String fontPath, int weight, boolean italic) {
-        String variation = "'wght' " + weight + (italic ? ", 'ital' 1" : "");
-
         if (fontPath.startsWith("content://")) {
             Context context = Utils.getContext();
             if (context == null) {
@@ -117,11 +115,10 @@ public final class CustomFontPatch {
                     return null;
                 }
 
-                return new Typeface.Builder(pfd.getFileDescriptor())
-                        .setFontVariationSettings(variation)
-                        .setWeight(weight)
-                        .setItalic(italic)
-                        .build();
+                Typeface baseTypeface = new Typeface.Builder(pfd.getFileDescriptor()).build();
+                return baseTypeface == null
+                        ? null
+                        : Typeface.create(baseTypeface, weight, italic);
             } catch (FileNotFoundException ex) {
                 Logger.printException(() -> "Font file not found", ex);
             } catch (IOException ex) {
@@ -131,11 +128,10 @@ public final class CustomFontPatch {
             return null;
         }
 
-        return new Typeface.Builder(new File(fontPath))
-                .setFontVariationSettings(variation)
-                .setWeight(weight)
-                .setItalic(italic)
-                .build();
+            Typeface baseTypeface = new Typeface.Builder(new File(fontPath)).build();
+            return baseTypeface == null
+                ? null
+                : Typeface.create(baseTypeface, weight, italic);
     }
 
     private static int weightFromPath(String path) {

--- a/extensions/reddit/src/main/java/app/morphe/extension/reddit/patches/ForceSystemFontPatch.java
+++ b/extensions/reddit/src/main/java/app/morphe/extension/reddit/patches/ForceSystemFontPatch.java
@@ -24,11 +24,53 @@ public final class ForceSystemFontPatch {
     /**
      * Injection point.
      */
-    public static Typeface getSystemTypeface(int style) {
+    public static Typeface getSystemTypeface(String path, int style) {
         if (!Settings.FORCE_SYSTEM_FONT.get() || Settings.CUSTOM_FONT.get()) {
             return null;
         }
 
-        return Typeface.create(Typeface.DEFAULT, style);
+        int weight = weightFromPath(path);
+        if ((style & Typeface.BOLD) != 0) {
+            weight = Math.max(weight, 700);
+        }
+
+        boolean italic = (style & Typeface.ITALIC) != 0
+                || (path != null && path.toLowerCase().contains("italic"));
+
+        return Typeface.create(Typeface.DEFAULT, weight, italic);
+    }
+
+    private static int weightFromPath(String path) {
+        if (path == null) {
+            return 400;
+        }
+
+        String lowerCasePath = path.toLowerCase();
+        if (lowerCasePath.contains("black")) {
+            return 900;
+        }
+        if (lowerCasePath.contains("extrabold") || lowerCasePath.contains("extra_bold")
+                || lowerCasePath.contains("extra-bold")) {
+            return 800;
+        }
+        if (lowerCasePath.contains("semibold") || lowerCasePath.contains("semi_bold")
+                || lowerCasePath.contains("semi-bold")
+                || lowerCasePath.contains("demibold") || lowerCasePath.contains("demi_bold")) {
+            return 600;
+        }
+        if (lowerCasePath.contains("bold")) {
+            return 700;
+        }
+        if (lowerCasePath.contains("medium")) {
+            return 500;
+        }
+        if (lowerCasePath.contains("light")) {
+            return 300;
+        }
+        if (lowerCasePath.contains("thin")) {
+            return 100;
+        }
+
+        return 400;
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/font/ForceSystemFontPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/font/ForceSystemFontPatch.kt
@@ -36,7 +36,7 @@ val forceSystemFontPatch = bytecodePatch(
             when (targetMethod.variant) {
                 TypefaceCompatCreateFromResourcesFontFileVariant.LEGACY_STATIC ->
                     """
-                        invoke-static { p4 }, $EXTENSION_CLASS->getSystemTypeface(I)Landroid/graphics/Typeface;
+                        invoke-static { p2, p4 }, $EXTENSION_CLASS->getSystemTypeface(Ljava/lang/String;I)Landroid/graphics/Typeface;
                         move-result-object v0
                         if-eqz v0, :original
                         return-object v0
@@ -46,7 +46,7 @@ val forceSystemFontPatch = bytecodePatch(
 
                 TypefaceCompatCreateFromResourcesFontFileVariant.MODERN_VIRTUAL ->
                     """
-                        invoke-static { p5 }, $EXTENSION_CLASS->getSystemTypeface(I)Landroid/graphics/Typeface;
+                        invoke-static { p4, p5 }, $EXTENSION_CLASS->getSystemTypeface(Ljava/lang/String;I)Landroid/graphics/Typeface;
                         move-result-object v0
                         if-eqz v0, :original
                         return-object v0

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/font/ForceSystemFontPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/font/ForceSystemFontPatch.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/2100
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */


### PR DESCRIPTION
### Description

Preserve bold and italic formatting when using the Reddit system or custom font options.

The system font patch now uses the original font resource path to determine the requested weight instead of relying only on the Android style value.

The custom font patch now creates the requested weighted and italic typeface from the loaded base font. This restores formatting for post titles, usernames, and subreddit names.

Closes #2356

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)