### PR TITLE
feat(YouTube - Hide player overlay buttons): Add option to change the player control buttons background opacity

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/CustomPlayerOverlayOpacityPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/CustomPlayerOverlayOpacityPatch.java
@@ -1,27 +1,25 @@
-package app.morphe.extension.youtube.patches;
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2764
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
 
-import static app.morphe.extension.shared.StringRef.str;
+package app.morphe.extension.youtube.patches;
 
 import android.widget.ImageView;
 
-import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.settings.preference.SeekBarPreference;
 import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
 public class CustomPlayerOverlayOpacityPatch {
 
-    private static final int PLAYER_OVERLAY_OPACITY_LEVEL;
-
-    static {
-        int opacity = Settings.PLAYER_OVERLAY_OPACITY.get();
-
-        if (opacity < 0 || opacity > 100) {
-            Utils.showToastLong(str("morphe_player_overlay_opacity_invalid_toast"));
-            opacity = Settings.PLAYER_OVERLAY_OPACITY.resetToDefault();
-        }
-
-        PLAYER_OVERLAY_OPACITY_LEVEL = (opacity * 255) / 100;
-    }
+    private static final int PLAYER_OVERLAY_OPACITY_LEVEL =
+            (SeekBarPreference.clampToRange(Settings.PLAYER_OVERLAY_OPACITY) * 255) / 100;
 
     /**
      * Injection point.

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/CustomPlayerOverlayOpacityPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/CustomPlayerOverlayOpacityPatch.java
@@ -10,8 +10,13 @@
 
 package app.morphe.extension.youtube.patches;
 
+import android.graphics.drawable.Drawable;
+import android.view.View;
 import android.widget.ImageView;
 
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.ResourceType;
+import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.settings.preference.SeekBarPreference;
 import app.morphe.extension.youtube.settings.Settings;
 
@@ -24,7 +29,35 @@ public class CustomPlayerOverlayOpacityPatch {
     /**
      * Injection point.
      */
-    public static void changeOpacity(ImageView imageView) {
-        imageView.setImageAlpha(PLAYER_OVERLAY_OPACITY_LEVEL);
+    public static void changeOpacity(ImageView scrimOverlay) {
+        scrimOverlay.setImageAlpha(PLAYER_OVERLAY_OPACITY_LEVEL);
+
+        if (PLAYER_OVERLAY_OPACITY_LEVEL == 255) return;
+
+        // The new player layout leaves the full screen scrim unused and dims with a top and
+        // bottom gradient instead, so the same opacity is applied to those siblings.
+        if (scrimOverlay.getParent() instanceof View parent) {
+            changeGradientOpacity(parent, "top_gradient_scrim_overlay");
+            changeGradientOpacity(parent, "bottom_gradient_scrim_overlay");
+        }
+    }
+
+    private static void changeGradientOpacity(View parent, String resourceName) {
+        final int id = ResourceUtils.getIdentifier(ResourceType.ID, resourceName);
+        if (id == 0) return;
+
+        View gradient = parent.findViewById(id);
+        if (gradient == null) {
+            Logger.printDebug(() -> "Could not find player scrim: R.id." + resourceName);
+            return;
+        }
+
+        // The gradients are set as a background rather than an image, so setImageAlpha
+        // does nothing for them.
+        Drawable background = gradient.getBackground();
+        if (background != null) {
+            // Mutate so the alpha does not leak into the same drawable used elsewhere.
+            background.mutate().setAlpha(PLAYER_OVERLAY_OPACITY_LEVEL);
+        }
     }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/HidePlayerOverlayButtonsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/HidePlayerOverlayButtonsPatch.java
@@ -7,15 +7,24 @@
 
 package app.morphe.extension.youtube.patches;
 
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.DrawableWrapper;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.LayerDrawable;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 
+import java.util.function.Consumer;
+
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.settings.preference.SeekBarPreference;
 import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
@@ -25,6 +34,14 @@ public final class HidePlayerOverlayButtonsPatch {
 
     private static final boolean HIDE_AUTOPLAY_BUTTON_ENABLED = Settings.HIDE_AUTOPLAY_BUTTON.get();
     private static final Boolean HIDE_FULLSCREEN_BUTTON_ENABLED = Settings.HIDE_FULLSCREEN_BUTTON.get();
+
+    private static final int CONTROL_BUTTONS_BACKGROUND_OPACITY =
+            SeekBarPreference.clampToRange(Settings.PLAYER_CONTROL_BUTTONS_BACKGROUND_OPACITY);
+
+    /** At the app default the drawables are left untouched, so the stock look stays exact. */
+    private static final boolean CONTROL_BUTTONS_BACKGROUND_OPACITY_CHANGED =
+            CONTROL_BUTTONS_BACKGROUND_OPACITY
+                    != Settings.PLAYER_CONTROL_BUTTONS_BACKGROUND_OPACITY.defaultValue;
 
     /**
      * Injection point.
@@ -160,19 +177,68 @@ public final class HidePlayerOverlayButtonsPatch {
     /**
      * Injection point.
      */
-    public static View hidePlayerControlButtonsBackground(View rootView) {
+    public static View styleControlButtonsBackground(View rootView) {
         try {
-            if (!Settings.HIDE_PLAYER_CONTROL_BUTTONS_BACKGROUND.get()) {
-                return rootView;
-            }
-
             // Each button is an ImageView with a background set to another drawable.
-            removeImageViewsBackgroundRecursive(rootView);
+            if (Settings.HIDE_PLAYER_CONTROL_BUTTONS_BACKGROUND.get()) {
+                forEachImageViewRecursive(rootView, imageView -> imageView.setBackground(null));
+            } else if (CONTROL_BUTTONS_BACKGROUND_OPACITY_CHANGED) {
+                forEachImageViewRecursive(rootView, imageView -> {
+                    Drawable background = imageView.getBackground();
+                    if (background != null) {
+                        imageView.setBackground(applyControlButtonsBackgroundOpacity(background));
+                    }
+                });
+            }
         } catch (Exception ex) {
-            Logger.printException(() -> "removePlayerControlButtonsBackground failure", ex);
+            Logger.printException(() -> "styleControlButtonsBackground failure", ex);
         }
 
         return rootView;
+    }
+
+    /**
+     * Also used for the bottom overlay buttons, which copy their background from the
+     * fullscreen button instead of declaring one in a layout.
+     *
+     * @return the drawable to use, unchanged if the opacity is left at the app default.
+     */
+    public static Drawable applyControlButtonsBackgroundOpacity(Drawable background) {
+        if (CONTROL_BUTTONS_BACKGROUND_OPACITY_CHANGED
+                && !Settings.HIDE_PLAYER_CONTROL_BUTTONS_BACKGROUND.get()) {
+            // Mutate so the color does not leak into the same drawable used elsewhere.
+            background = background.mutate();
+            setSolidColorOpacityRecursive(background);
+        }
+
+        return background;
+    }
+
+    /**
+     * The circle's transparency is baked into its solid color, so the color is replaced.
+     * setAlpha() only scales what is already there and can never exceed the app default.
+     */
+    private static void setSolidColorOpacityRecursive(Drawable drawable) {
+        if (drawable instanceof GradientDrawable gradient) {
+            ColorStateList color = gradient.getColor();
+            if (color != null) {
+                final int rgb = color.getDefaultColor();
+                // Replacing the alpha rather than scaling it keeps this safe to apply twice.
+                gradient.setColor(Color.argb(
+                        CONTROL_BUTTONS_BACKGROUND_OPACITY * 255 / 100,
+                        Color.red(rgb),
+                        Color.green(rgb),
+                        Color.blue(rgb)));
+            }
+        } else if (drawable instanceof LayerDrawable layers) {
+            for (int i = 0, count = layers.getNumberOfLayers(); i < count; i++) {
+                setSolidColorOpacityRecursive(layers.getDrawable(i));
+            }
+        } else if (drawable instanceof DrawableWrapper wrapper) {
+            // The bottom buttons get the circle wrapped in an InsetDrawable, which is not a
+            // LayerDrawable and would otherwise be skipped.
+            setSolidColorOpacityRecursive(wrapper.getDrawable());
+        }
     }
 
     private static void hideView(View parentView, String name) {
@@ -193,14 +259,14 @@ public final class HidePlayerOverlayButtonsPatch {
         });
     }
 
-    private static void removeImageViewsBackgroundRecursive(View currentView) {
+    private static void forEachImageViewRecursive(View currentView, Consumer<ImageView> action) {
         if (currentView instanceof ImageView imageView) {
-            imageView.setBackground(null);
+            action.accept(imageView);
         }
 
         if (currentView instanceof ViewGroup viewGroup) {
             for (int i = 0; i < viewGroup.getChildCount(); i++) {
-                removeImageViewsBackgroundRecursive(viewGroup.getChildAt(i));
+                forEachImageViewRecursive(viewGroup.getChildAt(i), action);
             }
         }
     }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MiniplayerPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/MiniplayerPatch.java
@@ -34,6 +34,7 @@ import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.settings.Setting;
+import app.morphe.extension.shared.settings.preference.SeekBarPreference;
 import app.morphe.extension.shared.ui.Dim;
 import app.morphe.extension.youtube.settings.Settings;
 
@@ -153,18 +154,8 @@ public final class MiniplayerPatch {
             "yt_outline_replay_arrow_vd_theme_24"
     );
 
-    private static final int OPACITY_LEVEL;
-
-    static {
-        int opacity = Settings.MINIPLAYER_OPACITY.get();
-
-        if (opacity < 0 || opacity > 100) {
-            Utils.showToastLong(str("morphe_miniplayer_opacity_invalid_toast"));
-            opacity = Settings.MINIPLAYER_OPACITY.resetToDefault();
-        }
-
-        OPACITY_LEVEL = (opacity * 255) / 100;
-    }
+    private static final int OPACITY_LEVEL =
+            (SeekBarPreference.clampToRange(Settings.MINIPLAYER_OPACITY) * 255) / 100;
 
     public static final class MiniplayerHorizontalDragAvailability implements Setting.Availability {
         @Override

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/theme/ThemePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/theme/ThemePatch.java
@@ -142,7 +142,7 @@ public class ThemePatch extends BaseThemePatch {
                 spinner.setPopupBackgroundDrawable(new ColorDrawable(backgroundColor));
             }
         } catch (Exception ex) {
-            Logger.printException(() -> "Overriding spinner popup background failed", ex);
+            Logger.printException(() -> "overrideSpinnerPopupBackground failure", ex);
         }
     }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -256,6 +256,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_COLLAPSE_BUTTON = new BooleanSetting("morphe_hide_collapse_button", FALSE, true);
     public static final BooleanSetting HIDE_FULLSCREEN_BUTTON = new BooleanSetting("morphe_hide_fullscreen_button", FALSE, true);
     public static final BooleanSetting HIDE_PLAYER_CONTROL_BUTTONS_BACKGROUND = new BooleanSetting("morphe_hide_player_control_buttons_background", FALSE, true);
+    public static final IntegerSetting PLAYER_CONTROL_BUTTONS_BACKGROUND_OPACITY = new IntegerSetting("morphe_player_control_buttons_background_opacity", 30, true, parentNot(HIDE_PLAYER_CONTROL_BUTTONS_BACKGROUND));
     public static final BooleanSetting HIDE_PLAYER_PREVIOUS_NEXT_BUTTONS = new BooleanSetting("morphe_hide_player_previous_next_buttons", FALSE, true);
     public static final BooleanSetting LOOP_VIDEO_BUTTON = new BooleanSetting("morphe_loop_video_button", FALSE, true);
     public static final BooleanSetting LOOP_VIDEO = new BooleanSetting("morphe_loop_video", FALSE);
@@ -892,6 +893,8 @@ public class Settings extends SharedYouTubeSettings {
         SeekBarPreference.register(new SeekBarConfig(MINIPLAYER_OPACITY,
                 0, 100, 1, "%"));
         SeekBarPreference.register(new SeekBarConfig(PLAYER_OVERLAY_OPACITY,
+                0, 100, 1, "%"));
+        SeekBarPreference.register(new SeekBarConfig(PLAYER_CONTROL_BUTTONS_BACKGROUND_OPACITY,
                 0, 100, 1, "%"));
         SeekBarPreference.register(new SeekBarConfig(SWIPE_VOLUME_SENSITIVITY,
                 1, 10, 1, ""));

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/SwipeControlsConfigurationProvider.kt
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/swipecontrols/SwipeControlsConfigurationProvider.kt
@@ -17,6 +17,7 @@ import app.morphe.extension.shared.StringRef.str
 import app.morphe.extension.shared.Utils
 import app.morphe.extension.shared.settings.Setting
 import app.morphe.extension.shared.settings.StringSetting
+import app.morphe.extension.shared.settings.preference.SeekBarPreference
 import app.morphe.extension.youtube.settings.Settings
 import app.morphe.extension.youtube.shared.PlayerType
 import app.morphe.extension.youtube.swipecontrols.controller.gesture.ClassicSwipeController
@@ -259,18 +260,10 @@ class SwipeControlsConfigurationProvider {
 
     /**
      * The background opacity of the overlay, converted from a percentage (0-100) to an alpha value (0-255).
-     * Resets to default and shows a toast if the value is out of range.
      */
     val overlayBackgroundOpacity: Int
         get() {
-            var opacity = Settings.SWIPE_OVERLAY_OPACITY.get()
-
-            if (opacity !in 0..100) {
-                Utils.showToastLong(str("morphe_swipe_overlay_background_opacity_invalid_toast"))
-                opacity = Settings.SWIPE_OVERLAY_OPACITY.resetToDefault()
-            }
-
-            opacity = opacity * 255 / 100
+            val opacity = SeekBarPreference.clampToRange(Settings.SWIPE_OVERLAY_OPACITY) * 255 / 100
             return Color.argb(opacity, 0, 0, 0)
         }
 
@@ -321,17 +314,9 @@ class SwipeControlsConfigurationProvider {
 
     /**
      * The text size in the overlay, in density-independent pixels (dp).
-     * Must be between 1 and 30 dp; resets to default and shows a toast if invalid.
      */
     val overlayTextSize: Int
-        get() {
-            val size = Settings.SWIPE_OVERLAY_TEXT_SIZE.get()
-            if (size !in 1..30) {
-                Utils.showToastLong(str("morphe_swipe_text_overlay_size_invalid_toast"))
-                return Settings.SWIPE_OVERLAY_TEXT_SIZE.resetToDefault()
-            }
-            return size
-        }
+        get() = SeekBarPreference.clampToRange(Settings.SWIPE_OVERLAY_TEXT_SIZE)
 
     /**
      * Defines the style of the swipe controls overlay, determining its layout and appearance.

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlayerOverlayButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/PlayerOverlayButton.java
@@ -8,8 +8,15 @@
 package app.morphe.extension.youtube.videoplayer;
 
 import android.content.res.Configuration;
+import android.graphics.Bitmap;
+import android.graphics.BlurMaskFilter;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.DrawableWrapper;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
@@ -17,6 +24,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.lang.ref.WeakReference;
@@ -35,6 +43,112 @@ import app.morphe.extension.youtube.settings.Settings;
 public class PlayerOverlayButton {
 
     public static final int BUTTON_WIDTH = (int) ResourceUtils.getDimension("controls_overlay_action_button_size");
+
+    private static final int ICON_SHADOW_OFFSET_X;
+    private static final int ICON_SHADOW_OFFSET_Y;
+    private static final int ICON_SHADOW_BLUR_RADIUS;
+    private static final int ICON_SHADOW_COLOR;
+
+    static {
+        int offsetX = 0, offsetY = 0, blurRadius = 0, color = Color.TRANSPARENT;
+        try {
+            // The app has both integer and dimension versions of these. The player controls read
+            // the integers as raw pixels, while only the miniplayer reads the dimensions.
+            offsetX = ResourceUtils.getInteger("shadow_icon_offset_x");
+            offsetY = ResourceUtils.getInteger("shadow_icon_offset_y");
+            blurRadius = ResourceUtils.getInteger("shadow_icon_size");
+            color = Color.argb(ResourceUtils.getInteger("shadow_icon_alpha"), 0, 0, 0);
+        } catch (Exception ex) {
+            Logger.printException(() -> "Could not resolve player icon shadow resources", ex);
+        }
+        ICON_SHADOW_OFFSET_X = offsetX;
+        ICON_SHADOW_OFFSET_Y = offsetY;
+        ICON_SHADOW_BLUR_RADIUS = blurRadius;
+        ICON_SHADOW_COLOR = color;
+    }
+
+    /**
+     * The app's own player icons carry a soft drop shadow, which is what keeps a white icon
+     * readable over bright video once the circle behind it is made transparent.
+     */
+    private static final class ShadowedIconDrawable extends DrawableWrapper {
+        @Nullable
+        private Bitmap shadow;
+
+        ShadowedIconDrawable(Drawable icon) {
+            super(icon);
+        }
+
+        @Override
+        protected void onBoundsChange(@NonNull Rect bounds) {
+            super.onBoundsChange(bounds);
+            shadow = null;
+        }
+
+        @Override
+        public void draw(@NonNull Canvas canvas) {
+            if (shadow == null) {
+                buildShadow();
+            }
+            if (shadow != null) {
+                Rect bounds = getBounds();
+                canvas.drawBitmap(shadow, bounds.left, bounds.top, null);
+            }
+
+            super.draw(canvas);
+        }
+
+        private void buildShadow() {
+            Drawable icon = getDrawable();
+            Rect bounds = getBounds();
+            if (icon == null || bounds.isEmpty()) return;
+
+            final int width = bounds.width();
+            final int height = bounds.height();
+
+            try {
+                Bitmap rendered = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+                // The wrapper draws the icon at the view bounds, so move it to the bitmap origin
+                // and put it back afterward.
+                Rect iconBounds = new Rect(icon.getBounds());
+                icon.setBounds(0, 0, width, height);
+                icon.draw(new Canvas(rendered));
+                icon.setBounds(iconBounds);
+
+                Bitmap mask = rendered.extractAlpha();
+                rendered.recycle();
+
+                Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+                paint.setColor(ICON_SHADOW_COLOR);
+                paint.setMaskFilter(new BlurMaskFilter(
+                        ICON_SHADOW_BLUR_RADIUS, BlurMaskFilter.Blur.NORMAL));
+
+                // Blurring at draw time into a bitmap the size of the icon keeps the shadow
+                // inside the icon box, the way the app builds its own player icon shadows.
+                Bitmap blurred = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+                new Canvas(blurred).drawBitmap(
+                        mask, ICON_SHADOW_OFFSET_X, ICON_SHADOW_OFFSET_Y, paint);
+                mask.recycle();
+
+                shadow = blurred;
+            } catch (Exception ex) {
+                Logger.printException(() -> "Could not build player icon shadow", ex);
+            }
+        }
+    }
+
+    /**
+     * Wraps the current icon so it keeps the shadow after a button swaps its own drawable,
+     * which the mute and video scale buttons do when their state changes.
+     */
+    private static void applyIconShadow(View button) {
+        if (ICON_SHADOW_BLUR_RADIUS <= 0 || !(button instanceof ImageView imageView)) return;
+
+        Drawable icon = imageView.getDrawable();
+        if (icon != null && !(icon instanceof ShadowedIconDrawable)) {
+            imageView.setImageDrawable(new ShadowedIconDrawable(icon));
+        }
+    }
 
     private static boolean skipFirstExceptionLog = true;
 
@@ -218,9 +332,12 @@ public class PlayerOverlayButton {
                 Drawable newBackground = newConstantState != null
                         ? newConstantState.newDrawable().mutate()
                         : sourceButtonBackground;
-                setBackground.setBackground(newBackground);
+                setBackground.setBackground(
+                        HidePlayerOverlayButtonsPatch.applyControlButtonsBackgroundOpacity(newBackground));
                 sourceBackgroundSnapshot = newConstantState;
             }
+
+            applyIconShadow(button);
 
             final float sourceButtonAlpha = source.getAlpha();
             if (button.getAlpha() != sourceButtonAlpha) {
@@ -248,6 +365,29 @@ public class PlayerOverlayButton {
 
     private static WeakReference<View> ytSourceButtonRef = new WeakReference<>(null);
     private static final List<PlayerOverlayButtonController> buttonControllers = new ArrayList<>();
+
+    /** ConstantState of the fullscreen button background the opacity was last applied to. */
+    @Nullable
+    private static Drawable.ConstantState sourceButtonBackgroundSnapshot;
+
+    /**
+     * The app assigns the circle background after the view exists, so this re-checks on every
+     * pre-draw pass and only does work when the drawable is actually replaced.
+     */
+    private static void styleSourceButtonBackground(View sourceButton) {
+        Drawable background = sourceButton.getBackground();
+        if (background == null) return;
+
+        // A null state cannot be tracked, so fall through and rely on mutate() being idempotent.
+        Drawable.ConstantState state = background.getConstantState();
+        if (state != null && state == sourceButtonBackgroundSnapshot) return;
+
+        Drawable styled = HidePlayerOverlayButtonsPatch.applyControlButtonsBackgroundOpacity(background);
+        if (styled != background) {
+            sourceButton.setBackground(styled);
+        }
+        sourceButtonBackgroundSnapshot = styled.getConstantState();
+    }
 
     /**
      * Returns the button width percentage based on the number of extra button slots needed,
@@ -388,6 +528,10 @@ public class PlayerOverlayButton {
         textOverlay.setTextSize(TypedValue.COMPLEX_UNIT_PX, Dim.dp(14));
         textOverlay.setTextColor(0xFFFFFFFF);
         textOverlay.setTypeface(Typeface.create("sans-serif-condensed", Typeface.BOLD));
+        if (ICON_SHADOW_BLUR_RADIUS > 0) {
+            textOverlay.setShadowLayer(ICON_SHADOW_BLUR_RADIUS,
+                    ICON_SHADOW_OFFSET_X, ICON_SHADOW_OFFSET_Y, ICON_SHADOW_COLOR);
+        }
         textOverlay.setOnClickListener(onClickListener);
         textOverlay.setOnLongClickListener(onLongClickListener);
         sourceButtonViewGroup.addView(textOverlay);
@@ -398,7 +542,8 @@ public class PlayerOverlayButton {
     }
 
     /**
-     * Unconditionally removes YouTube's native maxWidth restrictions from the chapter title.
+     * Unconditionally removes YouTube's native maxWidth restrictions from the chapter title,
+     * and styles the fullscreen button background that the other overlay buttons copy.
      */
     public static void initializeButton(View controlsViewGroup) {
         Utils.verifyOnMainThread();
@@ -407,6 +552,8 @@ public class PlayerOverlayButton {
             chapterTitleContainer.updateContainerRef(controlsViewGroup);
             controlsViewGroup.getViewTreeObserver().addOnPreDrawListener(() -> {
                 try {
+                    styleSourceButtonBackground(controlsViewGroup);
+
                     final int effectiveCustomButtons = Math.max(0, buttonControllers.size()
                             - (Settings.HIDE_FULLSCREEN_BUTTON.get() ? 1 : 0));
 
@@ -419,12 +566,12 @@ public class PlayerOverlayButton {
                     float spacingPercentage = getButtonWidthPercentage(effectiveCustomButtons, controlsViewGroup);
                     chapterTitleContainer.updateMargin(buttonWidth, effectiveCustomButtons, spacingPercentage);
                 } catch (Exception ex) {
-                    Logger.printDebug(() -> "Could not update chapter title margin", ex);
+                    Logger.printDebug(() -> "Could not update overlay button layout", ex);
                 }
                 return true;
             });
         } catch (Exception ex) {
-            Logger.printException(() -> "Failed to unrestrict chapter title", ex);
+            Logger.printException(() -> "Failed to initialize overlay button layout", ex);
         }
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/overlay/HidePlayerOverlayButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/overlay/HidePlayerOverlayButtonsPatch.kt
@@ -19,6 +19,7 @@ import app.morphe.patcher.util.smali.ExternalLabel
 import app.morphe.patches.all.misc.resources.ResourceType
 import app.morphe.patches.all.misc.resources.getResourceId
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
+import app.morphe.patches.shared.misc.settings.preference.NonInteractivePreference
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.shared.misc.settings.preference.noTitleUnsortedPreferenceCategory
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
@@ -45,8 +46,8 @@ private const val EXTENSION_CLASS =
 
 val hidePlayerOverlayButtonsPatch = bytecodePatch(
     name = "Hide player overlay buttons",
-    description = "Adds options to hide the player Cast, Autoplay, Captions, Previous & Next buttons, and the player " +
-        "control buttons background.",
+    description = "Adds options to hide the player Cast, Autoplay, Captions, Previous & Next buttons," +
+            " and to hide or change the opacity of the player control buttons background.",
 ) {
     dependsOn(
         sharedExtensionPatch,
@@ -69,6 +70,10 @@ val hidePlayerOverlayButtonsPatch = bytecodePatch(
                 SwitchPreference("morphe_hide_player_control_buttons_background", summary = true),
                 SwitchPreference("morphe_hide_player_previous_next_buttons"),
                 SwitchPreference("morphe_hide_settings_button"),
+            ),
+            NonInteractivePreference(
+                key = "morphe_player_control_buttons_background_opacity",
+                tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference",
             )
         )
 
@@ -260,7 +265,7 @@ val hidePlayerOverlayButtonsPatch = bytecodePatch(
                         # The result of the inflate method is by default not moved to a register after the method is called.
                         # 21.21+ now uses the returned inflated view but the changes here still work.
                         move-result-object v$freeRegister
-                        invoke-static { v$freeRegister }, $EXTENSION_CLASS->hidePlayerControlButtonsBackground(Landroid/view/View;)Landroid/view/View;
+                        invoke-static { v$freeRegister }, $EXTENSION_CLASS->styleControlButtonsBackground(Landroid/view/View;)Landroid/view/View;
                     """
                 )
             }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/overlay/HidePlayerOverlayButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/overlay/HidePlayerOverlayButtonsPatch.kt
@@ -46,8 +46,8 @@ private const val EXTENSION_CLASS =
 
 val hidePlayerOverlayButtonsPatch = bytecodePatch(
     name = "Hide player overlay buttons",
-    description = "Adds options to hide the player Cast, Autoplay, Captions, Previous & Next buttons," +
-            " and to hide or change the opacity of the player control buttons background.",
+    description = "Adds options to hide the player Cast, Autoplay, Captions, Previous & Next buttons, " +
+            "and to hide or change the opacity of the player control buttons background.",
 ) {
     dependsOn(
         sharedExtensionPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -13,9 +13,12 @@ package app.morphe.patches.youtube.layout.theme
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.methodCall
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patches.all.misc.resources.ResourceType
+import app.morphe.patches.all.misc.resources.getResourceId
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.patches.shared.layout.theme.STYLE_DEFAULT_COLOR_NAMES_DARK
 import app.morphe.patches.shared.layout.theme.STYLE_DEFAULT_COLOR_NAMES_LIGHT
@@ -43,15 +46,29 @@ import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
+import app.morphe.patches.youtube.shared.LayoutConstructorFingerprint
 import app.morphe.util.forEachChildElement
 import app.morphe.util.insertLiteralOverride
 import app.morphe.util.matchAllMethodIndicesForEach
 import app.morphe.util.registersUsed
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.WideLiteralInstruction
 import org.w3c.dom.Element
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/theme/ThemePatch;"
+
+/** The background of the light theme, and also the white the app draws over a video. */
+private const val STATIC_WHITE_COLOR_NAME = "yt_white1"
+
+/** The attributes of the second use, which have to stay white to be readable. */
+private val STATIC_WHITE_ATTRIBUTE_NAMES = setOf(
+    "ytStaticWhite",
+    "ytOverlayIconActiveOther"
+)
+
+/** Value of 'android.R.color.white'. A public id of the framework never changes. */
+private const val ANDROID_WHITE_COLOR_ID = 0x106000B
 
 private val youTubeColorNamesDark = {
     THEME_DEFAULT_COLOR_NAMES_DARK + if (is_21_06_or_greater)
@@ -226,6 +243,22 @@ val themePatch = baseThemePatch(
                                 textContent = colorValue
                             }
                         )
+                    }
+                }
+
+                // Replacing the resource repaints both of its uses, because the resource system
+                // cannot tell them apart, so these attributes keep the value the app gives them.
+                document("res/values/styles.xml").use { document ->
+                    val resourcesNode = document.getElementsByTagName("resources").item(0) as Element
+
+                    resourcesNode.forEachChildElement { style ->
+                        style.forEachChildElement { item ->
+                            if (item.getAttribute("name") in STATIC_WHITE_ATTRIBUTE_NAMES
+                                && item.textContent == "@color/$STATIC_WHITE_COLOR_NAME"
+                            ) {
+                                item.textContent = "@android:color/white"
+                            }
+                        }
                     }
                 }
 
@@ -489,6 +522,22 @@ val themePatch = baseThemePatch(
                     """
                 )
             }
+        }
+
+        // The player previous and next buttons read the same color as a value and not through
+        // an attribute, so the id itself is swapped. A disabled one carries a gray of its own.
+        val staticWhiteColorId = getResourceId(ResourceType.COLOR, STATIC_WHITE_COLOR_NAME)
+
+        LayoutConstructorFingerprint.method.apply {
+            implementation!!.instructions.toList().withIndex()
+                .filter { (_, instruction) ->
+                    (instruction as? WideLiteralInstruction)?.wideLiteral == staticWhiteColorId
+                }
+                .forEach { (index, instruction) ->
+                    val colorRegister = (instruction as OneRegisterInstruction).registerA
+
+                    replaceInstruction(index, "const v$colorRegister, $ANDROID_WHITE_COLOR_ID")
+                }
         }
 
         // A tint list the app builds hands its colors over as an array, so the array is rewritten

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -18,7 +18,7 @@ import app.morphe.patcher.methodCall
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.all.misc.resources.ResourceType
-import app.morphe.patches.all.misc.resources.getResourceId
+import app.morphe.patches.all.misc.resources.resourceLiteral
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.patches.shared.layout.theme.STYLE_DEFAULT_COLOR_NAMES_DARK
 import app.morphe.patches.shared.layout.theme.STYLE_DEFAULT_COLOR_NAMES_LIGHT
@@ -38,6 +38,7 @@ import app.morphe.patches.shared.misc.settings.preference.TextPreference
 import app.morphe.patches.shared.misc.settings.preference.noTitleUnsortedPreferenceCategory
 import app.morphe.patches.youtube.layout.seekbar.seekbarColorPatch
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
+import app.morphe.patches.youtube.misc.playservice.is_20_31_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_21_06_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_21_08_or_greater
 import app.morphe.patches.youtube.misc.playservice.is_21_30_or_greater
@@ -47,15 +48,13 @@ import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import app.morphe.patches.youtube.shared.LayoutConstructorFingerprint
+import app.morphe.util.findInstructionIndicesReversedOrThrow
 import app.morphe.util.forEachChildElement
-import app.morphe.util.getReference
 import app.morphe.util.insertLiteralOverride
 import app.morphe.util.matchAllMethodIndicesForEach
 import app.morphe.util.registersUsed
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.WideLiteralInstruction
-import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import org.w3c.dom.Element
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/theme/ThemePatch;"
@@ -71,14 +70,6 @@ private val STATIC_WHITE_ATTRIBUTE_NAMES = setOf(
 
 /** Value of 'android.R.color.white'. A public id of the framework never changes. */
 private const val ANDROID_WHITE_COLOR_ID = 0x106000B
-
-/** Parameters of the method the app tints a player transport button with. */
-private val PLAYER_BUTTON_TINT_PARAMETERS = listOf(
-    "Lcom/google/android/libraries/youtube/common/ui/TouchImageView;",
-    "I",
-    "Landroid/graphics/drawable/Drawable;",
-    "I"
-)
 
 private val youTubeColorNamesDark = {
     THEME_DEFAULT_COLOR_NAMES_DARK + if (is_21_06_or_greater)
@@ -263,8 +254,8 @@ val themePatch = baseThemePatch(
 
                     resourcesNode.forEachChildElement { style ->
                         style.forEachChildElement { item ->
-                            if (item.getAttribute("name") in STATIC_WHITE_ATTRIBUTE_NAMES
-                                && item.textContent == "@color/$STATIC_WHITE_COLOR_NAME"
+                            if (item.textContent == "@color/$STATIC_WHITE_COLOR_NAME"
+                                && item.getAttribute("name") in STATIC_WHITE_ATTRIBUTE_NAMES
                             ) {
                                 item.textContent = "@android:color/white"
                             }
@@ -536,27 +527,14 @@ val themePatch = baseThemePatch(
 
         // The player previous and next buttons read the same color as a value and not through
         // an attribute, so the id itself is swapped. A disabled one carries a gray of its own.
-        val staticWhiteColorId = getResourceId(ResourceType.COLOR, STATIC_WHITE_COLOR_NAME)
-
-        LayoutConstructorFingerprint.method.apply {
-            val methodInstructions = implementation!!.instructions.toList()
-
-            // A target that tints no button uses the color for something else of its own here.
-            val tintsPlayerButtons = methodInstructions.any { instruction ->
-                instruction.getReference<MethodReference>()
-                    ?.parameterTypes?.map(CharSequence::toString) == PLAYER_BUTTON_TINT_PARAMETERS
-            }
-
-            if (tintsPlayerButtons) {
-                methodInstructions.withIndex()
-                    .filter { (_, instruction) ->
-                        (instruction as? WideLiteralInstruction)?.wideLiteral == staticWhiteColorId
-                    }
-                    .forEach { (index, instruction) ->
-                        val colorRegister = (instruction as OneRegisterInstruction).registerA
-
-                        replaceInstruction(index, "const v$colorRegister, $ANDROID_WHITE_COLOR_ID")
-                    }
+        if (is_20_31_or_greater) {
+            LayoutConstructorFingerprint.method.apply {
+                findInstructionIndicesReversedOrThrow(
+                    resourceLiteral(ResourceType.COLOR, STATIC_WHITE_COLOR_NAME)
+                ).forEach { index ->
+                    val register = getInstruction<OneRegisterInstruction>(index).registerA
+                    replaceInstruction(index, "const v$register, $ANDROID_WHITE_COLOR_ID")
+                }
             }
         }
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/theme/ThemePatch.kt
@@ -48,12 +48,14 @@ import app.morphe.patches.youtube.misc.settings.settingsPatch
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import app.morphe.patches.youtube.shared.LayoutConstructorFingerprint
 import app.morphe.util.forEachChildElement
+import app.morphe.util.getReference
 import app.morphe.util.insertLiteralOverride
 import app.morphe.util.matchAllMethodIndicesForEach
 import app.morphe.util.registersUsed
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.WideLiteralInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import org.w3c.dom.Element
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/theme/ThemePatch;"
@@ -69,6 +71,14 @@ private val STATIC_WHITE_ATTRIBUTE_NAMES = setOf(
 
 /** Value of 'android.R.color.white'. A public id of the framework never changes. */
 private const val ANDROID_WHITE_COLOR_ID = 0x106000B
+
+/** Parameters of the method the app tints a player transport button with. */
+private val PLAYER_BUTTON_TINT_PARAMETERS = listOf(
+    "Lcom/google/android/libraries/youtube/common/ui/TouchImageView;",
+    "I",
+    "Landroid/graphics/drawable/Drawable;",
+    "I"
+)
 
 private val youTubeColorNamesDark = {
     THEME_DEFAULT_COLOR_NAMES_DARK + if (is_21_06_or_greater)
@@ -529,15 +539,25 @@ val themePatch = baseThemePatch(
         val staticWhiteColorId = getResourceId(ResourceType.COLOR, STATIC_WHITE_COLOR_NAME)
 
         LayoutConstructorFingerprint.method.apply {
-            implementation!!.instructions.toList().withIndex()
-                .filter { (_, instruction) ->
-                    (instruction as? WideLiteralInstruction)?.wideLiteral == staticWhiteColorId
-                }
-                .forEach { (index, instruction) ->
-                    val colorRegister = (instruction as OneRegisterInstruction).registerA
+            val methodInstructions = implementation!!.instructions.toList()
 
-                    replaceInstruction(index, "const v$colorRegister, $ANDROID_WHITE_COLOR_ID")
-                }
+            // A target that tints no button uses the color for something else of its own here.
+            val tintsPlayerButtons = methodInstructions.any { instruction ->
+                instruction.getReference<MethodReference>()
+                    ?.parameterTypes?.map(CharSequence::toString) == PLAYER_BUTTON_TINT_PARAMETERS
+            }
+
+            if (tintsPlayerButtons) {
+                methodInstructions.withIndex()
+                    .filter { (_, instruction) ->
+                        (instruction as? WideLiteralInstruction)?.wideLiteral == staticWhiteColorId
+                    }
+                    .forEach { (index, instruction) ->
+                        val colorRegister = (instruction as OneRegisterInstruction).registerA
+
+                        replaceInstruction(index, "const v$colorRegister, $ANDROID_WHITE_COLOR_ID")
+                    }
+            }
         }
 
         // A tint list the app builds hands its colors over as an array, so the array is rewritten

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -602,7 +602,6 @@ To fix this, turn on \'Spoof video streams\' and change the \'Default client\' t
     <string name="morphe_swipe_overlay_timeout_summary">The amount of milliseconds the overlay is visible</string>
     <string name="morphe_swipe_overlay_background_opacity_title">Swipe overlay background opacity</string>
     <string name="morphe_swipe_overlay_background_opacity_summary">Adjust the transparency level (0 is transparent, 100 is opaque)</string>
-    <string name="morphe_swipe_overlay_background_opacity_invalid_toast">Swipe opacity must be between 0-100</string>
     <string name="morphe_swipe_overlay_progress_brightness_color_title">Swipe overlay brightness color</string>
     <string name="morphe_swipe_overlay_progress_brightness_color_summary">Set the color of the brightness controls progress bar</string>
     <string name="morphe_swipe_overlay_progress_volume_color_title">Swipe overlay volume color</string>
@@ -611,7 +610,6 @@ To fix this, turn on \'Spoof video streams\' and change the \'Default client\' t
     <string name="morphe_swipe_overlay_progress_speed_color_summary">Set the color of the playback speed controls progress bar</string>
     <string name="morphe_swipe_text_overlay_size_title">Swipe overlay text size</string>
     <string name="morphe_swipe_text_overlay_size_summary">Adjust the size of the on-screen text (1-30)</string>
-    <string name="morphe_swipe_text_overlay_size_invalid_toast">The text size must be between 1-30</string>
     <string name="morphe_swipe_threshold_title">Swipe magnitude threshold</string>
     <string name="morphe_swipe_threshold_summary">Set the required swipe distance before an adjustment triggers</string>
     <string name="morphe_swipe_volume_sensitivity_title">Volume swipe sensitivity</string>
@@ -828,6 +826,8 @@ To show the \'Audio Track\' menu, change \'Spoof video streams\' to any client e
     <string name="morphe_hide_fullscreen_button_title">Hide Fullscreen button</string>
     <string name="morphe_hide_player_control_buttons_background_title">Hide player controls background</string>
     <string name="morphe_hide_player_control_buttons_background_summary">Hides the dark shading surrounding the video player controls</string>
+    <string name="morphe_player_control_buttons_background_opacity_title">Control buttons background opacity</string>
+    <string name="morphe_player_control_buttons_background_opacity_summary">Adjust the opacity of the circle behind the player control buttons (0 is invisible, 100 is solid)</string>
     <string name="morphe_hide_player_previous_next_buttons_title">Hide Previous &amp; Next buttons</string>
     <string name="morphe_hide_settings_button_title">Hide Settings button</string>
 
@@ -967,7 +967,6 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
     <!-- layout.player.overlay.customPlayerOverlayOpacityPatch -->
     <string name="morphe_player_overlay_opacity_title">Player overlay opacity</string>
     <string name="morphe_player_overlay_opacity_summary">Adjust the transparency level (0 is transparent, 100 is opaque)</string>
-    <string name="morphe_player_overlay_opacity_invalid_toast">Player overlay opacity must be between 0-100</string>
 
     <!-- layout.searchbar.wideSearchbarPatch -->
     <string name="morphe_searchbar_type_title">Search bar</string>
@@ -1099,7 +1098,6 @@ Limitation: If \'Restore old video action bar\' is turned off, \'More videos\' o
     <string name="morphe_miniplayer_width_dip_invalid_toast">Pixel size must be between %1$s and %2$s</string>
     <string name="morphe_miniplayer_opacity_title">Overlay opacity</string>
     <string name="morphe_miniplayer_opacity_summary">Adjust the transparency level (0 is transparent, 100 is opaque)</string>
-    <string name="morphe_miniplayer_opacity_invalid_toast">Miniplayer overlay opacity must be between 0-100</string>
 
     <!-- misc.fix.fixBackToExitGesturePatch -->
     <string name="morphe_back_button_always_exits_feed_title">Back button exits the feed</string>


### PR DESCRIPTION
### Description

Adds a **Control buttons background** opacity setting to _Player > Overlay buttons_, tuning the circle behind the player control buttons from invisible to solid, on both the center playback buttons and the bottom overlay row. Patch-added overlay buttons also gain the drop shadow the app draws on its own icons, so they stay readable once the circle is transparent.

Fixes **Player overlay opacity** having no effect on the new player layout, which dims with a top and bottom gradient instead of the full screen scrim the setting was applied to.

Fixes the player Cast, Previous and Next icons taking the theme color while **Change foreground color** is on. 

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
___
![Screenshot_2026-09-04-10-28-38-256_com.google.android.youtube.test-edit.jpg](https://github.com/user-attachments/assets/8a0cc606-0972-4427-8897-d1d49f1a6ddb)

![Screenshot_2026-09-04-10-29-14-797_com.google.android.youtube.test-edit.jpg](https://github.com/user-attachments/assets/332f34d6-2bcb-4356-ab29-baab189794d7)

