### PR TITLE
feat(YouTube Music - Hide music action buttons): Add "Hide 'Live chat replay' button" setting

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/components/MusicActionButtonsFilter.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/components/MusicActionButtonsFilter.java
@@ -38,6 +38,7 @@ public final class MusicActionButtonsFilter extends Filter {
         LIKE_DISLIKE(Settings.HIDE_LIKE_DISLIKE_BUTTON),
         DOWNLOAD(Settings.HIDE_DOWNLOAD_BUTTON),
         COMMENTS(Settings.HIDE_COMMENTS_BUTTON),
+        LIVE_CHAT_REPLAY(Settings.HIDE_LIVE_CHAT_REPLAY_BUTTON),
         LYRICS(Settings.HIDE_LYRICS_BUTTON),
         SHARE(Settings.HIDE_SHARE_BUTTON),
         RADIO(Settings.HIDE_RADIO_BUTTON),
@@ -66,6 +67,7 @@ public final class MusicActionButtonsFilter extends Filter {
     // (`offlinelist`) is the only download-specific string that survives into the buffer.
     private static final String DOWNLOAD_PROTO_MARKER = "offlinelist";
     private static final String COMMENTS_MARKER = "music-comment-panel";
+    private static final String LIVE_CHAT_REPLAY_MARKER = "live-chat-item-section";
     private static final String LYRICS_MARKER = "music_watch_lyrics_panel";
     private static final String SHARE_MARKER = "timestamp_share_switch_button_entity_key";
     private static final String RADIO_MARKER = "RDAMVM";
@@ -75,6 +77,7 @@ public final class MusicActionButtonsFilter extends Filter {
     // icon as data, and the icon lives in the first ~500 bytes of the buffer, well before
     // the shared icon catalogue that trails at the end.
     private static final String COMMENTS_ICON = "_text_bubble_";
+    private static final String LIVE_CHAT_REPLAY_ICON = "_bubble_stack_";
     private static final String LYRICS_ICON = "_quote_";
     private static final String THUMB_UP_ICON = "_thumb_up_";
     private static final String THUMB_DOWN_ICON = "_thumb_down_";
@@ -144,6 +147,9 @@ public final class MusicActionButtonsFilter extends Filter {
             String strings = asciiStrings.getStrings();
             if (strings.contains(COMMENTS_MARKER)) {
                 return Settings.HIDE_COMMENTS_BUTTON.get();
+            }
+            if (strings.contains(LIVE_CHAT_REPLAY_MARKER)) {
+                return Settings.HIDE_LIVE_CHAT_REPLAY_BUTTON.get();
             }
             if (strings.contains(LYRICS_MARKER)) {
                 return Settings.HIDE_LYRICS_BUTTON.get();
@@ -224,6 +230,7 @@ public final class MusicActionButtonsFilter extends Filter {
             return ActionButton.DOWNLOAD;
         }
         if (contents.contains(COMMENTS_MARKER)) return ActionButton.COMMENTS;
+        if (contents.contains(LIVE_CHAT_REPLAY_MARKER)) return ActionButton.LIVE_CHAT_REPLAY;
         if (contents.contains(LYRICS_MARKER)) return ActionButton.LYRICS;
         if (contents.contains(SHARE_MARKER)) return ActionButton.SHARE;
         if (contents.contains(RADIO_MARKER)) return ActionButton.RADIO;
@@ -236,6 +243,7 @@ public final class MusicActionButtonsFilter extends Filter {
             return ActionButton.LIKE_DISLIKE;
         }
         if (head.contains(COMMENTS_ICON)) return ActionButton.COMMENTS;
+        if (head.contains(LIVE_CHAT_REPLAY_ICON)) return ActionButton.LIVE_CHAT_REPLAY;
         if (head.contains(LYRICS_ICON)) return ActionButton.LYRICS;
         // Save button has no unique endpoint marker of its own; it's the fall-through.
         return ActionButton.SAVE;

--- a/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/settings/Settings.java
@@ -90,6 +90,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_ACTION_BAR = new BooleanSetting("morphe_music_hide_action_bar", FALSE, true);
     public static final BooleanSetting HIDE_LIKE_DISLIKE_BUTTON = new BooleanSetting("morphe_music_hide_like_dislike_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
     public static final BooleanSetting HIDE_COMMENTS_BUTTON = new BooleanSetting("morphe_music_hide_comments_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
+    public static final BooleanSetting HIDE_LIVE_CHAT_REPLAY_BUTTON = new BooleanSetting("morphe_music_hide_live_chat_replay_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
     public static final BooleanSetting HIDE_LYRICS_BUTTON = new BooleanSetting("morphe_music_hide_lyrics_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
     public static final BooleanSetting HIDE_SHARE_BUTTON = new BooleanSetting("morphe_music_hide_share_button", FALSE, true, parentNot(HIDE_ACTION_BAR));
     public static final BooleanSetting HIDE_SAVE_BUTTON = new BooleanSetting("morphe_music_hide_save_button", FALSE, true, parentNot(HIDE_ACTION_BAR));

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/buttons/action/HideMusicActionButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/buttons/action/HideMusicActionButtonsPatch.kt
@@ -52,6 +52,7 @@ val hideMusicActionButtonsPatch = bytecodePatch(
                     SwitchPreference("morphe_music_hide_action_bar"),
                     SwitchPreference("morphe_music_hide_like_dislike_button"),
                     SwitchPreference("morphe_music_hide_comments_button"),
+                    SwitchPreference("morphe_music_hide_live_chat_replay_button"),
                     SwitchPreference("morphe_music_hide_lyrics_button"),
                     SwitchPreference("morphe_music_hide_share_button"),
                     SwitchPreference("morphe_music_hide_save_button"),

--- a/patches/src/main/resources/addresources/values/music/strings.xml
+++ b/patches/src/main/resources/addresources/values/music/strings.xml
@@ -166,6 +166,8 @@ YouTube Music 8.x — crossfade only runs on 9.x and newer"</string>
     <string name="morphe_music_hide_action_bar_title">Hide action bar</string>
     <string name="morphe_music_hide_like_dislike_button_title">Hide Like and Dislike button</string>
     <string name="morphe_music_hide_comments_button_title">Hide Comments button</string>
+    <!-- 'Live chat replay' should be translated using the same localized wording YouTube Music displays for the button. -->
+    <string name="morphe_music_hide_live_chat_replay_button_title">Hide \'Live chat replay\' button</string>
     <!-- 'Lyrics' should be translated using the same localized wording YouTube Music displays for the button. -->
     <string name="morphe_music_hide_lyrics_button_title">Hide Lyrics button</string>
     <!-- 'Share' should be translated using the same localized wording YouTube Music displays for the button. -->
@@ -175,7 +177,7 @@ YouTube Music 8.x — crossfade only runs on 9.x and newer"</string>
     <!-- 'Download' should be translated using the same localized wording YouTube Music displays for the button. -->
     <string name="morphe_music_hide_download_button_title">Hide Download button</string>
     <!-- 'Start radio' should be translated using the same localized wording YouTube Music displays for the button. -->
-    <string name="morphe_music_hide_radio_button_title">Hide Start radio button</string>
+    <string name="morphe_music_hide_radio_button_title">Hide \'Start radio\' button</string>
 
     <!-- flyoutmenu.components.hideFlyoutMenuComponentsPatch -->
     <string name="morphe_music_hide_flyout_menu_components_screen_title">Flyout menu</string>


### PR DESCRIPTION
### Description

Closes #2668.

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
