### PR TITLE
fix(YouTube - Change header): Apply custom header logo to explore menu

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ChangeHeaderPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/ChangeHeaderPatch.java
@@ -1,9 +1,24 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches/pull/2910
+ *
+ * Original hard forked code:
+ * https://github.com/ReVanced/revanced-patches/commit/724e6d61b2ecd868c1a9a37d465a688e83a74799
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
 package app.morphe.extension.youtube.patches;
 
 import android.graphics.drawable.Drawable;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
+import android.widget.ImageView;
 
 import androidx.annotation.Nullable;
 
+import java.util.LinkedList;
 import java.util.Objects;
 
 import app.morphe.extension.shared.Logger;
@@ -40,7 +55,7 @@ public class ChangeHeaderPatch {
          * @return The attribute id of this header logo, or NULL if the logo should not be replaced.
          */
         @Nullable
-        private Integer getAttributeId() {
+        public Integer getAttributeId() {
             if (attributeName == null) {
                 return null;
             }
@@ -103,5 +118,68 @@ public class ChangeHeaderPatch {
         // Should never happen.
         Logger.printException(() -> "Could not find regular header logo resource");
         return original;
+    }
+
+    private static int drawerContentViewId = -1;
+
+    /**
+     * Injection point.
+     */
+    public static void updateDrawerLogo(ViewGroup drawerContentView) {
+        if (drawerContentView == null) {
+            return;
+        }
+
+        if (drawerContentViewId == -1) {
+            drawerContentViewId = ResourceUtils.getIdentifier(ResourceType.ID, "drawer_content_view");
+        }
+
+        if (drawerContentViewId != 0 && drawerContentView.getId() != drawerContentViewId) {
+            return;
+        }
+
+        drawerContentView.post(() -> {
+            LinkedList<ViewGroup> queue = new LinkedList<>();
+            queue.add(drawerContentView);
+
+            while (!queue.isEmpty()) {
+                ViewGroup current = queue.poll();
+                for (int i = 0; i < Objects.requireNonNull(current).getChildCount(); i++) {
+                    View child = current.getChildAt(i);
+
+                    if (child instanceof ImageView logoView) {
+
+                        if (logoView.getTag() == null) {
+                            logoView.setTag(true);
+
+                            logoView.getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
+                                @Override
+                                public boolean onPreDraw() {
+                                    Drawable currentDrawable = logoView.getDrawable();
+
+                                    if (currentDrawable != null) {
+                                        int viewWidth = logoView.getWidth();
+                                        int viewHeight = logoView.getHeight();
+
+                                        if (viewWidth > 0 && viewHeight > 0 && viewWidth > viewHeight * 2) {
+                                            Drawable customLogo = getDrawable(currentDrawable);
+
+                                            if (customLogo != null && currentDrawable != customLogo) {
+                                                logoView.setImageDrawable(customLogo);
+                                            }
+
+                                            logoView.getViewTreeObserver().removeOnPreDrawListener(this);
+                                        }
+                                    }
+                                    return true;
+                                }
+                            });
+                        }
+                    } else if (child instanceof ViewGroup) {
+                        queue.add((ViewGroup) child);
+                    }
+                }
+            }
+        });
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/branding/header/ChangeHeaderPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/branding/header/ChangeHeaderPatch.kt
@@ -23,6 +23,7 @@ import app.morphe.patches.youtube.misc.settings.PreferenceScreen
 import app.morphe.patches.youtube.shared.Constants.COMPATIBILITY_YOUTUBE
 import app.morphe.util.findElementByAttributeValueOrThrow
 import app.morphe.util.forEachLiteralValueInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 private val variants = arrayOf("light", "dark")
@@ -65,6 +66,20 @@ private val changeHeaderBytecodePatch = bytecodePatch {
                     """
                         invoke-static { v$register }, $EXTENSION_CLASS->getHeaderAttributeId(I)I
                         move-result v$register    
+                    """
+                )
+            }
+        }
+
+        DrawerHeaderRenderFingerprint.matchAll().forEach { match ->
+            match.method.apply {
+                val addViewIndex = match.instructionMatches.last().index
+                val viewGroupRegister = getInstruction<FiveRegisterInstruction>(addViewIndex).registerC
+
+                addInstructions(
+                    addViewIndex + 1,
+                    """
+                        invoke-static { v$viewGroupRegister }, $EXTENSION_CLASS->updateDrawerLogo(Landroid/view/ViewGroup;)V
                     """
                 )
             }

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/layout/branding/header/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/layout/branding/header/Fingerprints.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patches
+ *
+ * See the included NOTICE file for GPLv3 Section 7 terms that apply to Morphe contributions.
+ */
+
+package app.morphe.patches.youtube.layout.branding.header
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.methodCall
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+internal object DrawerHeaderRenderFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    returnType = "V",
+    parameters = listOf("L"),
+    filters = listOf(
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            smali = "Landroid/view/ViewGroup;->removeAllViews()V"
+        ),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            smali = "Landroid/view/ViewGroup;->addView(Landroid/view/View;)V"
+        )
+    )
+)


### PR DESCRIPTION
### Description

<img width="400" height="324" alt="Screen_Recording_20260912_030942_YouTube" src="https://github.com/user-attachments/assets/5920508a-fc41-42ad-8d72-23f7c55d8536" />


Closes #884.

### Additional context

Hooks the Elements UI container binder to dynamically replace the stock YouTube wordmark inside the explore menu using an `OnPreDrawListener` and strict aspect-ratio filtering.

### Test results

- [x] Tested on both the **minimum** and **maximum** supported versions
- [x] Tested on **experimental** supported versions (Optional)
