### PR TITLE
fix(YouTube - Hide player overlay buttons): Apply the control buttons background opacity to the player time bar

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/HidePlayerOverlayButtonsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/HidePlayerOverlayButtonsPatch.java
@@ -18,6 +18,9 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 
+import androidx.annotation.Nullable;
+
+import java.lang.ref.WeakReference;
 import java.util.function.Consumer;
 
 import app.morphe.extension.shared.Logger;
@@ -189,12 +192,102 @@ public final class HidePlayerOverlayButtonsPatch {
                         imageView.setBackground(applyControlButtonsBackgroundOpacity(background));
                     }
                 });
+
+                stylePillBackgrounds(rootView);
             }
         } catch (Exception ex) {
             Logger.printException(() -> "styleControlButtonsBackground failure", ex);
         }
 
         return rootView;
+    }
+
+    /**
+     * Bottom overlay views that carry the same background as the control buttons,
+     * but drawn as a pill instead of a circle.
+     */
+    private static final String[] PILL_BACKGROUND_RESOURCE_NAMES = {
+            "timestamps_container", // Current time and duration.
+            "time_bar_chapter_title",
+            "time_bar_timeline_title",
+    };
+
+    private static class PillBackground {
+        private final int id;
+        private WeakReference<View> viewRef = new WeakReference<>(null);
+        /** ConstantState of the background the opacity was last applied to. */
+        @Nullable
+        private Drawable.ConstantState backgroundSnapshot;
+
+        PillBackground(String resourceName) {
+            id = ResourceUtils.getIdentifier(ResourceType.ID, resourceName);
+        }
+
+        /**
+         * The timestamps pill is a container nested inside the one carrying the id,
+         * and older app targets leave that inner container unnamed.
+         */
+        private static View pillOf(View view) {
+            return view instanceof ViewGroup group && group.getChildAt(0) instanceof ViewGroup inner
+                    ? inner
+                    : view;
+        }
+
+        void update(View rootView) {
+            if (id == 0) return;
+
+            View pill = viewRef.get();
+            if (pill == null || !pill.isAttachedToWindow()) {
+                View container = rootView.findViewById(id);
+                if (container == null) return;
+
+                pill = pillOf(container);
+                viewRef = new WeakReference<>(pill);
+                backgroundSnapshot = null;
+            }
+
+            Drawable background = pill.getBackground();
+            if (background == null) return;
+
+            // A null state cannot be tracked, so fall through and rely on mutate() being idempotent.
+            Drawable.ConstantState state = background.getConstantState();
+            if (state != null && state == backgroundSnapshot) return;
+
+            Drawable styled = applyControlButtonsBackgroundOpacity(background);
+            if (styled != background) {
+                pill.setBackground(styled);
+            }
+            backgroundSnapshot = styled.getConstantState();
+        }
+    }
+
+    /**
+     * The pills live in the bottom overlay container, which is inflated from a stub of its own
+     * and can appear after the control buttons, so they are resolved on a draw pass instead.
+     */
+    private static void stylePillBackgrounds(View controlsView) {
+        // The buttons and the bottom overlay are inflated into the same controls layout,
+        // so the pills are searched for from the shared parent and not from the buttons.
+        if (!(controlsView.getParent() instanceof ViewGroup controlsLayout)) {
+            Logger.printDebug(() -> "Unknown control buttons parent: " + controlsView.getParent());
+            return;
+        }
+
+        PillBackground[] pills = new PillBackground[PILL_BACKGROUND_RESOURCE_NAMES.length];
+        for (int i = 0; i < pills.length; i++) {
+            pills[i] = new PillBackground(PILL_BACKGROUND_RESOURCE_NAMES[i]);
+        }
+
+        controlsView.getViewTreeObserver().addOnPreDrawListener(() -> {
+            try {
+                for (PillBackground pill : pills) {
+                    pill.update(controlsLayout);
+                }
+            } catch (Exception ex) {
+                Logger.printDebug(() -> "Could not style player overlay pill background", ex);
+            }
+            return true;
+        });
     }
 
     /**

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/HidePlayerOverlayButtonsPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/HidePlayerOverlayButtonsPatch.java
@@ -228,9 +228,13 @@ public final class HidePlayerOverlayButtonsPatch {
          * and older app targets leave that inner container unnamed.
          */
         private static View pillOf(View view) {
-            return view instanceof ViewGroup group && group.getChildAt(0) instanceof ViewGroup inner
-                    ? inner
-                    : view;
+            if (view instanceof ViewGroup group && group.getChildCount() > 0) {
+                View first = group.getChildAt(0);
+                if (first instanceof ViewGroup inner) {
+                    return inner;
+                }
+            }
+            return view;
         }
 
         void update(View rootView) {
@@ -274,7 +278,7 @@ public final class HidePlayerOverlayButtonsPatch {
         }
 
         PillBackground[] pills = new PillBackground[PILL_BACKGROUND_RESOURCE_NAMES.length];
-        for (int i = 0; i < pills.length; i++) {
+        for (int i = 0, length = pills.length; i < length; i++) {
             pills[i] = new PillBackground(PILL_BACKGROUND_RESOURCE_NAMES[i]);
         }
 

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -870,7 +870,7 @@ To show the \'Audio Track\' menu, change \'Spoof video streams\' to any client e
     <string name="morphe_hide_player_control_buttons_background_title">Hide player controls background</string>
     <string name="morphe_hide_player_control_buttons_background_summary">Hides the dark shading surrounding the video player controls</string>
     <string name="morphe_player_control_buttons_background_opacity_title">Control buttons background opacity</string>
-    <string name="morphe_player_control_buttons_background_opacity_summary">Adjust the opacity of the circle behind the player control buttons (0 is invisible, 100 is solid)</string>
+    <string name="morphe_player_control_buttons_background_opacity_summary">Adjust the opacity of the background behind the player control buttons and the time bar (0 is invisible, 100 is solid)</string>
     <string name="morphe_hide_player_previous_next_buttons_title">Hide Previous &amp; Next buttons</string>
     <string name="morphe_hide_settings_button_title">Hide Settings button</string>
 


### PR DESCRIPTION
### Description

The "Control buttons background opacity" setting skipped the pill holding the current time and the chapter title, since it only reached the ImageView control buttons. Those views now get the same opacity, on both the current and the older bottom overlay layouts.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
___
![Screenshot_2026-09-05-17-09-33-931_com.google.android.youtube.test-edit.jpg](https://github.com/user-attachments/assets/32d7d82f-c1a9-4c82-94d6-e7b9cf9d7e59)

