### PR TITLE
fix(YouTube - Hide layout components): Fix UI padding in comment replies and incognito search

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/components/LayoutComponentsFilter.java
@@ -596,6 +596,16 @@ public final class LayoutComponentsFilter extends Filter {
 
     /**
      * Injection point.
+     */
+    public static boolean disableUIPaddingFeatureFlags(boolean original) {
+        if (Settings.HIDE_COMPACT_BANNER.get()) {
+            return false;
+        }
+        return original;
+    }
+
+    /**
+     * Injection point.
      * Called from a different place then the other filters.
      */
     public static boolean filterMixPlaylists(@Nullable byte[] buffer) {

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -123,7 +123,7 @@ public class Settings extends SharedYouTubeSettings {
     public static final BooleanSetting HIDE_ARTIST_CARDS = new BooleanSetting("morphe_hide_artist_cards", FALSE);
     public static final BooleanSetting HIDE_AUTO_DUBBED_LABEL = new BooleanSetting("morphe_hide_auto_dubbed_label", FALSE);
     public static final BooleanSetting HIDE_COMMUNITY_POSTS = new BooleanSetting("morphe_hide_community_posts", FALSE);
-    public static final BooleanSetting HIDE_COMPACT_BANNER = new BooleanSetting("morphe_hide_compact_banner", TRUE);
+    public static final BooleanSetting HIDE_COMPACT_BANNER = new BooleanSetting("morphe_hide_compact_banner", TRUE, true);
     public static final EnumSetting<ExpandableCardStyle> HIDE_EXPANDABLE_CARD = new EnumSetting<>("morphe_hide_expandable_card", ExpandableCardStyle.HIDE_ALL);
     public static final BooleanSetting HIDE_FEED_FLYOUT_MENU = new BooleanSetting("morphe_hide_feed_flyout_menu", FALSE);
     public static final StringSetting  HIDE_FEED_FLYOUT_MENU_FILTER_STRINGS = new StringSetting("morphe_hide_feed_flyout_menu_filter_strings", "", true, parent(HIDE_FEED_FLYOUT_MENU));

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/Fingerprints.kt
@@ -783,3 +783,15 @@ internal object HideTimeBarEntryPointContainerFingerprint : Fingerprint(
         opcode(Opcode.MOVE_RESULT_OBJECT, location = MatchAfterImmediately())
     )
 )
+
+internal object CommentReplyPaddingFeatureFlagFingerprint : Fingerprint(
+    filters = listOf(
+        literal(45752241)
+    )
+)
+
+internal object IncognitoSearchPaddingFeatureFlagFingerprint : Fingerprint(
+    filters = listOf(
+        literal(45724388)
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -1270,7 +1270,6 @@ val hideLayoutComponentsPatch = bytecodePatch(
             CommentReplyPaddingFeatureFlagFingerprint,
             IncognitoSearchPaddingFeatureFlagFingerprint
         ).forEach { fingerprint ->
-            fingerprint.clearMatch()
             fingerprint.matchAll().forEach {
                 it.method.insertLiteralOverride(
                     it.instructionMatches.first().index,

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/hide/general/HideLayoutComponentsPatch.kt
@@ -1263,5 +1263,22 @@ val hideLayoutComponentsPatch = bytecodePatch(
         }
 
         // endregion
+
+        // region disable UI padding feature flags
+
+        listOf(
+            CommentReplyPaddingFeatureFlagFingerprint,
+            IncognitoSearchPaddingFeatureFlagFingerprint
+        ).forEach { fingerprint ->
+            fingerprint.clearMatch()
+            fingerprint.matchAll().forEach {
+                it.method.insertLiteralOverride(
+                    it.instructionMatches.first().index,
+                    "$LAYOUT_COMPONENTS_FILTER->disableUIPaddingFeatureFlags(Z)Z"
+                )
+            }
+        }
+
+        // endregion
     }
 }


### PR DESCRIPTION
### Description

Closes #2274.
Closes #2300.

### Additional context

Fixes visual overlap in the incognito search screen and excessive bottom padding in the comment replies screen by targeting their respective feature flags (`45724388` and `45752241`). 

These flags are now forced off when the user enables the "Hide compact banner" layout setting.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
