### PR TITLE
feat(YouTube - Hide layout components): Add "Report AI channel" video menu entry

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AiSListFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/AiSListFilter.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2026 Morphe.
  * https://github.com/MorpheApp/morphe-patches/pull/1972
+ * https://github.com/MorpheApp/morphe-patches/pull/2763
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
@@ -28,9 +29,6 @@ import app.morphe.extension.youtube.shared.PlayerType;
 
 @SuppressWarnings({"unused", "unchecked"})
 public final class AiSListFilter extends BufferPhraseFilter {
-
-    /** Refresh the cached list from GitHub raw after this long since last successful fetch. */
-    private static final long REFRESH_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000L; // 4 hours.
 
     private volatile ByteTrieSearch blocklistSearch;
     private volatile ByteTrieSearch warnlistSearch;
@@ -81,7 +79,7 @@ public final class AiSListFilter extends BufferPhraseFilter {
 
         final long now = System.currentTimeMillis();
         final long lastCheck = lastRefreshCheckMs.get();
-        if (now - lastCheck > REFRESH_CHECK_INTERVAL_MS
+        if (now - lastCheck > AiSListRequester.REFRESH_CHECK_INTERVAL_MS
                 && lastRefreshCheckMs.compareAndSet(lastCheck, now)) {
             Utils.runOnBackgroundThread(AiSListRequester::fetchAndStore);
         }
@@ -97,6 +95,56 @@ public final class AiSListFilter extends BufferPhraseFilter {
         if (currentWarnlist != lastWarnlistParsed) {
             parseWarnlist(currentWarnlist);
         }
+    }
+
+    /** The list a channel is on. */
+    public enum ListedIn {
+        BLOCKLIST,
+        WARNLIST
+    }
+
+    /**
+     * @return The list the handle is on, or null if it is on neither.
+     *         The cached text is scanned directly because the search tries are only
+     *         built while a scope toggle is on.
+     */
+    @Nullable
+    public static ListedIn listContainingHandle(String handle) {
+        if (containsHandle(Settings.AISLIST_BLOCKLIST_CACHE.get(), handle)) {
+            return ListedIn.BLOCKLIST;
+        }
+        if (containsHandle(Settings.AISLIST_WARNLIST_CACHE.get(), handle)) {
+            return ListedIn.WARNLIST;
+        }
+        return null;
+    }
+
+    private static boolean containsHandle(String list, String handle) {
+        final int handleLength = handle.length();
+        final int listLength = list.length();
+
+        int lineStart = 0;
+        while (lineStart < listLength) {
+            int lineEnd = list.indexOf('\n', lineStart);
+            if (lineEnd < 0) {
+                lineEnd = listLength;
+            }
+
+            int end = lineEnd;
+            while (end > lineStart && Character.isWhitespace(list.charAt(end - 1))) {
+                end--;
+            }
+
+            // Handles are compared without case because YouTube resolves them that way.
+            if (end - lineStart == handleLength
+                    && list.regionMatches(true, lineStart, handle, 0, handleLength)) {
+                return true;
+            }
+
+            lineStart = lineEnd + 1;
+        }
+
+        return false;
     }
 
     private synchronized void parseBlocklist(String raw) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/AiSListSubmitDialog.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/AiSListSubmitDialog.java
@@ -16,6 +16,7 @@ import android.widget.LinearLayout;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.settings.preference.BulletPointPreference;
 import app.morphe.extension.shared.ui.CustomDialog;
 import app.morphe.extension.youtube.patches.components.AiSListFilter;
 import app.morphe.extension.youtube.patches.utils.requests.AiSListRequester;
@@ -79,9 +80,10 @@ public final class AiSListSubmitDialog {
         Pair<Dialog, LinearLayout> dialogPair = CustomDialog.create(
                 activity,
                 str("morphe_aislist_submit_title"),
-                str("morphe_aislist_submit_dialog_message", handle),
-                null,                                            // No EditText.
-                str("morphe_aislist_submit_dialog_confirm"),     // OK button text.
+                BulletPointPreference.formatIntoBulletPoints(
+                        str("morphe_aislist_submit_dialog_message", handle)),
+                null,                                    // No EditText.
+                str("morphe_aislist_submit_dialog_confirm"), // OK button text.
                 () -> submit(videoId, handle, username),         // OK button action.
                 () -> {},                                        // Cancel button action (dismiss only).
                 null,                                            // No Neutral button text.

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/AiSListSubmitDialog.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/AiSListSubmitDialog.java
@@ -17,6 +17,8 @@ import android.widget.LinearLayout;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.ui.CustomDialog;
+import app.morphe.extension.youtube.patches.components.AiSListFilter;
+import app.morphe.extension.youtube.patches.utils.requests.AiSListRequester;
 import app.morphe.extension.youtube.patches.utils.requests.AiSListSubmitRequest;
 import app.morphe.extension.youtube.settings.Settings;
 
@@ -45,14 +47,23 @@ public final class AiSListSubmitDialog {
 
             Utils.runOnBackgroundThread(() -> {
                 String handle = AiSListSubmitRequest.fetchChannelHandle(videoId);
+                if (handle == null) {
+                    Utils.showToastShort(str("morphe_aislist_submit_failed_channel"));
+                    return;
+                }
 
-                Utils.runOnMainThread(() -> {
-                    if (handle == null) {
-                        Utils.showToastShort(str("morphe_aislist_submit_failed_channel"));
-                        return;
-                    }
-                    showConfirmDialog(videoId, handle, username);
-                });
+                AiSListRequester.fetchIfStale();
+                AiSListFilter.ListedIn listedIn = AiSListFilter.listContainingHandle(handle);
+                if (listedIn != null) {
+                    // Each list names itself in a whole sentence, because a language that
+                    // inflects the list name cannot build one from a substituted noun.
+                    Utils.showToastShort(str(listedIn == AiSListFilter.ListedIn.BLOCKLIST
+                            ? "morphe_aislist_submit_already_blocklisted"
+                            : "morphe_aislist_submit_already_warnlisted"));
+                    return;
+                }
+
+                Utils.runOnMainThread(() -> showConfirmDialog(videoId, handle, username));
             });
         } catch (Exception ex) {
             Logger.printException(() -> "show failure", ex);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/AiSListSubmitDialog.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/AiSListSubmitDialog.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2763
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.youtube.patches.utils;
+
+import static app.morphe.extension.shared.StringRef.str;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.util.Pair;
+import android.widget.LinearLayout;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.ui.CustomDialog;
+import app.morphe.extension.youtube.patches.utils.requests.AiSListSubmitRequest;
+import app.morphe.extension.youtube.settings.Settings;
+
+/**
+ * Confirms and sends an AiSList submission for the channel that published a video.
+ */
+public final class AiSListSubmitDialog {
+
+    private AiSListSubmitDialog() {
+    }
+
+    /**
+     * Resolves the channel of the video, then asks for confirmation before submitting.
+     */
+    public static void show(String videoId) {
+        try {
+            String username = Settings.AISLIST_SUBMIT_USERNAME.get().trim();
+            if (username.isEmpty()) {
+                // The name appears on the public submitter leaderboard, so it is never
+                // filled in silently and the user sets it in the settings instead.
+                Utils.showToastLong(str("morphe_aislist_submit_no_username"));
+                return;
+            }
+
+            Utils.showToastShort(str("morphe_aislist_submit_resolving"));
+
+            Utils.runOnBackgroundThread(() -> {
+                String handle = AiSListSubmitRequest.fetchChannelHandle(videoId);
+
+                Utils.runOnMainThread(() -> {
+                    if (handle == null) {
+                        Utils.showToastShort(str("morphe_aislist_submit_failed_channel"));
+                        return;
+                    }
+                    showConfirmDialog(videoId, handle, username);
+                });
+            });
+        } catch (Exception ex) {
+            Logger.printException(() -> "show failure", ex);
+        }
+    }
+
+    private static void showConfirmDialog(String videoId, String handle, String username) {
+        Activity activity = Utils.getActivity();
+        if (activity == null) {
+            return;
+        }
+
+        Pair<Dialog, LinearLayout> dialogPair = CustomDialog.create(
+                activity,
+                str("morphe_aislist_submit_title"),
+                str("morphe_aislist_submit_dialog_message", handle),
+                null,                                            // No EditText.
+                str("morphe_aislist_submit_dialog_confirm"),     // OK button text.
+                () -> submit(videoId, handle, username),         // OK button action.
+                () -> {},                                        // Cancel button action (dismiss only).
+                null,                                            // No Neutral button text.
+                null,                                            // No Neutral button action.
+                false                                            // Do not dismiss dialog when onNeutralClick.
+        );
+
+        Utils.showDialog(activity, dialogPair.first, false, null);
+    }
+
+    private static void submit(String videoId, String handle, String username) {
+        Utils.runOnBackgroundThread(() -> {
+            String messageKey = AiSListSubmitRequest.submit(
+                    handle, "https://youtu.be/" + videoId, username);
+
+            Utils.showToastShort(str(messageKey));
+        });
+    }
+}

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
@@ -128,6 +128,13 @@ public final class FlyoutUtils {
                             : "yt_outline_experimental_clock_vd_theme_24"
             );
     private static final String saveToWatchLaterButtonName = str("morphe_save_to_watch_later_flyout_title");
+    private static final Drawable aiSListSubmitDrawable =
+            ResourceUtils.getDrawable(
+                    LegacyPlayerControlsPatch.RESTORE_OLD_PLAYER_BUTTONS
+                            ? "yt_outline_flag_black_24"
+                            : "yt_outline_experimental_flag_vd_theme_24"
+            );
+    private static final String aiSListSubmitButtonName = str("morphe_aislist_submit_title");
 
     private static WeakReference<TextView> customItemTextRef = new WeakReference<>(null);
 
@@ -305,9 +312,40 @@ public final class FlyoutUtils {
             );
         }
 
+        if (Settings.AISLIST_SUBMIT_FLYOUT_MENU.get()) {
+            String videoId = getSubmittableVideoId();
+            if (!videoId.isEmpty()) {
+                nextButtonIndex = addFlyoutButton(
+                        flyoutPanel,
+                        aiSListSubmitDrawable,
+                        aiSListSubmitButtonName,
+                        v -> {
+                            AiSListSubmitDialog.show(videoId);
+
+                            dismissFlyout();
+                        },
+                        nextButtonIndex
+                );
+            }
+        }
+
         if (nextButtonIndex > 0) {
             addDivider(flyoutPanel, nextButtonIndex);
         }
+    }
+
+    /**
+     * @return The video the flyout belongs to. The player menu has no feed item to read the id
+     *         from, so the video that is playing is used for it instead.
+     */
+    private static String getSubmittableVideoId() {
+        if (!flyoutVideoId.isEmpty()) {
+            return flyoutVideoId;
+        }
+        if (PlayerType.getCurrent().isMaximizedOrFullscreen()) {
+            return VideoInformation.getVideoId();
+        }
+        return "";
     }
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/FlyoutUtils.java
@@ -136,7 +136,7 @@ public final class FlyoutUtils {
             );
     private static final String aiSListSubmitButtonName = str("morphe_aislist_submit_title");
 
-    private static WeakReference<TextView> customItemTextRef = new WeakReference<>(null);
+    private static final List<WeakReference<TextView>> customItemTextRefs = new ArrayList<>();
 
     private static String currentButtonName = "";
     private static int currentButtonIndex;
@@ -281,6 +281,10 @@ public final class FlyoutUtils {
     private static void addFlyoutElements(Object flyoutPanel) {
         int nextButtonIndex = 0;
 
+        // The items of the menu that is closing are gone, and their typeface is copied
+        // onto whatever this call adds instead.
+        customItemTextRefs.clear();
+
         // TODO: Add playlists compatibility to Morphe's queue.
         if (Settings.QUEUE_ADD_FLYOUT_MENU.get() &&
                 flyoutPlaylistId.isEmpty() &&
@@ -405,16 +409,19 @@ public final class FlyoutUtils {
      * so the custom item only matches them by taking the typeface of a bound item.
      */
     private static void copyListItemTypeface(ViewGroup itemList) {
-        TextView customItemText = customItemTextRef.get();
-        if (customItemText == null || ITEM_TEXT_ID == 0) {
+        if (customItemTextRefs.isEmpty() || ITEM_TEXT_ID == 0) {
             return;
         }
 
         if (itemList.getChildAt(0).findViewById(ITEM_TEXT_ID) instanceof TextView itemText) {
-            // setTypeface always requests a layout, so only call it when the font really differs.
             Typeface itemTypeface = itemText.getTypeface();
-            if (customItemText.getTypeface() != itemTypeface) {
-                customItemText.setTypeface(itemTypeface);
+
+            for (WeakReference<TextView> customItemTextRef : customItemTextRefs) {
+                TextView customItemText = customItemTextRef.get();
+                // setTypeface always requests a layout, so only call it when the font really differs.
+                if (customItemText != null && customItemText.getTypeface() != itemTypeface) {
+                    customItemText.setTypeface(itemTypeface);
+                }
             }
         }
     }
@@ -648,7 +655,7 @@ public final class FlyoutUtils {
         TextView textView = customButton.findViewById(ITEM_TEXT_ID);
         if (textView != null) {
             textView.setText(text);
-            customItemTextRef = new WeakReference<>(textView);
+            customItemTextRefs.add(new WeakReference<>(textView));
         }
 
         ImageView iconView = customButton.findViewById(

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/AiSListRequester.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/AiSListRequester.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2026 Morphe.
  * https://github.com/MorpheApp/morphe-patches/pull/1972
+ * https://github.com/MorpheApp/morphe-patches/pull/2763
  *
  * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
  */
@@ -33,11 +34,33 @@ public final class AiSListRequester {
     private static final String WARNLIST_URL =
             "https://raw.githubusercontent.com/Override92/AiSList/main/AiSList/aislist_warnlist.txt";
 
+    /** Refresh the cached list from GitHub raw after this long since last successful fetch. */
+    public static final long REFRESH_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000L; // 4 hours.
+
     private static final int CONNECT_TIMEOUT_MS = 30_000;
     private static final int READ_TIMEOUT_MS = 30_000;
     private static final int MAX_RESPONSE_BYTES = 5 * 1024 * 1024; // 5 MB safety cap.
 
     private AiSListRequester() {}
+
+    /**
+     * Makes the lists available to a caller that does not run the filters, which are what
+     * normally keep them fresh. Must be called off the main thread.
+     *
+     * <p>Waits for the fetch only when nothing is cached, because there is otherwise
+     * something usable to answer with right away.
+     */
+    public static void fetchIfStale() {
+        Utils.verifyOffMainThread();
+
+        if (Settings.AISLIST_BLOCKLIST_CACHE.get().isEmpty()
+                && Settings.AISLIST_WARNLIST_CACHE.get().isEmpty()) {
+            fetchAndStore();
+        } else if (System.currentTimeMillis() - Settings.AISLIST_LAST_FETCH_MS.get()
+                > REFRESH_CHECK_INTERVAL_MS) {
+            Utils.runOnBackgroundThread(AiSListRequester::fetchAndStore);
+        }
+    }
 
     /**
      * Fetches both lists sequentially. Must be called off the main thread.

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/AiSListSubmitRequest.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/utils/requests/AiSListSubmitRequest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2763
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to this code.
+ */
+
+package app.morphe.extension.youtube.patches.utils.requests;
+
+import androidx.annotation.Nullable;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.requests.Requester;
+
+/**
+ * Submits a channel to the AiSList community list, which the AI channel filter reads back
+ * from its published blocklist and warnlist.
+ */
+public final class AiSListSubmitRequest {
+
+    /**
+     * The Android client player response has no microformat, so the web client is used
+     * because it is the only one returning the owner profile url with the channel handle.
+     */
+    private static final String PLAYER_URL = "https://www.youtube.com/youtubei/v1/player"
+            + "?prettyPrint=false&fields=microformat.playerMicroformatRenderer.ownerProfileUrl";
+    private static final String WEB_CLIENT_VERSION = "2.20250101.00.00";
+
+    private static final String SUBMIT_URL = "https://api.aisloplist.com";
+
+    private static final int TIMEOUT_MS = 10 * 1000;
+    private static final int HTTP_TOO_MANY_REQUESTS = 429;
+
+    /**
+     * Longest handle the API accepts, including the leading '@'.
+     */
+    private static final int MAX_HANDLE_LENGTH = 31;
+
+    private static final String SUBMIT_FAILED_KEY = "morphe_aislist_submit_failed";
+
+    private AiSListSubmitRequest() {
+    }
+
+    private static String createPlayerBody(String videoId) throws JSONException {
+        JSONObject client = new JSONObject();
+        client.put("clientName", "WEB");
+        client.put("clientVersion", WEB_CLIENT_VERSION);
+        Locale locale = Locale.getDefault();
+        client.put("hl", locale.getLanguage());
+        client.put("gl", locale.getCountry());
+
+        JSONObject context = new JSONObject();
+        context.put("client", client);
+
+        JSONObject body = new JSONObject();
+        body.put("context", context);
+        body.put("contentCheckOk", true);
+        body.put("racyCheckOk", true);
+        body.put("videoId", videoId);
+
+        return body.toString();
+    }
+
+    /**
+     * @return The '@handle' of the channel that published the video, or null if it cannot be found.
+     */
+    @Nullable
+    public static String fetchChannelHandle(String videoId) {
+        Utils.verifyOffMainThread();
+
+        HttpURLConnection connection = null;
+        try {
+            connection = openPostConnection(PLAYER_URL);
+            connection.setRequestProperty("X-YouTube-Client-Name", "1");
+            connection.setRequestProperty("X-YouTube-Client-Version", WEB_CLIENT_VERSION);
+            writeBody(connection, createPlayerBody(videoId));
+
+            final int responseCode = connection.getResponseCode();
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                Logger.printDebug(() -> "Channel handle request failed with code: " + responseCode);
+                return null;
+            }
+
+            JSONObject json = Requester.parseJSONObject(connection);
+            String profileUrl = json.getJSONObject("microformat")
+                    .getJSONObject("playerMicroformatRenderer")
+                    .getString("ownerProfileUrl");
+
+            final int handleIndex = profileUrl.indexOf('@');
+            if (handleIndex < 0) {
+                Logger.printDebug(() -> "Owner profile url has no handle: " + profileUrl);
+                return null;
+            }
+            String handle = profileUrl.substring(handleIndex);
+
+            return isValidHandle(handle) ? handle : null;
+        } catch (Exception ex) {
+            Logger.printInfo(() -> "fetchChannelHandle failed for video: " + videoId, ex);
+            return null;
+        } finally {
+            if (connection != null) connection.disconnect();
+        }
+    }
+
+    /**
+     * Sends the submission. The channel is added to a list only after the maintainers review it.
+     *
+     * @return The string key of the message to show for the outcome.
+     */
+    public static String submit(String handle, String videoUrl, String username) {
+        Utils.verifyOffMainThread();
+
+        HttpURLConnection connection = null;
+        try {
+            JSONObject body = new JSONObject();
+            body.put("channel_handle", handle);
+            body.put("video_url", videoUrl);
+            body.put("username", username);
+
+            connection = openPostConnection(SUBMIT_URL);
+            writeBody(connection, body.toString());
+
+            final int responseCode = connection.getResponseCode();
+            if (responseCode == HttpURLConnection.HTTP_OK) {
+                return "morphe_aislist_submit_success";
+            }
+
+            String error = readErrorResponse(connection);
+            Logger.printDebug(() -> "Submit failed with code: " + responseCode
+                    + " response: " + error);
+
+            return switch (responseCode) {
+                case HttpURLConnection.HTTP_CONFLICT -> "morphe_aislist_submit_failed_conflict";
+                case HTTP_TOO_MANY_REQUESTS -> "morphe_aislist_submit_failed_rate_limit";
+                case HttpURLConnection.HTTP_BAD_REQUEST -> "morphe_aislist_submit_failed_rejected";
+                default -> SUBMIT_FAILED_KEY;
+            };
+        } catch (Exception ex) {
+            Logger.printInfo(() -> "submit failed for channel: " + handle, ex);
+            return SUBMIT_FAILED_KEY;
+        } finally {
+            if (connection != null) connection.disconnect();
+        }
+    }
+
+    /**
+     * Mirrors the field rules of the API, which no longer rejects malformed handles itself.
+     */
+    private static boolean isValidHandle(String handle) {
+        if (handle.length() < 4 || handle.length() > MAX_HANDLE_LENGTH) {
+            return false;
+        }
+
+        for (int i = 1, length = handle.length(); i < length; i++) {
+            final char c = handle.charAt(i);
+            if (!Character.isLetterOrDigit(c) && c != '_' && c != '-' && c != '.') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static HttpURLConnection openPostConnection(String url) throws Exception {
+        HttpURLConnection connection = Requester.openConnection(url);
+        connection.setRequestMethod("POST");
+        connection.setRequestProperty("Content-Type", "application/json");
+        connection.setUseCaches(false);
+        connection.setDoOutput(true);
+        connection.setConnectTimeout(TIMEOUT_MS);
+        connection.setReadTimeout(TIMEOUT_MS);
+        return connection;
+    }
+
+    private static void writeBody(HttpURLConnection connection, String body) throws Exception {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        connection.setFixedLengthStreamingMode(bytes.length);
+        connection.getOutputStream().write(bytes);
+    }
+
+    /**
+     * The API describes its errors in a plain text body, which is only used for logging.
+     */
+    private static String readErrorResponse(HttpURLConnection connection) {
+        try {
+            return Requester.parseErrorString(connection);
+        } catch (Exception ex) {
+            return "";
+        }
+    }
+}

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -158,6 +158,8 @@ public class Settings extends SharedYouTubeSettings {
     public static final LongSetting AISLIST_HIDE_COUNT_HOME = new LongSetting("morphe_aislist_hide_count_home", 0L);
     public static final LongSetting AISLIST_HIDE_COUNT_SEARCH = new LongSetting("morphe_aislist_hide_count_search", 0L);
     public static final StringSetting AISLIST_HIDES_24H = new StringSetting("morphe_aislist_hides_24h", "", false, false);
+    public static final BooleanSetting AISLIST_SUBMIT_FLYOUT_MENU = new BooleanSetting("morphe_aislist_submit_flyout_menu", FALSE);
+    public static final StringSetting AISLIST_SUBMIT_USERNAME = new StringSetting("morphe_aislist_submit_username", "", parent(AISLIST_SUBMIT_FLYOUT_MENU));
 
     // Alternative thumbnails
     public static final EnumSetting<ThumbnailOption> ALT_THUMBNAIL_HOME = new EnumSetting<>("morphe_alt_thumbnail_home", ThumbnailOption.ORIGINAL);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -304,6 +304,17 @@ val hideLayoutComponentsPatch = bytecodePatch(
                         )
                     ),
                     PreferenceCategory(
+                        key = "morphe_aislist_submit_category",
+                        sorting = Sorting.UNSORTED,
+                        preferences = setOf(
+                            SwitchPreference("morphe_aislist_submit_flyout_menu", summary = true),
+                            TextPreference(
+                                key = "morphe_aislist_submit_username",
+                                inputType = InputType.TEXT
+                            )
+                        )
+                    ),
+                    PreferenceCategory(
                         key = "morphe_hide_aislist_stats_category",
                         titleKey = "morphe_hide_stats_category_title",
                         sorting = Sorting.UNSORTED,

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -346,6 +346,30 @@ Limitations:
     <string name="morphe_hide_aislist_attribution_summary">"Data is provided by AiSList
 
 Tap here to open AiSlopList.com and see downloads for other platforms"</string>
+    <string name="morphe_aislist_submit_category_title">Report AI channels</string>
+    <string name="morphe_aislist_submit_flyout_menu_title">Add report entry to video menu</string>
+    <string name="morphe_aislist_submit_flyout_menu_summary">Add an entry to the video menu that reports the channel of a video to AiSList</string>
+    <string name="morphe_aislist_submit_username_title">Submitter name</string>
+    <string name="morphe_aislist_submit_username_summary">Name shown next to your reports on the public AiSList leaderboard. Reporting is unavailable while this is empty</string>
+    <string name="morphe_aislist_submit_title">Report AI channel</string>
+    <string name="morphe_aislist_submit_dialog_message">"Submit %s to AiSList, using this video as evidence?
+
+Only report channels that:
+• Use AI voices, visuals, scripts or music as their main content
+• Mass produce content with AI tools and little human work
+
+Do not report channels that only discuss AI, or use AI for some parts of their videos.
+
+Reports are public and are reviewed before a channel is added to a list. Removal is only possible through a request on GitHub"</string>
+    <string name="morphe_aislist_submit_dialog_confirm">Report</string>
+    <string name="morphe_aislist_submit_no_username">Set a submitter name in the AI channel filter settings to report channels</string>
+    <string name="morphe_aislist_submit_resolving">Looking up the channel…</string>
+    <string name="morphe_aislist_submit_failed_channel">Cannot find the channel of this video</string>
+    <string name="morphe_aislist_submit_success">Channel reported and awaiting review</string>
+    <string name="morphe_aislist_submit_failed_conflict">AiSList could not save the report, try again later</string>
+    <string name="morphe_aislist_submit_failed_rate_limit">Too many reports were sent, try again later</string>
+    <string name="morphe_aislist_submit_failed_rejected">AiSList rejected the report</string>
+    <string name="morphe_aislist_submit_failed">Report failed, check your connection</string>
 
     <!-- ad.hideAdsPatch -->
     <string name="morphe_hide_creator_store_shelf_title">Hide creator store shelf</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -361,6 +361,8 @@ Only report channels that:
 Do not report channels that only discuss AI, or use AI for some parts of their videos.
 
 Reports are public and are reviewed before a channel is added to a list. Removal is only possible through a request on GitHub"</string>
+    <string name="morphe_aislist_submit_already_blocklisted">This channel is already on the AiSList blocklist</string>
+    <string name="morphe_aislist_submit_already_warnlisted">This channel is already on the AiSList warnlist</string>
     <string name="morphe_aislist_submit_dialog_confirm">Report</string>
     <string name="morphe_aislist_submit_no_username">Set a submitter name in the AI channel filter settings to report channels</string>
     <string name="morphe_aislist_submit_resolving">Looking up the channel…</string>


### PR DESCRIPTION
### Description

Adds a "Report AI channel" entry to the video menu that submits the channel of a video to the AiSList community list, so users can grow the list the AI channel filter reads instead of only consuming it. The channel handle is resolved from the video id, and a confirmation dialog states the list's criteria before anything is sent.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
___
![Screenshot_2026-09-04-11-25-25-269_com.google.android.youtube.test-edit.jpg](https://github.com/user-attachments/assets/95c89ba3-e28f-4794-8653-325fd1bd7c5e)

