### PR TITLE
feat(YouTube - Remove background playback restrictions): Add "Auto pause when device is locked" setting

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/BackgroundPlaybackPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/BackgroundPlaybackPatch.java
@@ -35,6 +35,13 @@ public class BackgroundPlaybackPatch {
     private static boolean receiverRegistered = false;
 
     /**
+     * Injection point. Called during app initialization via onCreateHook.
+     */
+    public static void initialize(VideoInformation.PlaybackController controller) {
+        initialize();
+    }
+
+    /**
      * Injection point. Called during app initialization.
      */
     public static void initialize() {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/BackgroundPlaybackPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/BackgroundPlaybackPatch.java
@@ -1,17 +1,105 @@
 package app.morphe.extension.youtube.patches;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.media.AudioDeviceInfo;
+import android.media.AudioManager;
+import android.os.Build;
+import android.os.SystemClock;
+import android.view.KeyEvent;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
 import app.morphe.extension.youtube.settings.Settings;
 import app.morphe.extension.youtube.shared.PlayerType;
 import app.morphe.extension.youtube.shared.ShortsPlayerState;
+import app.morphe.extension.youtube.shared.VideoState;
 
 @SuppressWarnings("unused")
 public class BackgroundPlaybackPatch {
+
+    public enum AutoPauseOnLockMode {
+        OFF,
+        ALWAYS,
+        EXCEPT_WIRELESS_AUDIO
+    }
 
     private static final boolean REMOVE_BACKGROUND_PLAYBACK_RESTRICTIONS
             = Settings.REMOVE_BACKGROUND_PLAYBACK_RESTRICTIONS.get();
 
     private static final boolean REMOVE_BACKGROUND_PLAYBACK_RESTRICTIONS_SHORTS
             = !Settings.DISABLE_SHORTS_BACKGROUND_PLAYBACK.get();
+
+    private static boolean receiverRegistered = false;
+
+    /**
+     * Injection point. Called during app initialization.
+     */
+    public static void initialize() {
+        Context ctx = Utils.getContext();
+        if (!receiverRegistered && ctx != null) {
+            try {
+                ctx.registerReceiver(new BroadcastReceiver() {
+                    @Override
+                    public void onReceive(Context c, Intent i) {
+                        if (i != null && Intent.ACTION_SCREEN_OFF.equals(i.getAction())) {
+                            handleScreenOff(c);
+                        }
+                    }
+                }, new IntentFilter(Intent.ACTION_SCREEN_OFF));
+                receiverRegistered = true;
+            } catch (Exception ex) {
+                Logger.printException(() -> "BackgroundPlaybackPatch: Failed to register receiver", ex);
+            }
+        }
+    }
+
+    private static void handleScreenOff(Context context) {
+        AutoPauseOnLockMode mode = Settings.AUTO_PAUSE_ON_LOCK.get();
+        if (mode == AutoPauseOnLockMode.OFF || VideoState.getCurrent() != VideoState.PLAYING) {
+            return;
+        }
+
+        if (mode == AutoPauseOnLockMode.EXCEPT_WIRELESS_AUDIO && isWirelessAudioConnected(context)) {
+            return;
+        }
+
+        AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+        if (am != null) {
+            long now = SystemClock.uptimeMillis();
+            am.dispatchMediaKeyEvent(new KeyEvent(now, now, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MEDIA_PAUSE, 0));
+            am.dispatchMediaKeyEvent(new KeyEvent(now, now, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MEDIA_PAUSE, 0));
+        }
+    }
+
+    private static boolean isWirelessAudioConnected(Context context) {
+        AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+        if (am == null) return false;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            AudioDeviceInfo[] devices = am.getDevices(AudioManager.GET_DEVICES_OUTPUTS);
+            if (devices != null) {
+                for (AudioDeviceInfo d : devices) {
+                    int t = d.getType();
+                    if (t == AudioDeviceInfo.TYPE_BLUETOOTH_A2DP
+                            || t == AudioDeviceInfo.TYPE_BLUETOOTH_SCO
+                            || t == AudioDeviceInfo.TYPE_HEARING_AID) {
+                        return true;
+                    }
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        if (t == AudioDeviceInfo.TYPE_BLE_HEADSET
+                                || t == AudioDeviceInfo.TYPE_BLE_SPEAKER
+                                || t == AudioDeviceInfo.TYPE_BLE_BROADCAST) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return am.isBluetoothA2dpOn() || am.isBluetoothScoOn();
+    }
 
     /**
      * Injection point.

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/BackgroundPlaybackPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/BackgroundPlaybackPatch.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2719
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.youtube.patches;
 
 import android.content.BroadcastReceiver;
@@ -32,34 +42,28 @@ public class BackgroundPlaybackPatch {
     private static final boolean REMOVE_BACKGROUND_PLAYBACK_RESTRICTIONS_SHORTS
             = !Settings.DISABLE_SHORTS_BACKGROUND_PLAYBACK.get();
 
-    private static boolean receiverRegistered = false;
+    private static boolean receiverRegistered;
 
     /**
      * Injection point. Called during app initialization via onCreateHook.
      */
     public static void initialize(VideoInformation.PlaybackController controller) {
-        initialize();
-    }
-
-    /**
-     * Injection point. Called during app initialization.
-     */
-    public static void initialize() {
-        Context ctx = Utils.getContext();
-        if (!receiverRegistered && ctx != null) {
-            try {
-                ctx.registerReceiver(new BroadcastReceiver() {
-                    @Override
-                    public void onReceive(Context c, Intent i) {
-                        if (i != null && Intent.ACTION_SCREEN_OFF.equals(i.getAction())) {
-                            handleScreenOff(c);
-                        }
+        if (receiverRegistered) {
+            return;
+        }
+        try {
+            Utils.getContext().registerReceiver(new BroadcastReceiver() {
+                @Override
+                public void onReceive(Context context, Intent intent) {
+                    if (intent != null && Intent.ACTION_SCREEN_OFF.equals(intent.getAction())) {
+                        handleScreenOff(context);
                     }
-                }, new IntentFilter(Intent.ACTION_SCREEN_OFF));
-                receiverRegistered = true;
-            } catch (Exception ex) {
-                Logger.printException(() -> "BackgroundPlaybackPatch: Failed to register receiver", ex);
-            }
+                }
+            }, new IntentFilter(Intent.ACTION_SCREEN_OFF));
+        } catch (Exception ex) {
+            Logger.printException(() -> "initialize failure", ex);
+        } finally {
+            receiverRegistered = true;
         }
     }
 
@@ -75,7 +79,7 @@ public class BackgroundPlaybackPatch {
 
         AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
         if (am != null) {
-            long now = SystemClock.uptimeMillis();
+            final long now = SystemClock.uptimeMillis();
             am.dispatchMediaKeyEvent(new KeyEvent(now, now, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MEDIA_PAUSE, 0));
             am.dispatchMediaKeyEvent(new KeyEvent(now, now, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MEDIA_PAUSE, 0));
         }
@@ -85,27 +89,25 @@ public class BackgroundPlaybackPatch {
         AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
         if (am == null) return false;
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            AudioDeviceInfo[] devices = am.getDevices(AudioManager.GET_DEVICES_OUTPUTS);
-            if (devices != null) {
-                for (AudioDeviceInfo d : devices) {
-                    int t = d.getType();
-                    if (t == AudioDeviceInfo.TYPE_BLUETOOTH_A2DP
-                            || t == AudioDeviceInfo.TYPE_BLUETOOTH_SCO
-                            || t == AudioDeviceInfo.TYPE_HEARING_AID) {
-                        return true;
-                    }
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                        if (t == AudioDeviceInfo.TYPE_BLE_HEADSET
-                                || t == AudioDeviceInfo.TYPE_BLE_SPEAKER
-                                || t == AudioDeviceInfo.TYPE_BLE_BROADCAST) {
-                            return true;
-                        }
-                    }
+        // noinspection WrongConstant // Suppress bogus IDE warning.
+        AudioDeviceInfo[] devices = am.getDevices(AudioManager.GET_DEVICES_OUTPUTS);
+        for (AudioDeviceInfo device : devices) {
+            final int type = device.getType();
+            if (type == AudioDeviceInfo.TYPE_BLUETOOTH_A2DP
+                    || type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO
+                    || type == AudioDeviceInfo.TYPE_HEARING_AID) {
+                return true;
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                if (type == AudioDeviceInfo.TYPE_BLE_HEADSET
+                        || type == AudioDeviceInfo.TYPE_BLE_SPEAKER
+                        || type == AudioDeviceInfo.TYPE_BLE_BROADCAST) {
+                    return true;
                 }
             }
         }
-        return am.isBluetoothA2dpOn() || am.isBluetoothScoOn();
+
+        return false;
     }
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -30,6 +30,7 @@ import app.morphe.extension.youtube.patches.AlternativeThumbnailsPatch.StillImag
 import app.morphe.extension.youtube.patches.AlternativeThumbnailsPatch.ThumbnailOption;
 import app.morphe.extension.youtube.patches.AlternativeThumbnailsPatch.ThumbnailStillTime;
 import app.morphe.extension.youtube.patches.AutoCaptionsPatch.AutoCaptionsStyle;
+import app.morphe.extension.youtube.patches.BackgroundPlaybackPatch.AutoPauseOnLockMode;
 import app.morphe.extension.youtube.patches.ChangeFormFactorPatch.FormFactor;
 import app.morphe.extension.youtube.patches.ChangeFormFactorPatch.TabletLayoutInPlayerAvailability;
 import app.morphe.extension.youtube.patches.ChangeHeaderPatch.HeaderLogo;
@@ -555,6 +556,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting DISABLE_SCROLLING_SPEED = new BooleanSetting("morphe_disable_scrolling_speed_limit", TRUE, true);
 
     public static final BooleanSetting REMOVE_BACKGROUND_PLAYBACK_RESTRICTIONS = new BooleanSetting("morphe_remove_background_playback_restrictions", TRUE, true);
+    public static final EnumSetting<AutoPauseOnLockMode> AUTO_PAUSE_ON_LOCK = new EnumSetting<>("morphe_auto_pause_on_screen_lock", AutoPauseOnLockMode.OFF);
     public static final BooleanSetting BYPASS_LINK_REDIRECTS = new BooleanSetting("morphe_bypass_link_redirects", TRUE);
     public static final BooleanSetting EXTERNAL_BROWSER = new BooleanSetting("morphe_external_browser", TRUE, true);
     public static final BooleanSetting SPOOF_DEVICE_DIMENSIONS = new BooleanSetting("morphe_spoof_device_dimensions", FALSE, true,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/backgroundplayback/BackgroundPlaybackPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/backgroundplayback/BackgroundPlaybackPatch.kt
@@ -18,6 +18,7 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.patches.shared.misc.fix.bitmap.fixRecycledBitmapPatch
+import app.morphe.patches.shared.misc.settings.preference.ListPreference
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.playertype.playerTypeHookPatch
@@ -31,6 +32,7 @@ import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.BackgroundPlaybackManagerShortsFingerprint
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
+import app.morphe.patches.youtube.video.information.onCreateHook
 import app.morphe.patches.youtube.video.information.videoInformationPatch
 import app.morphe.util.addInstructionsAtControlFlowLabel
 import app.morphe.util.findInstructionIndicesReversedOrThrow
@@ -67,8 +69,11 @@ val backgroundPlaybackPatch = bytecodePatch(
         )
 
         PreferenceScreen.MISC.addPreferences(
-            SwitchPreference("morphe_remove_background_playback_restrictions")
+            SwitchPreference("morphe_remove_background_playback_restrictions"),
+            ListPreference("morphe_auto_pause_on_screen_lock")
         )
+
+        onCreateHook(EXTENSION_CLASS, "initialize")
 
         arrayOf(
             BackgroundPlaybackManagerFingerprint to "isBackgroundPlaybackAllowed",

--- a/patches/src/main/resources/addresources/values/youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/youtube/arrays.xml
@@ -1,4 +1,16 @@
 <resources>
+    <!-- misc.backgroundplayback.backgroundPlaybackPatch -->
+    <string-array name="morphe_auto_pause_on_screen_lock_entries">
+        <item>@string/morphe_auto_pause_on_screen_lock_off</item>
+        <item>@string/morphe_auto_pause_on_screen_lock_always</item>
+        <item>@string/morphe_auto_pause_on_screen_lock_except_wireless</item>
+    </string-array>
+    <string-array name="morphe_auto_pause_on_screen_lock_entry_values" translatable="false">
+        <item>OFF</item>
+        <item>ALWAYS</item>
+        <item>EXCEPT_WIRELESS_AUDIO</item>
+    </string-array>
+
     <!-- layout.branding.customBrandingPatch -->
     <string-array name="morphe_custom_branding_name_entries">
         <!-- Original must be first. -->

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -35,6 +35,10 @@ Second \"item\" text"</string>
     <!-- misc.backgroundplayback.backgroundPlaybackPatch -->
     <string name="morphe_remove_background_playback_restrictions_title">Remove background play restrictions</string>
     <string name="morphe_shorts_disable_background_playback_title">Disable background play</string>
+    <string name="morphe_auto_pause_on_screen_lock_title">Auto pause when device is locked</string>
+    <string name="morphe_auto_pause_on_screen_lock_off">Off</string>
+    <string name="morphe_auto_pause_on_screen_lock_always">Always pause when locked</string>
+    <string name="morphe_auto_pause_on_screen_lock_except_wireless">Pause unless wireless audio is connected</string>
 
     <!-- layout.disableScrollSpeedLimitPatch -->
     <string name="morphe_disable_scrolling_speed_limit_title">Disable scrolling speed limit</string>


### PR DESCRIPTION
### Description

Adds an "Auto pause when device is locked" preference under Miscellaneous settings within the "Remove background playback restrictions" patch.

Users can choose between:
• Off: Normal background playback behavior.
• Always pause when locked: Automatically pauses video playback whenever the device screen is locked.
• Pause unless wireless audio is connected: Automatically pauses playback on screen lock unless a wireless audio device (Bluetooth A2DP/SCO, BLE Audio, or Hearing Aid) is connected.

A dynamic broadcast receiver listens for system screen-off events (`ACTION_SCREEN_OFF`) and dispatches a media pause key event via `AudioManager` when active playback is detected without a connected wireless audio device.

Closes #2000


### Test results

- [x] Tested on `21.04.223` (Other versions do not require testing as the implementation relies directly on standard Android framework APIs).
