### PR TITLE
feat: Declare a category for every patch

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/all/misc/clone/CloneAppPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/all/misc/clone/CloneAppPatch.kt
@@ -125,6 +125,8 @@ val cloneAppPatch = resourcePatch(
             "may cause app crashes or other unexpected behavior.",
     default = false
 ) {
+    category("Miscellaneous")
+
     packageNameOption = stringOption(
         key = "packageName",
         default = "Default",

--- a/patches/src/main/kotlin/app/morphe/patches/all/misc/installer/ChangeInstallerSource.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/all/misc/installer/ChangeInstallerSource.kt
@@ -17,6 +17,8 @@ val changeInstallerSource = resourcePatch(
     description = "Spoofs the installer source so the app appears to be installed from an app store.",
     default = false
 ) {
+    category("Spoofing")
+
     val packageInstallerName = stringOption(
         key = "packageInstallerName",
         default = "com.android.vending",

--- a/patches/src/main/kotlin/app/morphe/patches/all/misc/network/OverrideCertificatePinningPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/all/misc/network/OverrideCertificatePinningPatch.kt
@@ -41,6 +41,8 @@ val overrideCertificatePinningPatch = resourcePatch(
     description = "Overrides certificate pinning, allowing to inspect traffic via a proxy.",
     default = false
 ) {
+    category("Privacy and network")
+
     execute {
         val resXmlDirectory = get("res/xml")
         var networkSecurityFileName = "network_security_config.xml"

--- a/patches/src/main/kotlin/app/morphe/patches/all/misc/updates/DisablePlayStoreUpdatesPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/all/misc/updates/DisablePlayStoreUpdatesPatch.kt
@@ -76,6 +76,7 @@ internal val disablePlayStoreUpdatesPatch = bytecodePatch(
             "app is installed by root mounting",
     default = false
 ) {
+    category("Miscellaneous")
 
     dependsOn(disablePlayStoreUpdatesResourcePatch)
 

--- a/patches/src/main/kotlin/app/morphe/patches/music/ad/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/ad/HideAdsPatch.kt
@@ -35,6 +35,8 @@ val hideAdsPatch = bytecodePatch(
     name = "Hide ads",
     description = "Adds options to hide fullscreen ads, Premium promotions and video ads."
 ) {
+    category("Ads")
+
     dependsOn(
         sharedExtensionPatch,
         hideFullscreenAdsPatch(PreferenceScreen.ADS),

--- a/patches/src/main/kotlin/app/morphe/patches/music/flyoutmenu/components/HideFlyoutMenuComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/flyoutmenu/components/HideFlyoutMenuComponentsPatch.kt
@@ -42,6 +42,8 @@ val hideFlyoutMenuComponentsPatch = bytecodePatch(
     name = "Hide flyout menu components",
     description = "Adds options to hide individual items from the player and queue flyout menus."
 ) {
+    category("Hide layout")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/crossfade/CrossfadePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/crossfade/CrossfadePatch.kt
@@ -177,6 +177,8 @@ val crossfadePatch = bytecodePatch(
     description = "Adds a true dual-player crossfade between consecutive tracks. " +
             "Requires YouTube Music 9.00 or newer; on older versions the patch is a no-op.",
 ) {
+    category("Video and audio")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/dislikeredirection/DisableDislikeRedirectionPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/dislikeredirection/DisableDislikeRedirectionPatch.kt
@@ -35,6 +35,8 @@ val disableDislikeRedirectionPatch = bytecodePatch(
     description = "Adds an option to prevent skipping to the next track when the dislike " +
             "button is pressed."
 ) {
+    category("Interaction")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/downloads/DownloadsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/downloads/DownloadsPatch.kt
@@ -53,6 +53,8 @@ val downloadsPatch = bytecodePatch(
     name = "Downloads",
     description = "Adds support to download songs with an external downloader app using the in-app download button.",
 ) {
+    category("Interaction")
+
     dependsOn(
         downloadsResourcePatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/remember/repeatstate/RememberRepeatStatePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/remember/repeatstate/RememberRepeatStatePatch.kt
@@ -28,6 +28,8 @@ val rememberRepeatStatePatch = bytecodePatch(
     name = "Remember repeat state",
     description = "Adds an option to remember the repeat state when playing a new track or playlist."
 ) {
+    category("Interaction")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/remember/shufflestate/RememberShuffleStatePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/remember/shufflestate/RememberShuffleStatePatch.kt
@@ -41,6 +41,8 @@ val rememberShuffleStatePatch = bytecodePatch(
     name = "Remember shuffle state",
     description = "Adds an option to remember the shuffle state when playing a new track or playlist."
 ) {
+    category("Interaction")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/interaction/scrobbling/ScrobblingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/interaction/scrobbling/ScrobblingPatch.kt
@@ -39,6 +39,8 @@ val scrobblingPatch = bytecodePatch(
     name = "Scrobbling",
     description = "Adds options to add played tracks to Last.fm and ListenBrainz."
 ) {
+    category("Integrations")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/buttons/HideButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/buttons/HideButtonsPatch.kt
@@ -36,6 +36,8 @@ val hideButtonsPatch = bytecodePatch(
     name = "Hide buttons",
     description = "Adds options to hide the cast, history, notification, and search buttons."
 ) {
+    category("Hide layout")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/buttons/action/HideMusicActionButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/buttons/action/HideMusicActionButtonsPatch.kt
@@ -35,6 +35,8 @@ val hideMusicActionButtonsPatch = bytecodePatch(
     name = "Hide music action buttons",
     description = "Adds options to hide action buttons under the player."
 ) {
+    category("Player")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/compactheader/HideFilterBarPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/compactheader/HideFilterBarPatch.kt
@@ -17,6 +17,8 @@ val hideFilterBarPatch = bytecodePatch(
     name = "Hide filter bar",
     description = "Adds an option to hide the filter bar at the top of the homepage."
 ) {
+    category("Hide layout")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -37,6 +37,8 @@ val hideLayoutComponentsPatch = bytecodePatch(
     name = "Hide layout components",
     description = "Adds options to hide general layout components."
 ) {
+    category("Hide layout")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/hide/settingsmenu/HideSettingsMenuFilterPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/hide/settingsmenu/HideSettingsMenuFilterPatch.kt
@@ -33,6 +33,8 @@ val hideSettingsMenuFilterPatch = bytecodePatch(
     name = "Settings menu filter",
     description = "Adds an option to hide items on the standard YouTube Music settings screen by their visible name."
 ) {
+    category("Hide layout")
+
     dependsOn(
         settingsPatch,
         sharedExtensionPatch

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/lyrics/LyricsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/lyrics/LyricsPatch.kt
@@ -36,6 +36,8 @@ val lyricsPatch = bytecodePatch(
     name = "Third-party lyrics",
     description = "Adds an option to show synced lyrics from LRCLIB or KuGou in the lyrics panel."
 ) {
+    category("Integrations")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/miniplayer/ChangeMiniplayerColorPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/miniplayer/ChangeMiniplayerColorPatch.kt
@@ -38,6 +38,8 @@ val changeMiniplayerColorPatch = bytecodePatch(
     name = "Change miniplayer color",
     description = "Adds an option to change the miniplayer background color to match the fullscreen player."
 ) {
+    category("Player")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/miniplayer/EnableForcedMiniplayerPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/miniplayer/EnableForcedMiniplayerPatch.kt
@@ -28,6 +28,8 @@ val enableForcedMiniplayerPatch = bytecodePatch(
     name = "Enable forced miniplayer",
     description = "Adds an option to enable forced miniplayer when switching between music videos, podcasts, or songs."
 ) {
+    category("Player")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/miniplayer/EnableSwipeToDismissMiniplayerPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/miniplayer/EnableSwipeToDismissMiniplayerPatch.kt
@@ -46,6 +46,8 @@ val enableSwipeToDismissMiniplayerPatch = bytecodePatch(
     name = "Enable swipe to dismiss miniplayer",
     description = "Adds an option to enable dismissing the miniplayer by swiping down on it."
 ) {
+    category("Player")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/miniplayer/MiniplayerNextPreviousButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/miniplayer/MiniplayerNextPreviousButtonsPatch.kt
@@ -97,6 +97,8 @@ val miniplayerPreviousNextButtonsPatch = bytecodePatch(
     name = "Miniplayer previous and next buttons",
     description = "Adds options to show previous and next track buttons in the miniplayer."
 ) {
+    category("Player")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/navigationbar/NavigationBarPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/navigationbar/NavigationBarPatch.kt
@@ -22,6 +22,8 @@ val navigationBarPatch = bytecodePatch(
     name = "Navigation bar",
     description = "Adds options to hide navigation bar, labels and buttons."
 ) {
+    category("Layout")
+
     dependsOn(
         resourceMappingPatch,
         sharedExtensionPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/returnyoutubedislike/ReturnYouTubeDislikePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/returnyoutubedislike/ReturnYouTubeDislikePatch.kt
@@ -64,6 +64,8 @@ val returnYouTubeDislikePatch = bytecodePatch(
     name = "Return YouTube Dislike",
     description = "Adds an option to show the dislike count of tracks with Return YouTube Dislike.",
 ) {
+    category("Integrations")
+
     dependsOn(
         returnYouTubeDislikeResourcePatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/sponsorblock/SponsorBlockPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/sponsorblock/SponsorBlockPatch.kt
@@ -41,6 +41,8 @@ val musicSponsorBlockPatch = bytecodePatch(
     name = "SponsorBlock",
     description = "Adds options to enable and configure SponsorBlock, which can skip non-music segments."
 ) {
+    category("Integrations")
+
     dependsOn(
         sharedExtensionPatch,
         musicVideoInformationPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/layout/startpage/ChangeStartPagePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/layout/startpage/ChangeStartPagePatch.kt
@@ -30,6 +30,8 @@ val changeStartPagePatch = bytecodePatch(
     name = "Change start page",
     description = "Adds an option to set which page the app opens in instead of the homepage.",
 ) {
+    category("Layout")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/album/PlayAlbumSongsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/album/PlayAlbumSongsPatch.kt
@@ -27,6 +27,8 @@ val playAlbumSongsPatch = bytecodePatch(
     name = "Play albums songs",
     description = "Adds an option to play the song version of album tracks instead of music videos."
 ) {
+    category("Interaction")
+
     compatibleWith(COMPATIBILITY_YOUTUBE_MUSIC)
 
     dependsOn(

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/BypassCertificateChecksPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/androidauto/BypassCertificateChecksPatch.kt
@@ -11,6 +11,8 @@ val bypassCertificateChecksPatch = bytecodePatch(
     name = "Bypass certificate checks",
     description = "Bypasses certificate checks which prevent YouTube Music from working on Android Auto.",
 ) {
+    category("Integrations")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/audio/EnableExclusiveAudioPlayback.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/audio/EnableExclusiveAudioPlayback.kt
@@ -22,6 +22,8 @@ val enableExclusiveAudioPlaybackPatch = bytecodePatch(
     name = "Enable exclusive audio playback",
     description = "Enables the option to play audio without video.",
 ) {
+    category("Video and audio")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/music/misc/backgroundplayback/BackgroundPlaybackPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/music/misc/backgroundplayback/BackgroundPlaybackPatch.kt
@@ -11,6 +11,8 @@ val backgroundPlaybackPatch = bytecodePatch(
     name = "Remove background playback restrictions",
     description = "Removes restrictions on background playback, including playing kids videos in the background.",
 ) {
+    category("Video and audio")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/ad/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/ad/HideAdsPatch.kt
@@ -32,6 +32,8 @@ val hideAdsPatch = bytecodePatch(
     name = "Hide ads",
     description = "Adds options to hide ads."
 ) {
+    category("Ads")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(settingsPatch, versionCheckPatch)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/font/CustomFontPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/font/CustomFontPatch.kt
@@ -22,6 +22,8 @@ val customFontPatch = bytecodePatch(
     description = "Adds an option to replace Reddit Sans / Roboto with a custom TTF or OTF font file at runtime.",
     default = true,
 ) {
+    category("Layout")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(settingsPatch)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/font/ForceSystemFontPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/font/ForceSystemFontPatch.kt
@@ -22,6 +22,8 @@ val forceSystemFontPatch = bytecodePatch(
     description = "Adds an option that renders Reddit with the device system font instead of Reddit Sans / Roboto.",
     default = true,
 ) {
+    category("Layout")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(settingsPatch)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/ask/HideAskButtonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/ask/HideAskButtonPatch.kt
@@ -24,6 +24,8 @@ val hideAskButtonPatch = bytecodePatch(
     name = "Hide Ask button",
     description = "Adds an option to hide Ask button in the search bar."
 ) {
+    category("Hide layout")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/branding/name/CustomBrandingNamePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/branding/name/CustomBrandingNamePatch.kt
@@ -22,6 +22,8 @@ val customBrandingNamePatch = resourcePatch(
     description = "Changes the Reddit app name to the name specified in patch options.",
     default = false
 ) {
+    category("Layout")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(spoofSignaturePatch)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/communities/HideCommunitiesShelf.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/communities/HideCommunitiesShelf.kt
@@ -25,6 +25,8 @@ val hideCommunitiesShelf = bytecodePatch(
     name = "Hide communities shelf",
     description = "Adds an option to hide the related or suggested communities shelf in subreddits."
 ) {
+    category("Hide layout")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(settingsPatch, versionCheckPatch)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/modern/DisableModernHomePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/modern/DisableModernHomePatch.kt
@@ -28,6 +28,8 @@ val disableModernHomePatch = bytecodePatch(
     name = "Disable modern home",
     description = "Adds an option to disable the modern home UI. This patch works with Reddit 2026.24.0 and earlier."
 ) {
+    category("Layout")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(settingsPatch, versionCheckPatch)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/navigation/HideNavigationButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/navigation/HideNavigationButtonsPatch.kt
@@ -40,6 +40,8 @@ val hideNavigationButtonsPatch = bytecodePatch(
     name = "Hide navigation buttons",
     description = "Adds options to hide buttons in the navigation bar."
 ) {
+    category("Hide layout")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(settingsPatch, versionCheckPatch)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/screenshotpopup/DisableScreenshotPopupPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/screenshotpopup/DisableScreenshotPopupPatch.kt
@@ -23,6 +23,8 @@ val disableScreenshotPopupPatch = bytecodePatch(
     name = "Disable screenshot popup",
     description = "Adds an option to disable the popup that appears when taking a screenshot."
 ) {
+    category("Hide layout")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(settingsPatch)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/search/HideRedditSearchPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/search/HideRedditSearchPatch.kt
@@ -19,6 +19,8 @@ val hideRedditSearchPatch = resourcePatch(
             "This patch does not work with root mounting",
     default = false
 ) {
+    category("Hide layout")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(spoofSignaturePatch)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/sidebar/HideSidebarComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/sidebar/HideSidebarComponentsPatch.kt
@@ -29,6 +29,8 @@ val hideSidebarComponentsPatch = bytecodePatch(
     name = "Hide sidebar components",
     description = "Adds options to hide the sidebar components."
 ) {
+    category("Hide layout")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(settingsPatch)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/subredditdialog/RemoveSubRedditDialogPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/subredditdialog/RemoveSubRedditDialogPatch.kt
@@ -24,6 +24,8 @@ val removeSubRedditDialogPatch = bytecodePatch(
     name = "Remove subreddit dialog",
     description = "Adds options to remove the NSFW community warning and notifications suggestion dialogs by dismissing them automatically."
 ) {
+    category("Hide layout")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/trending/HideTrendingShelvesPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/trending/HideTrendingShelvesPatch.kt
@@ -34,6 +34,8 @@ val hideTrendingShelvesPatch = bytecodePatch(
     name = "Hide Trending shelves",
     description = "Adds an option to hide the Trending shelves from feed and search suggestions."
 ) {
+    category("Hide layout")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(settingsPatch, versionCheckPatch)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/layout/viewcount/ShowViewCountPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/layout/viewcount/ShowViewCountPatch.kt
@@ -22,6 +22,8 @@ val showViewCountPatch = bytecodePatch(
     name = "Show view count",
     description = "Adds an option to show the view count of Posts."
 ) {
+    category("Layout")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/misc/fix/signature/SpoofSignaturePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/misc/fix/signature/SpoofSignaturePatch.kt
@@ -23,6 +23,8 @@ val spoofSignaturePatch = bytecodePatch(
     name = "Spoof signature",
     description = "Spoofs the signature of the app to fix notification issues."
 ) {
+    category("Spoofing")
+
     compatibleWith(COMPATIBILITY_REDDIT_INCLUDING_LEGACY)
 
     dependsOn(sharedExtensionPatch, changeInstallerSource, versionCheckPatch)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/misc/openlink/OpenLinksDirectlyPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/misc/openlink/OpenLinksDirectlyPatch.kt
@@ -21,6 +21,8 @@ val openLinksDirectlyPatch = bytecodePatch(
     name = "Open links directly",
     description = "Adds an option to skip over redirection URLs in external links."
 ) {
+    category("Integrations")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/misc/openlink/OpenLinksExternallyPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/misc/openlink/OpenLinksExternallyPatch.kt
@@ -22,6 +22,8 @@ val openLinksExternallyPatch = bytecodePatch(
     name = "Open links externally",
     description = "Adds an option to always open links in your browser instead of with the in-app-browser."
 ) {
+    category("Integrations")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/misc/privacy/SanitizeSharingLinksPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/misc/privacy/SanitizeSharingLinksPatch.kt
@@ -21,6 +21,8 @@ val sanitizeSharingLinksPatch = bytecodePatch(
     name = "Sanitize sharing links",
     description = "Adds an option to sanitize sharing links by removing tracking query parameters."
 ) {
+    category("Privacy and network")
+
     compatibleWith(COMPATIBILITY_REDDIT)
 
     dependsOn(settingsPatch)

--- a/patches/src/main/kotlin/app/morphe/patches/shared/interaction/dialog/RemoveViewerDiscretionDialogPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/interaction/dialog/RemoveViewerDiscretionDialogPatch.kt
@@ -38,6 +38,8 @@ internal fun removeViewerDiscretionDialogPatch(
     description = "Adds an option to remove the dialog that appears when opening a video that has been age-restricted " +
             "by accepting it automatically. This does not bypass the age restriction.",
 ) {
+    category("Player")
+
     block()
 
     execute {

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/BaseCustomBrandingPatch.kt
@@ -112,6 +112,7 @@ internal fun baseCustomBrandingPatch(
     description = "Adds options to change the app icon and app name. " +
             "Branding cannot be changed for mounted (root) installations."
 ) {
+    category("Layout")
 
     availability { installer, _ ->
         when (installer) {

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/header/BaseChangeHeaderPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/header/BaseChangeHeaderPatch.kt
@@ -36,6 +36,8 @@ internal fun baseChangeHeaderPatch(
     name = "Change header",
     description = "Adds an option to change the header logo in the top left corner of the app."
 ) {
+    category("Layout")
+
     val customHeaderResourceFileNames = variants.map { variant ->
         "${CUSTOM_HEADER_RESOURCE_NAME}_$variant.png"
     }.toTypedArray()

--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/theme/BaseThemePatch.kt
@@ -387,6 +387,8 @@ internal fun baseThemePatch(
     name = "Theme",
     description = "Adds options for theming, and settings to change the app foreground and background colors.",
 ) {
+    category("Layout")
+
     darkThemeColorOption()
 
     if (includeLightColor) {

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/audio/drc/DisableDRCAudioPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/audio/drc/DisableDRCAudioPatch.kt
@@ -28,6 +28,7 @@ internal fun disableDRCAudioPatch(
     name = "Disable DRC audio",
     description = "Adds an option to disable DRC (Dynamic Range Compression) audio."
 ) {
+    category("Video and audio")
 
     block()
 

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/audio/tracks/ForceOriginalAudioPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/audio/tracks/ForceOriginalAudioPatch.kt
@@ -61,6 +61,7 @@ internal fun forceOriginalAudioPatch(
     name = "Force original audio",
     description = "Adds an option to always use the original audio track.",
 ) {
+    category("Video and audio")
 
     block()
 

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/debugging/EnableDebuggingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/debugging/EnableDebuggingPatch.kt
@@ -50,6 +50,7 @@ internal fun enableDebuggingPatch(
     name = "Enable debugging",
     description = "Adds options for debugging and exporting Morphe logs to the clipboard.",
 ) {
+    category("Miscellaneous")
 
     dependsOn(
         resourcePatch {

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/dns/CheckWatchHistoryDomainNameResolutionPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/dns/CheckWatchHistoryDomainNameResolutionPatch.kt
@@ -20,6 +20,8 @@ internal fun checkWatchHistoryDomainNameResolutionPatch(
     name = "Check watch history domain name resolution",
     description = "Checks if the device DNS server is preventing user watch history from being saved.",
 ) {
+    category("Privacy and network")
+
     block()
 
     execute {

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/gms/GmsCoreSupportPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/gms/GmsCoreSupportPatch.kt
@@ -82,6 +82,7 @@ fun gmsCoreSupportPatch(
     description = "Allows the app to work without root by using a different package name when patched " +
             "using a GmsCore instead of Google Play Services.",
 ) {
+    category("Integrations")
 
     availability { installer, _ ->
         when (installer) {

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/potoken/PoTokenProviderPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/potoken/PoTokenProviderPatch.kt
@@ -42,6 +42,8 @@ internal fun poTokenProviderPatch(
     name = "PoToken provider",
     description = "Adds option to get PoToken using an external PoToken minter app."
 ) {
+    category("Spoofing")
+
     // The execute block still has to check the package name, because the CLI does not report one.
     availability { installer, _ ->
         when (installer) {

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/privacy/SanitizeSharingLinksPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/privacy/SanitizeSharingLinksPatch.kt
@@ -30,6 +30,8 @@ internal fun sanitizeSharingLinksPatch(
     name = "Sanitize sharing links",
     description = "Removes the tracking query parameters from shared links.",
 ) {
+    category("Privacy and network")
+
     block()
 
     execute {

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/proxy/BaseNetworkProxyPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/proxy/BaseNetworkProxyPatch.kt
@@ -36,6 +36,7 @@ internal fun baseNetworkProxyPatch(
     description = "Adds settings to route supported network requests through an HTTP or HTTPS proxy.",
     default = false
 ) {
+    category("Privacy and network")
 
     block()
 

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/quic/DisableQUICProtocolPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/quic/DisableQUICProtocolPatch.kt
@@ -23,6 +23,8 @@ internal fun disableQUICProtocolPatch(
     name = "Disable QUIC protocol",
     description = "Adds an option to disable QUIC (Quick UDP Internet Connections) network protocol."
 ) {
+    category("Privacy and network")
+
     block()
 
     execute {

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/refreshrate/BaseAppRefreshRatePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/refreshrate/BaseAppRefreshRatePatch.kt
@@ -28,6 +28,8 @@ fun baseAppRefreshRatePatch(
     name = "App refresh rate",
     description = "Adds an option to change the app refresh rate."
 ) {
+    category("Miscellaneous")
+
     block()
 
     execute {

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/SpoofVideoStreamsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/SpoofVideoStreamsPatch.kt
@@ -87,6 +87,8 @@ internal fun spoofVideoStreamsPatch(
     name = "Spoof video streams",
     description = "Adds options to spoof the client video streams to fix playback."
 ) {
+    category("Spoofing")
+
     block()
 
     dependsOn(

--- a/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/appversion/BaseSpoofAppVersionPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/misc/spoof/appversion/BaseSpoofAppVersionPatch.kt
@@ -34,6 +34,8 @@ fun baseSpoofAppVersionPatch(
     name = "Spoof app version",
     description = "Adds an option to trick the app into thinking you are running an older version."
 ) {
+    category("Spoofing")
+
     block()
 
     execute {

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/ad/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/ad/HideAdsPatch.kt
@@ -89,6 +89,8 @@ val hideAdsPatch = bytecodePatch(
     name = "Hide ads",
     description = "Adds options to hide general ads, Premium promotions and video ads."
 ) {
+    category("Ads")
+
     dependsOn(
         hideAdsResourcePatch,
         elementProtoParserHookPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/copyvideolink/CopyVideoLinkButtonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/copyvideolink/CopyVideoLinkButtonPatch.kt
@@ -46,6 +46,8 @@ val copyVideoLinkButtonPatch = bytecodePatch(
     name = "Copy video link",
     description = "Adds options to display buttons in the video player to copy video links.",
 ) {
+    category("Interaction")
+
     dependsOn(
         copyVideoLinkButtonResourcePatch,
         playerOverlayButtonsSettingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/doubletap/DisableChapterSkipDoubleTapPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/doubletap/DisableChapterSkipDoubleTapPatch.kt
@@ -21,6 +21,8 @@ val disableDoubleTapActionsPatch = bytecodePatch(
     name = "Disable double tap actions",
     description = "Adds an option to disable player double tap gestures.",
 ) {
+    category("Interaction")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/doubletap/DoubleTapLengthPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/doubletap/DoubleTapLengthPatch.kt
@@ -12,6 +12,8 @@ val doubleTapLengthPatch = resourcePatch(
     name = "Double tap to seek",
     description = "Adds additional double-tap to seek values to the YouTube settings menu."
 ) {
+    category("Interaction")
+
     dependsOn(
         sharedExtensionPatch,
     )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/downloads/DownloadsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/downloads/DownloadsPatch.kt
@@ -66,6 +66,8 @@ val downloadsPatch = bytecodePatch(
     description = "Adds support to download videos with an external downloader app " +
         "using the in-app download button or a video player action button.",
 ) {
+    category("Interaction")
+
     dependsOn(
         downloadsResourcePatch,
         videoInformationPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/hapticfeedback/DisableHapticFeedbackPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/hapticfeedback/DisableHapticFeedbackPatch.kt
@@ -31,6 +31,8 @@ val disableHapticFeedbackPatch = bytecodePatch(
     name = "Disable haptic feedback",
     description = "Adds an option to disable haptic feedback in the player for various actions.",
 ) {
+    category("Interaction")
+
     dependsOn(settingsPatch)
 
     compatibleWith(COMPATIBILITY_YOUTUBE)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/LoopVideoPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/LoopVideoPatch.kt
@@ -30,6 +30,8 @@ val loopVideoPatch = bytecodePatch(
     name = "Loop video",
     description = "Adds an option to loop videos and display loop video button in the video player.",
 ) {
+    category("Interaction")
+
     dependsOn(
         sharedExtensionPatch,
         loopVideoButtonPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/playall/PlayAllButtonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/playall/PlayAllButtonPatch.kt
@@ -51,6 +51,8 @@ val playAllButtonPatch = bytecodePatch(
     name = "Play all",
     description = "Adds an option to play all the videos from a channel and to display play all button in the video player.",
 ) {
+    category("Interaction")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/reload/ReloadVideoButtonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/reload/ReloadVideoButtonPatch.kt
@@ -67,6 +67,8 @@ val reloadVideoButtonPatch = bytecodePatch(
     name = "Reload video",
     description = "Adds an option to display reload video button in the video player.",
 ) {
+    category("Interaction")
+
     dependsOn(
         reloadVideoButtonResourcePatch,
         legacyPlayerControlsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/savetowatchlater/SaveToWatchLaterButtonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/savetowatchlater/SaveToWatchLaterButtonPatch.kt
@@ -45,6 +45,8 @@ val saveToWatchLaterButtonPatch = bytecodePatch(
     name = "Save to Watch later",
     description = "Adds an option to display save to Watch later button in the video player.",
 ) {
+    category("Interaction")
+
     dependsOn(
         saveToWatchLaterButtonResourcePatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/SeekbarPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/seekbar/SeekbarPatch.kt
@@ -14,6 +14,8 @@ val seekbarPatch = bytecodePatch(
             "enabling seeking in livestreams, " +
             "and expanding the livestream DVR duration."
 ) {
+    category("Player")
+
     dependsOn(
         disablePreciseSeekingGesturePatch,
         enableSlideToSeekPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/swipecontrols/SwipeControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/swipecontrols/SwipeControlsPatch.kt
@@ -150,6 +150,8 @@ val swipeControlsPatch = bytecodePatch(
     name = "Swipe controls",
     description = "Adds options to enable and configure volume and brightness swipe controls."
 ) {
+    category("Interaction")
+
     dependsOn(
         sharedExtensionPatch,
         playerTypeHookPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/HideVideoActionButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/action/HideVideoActionButtonsPatch.kt
@@ -41,6 +41,8 @@ val hideVideoActionButtonsPatch = bytecodePatch(
     name = "Hide video action buttons",
     description = "Adds options to hide video action buttons in fullscreen and portrait modes."
 ) {
+    category("Hide layout")
+
     dependsOn(
         settingsPatch,
         sharedExtensionPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/navigation/NavigationBarPatch.kt
@@ -77,6 +77,8 @@ val navigationBarPatch = bytecodePatch(
     description = "Adds options to hide and change the bottom navigation bar (such as the Shorts button) "
             + " and the upper navigation toolbar."
 ) {
+    category("Layout")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/overlay/HidePlayerOverlayButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/buttons/overlay/HidePlayerOverlayButtonsPatch.kt
@@ -49,6 +49,8 @@ val hidePlayerOverlayButtonsPatch = bytecodePatch(
     description = "Adds options to hide the player Cast, Autoplay, Captions, Previous & Next buttons, " +
             "and to hide or change the opacity of the player control buttons background.",
 ) {
+    category("Player")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/captions/CaptionsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/captions/CaptionsPatch.kt
@@ -16,6 +16,8 @@ val captionsPatch = bytecodePatch(
     name = "Captions",
     description = "Adds an option to disable captions from being automatically enabled or to set caption cookies.",
 ) {
+    category("Video and audio")
+
     dependsOn(
         autoCaptionsPatch,
         captionCookiesPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/disableupdates/DisableLayoutUpdatesPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/disableupdates/DisableLayoutUpdatesPatch.kt
@@ -23,6 +23,8 @@ val disableLayoutUpdatesPatch = bytecodePatch(
     name = "Disable layout updates",
     description = "Adds an option to disable server side layout updates and use an older UI.",
 ) {
+    category("Miscellaneous")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/flyout/AddToQueuePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/flyout/AddToQueuePatch.kt
@@ -75,6 +75,8 @@ val addToQueuePatch = bytecodePatch(
     name = "Add to queue",
     description = "Overrides the feed flyout 'Play next in queue' with the Morphe video queue."
 ) {
+    category("Interaction")
+
     dependsOn(
         settingsPatch,
         sharedExtensionPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/formfactor/ChangeFormFactorPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/formfactor/ChangeFormFactorPatch.kt
@@ -41,6 +41,8 @@ val changeFormFactorPatch = bytecodePatch(
     name = "Change form factor",
     description = "Adds an option to change the UI appearance to a phone, tablet, or automotive device.",
 ) {
+    category("Miscellaneous")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/ambientmode/AmbientModePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/ambientmode/AmbientModePatch.kt
@@ -41,6 +41,8 @@ val ambientModePatch = bytecodePatch(
     name = "Ambient mode",
     description = "Adds options to bypass power saving restrictions for Ambient mode and disable it entirely or in fullscreen.",
 ) {
+    category("Player")
+
     dependsOn(
         settingsPatch,
         sharedExtensionPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/autoplaypreview/HideAutoplayPreviewPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/autoplaypreview/HideAutoplayPreviewPatch.kt
@@ -26,6 +26,8 @@ val hideAutoplayPreviewPatch = bytecodePatch(
     name = "Hide autoplay preview",
     description = "Adds an option to hide the autoplay preview at the end of videos.",
 ) {
+    category("Player")
+
     dependsOn(
         settingsPatch,
         sharedExtensionPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/endscreencards/HideEndScreenCardsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/endscreencards/HideEndScreenCardsPatch.kt
@@ -35,6 +35,8 @@ val hideEndScreenCardsPatch = bytecodePatch(
     name = "Hide end screen cards",
     description = "Adds an option to hide suggested video cards at the end of videos.",
 ) {
+    category("Player")
+
     dependsOn(
         sharedExtensionPatch,
         hideEndScreenCardsResourcePatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/endscreensuggestedvideo/HideEndScreenSuggestedVideoPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/endscreensuggestedvideo/HideEndScreenSuggestedVideoPatch.kt
@@ -23,6 +23,8 @@ val hideEndScreenSuggestedVideoPatch = bytecodePatch(
     name = "Hide end screen suggested video",
     description = "Adds an option to hide the suggested video at the end of videos.",
 ) {
+    category("Player")
+
     dependsOn(sharedExtensionPatch)
 
     compatibleWith(COMPATIBILITY_YOUTUBE)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -99,6 +99,8 @@ val hideLayoutComponentsPatch = bytecodePatch(
     description = "Adds options to hide general layout components."
 
 ) {
+    category("Hide layout")
+
     dependsOn(
         lithoFilterPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/infocards/HideInfoCardsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/infocards/HideInfoCardsPatch.kt
@@ -26,6 +26,8 @@ val hideInfoCardsPatch = bytecodePatch(
     name = "Hide info cards",
     description = "Adds an option to hide info cards that creators add in the video player."
 ) {
+    category("Player")
+
     dependsOn(
         sharedExtensionPatch,
         lithoFilterPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/player/flyoutmenu/HidePlayerFlyoutMenuComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/player/flyoutmenu/HidePlayerFlyoutMenuComponentsPatch.kt
@@ -38,6 +38,8 @@ val hidePlayerFlyoutMenuComponentsPatch = bytecodePatch(
     name = "Hide player flyout menu components",
     description = "Adds options to hide menu components that appear when pressing the gear icon in the video player."
 ) {
+    category("Player")
+
     dependsOn(
         lithoFilterPatch,
         playerTypeHookPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/player/popup/DisablePlayerPopupPanelsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/player/popup/DisablePlayerPopupPanelsPatch.kt
@@ -16,6 +16,8 @@ val disablePlayerPopupPanelsPatch = bytecodePatch(
     name = "Disable player popup panels",
     description = "Adds an option to disable panels (such as live chat) from opening automatically.",
 ) {
+    category("Player")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/relatedvideooverlay/HideRelatedVideoOverlayPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/relatedvideooverlay/HideRelatedVideoOverlayPatch.kt
@@ -19,6 +19,8 @@ val hideRelatedVideoOverlayPatch = bytecodePatch(
     name = "Hide related video overlay",
     description = "Adds an option to hide the related video overlay shown when swiping up in fullscreen.",
 ) {
+    category("Player")
+
     dependsOn(
         settingsPatch,
         sharedExtensionPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/relatedvideos/HideRelatedVideosPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/relatedvideos/HideRelatedVideosPatch.kt
@@ -43,6 +43,8 @@ val hideRelatedVideosPatch = bytecodePatch(
     name = "Hide related videos",
     description = "Adds options to hide related videos."
 ) {
+    category("Hide layout")
+
     dependsOn(
         settingsPatch,
         sharedExtensionPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/rollingnumber/DisableRollingNumberAnimationPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/rollingnumber/DisableRollingNumberAnimationPatch.kt
@@ -30,6 +30,8 @@ val disableRollingNumberAnimationPatch = bytecodePatch(
     name = "Disable rolling number animations",
     description = "Adds an option to disable rolling number animations of video view count, user likes, and upload time.",
 ) {
+    category("Layout")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/settingsmenu/HideSettingsMenuFilterPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/settingsmenu/HideSettingsMenuFilterPatch.kt
@@ -31,6 +31,8 @@ val hideSettingsMenuFilterPatch = bytecodePatch(
     name = "Settings menu filter",
     description = "Adds an option to hide items on the standard YouTube settings screen by their visible name."
 ) {
+    category("Hide layout")
+
     dependsOn(
         settingsPatch,
         sharedExtensionPatch

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/shorts/HideShortsComponentsPatch.kt
@@ -169,6 +169,8 @@ val hideShortsComponentsPatch = bytecodePatch(
     name = "Hide Shorts components",
     description = "Adds options to hide components related to Shorts."
 ) {
+    category("Hide layout")
+
     dependsOn(
         engagementPanelHookPatch,
         hideShortsComponentsResourcePatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/signintotvpopup/DisableSignInToTVPopupPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/signintotvpopup/DisableSignInToTVPopupPatch.kt
@@ -30,6 +30,8 @@ val disableSignInToTVPopupPatch = bytecodePatch(
     description = "Adds options to disable the popups asking to sign into or connect to a TV " +
         "on the same local network.",
 ) {
+    category("Hide layout")
+
     dependsOn(
         settingsPatch,
         sharedExtensionPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/time/HideTimestampPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/time/HideTimestampPatch.kt
@@ -14,6 +14,8 @@ val hideTimestampPatch = bytecodePatch(
     name = "Hide timestamp",
     description = "Adds an option to hide the timestamp in the bottom left of the video player.",
 ) {
+    category("Player")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/livering/OpenChannelOfLiveAvatarPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/livering/OpenChannelOfLiveAvatarPatch.kt
@@ -26,6 +26,8 @@ val openChannelOfLiveAvatarPatch = bytecodePatch(
     name = "Open channel of live avatar",
     description = "Adds an option to prevent a channel's current live video from opening when tapping its avatar."
 ) {
+    category("Interaction")
+
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     dependsOn(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/MiniplayerPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/miniplayer/MiniplayerPatch.kt
@@ -62,6 +62,8 @@ val miniplayerPatch = bytecodePatch(
     description = "Adds options to change the in-app minimized player. " +
             "Patching 21.28.206 and lower has more miniplayer types to choose from."
 ) {
+    category("Player")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/music/OverrideYouTubeMusicButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/music/OverrideYouTubeMusicButtonsPatch.kt
@@ -48,6 +48,8 @@ val overrideYouTubeMusicButtonsPatch = bytecodePatch(
     name = "Override YouTube Music buttons",
     description = "Overrides YouTube Music buttons to open Morphe Music or any compatible third-party client.",
 ) {
+    category("Integrations")
+
     dependsOn(settingsPatch)
     dependsOn(overrideYouTubeMusicManifestPatch())
     compatibleWith(COMPATIBILITY_YOUTUBE)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/playbackinfeeds/PlaybackInFeedsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/playbackinfeeds/PlaybackInFeedsPatch.kt
@@ -36,6 +36,8 @@ val playbackInFeedsPatch = bytecodePatch(
     description = "Adds the 'Playback in feeds' setting of YouTube to the Morphe settings, " +
             "where it is always available even if YouTube hides it."
 ) {
+    category("Layout")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/buttons/MuteVideoButtonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/buttons/MuteVideoButtonPatch.kt
@@ -54,6 +54,8 @@ val muteVideoButtonPatch = bytecodePatch(
     name = "Mute button",
     description = "Adds an option to show a player button that mutes the video audio.",
 ) {
+    category("Player")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/DisableFullscreenGesturesPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/DisableFullscreenGesturesPatch.kt
@@ -34,6 +34,8 @@ val disableFullscreenGesturesPatch = bytecodePatch(
     name = "Disable fullscreen gestures",
     description = "Adds options to selectively disable gestures for entering and exiting fullscreen mode, and to disable pinch-to-zoom.",
 ) {
+    category("Player")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/ExitFullscreenPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/ExitFullscreenPatch.kt
@@ -25,6 +25,7 @@ internal val exitFullscreenPatch = bytecodePatch(
     name = "Exit fullscreen mode",
     description = "Adds options to automatically exit fullscreen mode when a video reaches the end."
 ) {
+    category("Player")
 
     compatibleWith(COMPATIBILITY_YOUTUBE)
 

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/FullscreenVideoScalePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/FullscreenVideoScalePatch.kt
@@ -65,6 +65,8 @@ val fullscreenVideoScalePatch = bytecodePatch(
     name = "Fullscreen video scale",
     description = "Adds options to stretch or zoom videos to fill the screen in fullscreen mode.",
 ) {
+    category("Player")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/OpenVideosFullscreenPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/OpenVideosFullscreenPatch.kt
@@ -16,6 +16,8 @@ val openVideosFullscreenPatch = bytecodePatch(
     name = "Open videos fullscreen",
     description = "Adds options to automatically open videos in fullscreen portrait or landscape mode."
 ) {
+    category("Player")
+
     dependsOn(
         openVideosFullscreenHookPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/overlay/CustomPlayerOverlayOpacityPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/overlay/CustomPlayerOverlayOpacityPatch.kt
@@ -19,6 +19,8 @@ val customPlayerOverlayOpacityPatch = bytecodePatch(
     name = "Custom player overlay opacity",
     description = "Adds an option to change the opacity of the video player background when player controls are visible.",
 ) {
+    category("Player")
+
     dependsOn(settingsPatch,
         resourceMappingPatch,
         playerOverlayButtonsSettingsPatch

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/playlistautoplay/DisablePlaylistAutoplayPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/playlistautoplay/DisablePlaylistAutoplayPatch.kt
@@ -27,6 +27,8 @@ val disablePlaylistAutoplayPatch = bytecodePatch(
     name = "Disable playlist autoplay",
     description = "Adds an option to stop a playlist from automatically advancing to the next video.",
 ) {
+    category("Player")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/returnyoutubedislike/ReturnYouTubeDislikePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/returnyoutubedislike/ReturnYouTubeDislikePatch.kt
@@ -62,6 +62,8 @@ val returnYouTubeDislikePatch = bytecodePatch(
     name = "Return YouTube Dislike",
     description = "Adds an option to show the dislike count of videos with Return YouTube Dislike.",
 ) {
+    category("Integrations")
+
     dependsOn(
         settingsPatch,
         sharedExtensionPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/scrolling/DisableScrollSpeedLimitPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/scrolling/DisableScrollSpeedLimitPatch.kt
@@ -28,6 +28,8 @@ val disableScrollSpeedLimitPatch = bytecodePatch(
     description = "Adds an option to remove limits of how fast the home and " +
             "subscription feed can be scrolled."
 ) {
+    category("Layout")
+
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     dependsOn(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/sharesheet/OpenSystemShareSheetPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/sharesheet/OpenSystemShareSheetPatch.kt
@@ -31,6 +31,7 @@ internal fun openSystemShareSheetPatch(
     name = "Open system share sheet",
     description = "Adds an option to always open the system share sheet instead of the in-app share sheet."
 ) {
+    category("Integrations")
 
     dependsOn(
         sharedExtensionPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/shortsautoplay/ShortsAutoplayPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/shortsautoplay/ShortsAutoplayPatch.kt
@@ -44,6 +44,8 @@ val shortsAutoplayPatch = bytecodePatch(
     name = "Shorts autoplay",
     description = "Adds options to automatically play the next Short.",
 ) {
+    category("Layout")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/shortsnoresume/DisableShortsResumingOnStartupPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/shortsnoresume/DisableShortsResumingOnStartupPatch.kt
@@ -30,6 +30,8 @@ val disableShortsResumingOnStartupPatch = bytecodePatch(
     name = "Disable Shorts resuming on startup",
     description = "Adds an option to disable Shorts from resuming on app startup when Shorts were last being watched.",
 ) {
+    category("Layout")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/shortsplayer/OpenShortsInRegularPlayerPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/shortsplayer/OpenShortsInRegularPlayerPatch.kt
@@ -35,6 +35,8 @@ val openShortsInRegularPlayerPatch = bytecodePatch(
     name = "Open Shorts in regular player",
     description = "Adds options to open Shorts in the regular video player.",
 ) {
+    category("Player")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/sponsorblock/SponsorBlockPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/sponsorblock/SponsorBlockPatch.kt
@@ -227,6 +227,8 @@ val sponsorBlockPatch = bytecodePatch(
     name = "SponsorBlock",
     description = "Adds options to enable and configure SponsorBlock, which can skip undesired video segments such as sponsored content."
 ) {
+    category("Integrations")
+
     dependsOn(
         sharedExtensionPatch,
         resourceMappingPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/startpage/ChangeStartPagePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/startpage/ChangeStartPagePatch.kt
@@ -18,6 +18,8 @@ val changeStartPagePatch = bytecodePatch(
     name = "Change start page",
     description = "Adds an option to set which page the app opens in instead of the homepage.",
 ) {
+    category("Layout")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/thumbnails/AlternativeThumbnailsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/thumbnails/AlternativeThumbnailsPatch.kt
@@ -22,6 +22,8 @@ val alternativeThumbnailsPatch = bytecodePatch(
     name = "Alternative thumbnails",
     description = "Adds options to replace video thumbnails using the DeArrow API or image captures from the video.",
 ) {
+    category("Layout")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/thumbnails/BypassImageRegionRestrictionsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/thumbnails/BypassImageRegionRestrictionsPatch.kt
@@ -17,6 +17,8 @@ val bypassImageRegionRestrictionsPatch = bytecodePatch(
     description = "Adds an option to use a different host for user avatar and channel images " +
         "and can fix missing images that are blocked in some countries.",
 ) {
+    category("Privacy and network")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/widesearchbar/WideSearchBarPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/widesearchbar/WideSearchBarPatch.kt
@@ -28,6 +28,8 @@ val wideSearchBarPatch = bytecodePatch(
     name = "Wide search bar",
     description = "Adds a wide search bar to the top of the home and subscription feed."
 ) {
+    category("Layout")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/backgroundplayback/BackgroundPlaybackPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/backgroundplayback/BackgroundPlaybackPatch.kt
@@ -51,6 +51,8 @@ val backgroundPlaybackPatch = bytecodePatch(
     name = "Remove background playback restrictions",
     description = "Removes restrictions on background playback, including playing kids videos in the background.",
 ) {
+    category("Video and audio")
+
     dependsOn(
         sharedExtensionPatch,
         playerTypeHookPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/links/BypassLinkRedirectsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/links/BypassLinkRedirectsPatch.kt
@@ -17,6 +17,8 @@ val bypassLinkRedirectsPatch = bytecodePatch(
     name = "Bypass link redirects",
     description = "Adds an option to bypass redirects and open the original link directly.",
 ) {
+    category("Privacy and network")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/links/OpenLinksExternallyPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/links/OpenLinksExternallyPatch.kt
@@ -17,6 +17,8 @@ val openLinksExternallyPatch = bytecodePatch(
     name = "Open links externally",
     description = "Adds an option to always open links in your browser instead of with the in-app browser.",
 ) {
+    category("Integrations")
+
     compatibleWith(COMPATIBILITY_YOUTUBE)
 
     execute {

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/medianotification/MediaNotificationControlsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/medianotification/MediaNotificationControlsPatch.kt
@@ -28,6 +28,8 @@ val mediaNotificationControlsPatch = bytecodePatch(
     description = "Adds options to disable the seekbar and previous/next buttons in the " +
             "media notification and headphone controls.",
 ) {
+    category("Integrations")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/misc/spoof/dimensions/SpoofDeviceDimensionsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/misc/spoof/dimensions/SpoofDeviceDimensionsPatch.kt
@@ -15,6 +15,8 @@ val spoofDeviceDimensionsPatch = bytecodePatch(
     name = "Spoof device dimensions",
     description = "Adds an option to spoof the device dimensions which can unlock higher video qualities.",
 ) {
+    category("Spoofing")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/codecs/DisableVideoCodecsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/codecs/DisableVideoCodecsPatch.kt
@@ -31,6 +31,8 @@ val disableVideoCodecsPatch = bytecodePatch(
     name = "Disable video codecs",
     description = "Adds options to disable or force HDR, and to disable VP9 codecs.",
 ) {
+    category("Video and audio")
+
     dependsOn(
         sharedExtensionPatch,
         settingsPatch

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/quality/VideoQualityPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/quality/VideoQualityPatch.kt
@@ -29,6 +29,8 @@ val videoQualityPatch = bytecodePatch(
     name = "Video quality",
     description = "Adds options to set default video qualities and always use the advanced video quality menu."
 ) {
+    category("Video and audio")
+
     dependsOn(
         rememberVideoQualityPatch,
         advancedVideoQualityMenuPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/PlaybackSpeedPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/speed/PlaybackSpeedPatch.kt
@@ -33,6 +33,8 @@ val playbackSpeedPatch = bytecodePatch(
     description = "Adds options to customize available playback speeds, set a default playback speed, " +
         "and show a speed dialog button in the video player.",
 ) {
+    category("Video and audio")
+
     dependsOn(
         customPlaybackSpeedPatch,
         rememberPlaybackSpeedPatch,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/voiceovertranslation/VoiceOverTranslationPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/voiceovertranslation/VoiceOverTranslationPatch.kt
@@ -58,6 +58,8 @@ val voiceOverTranslationPatch = bytecodePatch(
     name = "Voice over translation",
     description = "Adds additional voice over languages using text-to-speech synchronized to the video playback.",
 ) {
+    category("Video and audio")
+
     dependsOn(
         sharedExtensionPatch,
         videoInformationPatch,


### PR DESCRIPTION
## Summary

Adds an optional, bundle-declared **category** to patches and uses it to section the patch lists in the manager. A bundle picks its own taxonomy; the manager groups by whatever it finds and leaves everything else exactly as it is today.

Closes MorpheApp/morphe-manager#929
Closes MorpheApp/morphe-manager#933

Large bundles are hard to navigate: 145 patches in Morphe Patches, and third party bundles reach several hundred. Both issues ask for the same thing: collapsible sections by patch type, with search reaching inside them.

## What changes

**`morphe-patcher`**
- `Patch.category: String?`, added as a trailing field with a default, exactly the way `availability` was added.
- `PatchBuilder.category(name)` for the DSL.
- `api/morphe-patcher.api` regenerated.

**`morphe-patches-library`**
- `PatchListGenerator` writes `category` into `patches-list.json`. Purely additive: existing consumers ignore the new field.

**`morphe-patches`**
- Every named patch declares a category. 129 declarations, which is all 145 patches the manager loads (the difference is shared factories in `shared/` that build one patch per app).

**`morphe-manager`**
- `PatchInfo.category`, read straight off the loaded patch.
- `PatchesListShared.kt` is generalized from the fixed pair "app specific + universal" into a list of blocks: `PatchGroup`, `buildPatchGroups()`, `patchGroupRows()`. The universal block is now simply the last group, still folded by default.
- Settings → Appearance → **Patch list → Group by category** (on by default).

## Backwards compatibility

- **Existing bundles keep working untouched.** Bundles call the `bytecodePatch { }` DSL,never the `Patch` constructor, so a bundle compiled before this change simply never calls `category(...)` and the field stays `null`.
- **A bundle that declares no categories renders exactly the list it renders today**: one headerless block plus the universal tail. This is not a special case in the code, it is what `buildPatchGroups` produces when every category is `null`.
- **No data migration.** Selections, options, `SeenPatch` and exported configurations are keyed by patch name via `uniqueNames()`. `category` is deliberately not part of that key, so every stored selection stays valid.
- **Users who do not want it** switch the setting off, which collapses the categories back into the plain list.

## Declaring a category

One line in the patch builder. Patches that do not call it stay ungrouped.

```kotlin
val hideAdsPatch = bytecodePatch(
    name = "Hide ads",
    description = "Adds options to hide general ads, Premium promotions and video ads."
) {
    category("Ads")

    dependsOn(
        hideAdsResourcePatch,
        settingsPatch
    )

    compatibleWith(COMPATIBILITY_YOUTUBE)

    execute {
        // ...
    }
}
```

The name is free-form, matched by the manager as an opaque key, so a third party bundle can ship any taxonomy it likes. For a patch built by a shared factory, the call goes in the factory and covers every app at once:

```kotlin
internal fun disableDRCAudioPatch(
    block: BytecodePatchBuilder.() -> Unit,
    preferenceScreen: BasePreferenceScreen.Screen,
    useLegacyNormalizationFlag: BytecodePatchBuilder.() -> Boolean,
    useNormalizationFlag: BytecodePatchBuilder.() -> Boolean
) = bytecodePatch(
    name = "Disable DRC audio",
    description = "Adds an option to disable DRC (Dynamic Range Compression) audio."
) {
    category("Video and audio")

    block()

    // ...
}
```

## How it looks in the manager

- Each category is a collapsible header carrying its patch count, and a badge with thenumber of enabled patches so a folded block never hides a selection silently.
- Categories start expanded; the universal block keeps its current folded default.
- Searching or filtering forces every block open and drops the empty ones, so a match isnever hidden behind a fold.
- Ordering: uncategorized patches first (no header), then categories alphabetically, thenuniversal patches last.
- All three patch lists share the same code: the expert mode selection dialog, the per app patch list, and the bundle browser in Patch sources.
<details>
 <summary>Screenshot</summary>

<img width="1080" height="1986" alt="Screenshot_2026-09-05-00-14-55-060_app morphe manager debug-edit" src="https://github.com/user-attachments/assets/7aab821f-4046-4dae-b6d4-9f75bcd6773e" />

</details>

## Merge order

The repositories depend on each other, so merge and release in this order:

1. https://github.com/MorpheApp/morphe-patcher/pull/198
2. https://github.com/MorpheApp/morphe-patches-library/pull/54
3. https://github.com/MorpheApp/morphe-manager/pull/941
4. https://github.com/MorpheApp/morphe-patches/pull/2786