### PR TITLE
fix(YouTube - Hide layout components): App may crash when 'You may like' section is hidden

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -864,39 +864,47 @@ val hideLayoutComponentsPatch = bytecodePatch(
                             # If the setting is disabled or the typed string is not empty, do nothing.
                             if-eqz v1, :ignore
 
-                            ## Get a collection of search suggestions.
+                            # Get a collection of search suggestions.
                             iget-object v1, v0, $searchSuggestionCollectionField
-                            
+                            if-eqz v1, :ignore
+
+                            # Create a new list to hold filtered search suggestions.
+                            new-instance v2, Ljava/util/ArrayList;
+                            invoke-direct { v2 }, Ljava/util/ArrayList;-><init>()V
+
                             # Iterate through the collection and check if the search suggestion is the search history.
                             invoke-interface { v1 }, Ljava/util/Collection;->iterator()Ljava/util/Iterator;
-                            move-result-object v2
-                            
-                            :loop
-                            invoke-interface { v2 }, Ljava/util/Iterator;->hasNext()Z
-                            move-result v3
-                            if-eqz v3, :exit
-                            invoke-interface { v2 }, Ljava/util/Iterator;->next()Ljava/lang/Object;
                             move-result-object v3
-                            instance-of v4, v3, $searchSuggestionEndpointClass
-                            if-eqz v4, :loop
-                            check-cast v3, $searchSuggestionEndpointClass
+
+                            :loop
+                            invoke-interface { v3 }, Ljava/util/Iterator;->hasNext()Z
+                            move-result v1
+                            if-eqz v1, :exit
+
+                            invoke-interface { v3 }, Ljava/util/Iterator;->next()Ljava/lang/Object;
+                            move-result-object v1
+
+                            instance-of v4, v1, $searchSuggestionEndpointClass
+                            if-eqz v4, :add_item
+
+                            check-cast v1, $searchSuggestionEndpointClass
 
                             # Each search suggestion has a command endpoint.
                             # If the search suggestion is the search history, the command includes the keyword '/delete'.
-                            iget-object v4, v3, $searchSuggestionEndpointField
-                            invoke-static { v3, v4 }, $LAYOUT_COMPONENTS_FILTER->isSearchHistory(Ljava/lang/Object;Ljava/lang/String;)Z
-                            move-result v3
-                            
-                            # If this search suggestion is the search history, do nothing.
-                            if-nez v3, :loop
-                            
-                            # If this search suggestion is not the search history, remove it from the search suggestions collection.
-                            invoke-interface { v2 }, Ljava/util/Iterator;->remove()V
+                            iget-object v4, v1, $searchSuggestionEndpointField
+                            invoke-static { v1, v4 }, $LAYOUT_COMPONENTS_FILTER->isSearchHistory(Ljava/lang/Object;Ljava/lang/String;)Z
+                            move-result v4
+
+                            # If this search suggestion is not the search history, skip adding it.
+                            if-eqz v4, :loop
+
+                            :add_item
+                            invoke-virtual { v2, v1 }, Ljava/util/ArrayList;->add(Ljava/lang/Object;)Z
                             goto :loop
 
                             # Save the updated collection to a field.
                             :exit
-                            iput-object v1, v0, $searchSuggestionCollectionField
+                            iput-object v2, v0, $searchSuggestionCollectionField
 
                             :ignore
                             return-void


### PR DESCRIPTION
### Description

Possible fix for "Hide you may like" crash due to unmodifiable list iteration.

Cannot verify if this fixes the problem because I cannot reproduce.

Closes #2813

### Test results

- [ ] Tested on both the **minimum** and **maximum** supported versions
- [X] Tested on **experimental** supported versions (Optional)
