### PR TITLE
feat(YouTube Music - Scrobbling): Add "Fill in missing album" setting

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/ScrobbleManager.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/ScrobbleManager.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/1856
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
@@ -12,6 +12,8 @@ import android.media.session.PlaybackState;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Pair;
+
+import androidx.annotation.Nullable;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -461,6 +463,13 @@ public class ScrobbleManager {
                     currentDurationSeconds, songStartedAtSeconds);
         }
         lfScrobbled = true;
+    }
+
+    @Nullable
+    public static String getEffectiveAlbum(String artist, String track, @Nullable String album) {
+        if (album != null && !album.isBlank()) return album;
+        if (!Settings.SCROBBLING_GUESS_ALBUM.get()) return null;
+        return LastFM.fetchAlbum(artist, track);
     }
 
     /**

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/ScrobblePatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/ScrobblePatch.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/1856
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/lastfm/LastFM.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/lastfm/LastFM.java
@@ -7,6 +7,8 @@
 
 package app.morphe.extension.music.patches.scrobbling.lastfm;
 
+import androidx.annotation.Nullable;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -30,21 +32,31 @@ import app.morphe.extension.shared.requests.Requester;
 
 public class LastFM {
     private static final String BASE_URL = "https://ws.audioscrobbler.com/2.0/";
-    private static final String USER_AGENT = "Morphe/" + Utils.getPatchesReleaseVersion() + " (YTMusic/" + Utils.getAppVersionName() + ")";
+    private static final String USER_AGENT = "Morphe/" + Utils.getPatchesReleaseVersion()
+            + " (YTMusic/" + Utils.getAppVersionName() + ")";
 
     public static final String API_KEY = "986d00852eea80eda8b2930e0abf5c46";
     public static final String SECRET = "1d802c749ccec53103400582fcaebd01";
 
-    private static final Map<String, CacheEntry> albumCache = new HashMap<>();
-    private static final long CACHE_HIT_TTL = 24 * 60 * 60 * 1000L;
-    private static final long CACHE_MISS_TTL = 60 * 60 * 1000L;
+    private static final Map<String, CacheEntry> albumCache = Collections.synchronizedMap(
+            Utils.createSizeRestrictedMap(20));
 
     private static class CacheEntry {
-        final String album;
-        final long expiry;
-        CacheEntry(String album, long expiry) {
-            this.album = album;
-            this.expiry = expiry;
+        private static final long CACHE_HIT_TTL = 24 * 60 * 60 * 1000L;
+        private static final long CACHE_MISS_TTL = 60 * 60 * 1000L;
+
+        @Nullable
+        public final String album;
+        private final long expiry;
+
+        CacheEntry(@Nullable String album) {
+            final boolean nullAlbum = album == null || album.isBlank();
+            this.album = nullAlbum ? null : album;
+            this.expiry = System.currentTimeMillis() + (nullAlbum ? CACHE_MISS_TTL : CACHE_HIT_TTL);
+        }
+
+        boolean isValid() {
+            return System.currentTimeMillis() < expiry;
         }
     }
 
@@ -161,31 +173,29 @@ public class LastFM {
         }
     }
 
+    @Nullable
     public static String fetchAlbum(String artist, String track) {
         if (!Settings.SCROBBLING_GUESS_ALBUM.get()) return null;
         if (artist == null || artist.isBlank() || track == null || track.isBlank()) return null;
         String key = artist.toLowerCase() + "\u0000" + track.toLowerCase();
-        synchronized (albumCache) {
-            CacheEntry cached = albumCache.get(key);
-            if (cached != null && System.currentTimeMillis() < cached.expiry) {
-                if (cached.album == null || cached.album.isEmpty()) return null;
-                return cached.album;
-            }
+
+        CacheEntry cached = albumCache.get(key);
+        if (cached != null && cached.isValid()) {
+            return cached.album;
         }
+
         String fetched = null;
         try {
             fetched = fetchAlbumNetwork(artist, track);
-        } catch (Exception ignored) {
-            fetched = null;
+        } catch (Exception ex) {
+            Logger.printDebug(() -> "Last.fm: Could not fetch album", ex);
         }
-        synchronized (albumCache) {
-            if (albumCache.size() > 200) albumCache.clear();
-            long ttl = fetched != null ? CACHE_HIT_TTL : CACHE_MISS_TTL;
-            albumCache.put(key, new CacheEntry(fetched != null ? fetched : "", System.currentTimeMillis() + ttl));
-        }
+
+        albumCache.put(key, new CacheEntry(fetched));
         return fetched;
     }
 
+    @Nullable
     private static String fetchAlbumNetwork(String artist, String track) throws Exception {
         String url = BASE_URL + "?method=track.getInfo&api_key=" + URLEncoder.encode(API_KEY, "UTF-8")
                 + "&artist=" + URLEncoder.encode(artist, "UTF-8")

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/lastfm/LastFM.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/lastfm/LastFM.java
@@ -35,6 +35,19 @@ public class LastFM {
     public static final String API_KEY = "986d00852eea80eda8b2930e0abf5c46";
     public static final String SECRET = "1d802c749ccec53103400582fcaebd01";
 
+    private static final Map<String, CacheEntry> albumCache = new HashMap<>();
+    private static final long CACHE_HIT_TTL = 24 * 60 * 60 * 1000L;
+    private static final long CACHE_MISS_TTL = 60 * 60 * 1000L;
+
+    private static class CacheEntry {
+        final String album;
+        final long expiry;
+        CacheEntry(String album, long expiry) {
+            this.album = album;
+            this.expiry = expiry;
+        }
+    }
+
     public static class Session {
         public String name;
         public String key;
@@ -148,6 +161,67 @@ public class LastFM {
         }
     }
 
+    public static String fetchAlbum(String artist, String track) {
+        if (!Settings.SCROBBLING_GUESS_ALBUM.get()) return null;
+        if (artist == null || artist.isBlank() || track == null || track.isBlank()) return null;
+        String key = artist.toLowerCase() + "\u0000" + track.toLowerCase();
+        synchronized (albumCache) {
+            CacheEntry cached = albumCache.get(key);
+            if (cached != null && System.currentTimeMillis() < cached.expiry) {
+                if (cached.album == null || cached.album.isEmpty()) return null;
+                return cached.album;
+            }
+        }
+        String fetched = null;
+        try {
+            fetched = fetchAlbumNetwork(artist, track);
+        } catch (Exception ignored) {
+            fetched = null;
+        }
+        synchronized (albumCache) {
+            if (albumCache.size() > 200) albumCache.clear();
+            long ttl = fetched != null ? CACHE_HIT_TTL : CACHE_MISS_TTL;
+            albumCache.put(key, new CacheEntry(fetched != null ? fetched : "", System.currentTimeMillis() + ttl));
+        }
+        return fetched;
+    }
+
+    private static String fetchAlbumNetwork(String artist, String track) throws Exception {
+        String url = BASE_URL + "?method=track.getInfo&api_key=" + URLEncoder.encode(API_KEY, "UTF-8")
+                + "&artist=" + URLEncoder.encode(artist, "UTF-8")
+                + "&track=" + URLEncoder.encode(track, "UTF-8")
+                + "&autocorrect=1&format=json";
+        HttpURLConnection conn = Requester.openConnection(url);
+        conn.setRequestMethod("GET");
+        conn.setRequestProperty("User-Agent", USER_AGENT);
+        conn.setConnectTimeout(5000);
+        conn.setReadTimeout(5000);
+        int code = conn.getResponseCode();
+        if (code < 200 || code >= 300) {
+            conn.disconnect();
+            return null;
+        }
+        String response;
+        try (InputStreamReader reader = new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8)) {
+            StringBuilder sb = new StringBuilder();
+            char[] buffer = new char[1024];
+            int read;
+            while ((read = reader.read(buffer)) != -1) sb.append(buffer, 0, read);
+            response = sb.toString();
+        } finally {
+            conn.disconnect();
+        }
+        JSONObject root = new JSONObject(response);
+        if (root.has("error")) return null;
+        if (!root.has("track")) return null;
+        JSONObject trackObj = root.getJSONObject("track");
+        JSONObject albumObj = trackObj.optJSONObject("album");
+        if (albumObj == null) return null;
+        String title = albumObj.optString("title", "");
+        if (title == null || title.isBlank()) return null;
+        return title.trim();
+    }
+
     public static Session getMobileSession(String username, String password) throws Exception {
         Map<String, String> params = new HashMap<>();
         params.put("method", "auth.getMobileSession");
@@ -172,13 +246,20 @@ public class LastFM {
         if (sessionKey == null || sessionKey.isBlank()) return;
         ScrobbleManager.getInstance().runOnBackgroundThread(() -> {
             try {
+                String effectiveAlbum = album;
+                if ((effectiveAlbum == null || effectiveAlbum.isBlank()) && Settings.SCROBBLING_GUESS_ALBUM.get()) {
+                    try {
+                        String guessed = fetchAlbum(artist, track);
+                        if (guessed != null && !guessed.isBlank()) effectiveAlbum = guessed;
+                    } catch (Exception ignored) {}
+                }
                 Map<String, String> params = new HashMap<>();
                 params.put("method", "track.updateNowPlaying");
                 params.put("api_key", API_KEY);
                 params.put("sk", sessionKey);
                 params.put("artist", artist);
                 params.put("track", track);
-                if (album != null && !album.isBlank()) params.put("album", album);
+                if (effectiveAlbum != null && !effectiveAlbum.isBlank()) params.put("album", effectiveAlbum);
                 if (duration != null && duration > 0) params.put("duration", String.valueOf(duration));
 
                 executePostRequest(params);
@@ -240,6 +321,13 @@ public class LastFM {
         if (sessionKey == null || sessionKey.isBlank()) return;
         ScrobbleManager.getInstance().runOnBackgroundThread(() -> {
             try {
+                String effectiveAlbum = album;
+                if ((effectiveAlbum == null || effectiveAlbum.isBlank()) && Settings.SCROBBLING_GUESS_ALBUM.get()) {
+                    try {
+                        String guessed = fetchAlbum(artist, track);
+                        if (guessed != null && !guessed.isBlank()) effectiveAlbum = guessed;
+                    } catch (Exception ignored) {}
+                }
                 Map<String, String> params = new HashMap<>();
                 params.put("method", "track.scrobble");
                 params.put("api_key", API_KEY);
@@ -247,7 +335,7 @@ public class LastFM {
                 params.put("artist[0]", artist);
                 params.put("track[0]", track);
                 params.put("timestamp[0]", String.valueOf(timestamp));
-                if (album != null && !album.isBlank()) params.put("album[0]", album);
+                if (effectiveAlbum != null && !effectiveAlbum.isBlank()) params.put("album[0]", effectiveAlbum);
                 if (duration != null && duration > 0) params.put("duration[0]", String.valueOf(duration));
 
                 String response = executePostRequest(params);

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/lastfm/LastFM.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/lastfm/LastFM.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/1856
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
@@ -12,7 +12,6 @@ import androidx.annotation.Nullable;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URLEncoder;
@@ -137,40 +136,22 @@ public class LastFM {
             os.write(postDataBytes);
         }
 
-        int code = conn.getResponseCode();
+        final int code = conn.getResponseCode();
         Logger.printDebug(() -> "Last.fm: Response code: " + code + " for method: " + method);
 
         if (code >= 200 && code < 300) {
-            try (InputStreamReader reader = new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8)) {
-                StringBuilder response = new StringBuilder();
-                char[] buffer = new char[1024];
-                int read;
-                while ((read = reader.read(buffer)) != -1) {
-                    response.append(buffer, 0, read);
-                }
-                return response.toString();
-            }
-        } else {
-            try (InputStreamReader reader = new InputStreamReader(conn.getErrorStream() != null ? conn.getErrorStream() : conn.getInputStream(), StandardCharsets.UTF_8)) {
-                StringBuilder response = new StringBuilder();
-                char[] buffer = new char[1024];
-                int read;
-                while ((read = reader.read(buffer)) != -1) {
-                    response.append(buffer, 0, read);
-                }
-                String errResponse = response.toString();
-                Logger.printInfo(() -> "Last.fm: API error response: " + errResponse + " (HTTP Code: " + code + ")");
-                try {
-                    JSONObject errorObj = new JSONObject(errResponse);
-                    if (errorObj.has("error")) {
-                        throw new LastFMApiException(errorObj.optString("message", "API Error"), errorObj.getInt("error"));
-                    }
-                } catch (LastFMApiException e) {
-                    throw e;
-                } catch (Exception ignored) {}
-                throw new Exception("HTTP error " + code + ": " + errResponse);
+            return Requester.parseString(conn);
+        }
+
+        String errResponse = Requester.parseErrorString(conn);
+        Logger.printInfo(() -> "Last.fm: API error response: " + errResponse + " (HTTP Code: " + code + ")");
+        if (!errResponse.isEmpty()) {
+            JSONObject errorObj = new JSONObject(errResponse);
+            if (errorObj.has("error")) {
+                throw new LastFMApiException(errorObj.optString("message", "API Error"), errorObj.getInt("error"));
             }
         }
+        throw new Exception("HTTP error " + code + (errResponse.isEmpty() ? "" : ": " + errResponse));
     }
 
     @Nullable
@@ -206,21 +187,12 @@ public class LastFM {
         conn.setRequestProperty("User-Agent", USER_AGENT);
         conn.setConnectTimeout(5000);
         conn.setReadTimeout(5000);
-        int code = conn.getResponseCode();
+        final int code = conn.getResponseCode();
         if (code < 200 || code >= 300) {
             conn.disconnect();
             return null;
         }
-        String response;
-        try (InputStreamReader reader = new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8)) {
-            StringBuilder sb = new StringBuilder();
-            char[] buffer = new char[1024];
-            int read;
-            while ((read = reader.read(buffer)) != -1) sb.append(buffer, 0, read);
-            response = sb.toString();
-        } finally {
-            conn.disconnect();
-        }
+        String response = Requester.parseStringAndDisconnect(conn);
         JSONObject root = new JSONObject(response);
         if (root.has("error")) return null;
         if (!root.has("track")) return null;
@@ -256,13 +228,7 @@ public class LastFM {
         if (sessionKey == null || sessionKey.isBlank()) return;
         ScrobbleManager.getInstance().runOnBackgroundThread(() -> {
             try {
-                String effectiveAlbum = album;
-                if ((effectiveAlbum == null || effectiveAlbum.isBlank()) && Settings.SCROBBLING_GUESS_ALBUM.get()) {
-                    try {
-                        String guessed = fetchAlbum(artist, track);
-                        if (guessed != null && !guessed.isBlank()) effectiveAlbum = guessed;
-                    } catch (Exception ignored) {}
-                }
+                String effectiveAlbum = ScrobbleManager.getEffectiveAlbum(artist, track, album);
                 Map<String, String> params = new HashMap<>();
                 params.put("method", "track.updateNowPlaying");
                 params.put("api_key", API_KEY);
@@ -331,13 +297,7 @@ public class LastFM {
         if (sessionKey == null || sessionKey.isBlank()) return;
         ScrobbleManager.getInstance().runOnBackgroundThread(() -> {
             try {
-                String effectiveAlbum = album;
-                if ((effectiveAlbum == null || effectiveAlbum.isBlank()) && Settings.SCROBBLING_GUESS_ALBUM.get()) {
-                    try {
-                        String guessed = fetchAlbum(artist, track);
-                        if (guessed != null && !guessed.isBlank()) effectiveAlbum = guessed;
-                    } catch (Exception ignored) {}
-                }
+                String effectiveAlbum = ScrobbleManager.getEffectiveAlbum(artist, track, album);
                 Map<String, String> params = new HashMap<>();
                 params.put("method", "track.scrobble");
                 params.put("api_key", API_KEY);

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/listenbrainz/ListenBrainz.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/listenbrainz/ListenBrainz.java
@@ -16,6 +16,7 @@ import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 
 import app.morphe.extension.music.patches.scrobbling.ScrobbleManager;
+import app.morphe.extension.music.patches.scrobbling.lastfm.LastFM;
 import app.morphe.extension.music.settings.Settings;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
@@ -84,12 +85,19 @@ public class ListenBrainz {
         }
         ScrobbleManager.getInstance().runOnBackgroundThread(() -> {
             try {
+                String effectiveAlbum = album;
+                if ((effectiveAlbum == null || effectiveAlbum.isBlank()) && Settings.SCROBBLING_GUESS_ALBUM.get()) {
+                    try {
+                        String guessed = LastFM.fetchAlbum(artist, track);
+                        if (guessed != null && !guessed.isBlank()) effectiveAlbum = guessed;
+                    } catch (Exception ignored) {}
+                }
                 JSONObject req = new JSONObject();
                 req.put("listen_type", "single");
 
                 JSONObject payload = new JSONObject();
                 payload.put("listened_at", timestamp);
-                payload.put("track_metadata", createTrackMetadata(artist, track, songId, album, duration));
+                payload.put("track_metadata", createTrackMetadata(artist, track, songId, effectiveAlbum, duration));
 
                 JSONArray payloadArray = new JSONArray();
                 payloadArray.put(payload);
@@ -117,11 +125,18 @@ public class ListenBrainz {
         }
         ScrobbleManager.getInstance().runOnBackgroundThread(() -> {
             try {
+                String effectiveAlbum = album;
+                if ((effectiveAlbum == null || effectiveAlbum.isBlank()) && Settings.SCROBBLING_GUESS_ALBUM.get()) {
+                    try {
+                        String guessed = LastFM.fetchAlbum(artist, track);
+                        if (guessed != null && !guessed.isBlank()) effectiveAlbum = guessed;
+                    } catch (Exception ignored) {}
+                }
                 JSONObject req = new JSONObject();
                 req.put("listen_type", "playing_now");
 
                 JSONObject payload = new JSONObject();
-                payload.put("track_metadata", createTrackMetadata(artist, track, songId, album, duration));
+                payload.put("track_metadata", createTrackMetadata(artist, track, songId, effectiveAlbum, duration));
 
                 JSONArray payloadArray = new JSONArray();
                 payloadArray.put(payload);

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/listenbrainz/ListenBrainz.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/listenbrainz/ListenBrainz.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/1856
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
@@ -10,13 +10,11 @@ package app.morphe.extension.music.patches.scrobbling.listenbrainz;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 
 import app.morphe.extension.music.patches.scrobbling.ScrobbleManager;
-import app.morphe.extension.music.patches.scrobbling.lastfm.LastFM;
 import app.morphe.extension.music.settings.Settings;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
@@ -51,26 +49,19 @@ public class ListenBrainz {
 
         final int code = conn.getResponseCode();
         if (code == 200) {
-            try (InputStreamReader reader = new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8)) {
-                StringBuilder response = new StringBuilder();
-                char[] buffer = new char[1024];
-                int read;
-                while ((read = reader.read(buffer)) != -1) {
-                    response.append(buffer, 0, read);
-                }
-                JSONObject root = new JSONObject(response.toString());
-                TokenValidation validation = new TokenValidation();
-                validation.valid = root.optBoolean("valid");
-                validation.userName = root.optString("user_name");
-                validation.message = root.optString("message");
-                return validation;
-            }
-        } else {
+            String response = Requester.parseString(conn);
+            JSONObject root = new JSONObject(response);
             TokenValidation validation = new TokenValidation();
-            validation.valid = false;
-            validation.message = "HTTP error " + code;
+            validation.valid = root.optBoolean("valid");
+            validation.userName = root.optString("user_name");
+            validation.message = root.optString("message");
             return validation;
         }
+
+        TokenValidation validation = new TokenValidation();
+        validation.valid = false;
+        validation.message = "HTTP error " + code;
+        return validation;
     }
 
     /**
@@ -85,13 +76,7 @@ public class ListenBrainz {
         }
         ScrobbleManager.getInstance().runOnBackgroundThread(() -> {
             try {
-                String effectiveAlbum = album;
-                if ((effectiveAlbum == null || effectiveAlbum.isBlank()) && Settings.SCROBBLING_GUESS_ALBUM.get()) {
-                    try {
-                        String guessed = LastFM.fetchAlbum(artist, track);
-                        if (guessed != null && !guessed.isBlank()) effectiveAlbum = guessed;
-                    } catch (Exception ignored) {}
-                }
+                String effectiveAlbum = ScrobbleManager.getEffectiveAlbum(artist, track, album);
                 JSONObject req = new JSONObject();
                 req.put("listen_type", "single");
 
@@ -125,13 +110,7 @@ public class ListenBrainz {
         }
         ScrobbleManager.getInstance().runOnBackgroundThread(() -> {
             try {
-                String effectiveAlbum = album;
-                if ((effectiveAlbum == null || effectiveAlbum.isBlank()) && Settings.SCROBBLING_GUESS_ALBUM.get()) {
-                    try {
-                        String guessed = LastFM.fetchAlbum(artist, track);
-                        if (guessed != null && !guessed.isBlank()) effectiveAlbum = guessed;
-                    } catch (Exception ignored) {}
-                }
+                String effectiveAlbum = ScrobbleManager.getEffectiveAlbum(artist, track, album);
                 JSONObject req = new JSONObject();
                 req.put("listen_type", "playing_now");
 
@@ -196,7 +175,8 @@ public class ListenBrainz {
         if (code == 200) {
             return true;
         }
-        Logger.printException(() -> "ListenBrainz server returned code: " + code);
+        String errResponse = Requester.parseErrorStringAndDisconnect(conn);
+        Logger.printException(() -> "ListenBrainz server returned code: " + code + ". Response: " + errResponse);
         return false;
     }
 }

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -168,6 +168,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting SCROBBLING_METADATA_CLEANUP = new BooleanSetting("morphe_music_scrobbling_metadata_cleanup", TRUE, true, parentsAny(LISTENBRAINZ_SCROBBLING, LASTFM_SCROBBLING));
     public static final StringSetting SCROBBLING_CUSTOM_REGEX = new StringSetting("morphe_music_scrobbling_custom_regex", "", true, parentsAll(parent(SCROBBLING_METADATA_CLEANUP), parentsAny(LISTENBRAINZ_SCROBBLING, LASTFM_SCROBBLING)));
     public static final BooleanSetting SCROBBLING_PARSE_TITLE = new BooleanSetting("morphe_music_scrobbling_parse_title", FALSE, true, parentsAny(LISTENBRAINZ_SCROBBLING, LASTFM_SCROBBLING));
+    public static final BooleanSetting SCROBBLING_GUESS_ALBUM = new BooleanSetting("morphe_music_scrobbling_guess_album", FALSE, true, parentsAny(LISTENBRAINZ_SCROBBLING, LASTFM_SCROBBLING));
 
     // Lyrics
     public static final BooleanSetting LYRICS_ENABLED = new BooleanSetting("morphe_music_lyrics_enabled", FALSE, true);

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/preference/LastFMTokenPreference.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/preference/LastFMTokenPreference.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/1856
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/preference/ListenBrainzTokenPreference.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/preference/ListenBrainzTokenPreference.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/1856
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/requests/Requester.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/requests/Requester.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2524
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.shared.requests;
 
 import androidx.annotation.Nullable;
@@ -6,7 +16,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -67,14 +76,14 @@ public class Requester {
      * Parse the {@link HttpURLConnection}, and closes the underlying InputStream.
      */
     private static String parseInputStreamAndClose(InputStream inputStream) throws IOException {
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
-            StringBuilder jsonBuilder = new StringBuilder();
-            String line;
-            while ((line = reader.readLine()) != null) {
-                jsonBuilder.append(line);
-                jsonBuilder.append('\n');
+        try (InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
+            StringBuilder sb = new StringBuilder();
+            char[] buffer = new char[1024];
+            int read;
+            while ((read = reader.read(buffer)) != -1) {
+                sb.append(buffer, 0, read);
             }
-            return jsonBuilder.toString();
+            return sb.toString();
         }
     }
 

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/scrobbling/ScrobblingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/scrobbling/ScrobblingPatch.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 Morphe.
- * https://github.com/MorpheApp/morphe-patches
+ * https://github.com/MorpheApp/morphe-patches/pull/1856
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/scrobbling/ScrobblingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/scrobbling/ScrobblingPatch.kt
@@ -137,7 +137,8 @@ val scrobblingPatch = bytecodePatch(
                 preferences = setOf(
                     SwitchPreference("morphe_music_scrobbling_metadata_cleanup"),
                     TextPreference("morphe_music_scrobbling_custom_regex"),
-                    SwitchPreference("morphe_music_scrobbling_parse_title", summary = true)
+                    SwitchPreference("morphe_music_scrobbling_parse_title", summary = true),
+                    SwitchPreference("morphe_music_scrobbling_guess_album", summary = true)
                 )
             ),
             NonInteractivePreference(

--- a/patches/src/main/resources/addresources/values/music/strings.xml
+++ b/patches/src/main/resources/addresources/values/music/strings.xml
@@ -327,6 +327,8 @@ YouTube Music 8.x — crossfade only runs on 9.x and newer"</string>
     <string name="morphe_music_scrobbling_custom_regex_summary">Enter a custom regular expression to remove additional text from song titles, artists, or albums. Example: (?i)\\s*\\((clean|explicit)\\)</string>
     <string name="morphe_music_scrobbling_parse_title_title">Parse artist and track from title</string>
     <string name="morphe_music_scrobbling_parse_title_summary">Extract artist and track name from the video title using \" - \" separator. Useful for reuploaded content where the channel name may be used as the artist.</string>
+    <string name="morphe_music_scrobbling_guess_album_title">Fill in missing album</string>
+    <string name="morphe_music_scrobbling_guess_album_summary">When the music does not include an album, look it up on Last.fm so your scrobble is complete</string>
 
     <!-- 'scrobbling' must be kept untranslated -->
     <string name="morphe_music_scrobbling_about_title">About scrobbling</string>


### PR DESCRIPTION
When the music does not include an album, look it up on Last.fm so your scrobble is complete. Enable Fill in missing album in Music > Scrobbling. If Last.fm cannot find it, scrobble continues as usual without an album.