### PR TITLE
fix(YouTube Music - Downloads): Prevent external downloader triggering on non-download actions

### DIFF
--- a/extensions/music/src/main/java/app/morphe/extension/music/patches/DownloadsPatch.java
+++ b/extensions/music/src/main/java/app/morphe/extension/music/patches/DownloadsPatch.java
@@ -228,15 +228,33 @@ public final class DownloadsPatch {
             final boolean isDownloadClick = Utils.containsAny(p1String,
                     "[133724106]", "[443434441]");
             if (isDownloadClick) {
+                Object viewObj = map.get(ELEMENTS_SENDER_VIEW);
+
+                if (viewObj == null) {
+                    Logger.printDebug(() -> "Ignored programmatic download click (no sender_view).");
+                    return false;
+                }
+
+                if (viewObj instanceof ComponentHost componentHost) {
+                    CharSequence cd = componentHost.getContentDescription();
+                    if (cd != null && !downloadButtonLabel.isEmpty()) {
+                        String cdLower = cd.toString().toLowerCase();
+                        String labelLower = downloadButtonLabel.toLowerCase();
+
+                        if (!cdLower.contains(labelLower) && !labelLower.contains(cdLower)) {
+                            Logger.printDebug(() -> "Ignored false positive UI click (Content description mismatch).");
+                            return false;
+                        }
+                    }
+                }
+
                 Logger.printDebug(() -> "Flyout isDownloadClick");
                 final long now = System.currentTimeMillis();
                 if (now - lastFlyoutDownloadTime < IGNORE_DOUBLE_CLICK_DURATION_MS) {
                     return true;
                 }
 
-                Object viewObj = map.get(ELEMENTS_SENDER_VIEW);
                 final boolean inDialog = isViewInsideDialog(viewObj);
-
                 String targetId = extractVideoIdFromCommand(p1);
 
                 if (targetId == null && inDialog) {


### PR DESCRIPTION
### Description

- Resolves an issue where programmatic side-effects and other flyout actions (like "Save to playlist") were falsely triggering the external downloader.
- YouTube Music overloads the `[443434441]` Protobuf endpoint for offline state checks. The patch now strictly requires the presence of a `sender_view` and dynamically validates its `contentDescription` against the cached, localized download button label to ensure only genuine UI clicks trigger the interception.

Closes #2278

### Additional context

N/A

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
