### PR TITLE
feat(YouTube - Hide player flyout menu components): Add "Hide 'On-the-go' menu" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/PlayerFlyoutMenuComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/PlayerFlyoutMenuComponentsFilter.java
@@ -84,36 +84,6 @@ public final class PlayerFlyoutMenuComponentsFilter extends Filter {
 
         flyoutMenuBufferGroupList.addAll(
                 new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_CAPTIONS,
-                        "closed_caption_",
-                        "yt_outline_experimental_closed_captions_"
-                ),
-                new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_LISTEN_WITH_YOUTUBE_MUSIC,
-                        "yt_outline_youtube_music_",
-                        "yt_outline_experimental_youtube_music_"
-                ),
-                new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_HELP,
-                        "yt_outline_question_circle_",
-                        "yt_outline_experimental_help_circle_"
-                ),
-                new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_LOCK_SCREEN,
-                        "yt_outline_lock_",
-                        "yt_outline_experimental_lock_"
-                ),
-                new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_SPEED,
-                        "yt_outline_play_arrow_half_circle_",
-                        "yt_outline_experimental_play_circle_half_dashed_"
-                ),
-                new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_AUDIO_TRACK,
-                        "yt_outline_person_",
-                        "yt_outline_experimental_person_"
-                ),
-                new ByteArrayFilterGroup(
                         Settings.HIDE_PLAYER_FLYOUT_ADDITIONAL_SETTINGS,
                         "yt_outline_gear_",
                         "yt_outline_experimental_gear_"
@@ -124,10 +94,39 @@ public final class PlayerFlyoutMenuComponentsFilter extends Filter {
                         "yt_outline_experimental_ambient_mode_"
                 ),
                 new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_STABLE_VOLUME,
-                        "volume_stable_",
-                        "yt_fill_experimental_stable_volume_",
-                        "yt_outline_experimental_stable_volume_"
+                        Settings.HIDE_PLAYER_FLYOUT_AUDIO_TRACK,
+                        "yt_outline_person_",
+                        "yt_outline_experimental_person_"
+                ),
+                new ByteArrayFilterGroup(
+                        Settings.HIDE_PLAYER_FLYOUT_CAPTIONS,
+                        "closed_caption_",
+                        "yt_outline_experimental_closed_captions_"
+                ),
+                new ByteArrayFilterGroup(
+                        Settings.HIDE_PLAYER_FLYOUT_HELP,
+                        "yt_outline_question_circle_",
+                        "yt_outline_experimental_help_circle_"
+                ),
+                new ByteArrayFilterGroup(
+                        Settings.HIDE_PLAYER_FLYOUT_LISTEN_WITH_YOUTUBE_MUSIC,
+                        "yt_outline_youtube_music_",
+                        "yt_outline_experimental_youtube_music_"
+                ),
+                new ByteArrayFilterGroup(
+                        Settings.HIDE_PLAYER_FLYOUT_LOCK_SCREEN,
+                        "yt_outline_lock_",
+                        "yt_outline_experimental_lock_"
+                ),
+                new ByteArrayFilterGroup(
+                        Settings.HIDE_PLAYER_FLYOUT_ON_THE_GO,
+                        "yt_outline_headset_",
+                        "yt_outline_experimental_headset_"
+                ),
+                new ByteArrayFilterGroup(
+                        Settings.HIDE_PLAYER_FLYOUT_QUALITY,
+                        "yt_outline_adjust_",
+                        "yt_outline_experimental_adjust_"
                 ),
                 new ByteArrayFilterGroup(
                         Settings.HIDE_PLAYER_FLYOUT_SLEEP_TIMER,
@@ -135,14 +134,20 @@ public final class PlayerFlyoutMenuComponentsFilter extends Filter {
                         "yt_outline_experimental_sleep_timer_"
                 ),
                 new ByteArrayFilterGroup(
+                        Settings.HIDE_PLAYER_FLYOUT_SPEED,
+                        "yt_outline_play_arrow_half_circle_",
+                        "yt_outline_experimental_play_circle_half_dashed_"
+                ),
+                new ByteArrayFilterGroup(
+                        Settings.HIDE_PLAYER_FLYOUT_STABLE_VOLUME,
+                        "volume_stable_",
+                        "yt_fill_experimental_stable_volume_",
+                        "yt_outline_experimental_stable_volume_"
+                ),
+                new ByteArrayFilterGroup(
                         Settings.HIDE_PLAYER_FLYOUT_WATCH_IN_VR,
                         "yt_outline_vr_",
                         "yt_outline_experimental_vr_"
-                ),
-                new ByteArrayFilterGroup(
-                        Settings.HIDE_PLAYER_FLYOUT_QUALITY,
-                        "yt_outline_adjust_",
-                        "yt_outline_experimental_adjust_"
                 )
         );
     }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -422,6 +422,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_PLAYER_FLYOUT_LISTEN_WITH_YOUTUBE_MUSIC = new BooleanSetting("morphe_hide_player_flyout_listen_with_youtube_music", FALSE);
     public static final BooleanSetting HIDE_PLAYER_FLYOUT_LOCK_SCREEN = new BooleanSetting("morphe_hide_player_flyout_lock_screen", FALSE);
     public static final BooleanSetting HIDE_PLAYER_FLYOUT_LOOP_VIDEO = new BooleanSetting("morphe_hide_player_flyout_loop_video", FALSE);
