### PR TITLE
fix(YouTube - Theme): Apply the foreground color to text and icons in more locations

### DIFF
--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -53,6 +53,8 @@ import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.returnyoutubedislike.requests.RYDVoteData;
 import app.morphe.extension.shared.returnyoutubedislike.requests.ReturnYouTubeDislikeAPI;
 import app.morphe.extension.shared.settings.SharedYouTubeSettings;
+import app.morphe.extension.shared.theme.ThemeColorPatch;
+import app.morphe.extension.shared.theme.ThemeUtils;
 import app.morphe.extension.shared.ui.Dim;
 
 /**
@@ -319,9 +321,12 @@ public class ReturnYouTubeDislike {
                 }
 
                 if (originalDislikeSpan != null && replacementLikeDislikeSpan != null) {
-                    if (spansHaveEqualTextAndColor(original, originalDislikeSpan)) {
-                        final Spanned originalSpanFinal = original;
-                        Logger.printDebug(() -> "Replacing span: " + originalSpanFinal + " with " +
+                    // Check if colors match to fix changing light/dark mode while player is opened
+                    // and avoid recreating the span. But if theme foreground color is replaced
+                    // then always use replacement span as-is.
+                    if ((ThemeColorPatch.isPatchIncluded() && SharedYouTubeSettings.THEME_COLOR_CHANGE_FOREGROUND.get())
+                            || spansHaveEqualTextAndColor(original, originalDislikeSpan)) {
+                        Logger.printDebug(() -> "Replacing span: " + original + " with " +
                                 "previously created dislike span of data: " + videoId);
                         return replacementLikeDislikeSpan;
                     }
@@ -426,6 +431,24 @@ public class ReturnYouTubeDislike {
         return new SpannableString(builder);
     }
 
+    private static SpannableString setSpanForegroundColor(SpannableString span) {
+        if (ThemeColorPatch.isPatchIncluded()) {
+            // Remove any existing colors
+            ForegroundColorSpan[] existing = span.getSpans(0, span.length(), ForegroundColorSpan.class);
+            for (ForegroundColorSpan fcs : existing) {
+                span.removeSpan(fcs);
+            }
+
+            span.setSpan(
+                    new ForegroundColorSpan(ThemeUtils.getAppForegroundColor()),
+                    0,
+                    span.length(),
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+            );
+        }
+        return span;
+    }
+
     /**
      * @return If the text is likely for a previously created likes/dislikes segmented span.
      */
