### PR TITLE
fix(YouTube - Loop video): Respect sleep timer end of video state

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LoopVideoPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/LoopVideoPatch.java
@@ -10,6 +10,8 @@
 
 package app.morphe.extension.youtube.patches;
 
+import java.lang.ref.WeakReference;
+
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.youtube.settings.Settings;
 import app.morphe.extension.youtube.videoplayer.LoopVideoButton;
@@ -33,6 +35,27 @@ public class LoopVideoPatch {
     private static final long SEEK_COOLDOWN_MS = 2000;
     /** How early to seek before rangeEndMs when rangeEndIsVideoEnd, to avoid the end screen. */
     private static final long END_SCREEN_BUFFER_MS = 1500;
+
+    public interface SleepTimerController {
+        boolean patch_isSetToEndOfVideo();
+    }
+
+    private static WeakReference<SleepTimerController> sleepTimerControllerRef = new WeakReference<>(null);
+
+    /**
+     * Injection point.
+     */
+    public static void setSleepTimerController(SleepTimerController controller) {
+        sleepTimerControllerRef = new WeakReference<>(controller);
+    }
+
+    public static boolean isSleepTimerEndingVideo() {
+        SleepTimerController controller = sleepTimerControllerRef.get();
+        if (controller != null) {
+            return controller.patch_isSetToEndOfVideo();
+        }
+        return false;
+    }
 
     public static boolean isRangeActive() {
         return rangeStartMs >= 0 && rangeEndMs > rangeStartMs;
@@ -84,7 +107,12 @@ public class LoopVideoPatch {
         try {
             final boolean isEnded = Settings.LOOP_VIDEO.get()
                     && status != null && "ENDED".equals(status.name());
+
             if (isEnded) {
+                if (isSleepTimerEndingVideo()) {
+                    return false;
+                }
+
                 return VideoInformation.seekTo(isRangeActive()
                         // Fallback: if the video truly ended while range is active (videoTimeChanged was too slow),
                         // seek to range start so the end screen is dismissed.

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/Fingerprints.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
+package app.morphe.patches.youtube.interaction.loop
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.opcode
+import app.morphe.patches.all.misc.resources.ResourceType
+import app.morphe.patches.all.misc.resources.resourceLiteral
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+internal object SleepTimerCancelMethodFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf("Z"),
+    filters = listOf(
+        resourceLiteral(ResourceType.STRING, "sleeptimer_snackbar_canceled_text")
+    )
+)
+
+internal object SleepTimerConstructorFingerprint : Fingerprint(
+    classFingerprint = SleepTimerCancelMethodFingerprint,
+    name = "<init>"
+)
+
+internal object SleepTimerVideoEndedEventFingerprint : Fingerprint(
+    classFingerprint = SleepTimerCancelMethodFingerprint,
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf("I", "Z"),
+    filters = listOf(
+        opcode(Opcode.IGET_OBJECT),
+        opcode(Opcode.SGET_OBJECT)
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/Fingerprints.kt
@@ -8,6 +8,7 @@
 package app.morphe.patches.youtube.interaction.loop
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.methodCall
 import app.morphe.patcher.opcode
 import app.morphe.patches.all.misc.resources.ResourceType
 import app.morphe.patches.all.misc.resources.resourceLiteral
@@ -25,7 +26,10 @@ internal object SleepTimerCancelMethodFingerprint : Fingerprint(
 
 internal object SleepTimerConstructorFingerprint : Fingerprint(
     classFingerprint = SleepTimerCancelMethodFingerprint,
-    name = "<init>"
+    name = "<init>",
+    filters = listOf(
+        methodCall(opcode = Opcode.INVOKE_DIRECT, name = "<init>")
+    )
 )
 
 internal object SleepTimerVideoEndedEventFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/LoopVideoPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/LoopVideoPatch.kt
@@ -10,9 +10,12 @@
 
 package app.morphe.patches.youtube.interaction.loop
 
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
@@ -20,11 +23,20 @@ import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import app.morphe.patches.youtube.video.information.playerStatusMethodRef
 import app.morphe.patches.youtube.video.information.videoInformationPatch
 import app.morphe.patches.youtube.video.information.videoTimeHook
+import app.morphe.util.getReference
 import app.morphe.util.indexOfFirstInstructionOrThrow
+import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/LoopVideoPatch;"
+private const val EXTENSION_SLEEP_TIMER_INTERFACE =
+    $$"Lapp/morphe/extension/youtube/patches/LoopVideoPatch$SleepTimerController;"
 
 val loopVideoPatch = bytecodePatch(
     name = "Loop video",
@@ -69,6 +81,59 @@ val loopVideoPatch = bytecodePatch(
                     nop
                 """
             )
+        }
+
+        SleepTimerCancelMethodFingerprint.method.apply {
+            val stateFieldGetIndex = indexOfFirstInstructionOrThrow(Opcode.IGET_OBJECT)
+            val stateFieldRef = getInstruction<ReferenceInstruction>(stateFieldGetIndex).reference as FieldReference
+
+            SleepTimerVideoEndedEventFingerprint.method.apply {
+                val sgetInstructionIndex = indexOfFirstInstructionOrThrow(Opcode.SGET_OBJECT)
+                val endOfVideoEnumFieldRef = getInstruction<ReferenceInstruction>(sgetInstructionIndex).reference as FieldReference
+
+                SleepTimerCancelMethodFingerprint.classDef.apply {
+                    interfaces.add(EXTENSION_SLEEP_TIMER_INTERFACE)
+
+                    methods.add(
+                        ImmutableMethod(
+                            type,
+                            "patch_isSetToEndOfVideo",
+                            listOf(),
+                            "Z",
+                            AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+                            null,
+                            null,
+                            MutableMethodImplementation(3),
+                        ).toMutable().apply {
+                            addInstructions(
+                                0,
+                                """
+                                    iget-object v0, p0, $stateFieldRef
+                                    sget-object v1, $endOfVideoEnumFieldRef
+                                    if-ne v0, v1, :false
+                                    const/4 v0, 1
+                                    return v0
+                                    :false
+                                    const/4 v0, 0
+                                    return v0
+                                """
+                            )
+                        }
+                    )
+                }
+            }
+        }
+
+        SleepTimerConstructorFingerprint.matchAll().forEach { match ->
+            match.method.apply {
+                val index = indexOfFirstInstructionOrThrow {
+                    opcode == Opcode.INVOKE_DIRECT && getReference<MethodReference>()?.name == "<init>"
+                } + 1
+                addInstruction(
+                    index,
+                    "invoke-static { p0 }, $EXTENSION_CLASS->setSleepTimerController($EXTENSION_SLEEP_TIMER_INTERFACE)V"
+                )
+            }
         }
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/LoopVideoPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/interaction/loop/LoopVideoPatch.kt
@@ -11,11 +11,11 @@
 package app.morphe.patches.youtube.interaction.loop
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
-import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
+import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.patches.shared.misc.settings.preference.SwitchPreference
 import app.morphe.patches.youtube.misc.extension.sharedExtensionPatch
 import app.morphe.patches.youtube.misc.settings.PreferenceScreen
@@ -23,7 +23,6 @@ import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import app.morphe.patches.youtube.video.information.playerStatusMethodRef
 import app.morphe.patches.youtube.video.information.videoInformationPatch
 import app.morphe.patches.youtube.video.information.videoTimeHook
-import app.morphe.util.getReference
 import app.morphe.util.indexOfFirstInstructionOrThrow
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
@@ -31,7 +30,6 @@ import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
-import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
 
 private const val EXTENSION_CLASS = "Lapp/morphe/extension/youtube/patches/LoopVideoPatch;"
@@ -45,7 +43,8 @@ val loopVideoPatch = bytecodePatch(
     dependsOn(
         sharedExtensionPatch,
         loopVideoButtonPatch,
-        videoInformationPatch
+        videoInformationPatch,
+        resourceMappingPatch
     )
 
     compatibleWith(COMPATIBILITY_YOUTUBE)
@@ -105,7 +104,7 @@ val loopVideoPatch = bytecodePatch(
                             null,
                             MutableMethodImplementation(3),
                         ).toMutable().apply {
-                            addInstructions(
+                            addInstructionsWithLabels(
                                 0,
                                 """
                                     iget-object v0, p0, $stateFieldRef
@@ -126,12 +125,10 @@ val loopVideoPatch = bytecodePatch(
 
         SleepTimerConstructorFingerprint.matchAll().forEach { match ->
             match.method.apply {
-                val index = indexOfFirstInstructionOrThrow {
-                    opcode == Opcode.INVOKE_DIRECT && getReference<MethodReference>()?.name == "<init>"
-                } + 1
                 addInstruction(
-                    index,
-                    "invoke-static { p0 }, $EXTENSION_CLASS->setSleepTimerController($EXTENSION_SLEEP_TIMER_INTERFACE)V"
+                    match.instructionMatches.first().index + 1,
+                    "invoke-static { p0 }, $EXTENSION_CLASS->" +
+                            "setSleepTimerController($EXTENSION_SLEEP_TIMER_INTERFACE)V"
                 )
             }
         }


### PR DESCRIPTION
### Description

Closes #842.

### Additional context

The custom loop video patch previously intercepted the `ENDED` player status and immediately looped the video. This prevented YouTube's native Sleep Timer from receiving the event and stopping playback.

This fix hooks the native Sleep Timer controller to check if the "End of video" timer is active. If it is, the loop patch yields control back to the native player, allowing the sleep timer to correctly pause playback as the user intended.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
