### PR TITLE
feat(YouTube - Hide layout components): Add "Hide 'Top fans' button" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/CommentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/CommentsFilter.java
@@ -157,6 +157,11 @@ public class CommentsFilter extends Filter {
                 "composer_timestamp_button.e"
         );
 
+        var topFansButton = new StringFilterGroup(
+                Settings.HIDE_COMMENTS_TOP_FANS_BUTTON,
+                "live_viewer_leaderboard_chat_entry_point.e"
+        );
+
         addPathCallbacks(
                 channelGuidelines,
                 chatSummary,
@@ -173,7 +178,8 @@ public class CommentsFilter extends Filter {
                 previewComment,
                 previewCommentDotsSelector,
                 thanksButton,
-                timestampButton
+                timestampButton,
+                topFansButton
         );
     }
 

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -335,6 +335,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_COMMENTS_SECTION_IN_HOME_FEED = new BooleanSetting("morphe_hide_comments_section_in_home_feed", FALSE, parentNot(HIDE_COMMENTS_SECTION));
     public static final BooleanSetting HIDE_COMMENTS_THANKS_BUTTON = new BooleanSetting("morphe_hide_comments_thanks_button", TRUE, true);
     public static final BooleanSetting HIDE_COMMENTS_TIMESTAMP_BUTTON = new BooleanSetting("morphe_hide_comments_timestamp_button", FALSE);
+    public static final BooleanSetting HIDE_COMMENTS_TOP_FANS_BUTTON = new BooleanSetting("morphe_hide_comments_top_fans_button", FALSE);
     public static final BooleanSetting SANITIZE_COMMENTS_HIGHLIGHTED_SEARCH_LINKS = new BooleanSetting("morphe_sanitize_comments_highlighted_search_links", FALSE, true);
 
     // Description

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -175,6 +175,7 @@ val hideLayoutComponentsPatch = bytecodePatch(
                     SwitchPreference("morphe_hide_comments_preview_comment", summary = true),
                     SwitchPreference("morphe_hide_comments_thanks_button"),
                     SwitchPreference("morphe_hide_comments_timestamp_button"),
+                    SwitchPreference("morphe_hide_comments_top_fans_button"),
                     SwitchPreference("morphe_sanitize_comments_highlighted_search_links", summary = true)
                 ),
                 sorting = Sorting.UNSORTED

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -273,6 +273,7 @@ Changes include:
     <string name="morphe_hide_comments_preview_comment_summary">Hides the comment preview under video before opening the full comments section</string>
     <string name="morphe_hide_comments_thanks_button_title">Hide Thanks button</string>
     <string name="morphe_hide_comments_timestamp_button_title">Hide Timestamp button</string>
+    <string name="morphe_hide_comments_top_fans_button_title">Hide \'Top fans\' button</string>
     <string name="morphe_sanitize_comments_highlighted_search_links_title">Sanitize highlighted search links</string>
     <string name="morphe_sanitize_comments_highlighted_search_links_summary">Sanitizes highlighted search links, leaving only the original plain text</string>
 


### PR DESCRIPTION
### Description

Closes #2653.

### Additional context

```
08-29 18:13:37.017 19122 19122 D morphe: LithoFilterPatch: Searching ID: live_viewer_leaderboard_chat_entry_point.eml-js-fe|70ee1aae668a4f4e Path: live_viewer_leaderboard_chat_entry_point.eml-js-fe|70ee1aae668a4f4e|ContainerType| BufferStrings: Dlive_viewer_leaderboard_chat_entry_point_controller|f6b691ef28ea3bcc❙ILiveViewerLeaderboardChatEntryPointController_initialize|d93bfa7d729dfd39"❙Clive_viewer_leaderboard_chat_entry_point.eml-js-fe|70ee1aae668a4f4e2❙1788007415111766921❙live-chat-item-sectionR❙PAlive_viewer_leaderboardZH❙FwgovGAAiKSonChhVQ3NJaUlFR1JvQklMaThMU2tXTlBxWEESC2FqcWdfbS0ta0ZnMAE%3D❙Top fans(❙#yt_fill_experimental_crown_black_24❙0 XP@❙0 XPh❙Roboto%❙"#live-viewer-leaderboard-entry-point❙
``` 

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