+    public static final BooleanSetting HIDE_PLAYER_FLYOUT_ON_THE_GO = new BooleanSetting("morphe_hide_player_flyout_on_the_go", FALSE);
     public static final BooleanSetting HIDE_PLAYER_FLYOUT_SLEEP_TIMER = new BooleanSetting("morphe_hide_player_flyout_sleep_timer", FALSE);
     public static final BooleanSetting HIDE_PLAYER_FLYOUT_SPEED = new BooleanSetting("morphe_hide_player_flyout_speed", FALSE);
     public static final BooleanSetting HIDE_PLAYER_FLYOUT_STABLE_VOLUME = new BooleanSetting("morphe_hide_player_flyout_stable_volume", FALSE);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/player/flyoutmenu/HidePlayerFlyoutMenuComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/player/flyoutmenu/HidePlayerFlyoutMenuComponentsPatch.kt
@@ -55,27 +55,28 @@ val hidePlayerFlyoutMenuComponentsPatch = bytecodePatch(
             PreferenceScreenPreference(
                 key = "morphe_hide_player_flyout",
                 preferences = setOf(
-                    SwitchPreference("morphe_hide_player_flyout_captions"),
-                    SwitchPreference("morphe_hide_player_flyout_captions_footer"),
-                    SwitchPreference("morphe_hide_player_flyout_captions_header"),
-                    SwitchPreference("morphe_hide_player_flyout_listen_with_youtube_music"),
-                    SwitchPreference("morphe_hide_player_flyout_help"),
-                    SwitchPreference("morphe_hide_player_flyout_speed"),
-                    SwitchPreference("morphe_hide_player_flyout_lock_screen"),
+                    SwitchPreference("morphe_hide_player_flyout_additional_settings"),
+                    SwitchPreference("morphe_hide_player_flyout_ambient_mode"),
                     SwitchPreference(
                         key = "morphe_hide_player_flyout_audio_track",
                         tag = "app.morphe.extension.youtube.settings.preference.HideAudioFlyoutMenuPreference"),
                     SwitchPreference(
                         key = "morphe_hide_player_flyout_audio_track_footer",
                         tag = "app.morphe.extension.youtube.settings.preference.HideAudioFlyoutMenuPreference"),
+                    SwitchPreference("morphe_hide_player_flyout_captions"),
+                    SwitchPreference("morphe_hide_player_flyout_captions_footer"),
+                    SwitchPreference("morphe_hide_player_flyout_captions_header"),
+                    SwitchPreference("morphe_hide_player_flyout_help"),
+                    SwitchPreference("morphe_hide_player_flyout_listen_with_youtube_music"),
+                    SwitchPreference("morphe_hide_player_flyout_lock_screen"),
+                    SwitchPreference("morphe_hide_player_flyout_loop_video"),
+                    SwitchPreference("morphe_hide_player_flyout_on_the_go"),
                     SwitchPreference("morphe_hide_player_flyout_quality"),
                     SwitchPreference("morphe_hide_player_flyout_quality_footer"),
                     SwitchPreference("morphe_hide_player_flyout_quality_header"),
-                    SwitchPreference("morphe_hide_player_flyout_additional_settings"),
-                    SwitchPreference("morphe_hide_player_flyout_ambient_mode"),
-                    SwitchPreference("morphe_hide_player_flyout_stable_volume"),
-                    SwitchPreference("morphe_hide_player_flyout_loop_video"),
                     SwitchPreference("morphe_hide_player_flyout_sleep_timer"),
+                    SwitchPreference("morphe_hide_player_flyout_speed"),
+                    SwitchPreference("morphe_hide_player_flyout_stable_volume"),
                     SwitchPreference("morphe_hide_player_flyout_watch_in_vr")
                 )
             )

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -769,42 +769,44 @@ To access Settings, enable the Settings button via General → Toolbar → Show 
     <!-- layout.hide.player.flyoutmenupanel.hidePlayerFlyoutMenuPatch -->
     <string name="morphe_hide_player_flyout_title">Flyout menu</string>
     <string name="morphe_hide_player_flyout_summary">Choose which components appear in the flyout menu</string>
-    <!-- 'Audio Track' should be translated using the same localized wording YouTube displays for the menu item. -->
-    <string name="morphe_hide_player_flyout_audio_track_title">Hide \'Audio Track\' menu</string>
+    <!-- 'Additional settings / More' should be translated using the same localized wording YouTube displays for the menu item. -->
+    <string name="morphe_hide_player_flyout_additional_settings_title">Hide \'Additional settings\' / More menu</string>
+    <!-- 'Ambient mode' should be translated using the same localized wording YouTube displays for the menu item. -->
+    <string name="morphe_hide_player_flyout_ambient_mode_title">Hide \'Ambient mode\' menu</string>
     <!-- 'Spoof video streams' should match the language used in 'morphe_spoof_video_streams_screen_title'.
-          'Android Studio' and 'Android VR Downgraded' must be kept untranslated. -->
+         'Android Studio' and 'Android VR Downgraded' must be kept untranslated. -->
     <string name="morphe_hide_player_flyout_audio_track_not_available">"\'Audio Track\' menu is hidden
 
 To show the \'Audio Track\' menu, change \'Spoof video streams\' to any client except \'Android Studio\' and \'Android VR Downgraded\'"</string>
+    <!-- 'Audio Track' should be translated using the same localized wording YouTube displays for the menu item. -->
+    <string name="morphe_hide_player_flyout_audio_track_title">Hide \'Audio Track\' menu</string>
     <string name="morphe_hide_player_flyout_audio_track_footer_title">Hide \'Audio Track\' menu footer</string>
     <!-- 'Captions' should be translated using the same localized wording YouTube displays for the menu item. -->
     <string name="morphe_hide_player_flyout_captions_title">Hide Captions menu</string>
     <string name="morphe_hide_player_flyout_captions_footer_title">Hide Captions menu footer</string>
     <string name="morphe_hide_player_flyout_captions_header_title">Hide Captions menu header</string>
-    <!-- 'Additional settings / More' should be translated using the same localized wording YouTube displays for the menu item. -->
-    <string name="morphe_hide_player_flyout_additional_settings_title">Hide \'Additional settings\' / More menu</string>
-    <!-- 'Sleep timer' should be translated using the same localized wording YouTube displays for the menu item. -->
-    <string name="morphe_hide_player_flyout_sleep_timer_title">Hide \'Sleep timer\' menu</string>
-    <!-- 'Loop video' should be translated using the same localized wording YouTube displays for the menu item. -->
-    <string name="morphe_hide_player_flyout_loop_video_title">Hide \'Loop video\' menu</string>
-    <!-- 'Ambient mode' should be translated using the same localized wording YouTube displays for the menu item. -->
-    <string name="morphe_hide_player_flyout_ambient_mode_title">Hide \'Ambient mode\' menu</string>
-    <!-- 'Stable volume' should be translated using the same localized wording YouTube displays for the menu item. -->
-    <string name="morphe_hide_player_flyout_stable_volume_title">Hide \'Stable volume\' menu</string>
     <!-- 'Help & feedback' should be translated using the same localized wording YouTube displays for the menu item. -->
     <string name="morphe_hide_player_flyout_help_title">Hide \'Help &amp; feedback\' menu</string>
-    <!-- 'Playback speed' should be translated using the same localized wording YouTube displays for the menu item. -->
-    <string name="morphe_hide_player_flyout_speed_title">Hide \'Playback speed\' menu</string>
-    <!-- 'Lock screen' should be translated using the same localized wording YouTube displays for the menu item. -->
-    <string name="morphe_hide_player_flyout_lock_screen_title">Hide \'Lock screen\' menu</string>
     <!-- 'Listen with YouTube Music' should be translated using the same localized wording YouTube displays for the menu item. -->
     <string name="morphe_hide_player_flyout_listen_with_youtube_music_title">Hide \'Listen with YouTube Music\' menu</string>
-    <!-- 'Watch in VR' should be translated using the same localized wording YouTube displays for the menu item. -->
-    <string name="morphe_hide_player_flyout_watch_in_vr_title">Hide \'Watch in VR\' menu</string>
+    <!-- 'Lock screen' should be translated using the same localized wording YouTube displays for the menu item. -->
+    <string name="morphe_hide_player_flyout_lock_screen_title">Hide \'Lock screen\' menu</string>
+    <!-- 'Loop video' should be translated using the same localized wording YouTube displays for the menu item. -->
+    <string name="morphe_hide_player_flyout_loop_video_title">Hide \'Loop video\' menu</string>
+    <!-- 'On-the-go' should be translated using the same localized wording YouTube displays for the menu item. -->
+    <string name="morphe_hide_player_flyout_on_the_go_title">Hide \'On-the-go\' menu</string>
     <!-- 'Quality' should be translated using the same localized wording YouTube displays for the menu item. -->
     <string name="morphe_hide_player_flyout_quality_title">Hide Quality menu</string>
     <string name="morphe_hide_player_flyout_quality_footer_title">Hide Quality menu footer</string>
     <string name="morphe_hide_player_flyout_quality_header_title">Hide Quality menu header</string>
+    <!-- 'Sleep timer' should be translated using the same localized wording YouTube displays for the menu item. -->
+    <string name="morphe_hide_player_flyout_sleep_timer_title">Hide \'Sleep timer\' menu</string>
+    <!-- 'Playback speed' should be translated using the same localized wording YouTube displays for the menu item. -->
+    <string name="morphe_hide_player_flyout_speed_title">Hide \'Playback speed\' menu</string>
+    <!-- 'Stable volume' should be translated using the same localized wording YouTube displays for the menu item. -->
+    <string name="morphe_hide_player_flyout_stable_volume_title">Hide \'Stable volume\' menu</string>
+    <!-- 'Watch in VR' should be translated using the same localized wording YouTube displays for the menu item. -->
+    <string name="morphe_hide_player_flyout_watch_in_vr_title">Hide \'Watch in VR\' menu</string>
 
     <!-- layout.hide.autoplaypreview.hideAutoplayPreviewPatch -->
     <string name="morphe_hide_autoplay_preview_title">Hide autoplay preview</string>


### PR DESCRIPTION
### Description

Closes #1899.

### Additional context

```
09-01 03:40:19.596 17824 17824 D morphe: LithoFilterPatch: Searching ID: overflow_menu_item.eml-fe|f4296c96b04a3f6d Path: overflow_menu_item.eml-fe|f4296c96b04a3f6d|ContainerType| BufferStrings: 0bottom_sheet_list_option.eml-fe|8d2b9e2f80a30f22*❙@ZD(❙On-the-go❙Premium",❙(yt_outline_experimental_headset_black_24(❙PApremium_upsell❙igkCCA8%3D ❙j3id.elements.components.overflow_menu_item_On-the-goJ❙On-the-go 2❙theme|53082eb88e99f463❙333?❙dismiss❙$KEN_BURNS_ANIMATION_TYPE_UNSPECIFIED❙capabilities|41ba94d9a84bce52❙theme|53082eb88e99f463❙capabilities|41ba94d9a84bce5❙theme|53082eb88e99f463❙capabilities|41ba94d9a84bce5❙3buenos_aires_player_overflow_bottom_sheet_list_item❙bottom_sheet_list_option_key❙
``` 

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
