### PR TITLE
fix(YouTube - Video quality): Prevent infinite loading when opening videos from Shorts

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/VideoInformation.java
@@ -1064,6 +1064,14 @@ public final class VideoInformation {
                     // Only change Shorts quality if the quality actually needs to change, because
                     // the "Auto" option is not shown in the flyout and setting the same quality
                     // again can cause the Short to restart.
+                    //
+                    // If a regular video is opened via a link inside a Short, the Shorts UI fragment
+                    // remains open during the transition. Forcing a changeQuality() restart during
+                    // this specific overlapping state causes an ExoPlayer codec deadlock.
+                    if (ShortsPlayerState.isOpen() && !PlayerType.getCurrent().isNoneOrHidden()) {
+                        return i;
+                    }
+
                     if (qualityNeedsChange || !ShortsPlayerState.isOpen()) {
                         changeQuality(quality);
                         return i;


### PR DESCRIPTION
### Description

Closes #541.

### Additional context

<!-- ADD ADDITIONAL CONTEXT HERE -->

Prevents `changeQuality()` from firing a forced UI-update while the Shorts fragment and the new player are transitioning and fighting for hardware decoder resources. By returning the preferred quality index `i` during this transition state, YouTube natively handles the codec handover and successfully scales up the resolution without deadlocking.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
