### PR TITLE
fix(YouTube Music): Various issues of the `Play albums songs` patch

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/album/PlayAlbumSongsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/album/PlayAlbumSongsPatch.java
@@ -11,8 +11,10 @@ import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import app.morphe.extension.music.settings.Settings;
 import app.morphe.extension.shared.Logger;
@@ -79,8 +81,8 @@ public class PlayAlbumSongsPatch {
         void videoIdResolved(@NonNull String videoId, @NonNull String resolvedVideoId);
     }
 
-    @Nullable
-    private static volatile SubstitutionListener substitutionListener;
+    private static final Collection<SubstitutionListener> substitutionListeners =
+            new CopyOnWriteArrayList<>();
 
     static {
         StreamingDataRequest.setVideoIdResolver(PlayAlbumSongsPatch::resolveVideoIdToFetch);
@@ -90,8 +92,8 @@ public class PlayAlbumSongsPatch {
      * @param listener Notified for every video the streams are fetched for, including those
      *                 left playing as the music video.
      */
-    public static void setSubstitutionListener(@Nullable SubstitutionListener listener) {
-        substitutionListener = listener;
+    public static void addSubstitutionListener(@NonNull SubstitutionListener listener) {
+        substitutionListeners.add(listener);
     }
 
     private static boolean isEnabled() {
@@ -186,8 +188,7 @@ public class PlayAlbumSongsPatch {
 
             String resolvedVideoId = resolveAlbumSong(videoId);
 
-            SubstitutionListener listener = substitutionListener;
-            if (listener != null) {
+            for (SubstitutionListener listener : substitutionListeners) {
                 listener.videoIdResolved(videoId, resolvedVideoId);
             }
             return resolvedVideoId;

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/album/PlayAlbumSongsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/album/PlayAlbumSongsPatch.java
@@ -18,6 +18,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import app.morphe.extension.music.settings.Settings;
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.spoof.SpoofVideoStreamsPatch;
 import app.morphe.extension.shared.spoof.requests.StreamingDataRequest;
 
 /**
@@ -86,6 +87,7 @@ public class PlayAlbumSongsPatch {
 
     static {
         StreamingDataRequest.setVideoIdResolver(PlayAlbumSongsPatch::resolveVideoIdToFetch);
+        SpoofVideoStreamsPatch.setVideoLengthResolver(PlayAlbumSongsPatch::songLengthSeconds);
     }
 
     /**
@@ -177,6 +179,14 @@ public class PlayAlbumSongsPatch {
         synchronized (songs) {
             return songs.get(videoId);
         }
+    }
+
+    /**
+     * @return Length of the song playing under the given video, or zero if it is not substituted.
+     */
+    private static long songLengthSeconds(@NonNull String videoId) {
+        PlaylistRequest.Song song = getSong(videoId);
+        return song == null ? 0 : song.durationSeconds();
     }
 
     /**

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/album/PlayAlbumSongsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/album/PlayAlbumSongsPatch.java
@@ -71,8 +71,27 @@ public class PlayAlbumSongsPatch {
         }
     };
 
+    /**
+     * Notified when the streams to serve under a video are known, which can be after the app
+     * has already set up playback of the music video.
+     */
+    public interface SubstitutionListener {
+        void videoIdResolved(@NonNull String videoId, @NonNull String resolvedVideoId);
+    }
+
+    @Nullable
+    private static volatile SubstitutionListener substitutionListener;
+
     static {
         StreamingDataRequest.setVideoIdResolver(PlayAlbumSongsPatch::resolveVideoIdToFetch);
+    }
+
+    /**
+     * @param listener Notified for every video the streams are fetched for, including those
+     *                 left playing as the music video.
+     */
+    public static void setSubstitutionListener(@Nullable SubstitutionListener listener) {
+        substitutionListener = listener;
     }
 
     private static boolean isEnabled() {
@@ -87,8 +106,10 @@ public class PlayAlbumSongsPatch {
                                          int playlistIndex) {
         try {
             if (!isEnabled()) return;
-            if (playlistIndex < 0) return;
-            if (!playlistId.startsWith(YOUTUBE_MUSIC_ALBUM_PREFIX)) return;
+            if (playlistIndex < 0 || !playlistId.startsWith(YOUTUBE_MUSIC_ALBUM_PREFIX)) {
+                forgetSubstitution(videoId, playlistId);
+                return;
+            }
 
             synchronized (albumTracks) {
                 AlbumTrack existing = albumTracks.get(videoId);
@@ -128,6 +149,24 @@ public class PlayAlbumSongsPatch {
     }
 
     /**
+     * Stops serving the song of an album to a video that is now played outside of that album,
+     * which otherwise keeps the music video replaced until the app is restarted.
+     */
+    private static void forgetSubstitution(@NonNull String videoId, @NonNull String playlistId) {
+        synchronized (albumTracks) {
+            AlbumTrack track = albumTracks.get(videoId);
+            // The same album can build the player parameter again without a position,
+            // and that is still the album playing rather than the music video itself.
+            if (track == null || track.playlistId().equals(playlistId)) return;
+            albumTracks.remove(videoId);
+        }
+        synchronized (songs) {
+            songs.remove(videoId);
+        }
+        Logger.printDebug(() -> "No longer playing the song version of: " + videoId);
+    }
+
+    /**
      * @return The album track playing under the given video, or null if it is not substituted.
      */
     @Nullable
@@ -145,34 +184,48 @@ public class PlayAlbumSongsPatch {
         try {
             if (!isEnabled()) return videoId;
 
-            AlbumTrack track;
-            synchronized (albumTracks) {
-                track = albumTracks.get(videoId);
-            }
-            if (track == null) return videoId;
+            String resolvedVideoId = resolveAlbumSong(videoId);
 
-            PlaylistRequest request =
-                    PlaylistRequest.getRequestForPlaylistId(track.playlistId());
-            if (request == null) return videoId;
-
-            PlaylistRequest.Song song = request.awaitSong(
-                    track.playlistIndex(), MAX_MILLISECONDS_TO_WAIT_FOR_ALBUM);
-            if (song == null) {
-                Logger.printDebug(() -> "Official song not found, videoId: " + videoId);
-                return videoId;
+            SubstitutionListener listener = substitutionListener;
+            if (listener != null) {
+                listener.videoIdResolved(videoId, resolvedVideoId);
             }
-            if (song.videoId().equals(videoId)) {
-                // The album track has no music video, or is already the song version.
-                return videoId;
-            }
-
-            synchronized (songs) {
-                songs.put(videoId, song);
-            }
-            return song.videoId();
+            return resolvedVideoId;
         } catch (Exception ex) {
             Logger.printException(() -> "resolveVideoIdToFetch failure", ex);
             return videoId;
         }
+    }
+
+    /**
+     * @return The video whose streams to serve for the given video, which is the video itself
+     *         when it is not an album track playing as a music video.
+     */
+    private static String resolveAlbumSong(@NonNull String videoId) {
+        AlbumTrack track;
+        synchronized (albumTracks) {
+            track = albumTracks.get(videoId);
+        }
+        if (track == null) return videoId;
+
+        PlaylistRequest request =
+                PlaylistRequest.getRequestForPlaylistId(track.playlistId());
+        if (request == null) return videoId;
+
+        PlaylistRequest.Song song = request.awaitSong(
+                track.playlistIndex(), MAX_MILLISECONDS_TO_WAIT_FOR_ALBUM);
+        if (song == null) {
+            Logger.printDebug(() -> "Official song not found, videoId: " + videoId);
+            return videoId;
+        }
+        if (song.videoId().equals(videoId)) {
+            // The album track has no music video, or is already the song version.
+            return videoId;
+        }
+
+        synchronized (songs) {
+            songs.put(videoId, song);
+        }
+        return song.videoId();
     }
 }

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/album/PlaylistRequest.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/album/PlaylistRequest.java
@@ -72,7 +72,7 @@ public final class PlaylistRequest {
     /**
      * An album track as the album itself lists it, rather than as the queue plays it.
      */
-    public record Song(String videoId, String title, String artist) {
+    public record Song(String videoId, String title, String artist, int durationSeconds) {
     }
 
     private static final TimeZone TIME_ZONE = TimeZone.getDefault();
@@ -344,7 +344,23 @@ public final class PlaylistRequest {
             return null;
         }
         return new Song(videoId, parseRuns(renderer, "title"),
-                parseRuns(renderer, "longBylineText"));
+                parseRuns(renderer, "longBylineText"),
+                parseDuration(parseRuns(renderer, "lengthText")));
+    }
+
+    /**
+     * @return Seconds of a "m:ss" or "h:mm:ss" length, or zero if it cannot be read.
+     */
+    private static int parseDuration(@NonNull String lengthText) {
+        int seconds = 0;
+        for (String part : lengthText.split(":")) {
+            try {
+                seconds = seconds * 60 + Integer.parseInt(part.trim());
+            } catch (NumberFormatException ex) {
+                return 0;
+            }
+        }
+        return seconds;
     }
 
     @NonNull

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/lyrics/LyricsManager.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/lyrics/LyricsManager.java
@@ -82,7 +82,9 @@ public final class LyricsManager {
     private boolean playing;
 
     private LyricsManager() {
-        PlayAlbumSongsPatch.addSubstitutionListener(this::videoIdResolved);
+        PlayAlbumSongsPatch.addSubstitutionListener(
+                (videoId, resolvedVideoId) -> reloadCurrentTrack());
+        VideoInformation.addVideoIdListener(videoId -> reloadCurrentTrack());
     }
 
     public static LyricsManager getInstance() {
@@ -138,13 +140,13 @@ public final class LyricsManager {
     }
 
     /**
-     * The song of an album is often only known after its metadata is set, so the track is
-     * read again once it is, and the music video lyrics give way to the song ones.
+     * The song of an album, and the video id of the app itself, can both land after the metadata
+     * of a track, so the track is read again whenever either of them arrives.
      */
-    private void videoIdResolved(String videoId, String resolvedVideoId) {
+    private void reloadCurrentTrack() {
         Utils.runOnMainThread(() -> {
             MediaMetadata metadata = currentMetadata;
-            if (metadata != null && videoId.equals(VideoInformation.getVideoId())) {
+            if (metadata != null) {
                 loadTrackOf(metadata);
             }
         });

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/lyrics/LyricsManager.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/lyrics/LyricsManager.java
@@ -18,10 +18,13 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import app.morphe.extension.music.patches.album.PlayAlbumSongsPatch;
+import app.morphe.extension.music.patches.album.PlaylistRequest;
 import app.morphe.extension.music.patches.lyrics.requests.KuGouProvider;
 import app.morphe.extension.music.patches.lyrics.requests.LrcLibProvider;
 import app.morphe.extension.music.patches.lyrics.requests.LyricsProvider;
 import app.morphe.extension.music.settings.Settings;
+import app.morphe.extension.music.shared.VideoInformation;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
 
@@ -58,6 +61,10 @@ public final class LyricsManager {
     @Nullable
     private TrackInfo currentTrack;
 
+    /** Metadata of the current track, kept so it can be read again as the song of an album. */
+    @Nullable
+    private MediaMetadata currentMetadata;
+
     @Nullable
     private Lyrics currentLyrics;
 
@@ -75,6 +82,7 @@ public final class LyricsManager {
     private boolean playing;
 
     private LyricsManager() {
+        PlayAlbumSongsPatch.addSubstitutionListener(this::videoIdResolved);
     }
 
     public static LyricsManager getInstance() {
@@ -122,7 +130,28 @@ public final class LyricsManager {
      */
     public void onSetMetadata(@Nullable MediaMetadata metadata) {
         Utils.verifyOnMainThread();
-        if (metadata == null || !Settings.LYRICS_ENABLED.get()) {
+        if (metadata == null) {
+            return;
+        }
+        currentMetadata = metadata;
+        loadTrackOf(metadata);
+    }
+
+    /**
+     * The song of an album is often only known after its metadata is set, so the track is
+     * read again once it is, and the music video lyrics give way to the song ones.
+     */
+    private void videoIdResolved(String videoId, String resolvedVideoId) {
+        Utils.runOnMainThread(() -> {
+            MediaMetadata metadata = currentMetadata;
+            if (metadata != null && videoId.equals(VideoInformation.getVideoId())) {
+                loadTrackOf(metadata);
+            }
+        });
+    }
+
+    private void loadTrackOf(MediaMetadata metadata) {
+        if (!Settings.LYRICS_ENABLED.get()) {
             return;
         }
 
@@ -132,11 +161,23 @@ public final class LyricsManager {
             return;
         }
 
+        int durationSeconds = (int) (metadata.getLong(MediaMetadata.METADATA_KEY_DURATION) / 1000);
+
+        // An album track playing its song version is still described by the app as the music
+        // video, whose title and duration find no lyrics or the lyrics of another version.
+        PlaylistRequest.Song song = PlayAlbumSongsPatch.getSong(VideoInformation.getVideoId());
+        if (song != null) {
+            rawTitle = song.title();
+            if (song.durationSeconds() > 0) {
+                durationSeconds = song.durationSeconds();
+            }
+        }
+
         TrackInfo track = new TrackInfo(
                 MetadataCleaner.cleanTitle(rawTitle),
                 MetadataCleaner.cleanArtist(rawArtist),
                 MetadataCleaner.cleanAlbum(metadata.getString(MediaMetadata.METADATA_KEY_ALBUM)),
-                (int) (metadata.getLong(MediaMetadata.METADATA_KEY_DURATION) / 1000)
+                durationSeconds
         );
 
         if (track.title().isEmpty() || track.artist().isEmpty()) {
@@ -259,6 +300,12 @@ public final class LyricsManager {
             } catch (Exception ex) {
                 Logger.printException(() -> "Lyrics listener failure", ex);
             }
+        }
+
+        if (newState == State.LOADED) {
+            // A panel is only detected while the app builds its own lyrics into it, which it
+            // never does for a music video, so an open panel is covered from here instead.
+            LyricsPanelInstaller.onLyricsPanelDetected();
         }
     }
 

--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/ScrobbleManager.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/scrobbling/ScrobbleManager.java
@@ -21,6 +21,7 @@ import app.morphe.extension.music.patches.album.PlaylistRequest;
 import app.morphe.extension.music.patches.scrobbling.lastfm.LastFM;
 import app.morphe.extension.music.patches.scrobbling.listenbrainz.ListenBrainz;
 import app.morphe.extension.music.settings.Settings;
+import app.morphe.extension.music.shared.VideoInformation;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
 
@@ -40,6 +41,9 @@ public class ScrobbleManager {
 
     private final Handler handler = new Handler(Looper.getMainLooper());
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    /** Metadata of the current track, kept so it can be read again as the song of an album. */
+    private MediaMetadata currentMetadata;
 
     private String currentTitle;
     private String currentArtist;
@@ -63,7 +67,24 @@ public class ScrobbleManager {
     private boolean lfScrobbled;
     private Runnable lfRunnable;
 
-    private ScrobbleManager() {}
+    private ScrobbleManager() {
+        PlayAlbumSongsPatch.addSubstitutionListener(
+                (videoId, resolvedVideoId) -> reloadCurrentTrack());
+        VideoInformation.addVideoIdListener(videoId -> reloadCurrentTrack());
+    }
+
+    /**
+     * The song of an album, and the video id of the app itself, can both land after the metadata
+     * of a track, so the track is read again whenever either of them arrives.
+     */
+    private void reloadCurrentTrack() {
+        Utils.runOnMainThread(() -> {
+            MediaMetadata metadata = currentMetadata;
+            if (metadata != null) {
+                onSetMetadata(metadata);
+            }
+        });
+    }
 
     private String cleanTitle(String title) {
         if (title == null) return null;
@@ -134,26 +155,27 @@ public class ScrobbleManager {
         Utils.verifyOnMainThread();
         if (metadata == null) return;
 
+        currentMetadata = metadata;
+
         try {
             String songId = metadata.getString(MediaMetadata.METADATA_KEY_MEDIA_ID);
             String album = cleanAlbum(metadata.getString(MediaMetadata.METADATA_KEY_ALBUM));
             String rawTitle = metadata.getString(MediaMetadata.METADATA_KEY_TITLE);
             String rawArtist = metadata.getString(MediaMetadata.METADATA_KEY_ARTIST);
 
-            // The metadata of a substituted track still describes the music video,
-            // which can name a different version of the song than the one playing.
-            PlaylistRequest.Song song = PlayAlbumSongsPatch.getSong(songId);
+            // The metadata of a substituted track still describes the music video, which names
+            // another version of the song and is minutes longer. Only the artist is the same.
+            PlaylistRequest.Song song = PlayAlbumSongsPatch.getSong(VideoInformation.getVideoId());
             if (song != null && !song.title().isBlank()) {
                 rawTitle = song.title();
-                if (!song.artist().isBlank()) {
-                    rawArtist = song.artist();
-                }
             }
 
             Pair<String, String> resolved = resolveTitleAndArtist(rawTitle, rawArtist);
             String title = resolved.first;
             String artist = resolved.second;
-            final int duration = (int) (metadata.getLong(MediaMetadata.METADATA_KEY_DURATION) / 1000);
+            final int duration = song != null && song.durationSeconds() > 0
+                    ? song.durationSeconds()
+                    : (int) (metadata.getLong(MediaMetadata.METADATA_KEY_DURATION) / 1000);
             if (title == null || title.isBlank() || artist == null || artist.isBlank()) {
                 return;
             }

--- a/extensions/music/src/main/java/app/morphe/extension/music/shared/VideoInformation.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/shared/VideoInformation.java
@@ -83,7 +83,9 @@ public final class VideoInformation {
 
     /** Injection point. */
     public static void setVideoLength(final long length) {
-        if (videoLength != length) videoLength = length;
+        if (videoLength == length) return;
+        Logger.printDebug(() -> "VideoInformation: new video length: " + length);
+        videoLength = length;
     }
 
     public static long getVideoLength() { return videoLength; }

--- a/extensions/music/src/main/java/app/morphe/extension/music/shared/VideoInformation.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/shared/VideoInformation.java
@@ -9,7 +9,9 @@ package app.morphe.extension.music.shared;
 
 import androidx.annotation.NonNull;
 
+import java.util.Collection;
 import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
@@ -20,6 +22,13 @@ import app.morphe.extension.shared.Utils;
  */
 @SuppressWarnings("unused")
 public final class VideoInformation {
+
+    /** Notified when the app starts another video. */
+    public interface VideoIdListener {
+        void newVideoId(@NonNull String videoId);
+    }
+
+    private static final Collection<VideoIdListener> videoIdListeners = new CopyOnWriteArrayList<>();
 
     @NonNull
     private static String videoId = "";
@@ -48,11 +57,23 @@ public final class VideoInformation {
         return videoId;
     }
 
+    public static void addVideoIdListener(@NonNull VideoIdListener listener) {
+        videoIdListeners.add(listener);
+    }
+
     /** Injection point. Stored for downstream patches; SponsorBlock routes its own id hook. */
     public static void setVideoId(@NonNull String newVideoId) {
         if (Objects.equals(newVideoId, videoId)) return;
         Logger.printDebug(() -> "VideoInformation: new video id: " + newVideoId);
         videoId = newVideoId;
+
+        for (VideoIdListener listener : videoIdListeners) {
+            try {
+                listener.newVideoId(newVideoId);
+            } catch (Exception ex) {
+                Logger.printException(() -> "newVideoId failure", ex);
+            }
+        }
     }
 
     /** Injection point. Called on main thread ~every 1000ms. */

--- a/extensions/music/src/main/java/app/morphe/extension/music/sponsorblock/MusicSponsorBlockConfig.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/sponsorblock/MusicSponsorBlockConfig.java
@@ -56,7 +56,7 @@ public final class MusicSponsorBlockConfig implements Configuration {
         synchronized (MusicSponsorBlockConfig.class) {
             if (installed) return;
             SponsorBlockApi.configure(INSTANCE);
-            PlayAlbumSongsPatch.setSubstitutionListener(MusicSponsorBlockConfig::videoIdResolved);
+            PlayAlbumSongsPatch.addSubstitutionListener(MusicSponsorBlockConfig::videoIdResolved);
             installed = true;
         }
     }

--- a/extensions/music/src/main/java/app/morphe/extension/music/sponsorblock/MusicSponsorBlockConfig.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/sponsorblock/MusicSponsorBlockConfig.java
@@ -13,8 +13,11 @@ import android.graphics.Rect;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import app.morphe.extension.music.patches.album.PlayAlbumSongsPatch;
+import app.morphe.extension.music.patches.album.PlaylistRequest;
 import app.morphe.extension.music.settings.Settings;
 import app.morphe.extension.music.shared.VideoInformation;
+import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.BooleanSetting;
 import app.morphe.extension.shared.settings.FloatSetting;
 import app.morphe.extension.shared.settings.IntegerSetting;
@@ -43,12 +46,17 @@ public final class MusicSponsorBlockConfig implements Configuration {
 
     private static volatile boolean installed;
 
+    /** Video the player last reported, before any album song substitution. */
+    @Nullable
+    private static volatile String currentVideoId;
+
     /** Idempotent. Configures {@link SponsorBlockApi} on first call. */
     public static void install() {
         if (installed) return;
         synchronized (MusicSponsorBlockConfig.class) {
             if (installed) return;
             SponsorBlockApi.configure(INSTANCE);
+            PlayAlbumSongsPatch.setSubstitutionListener(MusicSponsorBlockConfig::videoIdResolved);
             installed = true;
         }
     }
@@ -69,7 +77,20 @@ public final class MusicSponsorBlockConfig implements Configuration {
     /** Injection point. */
     @SuppressWarnings("unused")
     public static void setCurrentVideoId(@Nullable String videoId) {
-        SegmentPlaybackController.setCurrentVideoId(videoId);
+        currentVideoId = videoId;
+        // The album patch can serve the streams of a song under the id of its music video,
+        // and the segments of the music video do not match that audio.
+        PlaylistRequest.Song song = PlayAlbumSongsPatch.getSong(videoId);
+        SegmentPlaybackController.setCurrentVideoId(song == null ? videoId : song.videoId());
+    }
+
+    /**
+     * The song of an album is often only known after the video id is set, so the segments of the
+     * music video are replaced once it is.
+     */
+    private static void videoIdResolved(@NonNull String videoId, @NonNull String resolvedVideoId) {
+        if (!videoId.equals(currentVideoId)) return;
+        Utils.runOnMainThread(() -> SegmentPlaybackController.setCurrentVideoId(resolvedVideoId));
     }
 
     /** Injection point. Inset by the rounded-end radius so segment markers align with the

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/spoof/SpoofVideoStreamsPatch.java
@@ -176,6 +176,48 @@ public class SpoofVideoStreamsPatch {
     }
 
     /**
+     * Supplies the length of the video the streams are really of, when it is not the video the
+     * app thinks it is playing.
+     */
+    public interface VideoLengthResolver {
+        /**
+         * @return Length in seconds, or zero to keep the length of the app.
+         */
+        long getVideoLengthSeconds(@NonNull String videoId);
+    }
+
+    @Nullable
+    private static volatile VideoLengthResolver videoLengthResolver;
+
+    public static void setVideoLengthResolver(@Nullable VideoLengthResolver resolver) {
+        videoLengthResolver = resolver;
+    }
+
+    /**
+     * Injection point.
+     * The app takes the length of the track from the response of the video it asked for, which is
+     * not the video the streams are of when another one is served in its place.
+     *
+     * @return Length in seconds, or zero to keep the length of the app.
+     */
+    public static long getVideoLengthSeconds(String videoId) {
+        try {
+            VideoLengthResolver resolver = videoLengthResolver;
+            if (resolver == null || videoId == null) return 0;
+
+            final long lengthSeconds = resolver.getVideoLengthSeconds(videoId);
+            if (lengthSeconds > 0) {
+                Logger.printDebug(() -> "Overriding video length of: " + videoId
+                        + " with: " + lengthSeconds + " seconds");
+            }
+            return lengthSeconds;
+        } catch (Exception ex) {
+            Logger.printException(() -> "getVideoLengthSeconds failure", ex);
+            return 0;
+        }
+    }
+
+    /**
      * Injection point.
      */
     public static boolean isSpoofingEnabled() {

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/translation/TextTranslator.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/translation/TextTranslator.java
@@ -43,6 +43,9 @@ public final class TextTranslator {
      */
     public static final int MAXIMUM_BATCH_CHARACTERS = 4_000;
 
+    /** A rate limited response is a whole HTML page, of which only the start is worth logging. */
+    private static final int MAXIMUM_ERROR_CHARACTERS = 200;
+
     private TextTranslator() {
     }
 
@@ -127,9 +130,14 @@ public final class TextTranslator {
 
         final int code = connection.getResponseCode();
         if (code != 200) {
+            // Reading the input stream of a failed response throws instead of returning the body,
+            // which hid the status code the caller reacts to behind a FileNotFoundException.
+            String response = Requester.parseErrorString(connection);
+            String responseStart = response.substring(0,
+                    Math.min(response.length(), MAXIMUM_ERROR_CHARACTERS));
             throw new TranslationHttpException(code, "Translation HTTP status: " + code
                     + " language: " + targetLanguage
-                    + " response: " + Requester.parseString(connection));
+                    + " response: " + responseStart);
         }
 
         // Response: [[["translated","original",...],...],null,"src_lang",...]

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/scrobbling/ScrobblingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/scrobbling/ScrobblingPatch.kt
@@ -16,6 +16,7 @@ import app.morphe.patches.music.misc.settings.settingsPatch
 import app.morphe.patches.music.shared.Constants.COMPATIBILITY_YOUTUBE_MUSIC
 import app.morphe.patches.music.shared.MediaSessionSetMetadataFingerprint
 import app.morphe.patches.music.shared.hookMediaSessionArgument
+import app.morphe.patches.music.video.information.musicVideoInformationPatch
 import app.morphe.patches.shared.layout.returnyoutubedislike.DislikeFingerprint
 import app.morphe.patches.shared.layout.returnyoutubedislike.EndpointServiceNameFingerprint
 import app.morphe.patches.shared.layout.returnyoutubedislike.likeEndpointParserFingerprint
@@ -40,7 +41,9 @@ val scrobblingPatch = bytecodePatch(
 ) {
     dependsOn(
         sharedExtensionPatch,
-        settingsPatch
+        settingsPatch,
+        // The video id tells whether the album patch is playing the song of the track instead.
+        musicVideoInformationPatch
     )
 
     compatibleWith(COMPATIBILITY_YOUTUBE_MUSIC)

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/SpoofVideoStreamsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/SpoofVideoStreamsPatch.kt
@@ -193,6 +193,21 @@ internal fun spoofVideoStreamsPatch(
                         )
                     }
 
+                // The replacement streams can be of another video, such as an album track played
+                // as its song version, and then the app keeps the timeline of the music video.
+                val videoLengthField = classDefBy(videoDetailsClass).fields
+                    .singleOrNull { field -> field.type == "J" }
+                val overrideVideoLength = if (videoLengthField == null) "nop" else """
+                    invoke-static { v2 }, $EXTENSION_CLASS->getVideoLengthSeconds(Ljava/lang/String;)J
+                    move-result-wide v3
+                    const-wide/16 v6, 0x0
+                    cmp-long v0, v3, v6
+                    if-lez v0, :length_overridden
+                    iput-wide v3, p1, $videoDetailsClass->${videoLengthField.name}:J
+                    :length_overridden
+                    nop
+                """
+
                 val castInstruction = if (castReference.type != buildMethod.definingClass) """
                     check-cast v4, $castReference
                 """ else """
@@ -238,6 +253,9 @@ internal fun spoofVideoStreamsPatch(
                             iget-object v6, v5, $getStreamingDataField
                             if-eqz v6, :disabled
                             iput-object v6, p0, $setStreamingDataField
+
+                            # Set video length.
+                            $overrideVideoLength
 
                             # Get player config.
                             invoke-static { v2 }, $EXTENSION_CLASS->getPlayerConfig(Ljava/lang/String;)[B


### PR DESCRIPTION
### Description

Fixes of the `Play albums songs` patch, where everything the app derives from the video kept describing the music video instead of the song being played:

- **Duration**: the timeline showed the length of the music video and playback ran on in silence for minutes after the song had ended
- **SponsorBlock**: segments of the music video were downloaded and cut into the song
- **Lyrics**: looked up by the title and length of the music video, and the panel was never filled in, since the app builds no lyrics of its own for a music video
- **Scrobbling**: the scrobble named the music video and used its length
- **Music videos stayed replaced**: playing one outside of its album kept serving the song until the app was restarted

Partially closes #2696

### Test results

- [ ] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
