### PR TITLE
fix(YouTube - Disable fullscreen gestures): Restore pinch-to-zoom past fill on `21.36`+

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableFullscreenGesturesPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableFullscreenGesturesPatch.java
@@ -10,7 +10,21 @@
 
 package app.morphe.extension.youtube.patches;
 
+import android.app.Activity;
+import android.view.ScaleGestureDetector;
+import android.view.SurfaceView;
+import android.view.TextureView;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
+import android.view.Window;
+
+import androidx.annotation.Nullable;
+
+import java.lang.ref.WeakReference;
+
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
 import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
@@ -30,12 +44,9 @@ public class DisableFullscreenGesturesPatch {
     }
 
     /**
-     * Injection point.
+     * Injection point. Pre-21.36 zoom-flag override.
      */
     public static boolean disableBrokenFullscreenZoomFlag(boolean original) {
-        if (original) {
-            Logger.printInfo(() -> "Problematic pinch to zoom flag is on: " + 45698813);
-        }
         return false;
     }
 
@@ -44,5 +55,242 @@ public class DisableFullscreenGesturesPatch {
      */
     public static boolean disableZoomGesture() {
         return Settings.DISABLE_FULLSCREEN_ZOOM_GESTURE.get();
+    }
+
+    /**
+     * 21.36+ PlayerView is a 16:9 box. Native pinch scales inside that box (Nx HUD)
+     * and never eats the window letterbox. Scale the player view while pinched.
+     * At scale 1 this does not write scaleX/Y so Fullscreen video scale can own
+     * the view at rest.
+     */
+    private static WeakReference<View> playerViewRef = new WeakReference<>(null);
+    private static WeakReference<View> overlayRef = new WeakReference<>(null);
+    private static volatile float pinchScale = 1f;
+    private static boolean pinchOwningView;
+    private static final float MIN_PINCH_SCALE = 1f;
+    private static final float MAX_PINCH_SCALE = 8f;
+
+    @Nullable
+    private static ViewTreeObserver.OnPreDrawListener preDrawListener;
+    private static WeakReference<View> preDrawHostRef = new WeakReference<>(null);
+
+    /**
+     * Injection point. {@code YouTubePlayerOverlaysLayout} constructor.
+     */
+    public static void attachPlayerOverlay(View overlay) {
+        if (overlay == null) {
+            return;
+        }
+        overlayRef = new WeakReference<>(overlay);
+    }
+
+    /**
+     * Injection point. {@code YouTubePlayerViewNotForReflection.onLayout}.
+     */
+    public static void onPlayerViewLayout(View playerView) {
+        if (playerView == null) {
+            return;
+        }
+        playerViewRef = new WeakReference<>(playerView);
+        if (playerView.getHeight() > playerView.getWidth() + 8) {
+            pinchScale = MIN_PINCH_SCALE;
+        }
+        applyPinchTransform(playerView);
+    }
+
+    /**
+     * Current pinch factor (>= 1). Fullscreen video scale reads this so Stretch/Zoom
+     * stay applied while pinched.
+     */
+    public static float getPinchScale() {
+        return pinchScale < MIN_PINCH_SCALE ? MIN_PINCH_SCALE : pinchScale;
+    }
+
+    /**
+     * Injection point. {@code ScaleGestureDetector.OnScaleGestureListener.onScale}.
+     */
+    public static void onPinchScale(ScaleGestureDetector detector) {
+        if (detector == null || disableZoomGesture()) {
+            return;
+        }
+        pinchScale *= detector.getScaleFactor();
+        if (pinchScale < MIN_PINCH_SCALE) {
+            pinchScale = MIN_PINCH_SCALE;
+        } else if (pinchScale > MAX_PINCH_SCALE) {
+            pinchScale = MAX_PINCH_SCALE;
+        }
+        Logger.printDebug(() -> "pinch scale=" + pinchScale);
+        applyPinchTransform(resolvePlayerView());
+    }
+
+    /**
+     * Injection point. {@code onScaleEnd}.
+     */
+    public static void onPinchScaleEnd(ScaleGestureDetector detector) {
+        applyPinchTransform(resolvePlayerView());
+    }
+
+    private static void applyPinchTransform(@Nullable View preferred) {
+        if (fullscreenScaleOwnsTransform()) {
+            pinchOwningView = false;
+            detachPreDraw();
+            FullscreenVideoScalePatch.applyScale();
+            return;
+        }
+        View view = preferred != null ? preferred : resolvePlayerView();
+        if (pinchScale <= MIN_PINCH_SCALE + 0.01f) {
+            if (pinchOwningView && view != null) {
+                applyScaleToViewAndSurfaces(view, 1f);
+            }
+            pinchOwningView = false;
+            detachPreDraw();
+            return;
+        }
+        if (view == null) {
+            Logger.printDebug(() -> "pinch: no player view, scale=" + pinchScale);
+            return;
+        }
+        pinchOwningView = true;
+        disableClipping(view);
+        applyScaleToViewAndSurfaces(view, pinchScale);
+        attachPreDraw(view);
+    }
+
+    private static boolean fullscreenScaleOwnsTransform() {
+        FullscreenVideoScalePatch.VideoScaleMode mode = Settings.FULLSCREEN_VIDEO_SCALE.get();
+        return mode == FullscreenVideoScalePatch.VideoScaleMode.STRETCH
+                || mode == FullscreenVideoScalePatch.VideoScaleMode.ZOOM;
+    }
+
+    private static void applyScaleToViewAndSurfaces(View view, float scale) {
+        setViewScale(view, scale);
+        if (view instanceof ViewGroup group) {
+            for (int i = 0, n = group.getChildCount(); i < n; i++) {
+                View child = group.getChildAt(i);
+                if (child instanceof SurfaceView || child instanceof TextureView) {
+                    setViewScale(child, scale);
+                }
+            }
+        }
+    }
+
+    private static void setViewScale(View view, float scale) {
+        final int w = view.getWidth();
+        final int h = view.getHeight();
+        if (w > 0 && h > 0) {
+            view.setPivotX(w / 2f);
+            view.setPivotY(h / 2f);
+        }
+        view.setClipBounds(null);
+        view.setScaleX(scale);
+        view.setScaleY(scale);
+    }
+
+    private static void attachPreDraw(@Nullable View host) {
+        if (host == null) {
+            host = resolvePlayerView();
+        }
+        if (host == null) {
+            return;
+        }
+        View currentHost = preDrawHostRef.get();
+        if (preDrawListener != null && currentHost == host) {
+            return;
+        }
+        detachPreDraw();
+        ViewTreeObserver observer = host.getViewTreeObserver();
+        if (observer == null || !observer.isAlive()) {
+            return;
+        }
+        preDrawListener = () -> {
+            try {
+                applyPinchTransform(resolvePlayerView());
+            } catch (Exception ex) {
+                Logger.printException(() -> "pinch pre-draw failure", ex);
+            }
+            return true;
+        };
+        observer.addOnPreDrawListener(preDrawListener);
+        preDrawHostRef = new WeakReference<>(host);
+    }
+
+    private static void detachPreDraw() {
+        ViewTreeObserver.OnPreDrawListener listener = preDrawListener;
+        View host = preDrawHostRef.get();
+        preDrawListener = null;
+        preDrawHostRef = new WeakReference<>(null);
+        if (listener == null || host == null) {
+            return;
+        }
+        ViewTreeObserver observer = host.getViewTreeObserver();
+        if (observer != null && observer.isAlive()) {
+            observer.removeOnPreDrawListener(listener);
+        }
+    }
+
+    @Nullable
+    private static View resolvePlayerView() {
+        View cached = playerViewRef.get();
+        if (cached != null && cached.isAttachedToWindow() && cached.getWidth() > 0) {
+            return cached;
+        }
+        Activity activity = Utils.getActivity();
+        if (activity != null) {
+            Window window = activity.getWindow();
+            if (window != null) {
+                View found = findPlayerView(window.getDecorView(), 0);
+                if (found != null) {
+                    playerViewRef = new WeakReference<>(found);
+                    return found;
+                }
+            }
+        }
+        View overlay = overlayRef.get();
+        if (overlay != null) {
+            View found = findPlayerView(overlay.getRootView(), 0);
+            if (found != null) {
+                playerViewRef = new WeakReference<>(found);
+                return found;
+            }
+        }
+        return cached;
+    }
+
+    @Nullable
+    private static View findPlayerView(View view, int depth) {
+        if (depth > 18 || view == null) {
+            return null;
+        }
+        String name = view.getClass().getName();
+        if (name.endsWith("YouTubePlayerViewNotForReflection")
+                || name.endsWith("player.ui.PlayerView")) {
+            return view;
+        }
+        if (!(view instanceof ViewGroup group)) {
+            return null;
+        }
+        for (int i = 0, n = group.getChildCount(); i < n; i++) {
+            View found = findPlayerView(group.getChildAt(i), depth + 1);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    private static void disableClipping(View view) {
+        View current = view;
+        for (int i = 0; i < 16 && current != null; i++) {
+            current.setClipToOutline(false);
+            current.setClipBounds(null);
+            if (current instanceof ViewGroup group) {
+                group.setClipChildren(false);
+                group.setClipToPadding(false);
+            }
+            if (!(current.getParent() instanceof View parent)) {
+                break;
+            }
+            current = parent;
+        }
     }
 }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableFullscreenGesturesPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/DisableFullscreenGesturesPatch.java
@@ -103,6 +103,9 @@ public class DisableFullscreenGesturesPatch {
      * stay applied while pinched.
      */
     public static float getPinchScale() {
+        if (!Settings.RESTORE_PINCH_TO_ZOOM.get()) {
+            return MIN_PINCH_SCALE;
+        }
         return pinchScale < MIN_PINCH_SCALE ? MIN_PINCH_SCALE : pinchScale;
     }
 
@@ -110,7 +113,7 @@ public class DisableFullscreenGesturesPatch {
      * Injection point. {@code ScaleGestureDetector.OnScaleGestureListener.onScale}.
      */
     public static void onPinchScale(ScaleGestureDetector detector) {
-        if (detector == null || disableZoomGesture()) {
+        if (detector == null || disableZoomGesture() || !Settings.RESTORE_PINCH_TO_ZOOM.get()) {
             return;
         }
         pinchScale *= detector.getScaleFactor();
@@ -131,6 +134,9 @@ public class DisableFullscreenGesturesPatch {
     }
 
     private static void applyPinchTransform(@Nullable View preferred) {
+        if (!Settings.RESTORE_PINCH_TO_ZOOM.get()) {
+            pinchScale = MIN_PINCH_SCALE;
+        }
         if (fullscreenScaleOwnsTransform()) {
             pinchOwningView = false;
             detachPreDraw();

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/FullscreenVideoScalePatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/FullscreenVideoScalePatch.java
@@ -223,8 +223,9 @@ public class FullscreenVideoScalePatch {
         view.getLocationOnScreen(loc);
 
         VideoScaleMode mode = Settings.FULLSCREEN_VIDEO_SCALE.get();
+        final float pinch = Math.max(1f, DisableFullscreenGesturesPatch.getPinchScale());
         if (mode == VideoScaleMode.ZOOM) {
-            final float scale = Math.max(displayW / contentW, displayH / contentH);
+            final float scale = Math.max(displayW / contentW, displayH / contentH) * pinch;
             view.setPivotX(contentLeft + contentW / 2f);
             view.setPivotY(contentTop + contentH / 2f);
             view.setScaleX(scale);
@@ -236,10 +237,24 @@ public class FullscreenVideoScalePatch {
             return;
         }
 
+        final float scaleX = (displayW / contentW) * pinch;
+        final float scaleY = (displayH / contentH) * pinch;
+        if (pinch > 1.01f) {
+            view.setPivotX(contentLeft + contentW / 2f);
+            view.setPivotY(contentTop + contentH / 2f);
+            view.setScaleX(scaleX);
+            view.setScaleY(scaleY);
+            final float contentCenterX = loc[0] + contentLeft + contentW / 2f;
+            final float contentCenterY = loc[1] + contentTop + contentH / 2f;
+            view.setTranslationX(displayW / 2f - contentCenterX);
+            view.setTranslationY(displayH / 2f - contentCenterY);
+            return;
+        }
+
         view.setPivotX(contentLeft);
         view.setPivotY(contentTop);
-        view.setScaleX(displayW / contentW);
-        view.setScaleY(displayH / contentH);
+        view.setScaleX(scaleX);
+        view.setScaleY(scaleY);
         view.setTranslationX(-(loc[0] + contentLeft));
         view.setTranslationY(-(loc[1] + contentTop));
     }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -224,6 +224,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting DISABLE_FULLSCREEN_SLIDING_GESTURE = new BooleanSetting("morphe_disable_fullscreen_sliding_down_gesture", FALSE);
     public static final BooleanSetting DISABLE_FULLSCREEN_DRAGGED_DOWN_GESTURE = new BooleanSetting("morphe_disable_fullscreen_dragged_down_gesture", FALSE);
     public static final BooleanSetting DISABLE_FULLSCREEN_ZOOM_GESTURE = new BooleanSetting("morphe_disable_fullscreen_zoom_gesture", FALSE);
+    public static final BooleanSetting RESTORE_PINCH_TO_ZOOM = new BooleanSetting("morphe_restore_pinch_to_zoom", FALSE);
     public static final BooleanSetting DISABLE_ROLLING_NUMBER_ANIMATIONS = new BooleanSetting("morphe_disable_rolling_number_animations", FALSE);
     public static final EnumSetting<FullscreenMode> EXIT_FULLSCREEN = new EnumSetting<>("morphe_exit_fullscreen", FullscreenMode.DISABLED);
     public static final EnumSetting<VideoScaleMode> FULLSCREEN_VIDEO_SCALE = new EnumSetting<>("morphe_fullscreen_video_scale", VideoScaleMode.DEFAULT);

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/DisableFullscreenGesturesPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/DisableFullscreenGesturesPatch.kt
@@ -57,7 +57,8 @@ val disableFullscreenGesturesPatch = bytecodePatch(
                     SwitchPreference("morphe_disable_fullscreen_pulled_up_gesture"),
                     SwitchPreference("morphe_disable_fullscreen_dragged_down_gesture"),
                     SwitchPreference("morphe_disable_fullscreen_sliding_down_gesture"),
-                    SwitchPreference("morphe_disable_fullscreen_zoom_gesture")
+                    SwitchPreference("morphe_disable_fullscreen_zoom_gesture"),
+                    SwitchPreference("morphe_restore_pinch_to_zoom", summary = true)
                 )
             )
         )

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/DisableFullscreenGesturesPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/DisableFullscreenGesturesPatch.kt
@@ -10,16 +10,17 @@
 
 package app.morphe.patches.youtube.layout.player.fullscreen
 
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.patcher.util.smali.ExternalLabel
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference
 import app.morphe.patches.shared.misc.settings.preference.PreferenceScreenPreference.Sorting
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.playservice.is_20_40_or_greater
+import app.morphe.patches.youtube.misc.playservice.is_21_36_or_greater
 import app.morphe.patches.youtube.misc.playservice.versionCheckPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.misc.settings.settingsPatch
@@ -109,7 +110,40 @@ val disableFullscreenGesturesPatch = bytecodePatch(
             """
         )
 
-        if (is_20_40_or_greater) {
+        if (is_21_36_or_greater) {
+            // Native pinch scales inside the 16:9 PlayerView (Nx HUD, side bars
+            // stay). Scale that view with the gesture so the bars are eaten.
+            // Do not force YouTube flag 45698813; that hides the seekbar and is
+            // not required for the view transform.
+            VideoZoomScaleBeginFingerprint.classDef.methods.forEach { method ->
+                when (method.name) {
+                    "onScale" -> method.addInstructions(
+                        0,
+                        "invoke-static { p1 }, $EXTENSION_CLASS->" +
+                            "onPinchScale(Landroid/view/ScaleGestureDetector;)V"
+                    )
+                    "onScaleEnd" -> method.addInstructions(
+                        0,
+                        "invoke-static { p1 }, $EXTENSION_CLASS->" +
+                            "onPinchScaleEnd(Landroid/view/ScaleGestureDetector;)V"
+                    )
+                }
+            }
+            YouTubePlayerViewOnLayoutFingerprint.let {
+                it.method.addInstructionsAtControlFlowLabel(
+                    it.instructionMatches.first().index,
+                    "invoke-static { p0 }, $EXTENSION_CLASS->" +
+                        "onPlayerViewLayout(Landroid/view/View;)V"
+                )
+            }
+            YouTubePlayerOverlaysLayoutConstructorFingerprint.matchAll().forEach {
+                it.method.addInstruction(
+                    it.instructionMatches.first().index,
+                    "invoke-static { p0 }, $EXTENSION_CLASS->" +
+                        "attachPlayerOverlay(Landroid/view/View;)V"
+                )
+            }
+        } else if (is_20_40_or_greater) {
             FullscreenGestureZoomFingerprint.apply {
                 method.apply {
                     val instructionIndex = instructionMatches[9].index

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -990,6 +990,8 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
     <string name="morphe_disable_fullscreen_sliding_down_gesture_title">Disable portrait swipe-down gesture</string>
     <string name="morphe_disable_fullscreen_dragged_down_gesture_title">Disable landscape swipe-down gesture</string>
     <string name="morphe_disable_fullscreen_zoom_gesture_title">Disable pinch-to-zoom gesture</string>
+    <string name="morphe_restore_pinch_to_zoom_title">Restore pinch to zoom</string>
+    <string name="morphe_restore_pinch_to_zoom_summary">21.36+ only. Native pinch stops at zoom-to-fill; this scales the player view so pinch can crop past fill. Off by default.</string>
 
     <!-- layout.player.fullscreen.openVideosFullscreenPatch -->
     <string name="morphe_open_videos_fullscreen_title">Open videos in fullscreen mode</string>


### PR DESCRIPTION
## Description

On YouTube 21.36+, native pinch only scales inside the 16:9 `PlayerView` (the Nx badge). The window letterbox never moves, so pinch stops at zoom-to-fill.

This scales that player view with the gesture so the picture crops past fill.

- Does **not** force flag `45698813` (that hides the seekbar / freezes the timer).
- No patch `dependsOn` Fullscreen video scale. Stretch/Zoom read `DisableFullscreenGesturesPatch.getPinchScale()` in the YouTube extension so they stay applied while pinched.
- Pre-21.36 still uses the existing opcode hook.

Fixes #2835

## Test results

- [ ] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)

So far: SM-S948U1, YouTube **21.36.45**, full default Morphe patch list.

- Default scale: pinch past fill, seekbar stays, pinch back to 1x restores letterbox.
- Stretch: pinch keeps stretch (no right-side bar); pinch back to 1x restores stretch-at-rest.