### PR TITLE
fix(YouTube - Fullscreen video scale): Restore UI after leaving fullscreen on tablet/foldable landscape

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/FullscreenVideoScalePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/FullscreenVideoScalePatch.java
@@ -24,6 +24,7 @@ import androidx.annotation.Nullable;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.List;
 
 import app.morphe.extension.shared.Logger;
@@ -75,6 +76,12 @@ public class FullscreenVideoScalePatch {
     private static ViewTreeObserver.OnPreDrawListener preDrawListener;
     private static WeakReference<View> preDrawHostRef = new WeakReference<>(null);
     private static boolean preDrawAttached;
+
+    /**
+     * Clip flags disabled while scaled, restored when leaving fullscreen.
+     */
+    @Nullable
+    private static List<SavedClipState> savedClipStates;
 
     static {
         PlayerType.getOnChange().addObserver((PlayerType type) -> {
@@ -260,9 +267,22 @@ public class FullscreenVideoScalePatch {
         return DEFAULT_VIDEO_ASPECT;
     }
 
+    /**
+     * Snapshot clip flags on the first call so restore can put back YouTube's values
+     * instead of leaving {@code clipChildren=false} on the watch-page ancestors.
+     */
     private static void disableClipping(View view) {
+        List<SavedClipState> saved = savedClipStates;
+        final boolean snapshot = saved == null;
+        if (saved == null) {
+            saved = new ArrayList<>();
+            savedClipStates = saved;
+        }
         View current = view;
         for (int i = 0; i < 16 && current != null; i++) {
+            if (snapshot) {
+                saved.add(new SavedClipState(current));
+            }
             current.setClipToOutline(false);
             if (current instanceof ViewGroup group) {
                 group.setClipChildren(false);
@@ -272,6 +292,17 @@ public class FullscreenVideoScalePatch {
                 break;
             }
             current = parent;
+        }
+    }
+
+    private static void restoreClipping() {
+        List<SavedClipState> saved = savedClipStates;
+        savedClipStates = null;
+        if (saved == null) {
+            return;
+        }
+        for (int i = saved.size() - 1; i >= 0; i--) {
+            saved.get(i).restore();
         }
     }
 
@@ -324,6 +355,7 @@ public class FullscreenVideoScalePatch {
             resetViewTransform(previous);
         }
         scaledViewRef = new WeakReference<>(null);
+        restoreClipping();
     }
 
     private static void resetViewTransform(@Nullable View view) {
@@ -352,6 +384,12 @@ public class FullscreenVideoScalePatch {
         preDrawListener = () -> {
             try {
                 if (!shouldScale() || Settings.FULLSCREEN_VIDEO_SCALE.get() == VideoScaleMode.DEFAULT) {
+                    View target = scaledViewRef.get();
+                    if (target == null) {
+                        target = resolvePlayerView();
+                    }
+                    detachPreDraw();
+                    restoreDefaultTransform(target);
                     return true;
                 }
                 View target = scaledViewRef.get();
@@ -393,14 +431,23 @@ public class FullscreenVideoScalePatch {
         }
     }
 
+    /**
+     * Stretch/Zoom maps the player onto the full window, which is only valid in
+     * true fullscreen.
+     * <p>
+     * Landscape {@link PlayerType#WATCH_WHILE_MAXIMIZED} is the tablet / foldable
+     * inner-screen watch page (player in a pane), not fullscreen. Phone landscape
+     * already reports {@link PlayerType#WATCH_WHILE_FULLSCREEN}.
+     * <p>
+     * {@link PlayerType#WATCH_WHILE_SLIDING_MAXIMIZED_FULLSCREEN} is used for both
+     * enter and exit. Scaling during it would keep the full-window transform while
+     * the player is already shrinking back into the watch page.
+     *
+     * @see <a href="https://github.com/MorpheApp/morphe-patches/issues/2652">#2652</a>
+     */
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     private static boolean shouldScale() {
-        PlayerType type = PlayerType.getCurrent();
-        if (type == PlayerType.WATCH_WHILE_FULLSCREEN
-                || type == PlayerType.WATCH_WHILE_SLIDING_MAXIMIZED_FULLSCREEN) {
-            return true;
-        }
-        return type == PlayerType.WATCH_WHILE_MAXIMIZED && Utils.isLandscapeOrientation();
+        return PlayerType.getCurrent() == PlayerType.WATCH_WHILE_FULLSCREEN;
     }
 
     @Nullable
@@ -509,5 +556,38 @@ public class FullscreenVideoScalePatch {
 
     private static boolean isUsableVideoView(@Nullable View view) {
         return view instanceof TextureView || view instanceof SurfaceView;
+    }
+
+    private static final class SavedClipState {
+        final WeakReference<View> viewRef;
+        final boolean clipToOutline;
+        final boolean clipChildren;
+        final boolean clipToPadding;
+        final boolean isGroup;
+
+        SavedClipState(View view) {
+            viewRef = new WeakReference<>(view);
+            clipToOutline = view.getClipToOutline();
+            isGroup = view instanceof ViewGroup;
+            if (view instanceof ViewGroup group) {
+                clipChildren = group.getClipChildren();
+                clipToPadding = group.getClipToPadding();
+            } else {
+                clipChildren = false;
+                clipToPadding = false;
+            }
+        }
+
+        void restore() {
+            View view = viewRef.get();
+            if (view == null) {
+                return;
+            }
+            view.setClipToOutline(clipToOutline);
+            if (isGroup && view instanceof ViewGroup group) {
+                group.setClipChildren(clipChildren);
+                group.setClipToPadding(clipToPadding);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Description

Fullscreen video scale (Stretch / Zoom) maps the 16:9 `PlayerView` onto the full window. `shouldScale()` also treated landscape `WATCH_WHILE_MAXIMIZED` as fullscreen.

On a foldable inner screen / tablet, landscape watch is maximized, not fullscreen (player in a pane, related videos beside or below). The compositor transform then stretched the player over the rest of the UI, and it was never restored after leaving fullscreen. Portrait was unaffected because that extra condition requires landscape.

This PR:

- Applies Stretch/Zoom only when `PlayerType` is `WATCH_WHILE_FULLSCREEN`
- Does not scale during `WATCH_WHILE_SLIDING_MAXIMIZED_FULLSCREEN` (used for both enter and exit)
- Snapshots and restores ancestor clip flags
- Restores the transform from the pre-draw listener when scaling should stop, instead of leaving the last scale in place

Waiting on reporter confirmation on an Oppo Find N6 inner display before marking ready for review.

Fixes #2652

### Additional context

Phone landscape already reports `WATCH_WHILE_FULLSCREEN`, so Stretch/Zoom on phones should be unchanged.

@Haerion please try this draft on the Find N6 inner screen (steps on the issue comment). I will keep this PR as a draft until that check lands.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [ ] Tested on **experimental** supported versions (Optional)

Not tested on a foldable here. Asking @Haerion to try the PR **Build** artifact on YouTube `21.04.223` (the version in #2652).