@@ -452,8 +475,8 @@ public class ReturnYouTubeDislike {
     }
 
     protected static SpannableString newSpanUsingStylingOfAnotherSpan(Spanned sourceStyle, CharSequence newSpanText) {
-        if (sourceStyle == newSpanText && sourceStyle instanceof SpannableString) {
-            return (SpannableString) sourceStyle;
+        if (sourceStyle == newSpanText && sourceStyle instanceof SpannableString spannable) {
+            return setSpanForegroundColor(spannable);
         }
 
         SpannableString destination = new SpannableString(newSpanText);
@@ -461,6 +484,9 @@ public class ReturnYouTubeDislike {
         for (Object span : spans) {
             destination.setSpan(span, 0, destination.length(), sourceStyle.getSpanFlags(span));
         }
+
+        // Apply theme color.
+        setSpanForegroundColor(destination);
 
         return destination;
     }

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/BaseThemePatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/BaseThemePatch.java
@@ -41,6 +41,13 @@ public abstract class BaseThemePatch {
      */
     @ColorInt
     protected static int processColorValue(int originalValue, int[] darkValues, @Nullable int[] lightValues) {
+        // A Litho component is also given the color the app uses for its own text and icons,
+        // such as the background of the chip that is selected, which is drawn with it.
+        final int foreground = ThemeColorPatch.getForegroundColor(originalValue);
+        if (foreground != originalValue) {
+            return foreground;
+        }
+
         // The values that are replaced here are the backgrounds the app hard codes into its
         // Litho components. They only have to follow along when the app background is changed.
         // With the background of the app itself the app is left alone. Otherwise, a component

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
@@ -540,6 +540,48 @@ public class ThemeColorPatch {
     }
 
     /**
+     * The primary text colors of each theme. The white the app keeps for what it draws on a
+     * thumbnail or a video is left out, because that has to stay readable on any of them.
+     */
+    private static final int[] DARK_THEME_FOREGROUND_VALUES = {
+            0xFFF1F1F1, // Default palette.
+            0xFFF2F2F5, // Carbon palette.
+    };
+
+    private static final int[] LIGHT_THEME_FOREGROUND_VALUES = {
+            0xFF0F0F0F, // Default palette.
+            0xFF09090A, // Carbon palette.
+    };
+
+    /**
+     * Injection point.
+     * <p>
+     * The color of a text or an icon the app colors itself, which is a value and not a color
+     * resource, so the value of the app is matched instead of replacing a resource.
+     */
+    @ColorInt
+    public static int getForegroundColor(@ColorInt int originalValue) {
+        try {
+            if (isAppDefaultColor()
+                    || !SharedYouTubeSettings.THEME_COLOR_CHANGE_FOREGROUND.get()) {
+                return originalValue;
+            }
+
+            // The app draws its foreground with the color of the theme it does not show.
+            final boolean dark = isDarkTheme();
+            for (int value : dark ? DARK_THEME_FOREGROUND_VALUES : LIGHT_THEME_FOREGROUND_VALUES) {
+                if (value == originalValue) {
+                    return themeColor(!dark);
+                }
+            }
+        } catch (Exception ex) {
+            Logger.printException(() -> "getForegroundColor failure", ex);
+        }
+
+        return originalValue;
+    }
+
+    /**
      * If the app shows its dark theme.
      * <p>
      * The theme of the app is resolved after the first contexts of the app attach, and the theme

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
@@ -623,6 +623,42 @@ public class ThemeColorPatch {
     }
 
     /**
+     * Injection point.
+     * <p>
+     * The color of a layer of a Lottie animation, which the app plays for its like button.
+     * <p>
+     * An animation carries the artwork of itself, and the artwork of an icon is drawn with the
+     * plain white or black of a theme instead of the color the app uses everywhere else. Only a
+     * layer of an animation is matched with them, because the app keeps that white for what it
+     * draws on a thumbnail or a video, where it has to stay readable.
+     */
+    @ColorInt
+    public static int getForegroundLottieColor(@ColorInt int originalValue) {
+        try {
+            // A layer is drawn with the alpha of the animation, which the color carries.
+            final int opaque = originalValue | 0xFF000000;
+            if (opaque != Color.WHITE && opaque != Color.BLACK) {
+                return getForegroundColor(originalValue);
+            }
+
+            if (isAppDefaultColor()
+                    || !SharedYouTubeSettings.THEME_COLOR_CHANGE_FOREGROUND.get()) {
+                return originalValue;
+            }
+
+            // The artwork of an icon is white while the app is dark, and black while it is not.
+            final boolean dark = isDarkTheme();
+            if (dark == (opaque == Color.WHITE)) {
+                return (originalValue & 0xFF000000) | (themeColor(!dark) & 0x00FFFFFF);
+            }
+        } catch (Exception ex) {
+            Logger.printException(() -> "getForegroundLottieColor failure", ex);
+        }
+
+        return originalValue;
+    }
+
+    /**
      * The single pixel a filter is applied to, to read the color of it. The color a filter holds
      * is not part of the SDK, and what the filter leaves on an opaque pixel is the same color.
      */

--- a/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
+++ b/extensions/shared-youtube/library/src/main/java/app/morphe/extension/shared/theme/ThemeColorPatch.java
@@ -11,7 +11,13 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.Configuration;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.ColorFilter;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
@@ -553,6 +559,15 @@ public class ThemeColorPatch {
             0xFF09090A, // Carbon palette.
     };
 
+    private static boolean isForegroundValue(@ColorInt int value, boolean dark) {
+        for (int foreground : dark ? DARK_THEME_FOREGROUND_VALUES : LIGHT_THEME_FOREGROUND_VALUES) {
+            if (foreground == value) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Injection point.
      * <p>
@@ -562,6 +577,13 @@ public class ThemeColorPatch {
     @ColorInt
     public static int getForegroundColor(@ColorInt int originalValue) {
         try {
+            // Almost every color that arrives here is not one of the app foreground, and matching
+            // the value first keeps all of those to a handful of comparisons.
+            final boolean darkValue = isForegroundValue(originalValue, true);
+            if (!darkValue && !isForegroundValue(originalValue, false)) {
+                return originalValue;
+            }
+
             if (isAppDefaultColor()
                     || !SharedYouTubeSettings.THEME_COLOR_CHANGE_FOREGROUND.get()) {
                 return originalValue;
@@ -569,16 +591,86 @@ public class ThemeColorPatch {
 
             // The app draws its foreground with the color of the theme it does not show.
             final boolean dark = isDarkTheme();
-            for (int value : dark ? DARK_THEME_FOREGROUND_VALUES : LIGHT_THEME_FOREGROUND_VALUES) {
-                if (value == originalValue) {
-                    return themeColor(!dark);
-                }
+            if (dark == darkValue) {
+                return themeColor(!dark);
             }
         } catch (Exception ex) {
             Logger.printException(() -> "getForegroundColor failure", ex);
         }
 
         return originalValue;
+    }
+
+    /**
+     * Injection point.
+     * <p>
+     * The colors of a tint list the app builds for a text or an icon it colors itself.
+     * They are handed over as an array and not as a value, so the array is rewritten
+     * before the list of it is created.
+     */
+    public static void replaceForegroundColors(int[] colors) {
+        try {
+            if (colors == null) {
+                return;
+            }
+
+            for (int i = 0; i < colors.length; i++) {
+                colors[i] = getForegroundColor(colors[i]);
+            }
+        } catch (Exception ex) {
+            Logger.printException(() -> "replaceForegroundColors failure", ex);
+        }
+    }
+
+    /**
+     * The single pixel a filter is applied to, to read the color of it. The color a filter holds
+     * is not part of the SDK, and what the filter leaves on an opaque pixel is the same color.
+     */
+    private static final Bitmap filterProbe =
+            Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888);
+
+    /**
+     * Injection point.
+     * <p>
+     * The color of an icon of a Litho component, which the app keeps inside a filter on the paint
+     * of the drawable, so the filter is replaced with one of the color of the theme.
+     */
+    public static ColorFilter getForegroundColorFilter(ColorFilter filter) {
+        try {
+            if (filter == null
+                    || isAppDefaultColor()
+                    || !SharedYouTubeSettings.THEME_COLOR_CHANGE_FOREGROUND.get()) {
+                return filter;
+            }
+
+            final int color = filterColor(filter);
+            final int replaced = getForegroundColor(color);
+            if (replaced != color) {
+                return new PorterDuffColorFilter(replaced, PorterDuff.Mode.SRC_IN);
+            }
+        } catch (Exception ex) {
+            Logger.printException(() -> "getForegroundColorFilter failure", ex);
+        }
+
+        return filter;
+    }
+
+    /**
+     * The color a filter leaves on an opaque pixel, which for a filter that tints an icon is the
+     * color the icon is drawn with.
+     */
+    @ColorInt
+    private static int filterColor(ColorFilter filter) {
+        Paint paint = new Paint();
+        paint.setColor(Color.WHITE);
+        paint.setColorFilter(filter);
+
+        synchronized (filterProbe) {
+            // The pixel is painted over, so what it holds from the filter before must be gone.
+            filterProbe.eraseColor(Color.TRANSPARENT);
+            new Canvas(filterProbe).drawRect(0, 0, 1, 1, paint);
+            return filterProbe.getPixel(0, 0);
+        }
     }
 
     /**

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
@@ -28,32 +28,23 @@ internal object UseGradientLoadingScreenFingerprint : Fingerprint(
     )
 )
 
-/**
- * The app colors a text of its own with a span, using a color that the server sent with the text
- * and not a color resource, so no resource variant of the theme can replace it.
- */
-internal object LithoTextSpanColorFingerprint : Fingerprint(
-    filters = listOf(
-        methodCall(
-            opcode = Opcode.INVOKE_DIRECT,
-            smali = "Landroid/text/style/ForegroundColorSpan;-><init>(I)V"
+internal object LithoImageColorFilterFingerprint : Fingerprint(
+    classFingerprint = Fingerprint(
+        name = "draw",
+        parameters = listOf("Landroid/graphics/Canvas;"),
+        returnType = "V",
+        filters = listOf(
+            methodCall(
+                smali = $$"Landroid/graphics/BitmapShader;-><init>(Landroid/graphics/Bitmap;Landroid/graphics/Shader$TileMode;Landroid/graphics/Shader$TileMode;)V"
+            ),
+            methodCall(
+                smali = "Landroid/graphics/Canvas;->drawRect(Landroid/graphics/RectF;Landroid/graphics/Paint;)V"
+            )
         )
-    )
-)
-
-/**
- * An icon is colored the same way, with a value the app tints the drawable with.
- */
-internal object IconDrawableColorFilterFingerprint : Fingerprint(
-    filters = listOf(
-        methodCall(smali = $$"Landroid/graphics/drawable/Drawable;->setColorFilter(ILandroid/graphics/PorterDuff$Mode;)V")
-    )
-)
-
-internal object IconImageColorFilterFingerprint : Fingerprint(
-    filters = listOf(
-        methodCall(smali = $$"Landroid/widget/ImageView;->setColorFilter(ILandroid/graphics/PorterDuff$Mode;)V")
-    )
+    ),
+    name = "setColorFilter",
+    parameters = listOf("Landroid/graphics/ColorFilter;"),
+    returnType = "V"
 )
 
 internal object CarbonColorThemeFeatureFlagFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
@@ -28,6 +28,34 @@ internal object UseGradientLoadingScreenFingerprint : Fingerprint(
     )
 )
 
+/**
+ * The app colors a text of its own with a span, using a color that the server sent with the text
+ * and not a color resource, so no resource variant of the theme can replace it.
+ */
+internal object LithoTextSpanColorFingerprint : Fingerprint(
+    filters = listOf(
+        methodCall(
+            opcode = Opcode.INVOKE_DIRECT,
+            smali = "Landroid/text/style/ForegroundColorSpan;-><init>(I)V"
+        )
+    )
+)
+
+/**
+ * An icon is colored the same way, with a value the app tints the drawable with.
+ */
+internal object IconDrawableColorFilterFingerprint : Fingerprint(
+    filters = listOf(
+        methodCall(smali = $$"Landroid/graphics/drawable/Drawable;->setColorFilter(ILandroid/graphics/PorterDuff$Mode;)V")
+    )
+)
+
+internal object IconImageColorFilterFingerprint : Fingerprint(
+    filters = listOf(
+        methodCall(smali = $$"Landroid/widget/ImageView;->setColorFilter(ILandroid/graphics/PorterDuff$Mode;)V")
+    )
+)
+
 internal object CarbonColorThemeFeatureFlagFingerprint : Fingerprint(
     filters = listOf(
         literal(45760313)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/Fingerprints.kt
@@ -47,6 +47,18 @@ internal object LithoImageColorFilterFingerprint : Fingerprint(
     returnType = "V"
 )
 
+internal object LottieLayerColorFingerprint : Fingerprint(
+    parameters = listOf(
+        "Landroid/graphics/Canvas;",
+        "Landroid/graphics/Matrix;",
+        "I"
+    ),
+    returnType = "V",
+    filters = listOf(
+        methodCall(smali = "Landroid/graphics/Paint;->setColor(I)V")
+    )
+)
+
 internal object CarbonColorThemeFeatureFlagFingerprint : Fingerprint(
     filters = listOf(
         literal(45760313)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -521,6 +521,21 @@ val themePatch = baseThemePatch(
             """
         )
 
+        // The color of a Lottie layer is played from the animation itself, so it reaches no
+        // call that hands a color over and no resource of the app either. It has a replacement
+        // of its own, because the artwork of an animation is drawn with a plain white or black.
+        LottieLayerColorFingerprint.matchAllMethodIndicesForEach { index ->
+            val colorRegister = getInstruction(index).registersUsed[1]
+
+            addInstructions(
+                index,
+                """
+                    invoke-static/range { v$colorRegister .. v$colorRegister }, $THEME_COLOR_EXTENSION_CLASS->getForegroundLottieColor(I)I
+                    move-result v$colorRegister
+                """
+            )
+        }
+
         UseGradientLoadingScreenFingerprint.matchAll().forEach {
             it.method.insertLiteralOverride(
                 it.instructionMatches.first().index,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -13,6 +13,7 @@ package app.morphe.patches.youtube.layout.theme
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.methodCall
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
@@ -44,11 +45,11 @@ import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import app.morphe.util.forEachChildElement
 import app.morphe.util.insertLiteralOverride
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
+import app.morphe.util.matchAllMethodIndicesForEach
+import app.morphe.util.registersUsed
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import org.w3c.dom.Element
-import kotlin.collections.plus
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/theme/ThemePatch;"
 
@@ -148,6 +149,56 @@ private val youTubeStyleNamesLight = {
     }
 }
 
+/**
+ * Every call that hands over a color the app colors a text or an icon of its own with, and the
+ * position the color has in the registers of the call. Such a color is a value and not a color
+ * resource, so no resource variant of the theme can replace it.
+ *
+ * The class a call is declared with is left out where the method is inherited, because the same
+ * method called with a subclass is a reference of its own that a declared class would not match.
+ */
+private val FOREGROUND_COLOR_CALLS = listOf(
+    methodCall(
+        definingClass = "Landroid/text/style/ForegroundColorSpan;",
+        name = "<init>",
+        parameters = listOf("I"),
+        returnType = "V"
+    ) to 1,
+    methodCall(
+        definingClass = "Landroid/graphics/PorterDuffColorFilter;",
+        name = "<init>",
+        parameters = listOf("I", $$"Landroid/graphics/PorterDuff$Mode;"),
+        returnType = "V"
+    ) to 1,
+    methodCall(
+        definingClass = "Landroid/graphics/BlendModeColorFilter;",
+        name = "<init>",
+        parameters = listOf("I", "Landroid/graphics/BlendMode;"),
+        returnType = "V"
+    ) to 1,
+    // A tint list of a single color, which is how the app tints an icon of a Litho component.
+    methodCall(
+        definingClass = "Landroid/content/res/ColorStateList;",
+        name = "valueOf",
+        parameters = listOf("I"),
+        returnType = "Landroid/content/res/ColorStateList;"
+    ) to 0,
+    methodCall(
+        name = "setColorFilter",
+        parameters = listOf("I", $$"Landroid/graphics/PorterDuff$Mode;"),
+        returnType = "V"
+    ) to 1,
+    methodCall(
+        name = "setColorFilter",
+        parameters = listOf("I"),
+        returnType = "V"
+    ) to 1,
+    methodCall(
+        name = "setTint",
+        parameters = listOf("I"),
+        returnType = "V"
+    ) to 1
+)
 
 val themePatch = baseThemePatch(
     extensionClassDescriptor = EXTENSION_CLASS,
@@ -424,28 +475,51 @@ val themePatch = baseThemePatch(
 
         // The app colors its own text and icons with a value, so every place that hands one
         // over is given the color of the selected theme instead.
-        arrayOf(
-            LithoTextSpanColorFingerprint,
-            IconDrawableColorFilterFingerprint,
-            IconImageColorFilterFingerprint
-        ).forEach { fingerprint ->
-            fingerprint.matchAll().forEach {
-                it.method.apply {
-                    val index = it.instructionMatches.first().index
-                    val colorRegister = getInstruction<FiveRegisterInstruction>(index).registerD
+        FOREGROUND_COLOR_CALLS.forEach { (filter, colorPosition) ->
+            filter.matchAllMethodIndicesForEach(requireMatches = false) { index ->
+                val colorRegister = getInstruction(index).registersUsed[colorPosition]
 
-                    // The color can be in a parameter register above v15,
-                    // so the range format is used.
-                    addInstructions(
-                        index,
-                        """
-                            invoke-static/range { v$colorRegister .. v$colorRegister }, $THEME_COLOR_EXTENSION_CLASS->getForegroundColor(I)I
-                            move-result v$colorRegister
-                        """
-                    )
-                }
+                // The color can be in a parameter register above v15,
+                // so the range format is used.
+                addInstructions(
+                    index,
+                    """
+                        invoke-static/range { v$colorRegister .. v$colorRegister }, $THEME_COLOR_EXTENSION_CLASS->getForegroundColor(I)I
+                        move-result v$colorRegister
+                    """
+                )
             }
         }
+
+        // A tint list the app builds hands its colors over as an array, so the array is rewritten
+        // in place. Replacing the list itself would give the register of the list a type of its
+        // own, which the verifier rejects where the register is reused.
+        methodCall(
+            definingClass = "Landroid/content/res/ColorStateList;",
+            name = "<init>",
+            parameters = listOf("[[I", "[I"),
+            returnType = "V"
+        ).matchAllMethodIndicesForEach(requireMatches = false) { index ->
+            val colorsRegister = getInstruction(index).registersUsed[2]
+
+            addInstruction(
+                index,
+                "invoke-static/range { v$colorsRegister .. v$colorsRegister }, " +
+                        "$THEME_COLOR_EXTENSION_CLASS->replaceForegroundColors([I)V"
+            )
+        }
+
+        // The app colors an icon of a Litho component with a filter the drawable keeps on its
+        // own paint, so the color never reaches a call that hands one over as a value. The
+        // filter is replaced on the parameter of the call, which is a register the replacement
+        // always fits.
+        LithoImageColorFilterFingerprint.method.addInstructions(
+            0,
+            """
+                invoke-static { p1 }, $THEME_COLOR_EXTENSION_CLASS->getForegroundColorFilter(Landroid/graphics/ColorFilter;)Landroid/graphics/ColorFilter;
+                move-result-object p1
+            """
+        )
 
         UseGradientLoadingScreenFingerprint.matchAll().forEach {
             it.method.insertLiteralOverride(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -44,6 +44,7 @@ import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import app.morphe.util.forEachChildElement
 import app.morphe.util.insertLiteralOverride
+import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import org.w3c.dom.Element
@@ -59,6 +60,7 @@ private val youTubeColorNamesDark = {
 //            "yt_ref_color_constants_default_baseline_black_black2",
             "yt_ref_color_constants_default_baseline_black_black3",
 //            "yt_ref_color_constants_default_baseline_black_black4",
+            "yt_ref_color_constants_cooler_baseline_black_black3",
             "yt_sys_color_baseline_dark_menu_background",
             "yt_sys_color_baseline_dark_static_black",
             "yt_sys_color_baseline_dark_raised_background",
@@ -80,8 +82,9 @@ private val youTubeColorNamesLight = {
 //            "yt_ref_color_constants_baseline_white_white3",
 //            "yt_ref_color_constants_baseline_white_white4",
 //            "yt_ref_color_constants_default_baseline_white_white2",
-//            "yt_ref_color_constants_default_baseline_white_white3",
 //            "yt_ref_color_constants_default_baseline_white_white4",
+            "yt_ref_color_constants_default_baseline_white_white3",
+            "yt_ref_color_constants_cooler_baseline_white_white3",
 
             "yt_sys_color_baseline_light_menu_background",
 //            "yt_sys_color_baseline_light_static_white",
@@ -414,6 +417,31 @@ val themePatch = baseThemePatch(
                         checkCastIndex + 1,
                         "invoke-static { v$stubRegister }, $THEME_COLOR_EXTENSION_CLASS" +
                                 "->onNewContentIndicator(Landroid/view/ViewStub;)V"
+                    )
+                }
+            }
+        }
+
+        // The app colors its own text and icons with a value, so every place that hands one
+        // over is given the color of the selected theme instead.
+        arrayOf(
+            LithoTextSpanColorFingerprint,
+            IconDrawableColorFilterFingerprint,
+            IconImageColorFilterFingerprint
+        ).forEach { fingerprint ->
+            fingerprint.matchAll().forEach {
+                it.method.apply {
+                    val index = it.instructionMatches.first().index
+                    val colorRegister = getInstruction<FiveRegisterInstruction>(index).registerD
+
+                    // The color can be in a parameter register above v15,
+                    // so the range format is used.
+                    addInstructions(
+                        index,
+                        """
+                            invoke-static/range { v$colorRegister .. v$colorRegister }, $THEME_COLOR_EXTENSION_CLASS->getForegroundColor(I)I
+                            move-result v$colorRegister
+                        """
                     )
                 }
             }


### PR DESCRIPTION
### Description

The foreground color setting only replaced color resources, so video titles, feed text and Litho icons kept the stock color. These are colored by the app with a value rather than a resource, which is now replaced as well.

Artifact https://github.com/MorpheApp/morphe-patches/actions/runs/33742293219/artifacts/9888303242

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
___
<details>
 <summary>Screenshots</summary>

![Screenshot_2026-09-03-13-05-53-623_com.google.android.youtube.test-edit.jpg](https://github.com/user-attachments/assets/af0b83a3-8b83-485b-9f2e-56b06d86c760)

![Screenshot_2026-09-03-13-05-44-918_com.google.android.youtube.test-edit.jpg](https://github.com/user-attachments/assets/07f1e6e8-2947-4419-bc4d-7a7b8b3ec2ad)

![Screenshot_2026-09-03-13-05-30-652_com.google.android.youtube.test-edit.jpg](https://github.com/user-attachments/assets/c8ae486a-6cd6-491b-8577-3863b2d6f955)

![Screenshot_2026-09-03-13-06-58-584_com.google.android.youtube.test-edit.jpg](https://github.com/user-attachments/assets/f50470dc-0f1c-44c8-8696-645d002b25c6)

![Screenshot_2026-09-03-13-06-19-598_com.google.android.youtube.test-edit.jpg](https://github.com/user-attachments/assets/a93e5294-9a90-45ec-b23e-67ceade51c61)

</details>


