### PR TITLE
feat(YouTube - Fullscreen video scale): Add option to show scale button only in fullscreen

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -256,6 +256,7 @@ public class Settings extends SharedYouTubeSettings {
 
     // Overlay buttons
     public static final BooleanSetting FULLSCREEN_VIDEO_SCALE_BUTTON = new BooleanSetting("morphe_fullscreen_video_scale_button", FALSE, true);
+    public static final BooleanSetting FULLSCREEN_VIDEO_SCALE_BUTTON_FULLSCREEN_ONLY = new BooleanSetting("morphe_fullscreen_video_scale_button_fullscreen_only", FALSE, parent(FULLSCREEN_VIDEO_SCALE_BUTTON));
     public static final BooleanSetting COPY_VIDEO_LINK_BUTTON = new BooleanSetting("morphe_copy_video_link_button", FALSE, true);
     public static final BooleanSetting COPY_VIDEO_LINK_WITH_TIMESTAMP_BUTTON = new BooleanSetting("morphe_copy_video_link_with_timestamp_button", TRUE, true, parent(COPY_VIDEO_LINK_BUTTON));
     public static final BooleanSetting HIDE_AUTOPLAY_BUTTON = new BooleanSetting("morphe_hide_autoplay_button", TRUE, true);

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/FullscreenVideoScaleButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/FullscreenVideoScaleButton.java
@@ -24,6 +24,7 @@ import app.morphe.extension.youtube.patches.LegacyPlayerControlsPatch;
 import app.morphe.extension.youtube.patches.FullscreenVideoScalePatch;
 import app.morphe.extension.youtube.patches.FullscreenVideoScalePatch.VideoScaleMode;
 import app.morphe.extension.youtube.settings.Settings;
+import app.morphe.extension.youtube.shared.PlayerType;
 
 @SuppressWarnings("unused")
 public class FullscreenVideoScaleButton {
@@ -43,12 +44,28 @@ public class FullscreenVideoScaleButton {
                 return;
             }
 
-            overlayButtonRef = new WeakReference<>(PlayerOverlayButton.addButton(
+            ImageView button = new ImageView(controlsView.getContext()) {
+                @Override
+                public void setVisibility(int visibility) {
+                    super.setVisibility(isOverlayButtonVisible() ? visibility : GONE);
+                }
+            };
+            ImageView added = PlayerOverlayButton.addButton(
                     controlsView,
+                    button,
                     getIconName(Settings.FULLSCREEN_VIDEO_SCALE.get()),
                     view -> cycleScaleMode(),
                     null
-            ));
+            );
+            overlayButtonRef = new WeakReference<>(added);
+            if (added != null) {
+                added.getViewTreeObserver().addOnPreDrawListener(() -> {
+                    if (!isOverlayButtonVisible() && added.getVisibility() != View.GONE) {
+                        added.setVisibility(View.GONE);
+                    }
+                    return true;
+                });
+            }
         } catch (Exception ex) {
             Logger.printException(() -> "initializeButton failure", ex);
         }
@@ -68,13 +85,27 @@ public class FullscreenVideoScaleButton {
                     "fullscreen_video_scale_button",
                     null,
                     Settings.FULLSCREEN_VIDEO_SCALE.get().iconBaseName,
-                    Settings.FULLSCREEN_VIDEO_SCALE_BUTTON,
+                    () -> isOverlayButtonVisible()
+                            ? LegacyPlayerControlButton.ButtonVisibility.ENABLED
+                            : LegacyPlayerControlButton.ButtonVisibility.DISABLED,
                     view -> cycleScaleMode(),
                     null
             );
         } catch (Exception ex) {
             Logger.printException(() -> "initializeLegacyButton failure", ex);
         }
+    }
+
+    private static boolean isOverlayButtonVisible() {
+        if (!Settings.FULLSCREEN_VIDEO_SCALE_BUTTON.get()) {
+            return false;
+        }
+        if (!Settings.FULLSCREEN_VIDEO_SCALE_BUTTON_FULLSCREEN_ONLY.get()) {
+            return true;
+        }
+        PlayerType type = PlayerType.getCurrent();
+        return type == PlayerType.WATCH_WHILE_FULLSCREEN
+                || type == PlayerType.WATCH_WHILE_SLIDING_MAXIMIZED_FULLSCREEN;
     }
 
     private static void cycleScaleMode() {

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/FullscreenVideoScalePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/player/fullscreen/FullscreenVideoScalePatch.kt
@@ -12,6 +12,7 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.shared.misc.settings.preference.ListPreference
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
+import app.morphe.patches.shared.misc.settings.preference.noTitleUnsortedPreferenceCategory
 import app.morphe.patches.youtube.layout.buttons.overlay.addPlayerOverlayPreferences
 import app.morphe.patches.youtube.layout.buttons.overlay.playerOverlayButtonsSettingsPatch
 import app.morphe.patches.youtube.layout.player.buttons.addPlayerBottomButton
@@ -84,7 +85,10 @@ val fullscreenVideoScalePatch = bytecodePatch(
         )
 
         addPlayerOverlayPreferences(
-            SwitchPreference("morphe_fullscreen_video_scale_button", summary = true)
+            noTitleUnsortedPreferenceCategory(
+                SwitchPreference("morphe_fullscreen_video_scale_button", summary = true),
+                SwitchPreference("morphe_fullscreen_video_scale_button_fullscreen_only", summary = true)
+            )
         )
 
         addPlayerBottomButton(EXTENSION_BUTTON)

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1004,6 +1004,8 @@ Settings → Playback (or Autoplay) → Autoplay next video"</string>
     <string name="morphe_fullscreen_video_scale_entry_zoom">Zoom (crop to fill)</string>
     <string name="morphe_fullscreen_video_scale_button_title">Show video scale button</string>
     <string name="morphe_fullscreen_video_scale_button_summary">Tap to cycle Default, Stretch, and Zoom</string>
+    <string name="morphe_fullscreen_video_scale_button_fullscreen_only_title">Show only in fullscreen</string>
+    <string name="morphe_fullscreen_video_scale_button_fullscreen_only_summary">Hide the video scale button in the portrait player</string>
 
     <!-- layout.player.buttons.muteVideoButtonPatch -->
     <string name="morphe_mute_video_button_title">Show Mute button</string>


### PR DESCRIPTION
### Description

Adds an overlay-button option **Show only in fullscreen** under **Show video scale button**.

When enabled, the video scale button is shown only in fullscreen (`WATCH_WHILE_FULLSCREEN` / sliding into it). Portrait player keeps the button hidden. Default is off, so existing behavior is unchanged.

Visibility is handled only in `FullscreenVideoScaleButton` (custom `ImageView` + pre-draw). Shared overlay layout (`PlayerOverlayButton`) is not modified, so mute/speed/quality/copy slots stay put.

Closes #2654

### Additional context

Tested on SM-S948U1 with patched YouTube 21.36.45 (`app.morphe.android.youtube`).

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
